### PR TITLE
Support user customization of EE mount options and mount paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           ansible-galaxy collection install -r molecule/requirements.yml
           sudo rm -f $(which kustomize)
           make kustomize
-          KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule test -s kind
+          KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule -v test -s kind
         env:
           AWX_TEST_IMAGE: awx
           AWX_TEST_VERSION: ci

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -259,10 +259,14 @@ register(
 
 register(
     'AWX_ISOLATION_SHOW_PATHS',
-    field_class=fields.StringListField,
+    field_class=fields.StringListIsolatedPathField,
     required=False,
     label=_('Paths to expose to isolated jobs'),
-    help_text=_('List of paths that would otherwise be hidden to expose to isolated jobs. Enter one path per line.'),
+    help_text=_(
+        'List of paths that would otherwise be hidden to expose to isolated jobs. Enter one path per line. '
+        'Volumes will be mounted from the execution node to the container. '
+        'The supported format is HOST-DIR[:CONTAINER-DIR[:OPTIONS]]. '
+    ),
     category=_('Jobs'),
     category_slug='jobs',
 )

--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -85,3 +85,10 @@ RECEPTOR_PENDING = 'ansible-runner-???'
 # Naming pattern for AWX jobs in /tmp folder, like /tmp/awx_42_xiwm
 # also update awxkit.api.pages.unified_jobs if changed
 JOB_FOLDER_PREFIX = 'awx_%s_'
+
+# :z option tells Podman that two containers share the volume content with r/w
+# :O option tells Podman to mount the directory from the host as a temporary storage using the overlay file system.
+# see podman-run manpage for further details
+# /HOST-DIR:/CONTAINER-DIR:OPTIONS
+CONTAINER_VOLUMES_MOUNT_TYPES = ['z', 'O']
+MAX_ISOLATED_PATH_COLON_DELIMITER = 2

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -37,7 +37,13 @@ from gitdb.exc import BadName as BadGitName
 from awx.main.constants import ACTIVE_STATES
 from awx.main.dispatch.publish import task
 from awx.main.dispatch import get_local_queuename
-from awx.main.constants import PRIVILEGE_ESCALATION_METHODS, STANDARD_INVENTORY_UPDATE_ENV, MINIMAL_EVENTS, JOB_FOLDER_PREFIX
+from awx.main.constants import (
+    PRIVILEGE_ESCALATION_METHODS,
+    STANDARD_INVENTORY_UPDATE_ENV,
+    MINIMAL_EVENTS,
+    JOB_FOLDER_PREFIX,
+    MAX_ISOLATED_PATH_COLON_DELIMITER,
+)
 from awx.main.redact import UriCleaner
 from awx.main.models import (
     Instance,
@@ -147,6 +153,9 @@ class BaseTask(object):
         return os.path.abspath(os.path.join(os.path.dirname(__file__), *args))
 
     def build_execution_environment_params(self, instance, private_data_dir):
+        """
+        Return params structure to be executed by the container runtime
+        """
         if settings.IS_K8S:
             return {}
 
@@ -157,6 +166,9 @@ class BaseTask(object):
             "process_isolation_executable": "podman",  # need to provide, runner enforces default via argparse
             "container_options": ['--user=root'],
         }
+
+        if settings.DEFAULT_CONTAINER_RUN_OPTIONS:
+            params['container_options'].extend(settings.DEFAULT_CONTAINER_RUN_OPTIONS)
 
         if instance.execution_environment.credential:
             cred = instance.execution_environment.credential
@@ -176,9 +188,17 @@ class BaseTask(object):
         if settings.AWX_ISOLATION_SHOW_PATHS:
             params['container_volume_mounts'] = []
             for this_path in settings.AWX_ISOLATION_SHOW_PATHS:
-                # Using z allows the dir to mounted by multiple containers
+                # Verify if a mount path and SELinux context has been passed
+                # Using z allows the dir to be mounted by multiple containers
                 # Uppercase Z restricts access (in weird ways) to 1 container at a time
-                params['container_volume_mounts'].append(f'{this_path}:{this_path}:z')
+                if this_path.count(':') == MAX_ISOLATED_PATH_COLON_DELIMITER:
+                    src, dest, scontext = this_path.split(':')
+                    params['container_volume_mounts'].append(f'{src}:{dest}:{scontext}')
+                elif this_path.count(':') == MAX_ISOLATED_PATH_COLON_DELIMITER - 1:
+                    src, dest = this_path.split(':')
+                    params['container_volume_mounts'].append(f'{src}:{dest}:z')
+                else:
+                    params['container_volume_mounts'].append(f'{this_path}:{this_path}:z')
         return params
 
     def build_private_data(self, instance, private_data_dir):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -989,3 +989,8 @@ DEFAULT_EXECUTION_QUEUE_NAME = 'default'
 DEFAULT_EXECUTION_QUEUE_POD_SPEC_OVERRIDE = ''
 # Name of the default controlplane queue
 DEFAULT_CONTROL_PLANE_QUEUE_NAME = 'controlplane'
+
+# Extend container runtime attributes.
+# For example, to disable SELinux in containers for podman
+# DEFAULT_CONTAINER_RUN_OPTIONS = ['--security-opt', 'label=disable']
+DEFAULT_CONTAINER_RUN_OPTIONS = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows the user to customize mount points and the mount options for podman

@nixocio how difficult would be to request some extra documentation to be added to this `tooltip` helper?

Related: https://github.com/ansible/awx/issues/10787

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```
**Updated  `tooltip`** @nixocio++
![image](https://user-images.githubusercontent.com/809840/150465633-be21fd46-63b0-4972-a344-56c7ff8c1aae.png)


##### ADDITIONAL INFORMATION
1. Expose the current desired paths
![image](https://user-images.githubusercontent.com/809840/150465759-2de1f5d7-e169-4630-a9be-edf9dd3d673d.png)

2. Running a test playbook
![image](https://user-images.githubusercontent.com/809840/150465857-063b6ee5-c883-4d59-b324-c91782181942.png)

3. Inspecting the mounting values
```
[awx@183-addr ~]$ python3 -c "print(' '.join($(curl -s -u admin:redhat00 localhost/api/v2/jobs/36/ | jq -r .job_args)))"
podman run --rm --tty --interactive --workdir /runner/project  \
    -v /tmp/awx_36_za_o6vpz/:/runner/:Z \
    -v /etc/pki/ca-trust/:/etc/pki/ca-trust/:O \
    -v /shared_data/:/shared_data/:z \
    -v /shared_data2/:/custom_data/:z \
    -v /usr/share/pki/:/usr/share/pki/:O \
    --env-file /tmp/awx_36_za_o6vpz/artifacts/36/env.list --quiet \
    --name ansible_runner_36 --user=root \
    --pull=never quay.io/ansible/awx-ee:latest ansible-playbook -u admin -i /runner/inventory/hosts -e @/runner/env/extravars hello_world.yml

```

Inspecting that `EE` manually, we can see the mount points looking good:

```
[[awx@183-addr ~]$ podman run --rm --tty --interactive --workdir /runner/project -v /etc/pki/ca-trust/:/etc/pki/ca-trust/:O -v /usr/share/pki/:/usr/share/pki/:O -v /shared_data/:/shared_data/:z -v /shared_data2/:/custom_data/:z  --user=root --pull=never quay.io/ansible/awx-ee:latest /bin/bash
bash-4.4# df
Filesystem     1K-blocks    Used Available Use% Mounted on
fuse-overlayfs  20856812 5910580  14946232  29% /
/dev/vda3       20856812 5910580  14946232  29% /custom_data
tmpfs              65536       0     65536   0% /dev
shm                64000       0     64000   0% /dev/shm
cgroup              1024       0      1024   0% /sys/fs/cgroup
fuse-overlayfs  20856812 5910580  14946232  29% /usr/share/pki
fuse-overlayfs  20856812 5910580  14946232  29% /etc/pki/ca-trust
devtmpfs         1878964       0   1878964   0% /dev/tty

bash-4.4# ls -la /etc/pki/ca-trust/
total 8
drwxr-xr-x. 4 nobody nobody   6 Jan 19 22:04 .
-rw-r--r--. 1 nobody nobody 166 Jun 22  2020 README
-rw-r--r--. 1 nobody nobody 980 Jun 22  2020 ca-legacy.conf
drwxr-xr-x. 6 nobody nobody  70 May  4  2021 extracted
drwxr-xr-x. 4 nobody nobody  80 May  4  2021 source

bash-4.4# ls -la /usr/share/pki    
total 0
drwxr-xr-x. 4 nobody nobody  6 Jan 19 22:04 .
drwxr-xr-x. 2 nobody nobody 78 May  4  2021 ca-trust-legacy
drwxr-xr-x. 4 nobody nobody 83 May  4  2021 ca-trust-source

bash-4.4# update-ca-trust 
bash-4.4# echo $?
0
bash-4.4# trust list | wc -l
894

bash-4.4# touch /shared_data/test
bash-4.4# echo $?
0
bash-4.4# touch /custom_data/test
bash-4.4# echo $?
0
```