### PR TITLE
Handeling different types of response.data

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -214,8 +214,15 @@ class APIView(views.APIView):
                 'user_name': request.user,
                 'url_path': request.path,
                 'remote_addr': request.META.get('REMOTE_ADDR', None),
-                'error': response.data.get('error', response.status_text),
             }
+
+            if type(response.data) is dict:
+                msg_data['error'] = response.data.get('error', response.status_text)
+            elif type(response.data) is list:
+                msg_data['error'] = ", ".join(list(map(lambda x: x.get('error', response.status_text), response.data)))
+            else:
+                msg_data['error'] = response.status_text
+
             try:
                 status_msg = getattr(settings, 'API_400_ERROR_LOG_FORMAT').format(**msg_data)
             except Exception as e:

--- a/awx/main/tests/functional/test_api_generics.py
+++ b/awx/main/tests/functional/test_api_generics.py
@@ -24,3 +24,8 @@ def test_custom_400_error_log(caplog, post, admin_user):
     with override_settings(API_400_ERROR_LOG_FORMAT="{status_code} {error}"):
         post(url=reverse('api:setting_logging_test'), data={}, user=admin_user, expect=409)
         assert '409 Logging not enabled' in caplog.text
+
+
+# The above tests the generation function with a dict/object.
+# The tower-qa test tests.api.inventories.test_inventory_update.TestInventoryUpdate.test_update_all_inventory_sources_with_nonfunctional_sources tests the function with a list
+# Someday it would be nice to test the else condition (not a dict/list) but we need to find an API test which will do this. For now it was added just as a catch all


### PR DESCRIPTION
It was discovered that response.data may be in different formats other than a dict

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 1.0.7.dev13865+gdc610a4e4c
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
