### PR TITLE
Add info popover to WF node list items

### DIFF
--- a/awx/ui/src/components/CheckboxListItem/CheckboxListItem.js
+++ b/awx/ui/src/components/CheckboxListItem/CheckboxListItem.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { t } from '@lingui/macro';
 import { Td, Tr } from '@patternfly/react-table';
+import { ActionsTd } from 'components/PaginatedTable';
 
 const CheckboxListItem = ({
   isRadio = false,
@@ -15,6 +16,7 @@ const CheckboxListItem = ({
   onSelect,
   columns,
   item,
+  rowActions,
 }) => {
   const handleRowClick = () => {
     if (isSelected && !isRadio) {
@@ -61,6 +63,16 @@ const CheckboxListItem = ({
         >
           <b>{label}</b>
         </Td>
+      )}
+      {rowActions && (
+        <ActionsTd>
+          {rowActions.map((rowAction) => {
+            const {
+              props: { id },
+            } = rowAction;
+            return <React.Fragment key={id}>{rowAction}</React.Fragment>;
+          })}
+        </ActionsTd>
       )}
     </Tr>
   );

--- a/awx/ui/src/components/CheckboxListItem/CheckboxListItem.test.js
+++ b/awx/ui/src/components/CheckboxListItem/CheckboxListItem.test.js
@@ -21,4 +21,33 @@ describe('CheckboxListItem', () => {
     );
     expect(wrapper).toHaveLength(1);
   });
+
+  test('should render row actions', () => {
+    const wrapper = mount(
+      <table>
+        <tbody>
+          <CheckboxListItem
+            itemId={1}
+            name="Buzz"
+            label="Buzz"
+            isSelected={false}
+            onSelect={() => {}}
+            onDeselect={() => {}}
+            rowActions={[
+              <div id="1">action_1</div>,
+              <div id="2">action_2</div>,
+            ]}
+          />
+        </tbody>
+      </table>
+    );
+    expect(
+      wrapper
+        .find('ActionsTd')
+        .containsAllMatchingElements([
+          <div id="1">action_1</div>,
+          <div id="2">action_2</div>,
+        ])
+    ).toEqual(true);
+  });
 });

--- a/awx/ui/src/components/DetailList/DetailList.js
+++ b/awx/ui/src/components/DetailList/DetailList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { TextList, TextListVariants } from '@patternfly/react-core';
 import styled from 'styled-components';
 
-const DetailList = ({ children, stacked, ...props }) => (
+const DetailList = ({ children, stacked, compact, ...props }) => (
   <TextList component={TextListVariants.dl} {...props}>
     {children}
   </TextList>
@@ -10,8 +10,8 @@ const DetailList = ({ children, stacked, ...props }) => (
 
 export default styled(DetailList)`
   display: grid;
-  grid-gap: 20px;
   align-items: start;
+  ${(props) => (props.compact ? `column-gap: 20px;` : `grid-gap: 20px;`)}
   ${(props) =>
     props.stacked
       ? `

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeTypeStep/JobTemplatesList.test.js
@@ -82,6 +82,45 @@ describe('JobTemplatesList', () => {
     });
   });
 
+  test('Row should display popover', async () => {
+    JobTemplatesAPI.read.mockResolvedValueOnce({
+      data: {
+        count: 1,
+        results: [
+          {
+            id: 1,
+            name: 'Test Job Template',
+            type: 'job_template',
+            url: '/api/v2/job_templates/1',
+            inventory: 1,
+            project: 2,
+          },
+        ],
+      },
+    });
+    JobTemplatesAPI.readOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {},
+          POST: {},
+        },
+        related_search_fields: [],
+      },
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <JobTemplatesList
+          nodeResource={nodeResource}
+          onUpdateNodeResource={onUpdateNodeResource}
+        />
+      );
+    });
+    wrapper.update();
+    expect(
+      wrapper.find('CheckboxListItem[name="Test Job Template"] Popover').length
+    ).toBe(1);
+  });
+
   test('Error shown when read() request errors', async () => {
     JobTemplatesAPI.read.mockRejectedValue(new Error());
     JobTemplatesAPI.readOptions.mockResolvedValue({


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/issues/11325

* Add ability to pass row action items to checkbox rows 
* Add a "compact" detail list option
* Add detail popover to Template list items within the workflow addition node

![popover](https://user-images.githubusercontent.com/15881645/150587952-4b90e711-fd22-4d37-8988-edab7104b6a7.gif)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Enhancement Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
