### PR TITLE
Avoid duplicated entries when calling create_preload_data

### DIFF
--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -23,44 +23,50 @@ class Command(BaseCommand):
         with impersonate(superuser):
             with disable_computed_fields():
                 if not Organization.objects.exists():
-                    o = Organization.objects.create(name='Default')
+                    o, _ = Organization.objects.get_or_create(name='Default')
 
-                    p = Project(
+                    p, _ = Project.objects.get_or_create(
                         name='Demo Project',
                         scm_type='git',
                         scm_url='https://github.com/ansible/ansible-tower-samples',
                         scm_update_on_launch=True,
                         scm_update_cache_timeout=0,
-                        organization=o,
                     )
-                    p.save(skip_update=True)
+                    p.organization = o
+                    p.save()
 
                     ssh_type = CredentialType.objects.filter(namespace='ssh').first()
-                    c = Credential.objects.create(
+                    c, _ = Credential.objects.get_or_create(
                         credential_type=ssh_type, name='Demo Credential', inputs={'username': superuser.username}, created_by=superuser
                     )
 
                     c.admin_role.members.add(superuser)
 
-                    public_galaxy_credential = Credential(
+                    public_galaxy_credential, _ = Credential.objects.get_or_create(
                         name='Ansible Galaxy',
                         managed=True,
                         credential_type=CredentialType.objects.get(kind='galaxy'),
                         inputs={'url': 'https://galaxy.ansible.com/'},
                     )
-                    public_galaxy_credential.save()
                     o.galaxy_credentials.add(public_galaxy_credential)
 
-                    i = Inventory.objects.create(name='Demo Inventory', organization=o, created_by=superuser)
+                    i, _ = Inventory.objects.get_or_create(name='Demo Inventory', organization=o, created_by=superuser)
 
-                    Host.objects.create(
+                    Host.objects.get_or_create(
                         name='localhost',
                         inventory=i,
                         variables="ansible_connection: local\nansible_python_interpreter: '{{ ansible_playbook_python }}'",
                         created_by=superuser,
                     )
 
-                    jt = JobTemplate.objects.create(name='Demo Job Template', playbook='hello_world.yml', project=p, inventory=i)
+                    jt = JobTemplate.objects.filter(name='Demo Job Template').first()
+                    if jt:
+                        jt.project = p
+                        jt.inventory = i
+                        jt.playbook = 'hello_world.yml'
+                        jt.save()
+                    else:
+                        jt, _ = JobTemplate.objects.get_or_create(name='Demo Job Template', playbook='hello_world.yml', project=p, inventory=i)
                     jt.credentials.add(c)
 
                     print('Default organization added.')

--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
                         scm_update_cache_timeout=0,
                     )
                     p.organization = o
-                    p.save()
+                    p.save(skip_update=True)
 
                     ssh_type = CredentialType.objects.filter(namespace='ssh').first()
                     c, _ = Credential.objects.get_or_create(


### PR DESCRIPTION
##### SUMMARY
When deleting the `Default Organization`, re-running the `create_preload_data` causes the database integrity issue as some `read-only` resources will get be duplicated in the database


<!--- Describe the change, including rationale and design decisions -->

#### Steps to reproduce
1. Delete the `Default Org from the weUI
2. Run the `create_preload_data` script 3 times. 
```bash
awx-manage create_preload_data
```
 
![image](https://user-images.githubusercontent.com/809840/150030505-2a77a64c-09c0-40d3-b0e0-e7f5c7631194.png)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```

##### Testing after patching the code
1. Cleaning database
```bash
$ awx-manage shell_plus
JobTemplate.objects.all().delete()
Credential.objects.all().delete()
Project.objects.all().delete()
Inventory.objects.all().delete()
Organization.objects.all().delete()
```
2. Run multiple times the `awx-manage create_preload_data` 

3. Things should look good :) 


