### PR TITLE
fix deprecated indentation and type

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -32,7 +32,7 @@ options:
         removed_from_collection: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
-        alternative: 'CONTROLLER_USERNAME'
+        alternatives: 'CONTROLLER_USERNAME'
   password:
     description: The password for your controller user.
     env:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -19,7 +19,7 @@ options:
     - name: CONTROLLER_HOST
     - name: TOWER_HOST
       deprecated:
-        removed_from_collection: 'awx.awx'
+        collection_name: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_HOST'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -50,7 +50,7 @@ options:
     - name: CONTROLLER_OAUTH_TOKEN
     - name: TOWER_OAUTH_TOKEN
       deprecated:
-        removed_from_collection: 'awx.awx'
+        collection_name: 'awx.awx'
         version: '4.0.0'
         why: Collection name change
         alternatives: 'CONTROLLER_OAUTH_TOKEN'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -22,7 +22,7 @@ options:
         collection_name: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
-        alternative: 'CONTROLLER_HOST'
+        alternatives: 'CONTROLLER_HOST'
   username:
     description: The user that you plan to use to access inventories on the controller.
     env:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -51,7 +51,7 @@ options:
     - name: TOWER_OAUTH_TOKEN
       deprecated:
         removed_from_collection: 'awx.awx'
-        removed_in: '4.0.0'
+        version: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_OAUTH_TOKEN'
   verify_ssl:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -40,7 +40,7 @@ options:
     - name: TOWER_PASSWORD
       deprecated:
         collection_name: 'awx.awx'
-        removed_in: '4.0.0'
+        version: '4.0.0'
         why: Collection name change
         alternatives: 'CONTROLLER_PASSWORD'
   oauth_token:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -19,7 +19,7 @@ options:
     - name: CONTROLLER_HOST
     - name: TOWER_HOST
       deprecated:
-        removed_from_collection: 'awx.awx.controller'
+        removed_from_collection: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_HOST'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -50,7 +50,7 @@ options:
     - name: CONTROLLER_OAUTH_TOKEN
     - name: TOWER_OAUTH_TOKEN
       deprecated:
-        removed_from_collection: 'awx.awx.controller'
+        removed_from_collection: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_OAUTH_TOKEN'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -39,7 +39,7 @@ options:
     - name: CONTROLLER_PASSWORD
     - name: TOWER_PASSWORD
       deprecated:
-        removed_from_collection: 'awx.awx.controller'
+        removed_from_collection: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_PASSWORD'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -63,7 +63,7 @@ options:
     - name: CONTROLLER_VERIFY_SSL
     - name: TOWER_VERIFY_SSL
       deprecated:
-        removed_from_collection: 'awx.awx'
+        collection_name: 'awx.awx'
         version: '4.0.0'
         why: Collection name change
         alternatives: 'CONTROLLER_VERIFY_SSL'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -30,7 +30,7 @@ options:
     - name: TOWER_USERNAME
       deprecated:
         collection_name: 'awx.awx'
-        removed_in: '4.0.0'
+        version: '4.0.0'
         why: Collection name change
         alternatives: 'CONTROLLER_USERNAME'
   password:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -20,7 +20,7 @@ options:
     - name: TOWER_HOST
       deprecated:
         collection_name: 'awx.awx'
-        removed_in: '4.0.0'
+        version: '4.0.0'
         why: Collection name change
         alternatives: 'CONTROLLER_HOST'
   username:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -18,42 +18,42 @@ options:
     env:
     - name: CONTROLLER_HOST
     - name: TOWER_HOST
-    deprecated:
-    - removed_from_collection: 'awx.awx.controller'
-    - removed_in: '4.0.0'
-    - why: Collection name change
-    - alternative: 'CONTROLLER_HOST'
+      deprecated:
+        removed_from_collection: 'awx.awx.controller'
+        removed_in: '4.0.0'
+        why: Collection name change
+        alternative: 'CONTROLLER_HOST'
   username:
     description: The user that you plan to use to access inventories on the controller.
     env:
     - name: CONTROLLER_USERNAME
     - name: TOWER_USERNAME
-    deprecated:
-    - removed_from_collection: 'awx.awx.controller'
-    - removed_in: '4.0.0'
-    - why: Collection name change
-    - alternative: 'CONTROLLER_USERNAME'
+      deprecated:
+        removed_from_collection: 'awx.awx.controller'
+        removed_in: '4.0.0'
+        why: Collection name change
+        alternative: 'CONTROLLER_USERNAME'
   password:
     description: The password for your controller user.
     env:
     - name: CONTROLLER_PASSWORD
     - name: TOWER_PASSWORD
-    deprecated:
-    - removed_from_collection: 'awx.awx.controller'
-    - removed_in: '4.0.0'
-    - why: Collection name change
-    - alternative: 'CONTROLLER_PASSWORD'
+      deprecated:
+        removed_from_collection: 'awx.awx.controller'
+        removed_in: '4.0.0'
+        why: Collection name change
+        alternative: 'CONTROLLER_PASSWORD'
   oauth_token:
     description:
     - The OAuth token to use.
     env:
     - name: CONTROLLER_OAUTH_TOKEN
     - name: TOWER_OAUTH_TOKEN
-    deprecated:
-    - removed_from_collection: 'awx.awx.controller'
-    - removed_in: '4.0.0'
-    - why: Collection name change
-    - alternative: 'CONTROLLER_OAUTH_TOKEN'
+      deprecated:
+        removed_from_collection: 'awx.awx.controller'
+        removed_in: '4.0.0'
+        why: Collection name change
+        alternative: 'CONTROLLER_OAUTH_TOKEN'
   verify_ssl:
     description:
     - Specify whether Ansible should verify the SSL certificate of the controller host.
@@ -62,11 +62,11 @@ options:
     env:
     - name: CONTROLLER_VERIFY_SSL
     - name: TOWER_VERIFY_SSL
-    deprecated:
-    - removed_from_collection: 'awx.awx.controller'
-    - removed_in: '4.0.0'
-    - why: Collection name change
-    - alternative: 'CONTROLLER_VERIFY_SSL'
+      deprecated:
+        removed_from_collection: 'awx.awx.controller'
+        removed_in: '4.0.0'
+        why: Collection name change
+        alternative: 'CONTROLLER_VERIFY_SSL'
     aliases: [ validate_certs ]
 
 notes:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -39,7 +39,7 @@ options:
     - name: CONTROLLER_PASSWORD
     - name: TOWER_PASSWORD
       deprecated:
-        removed_from_collection: 'awx.awx'
+        collection_name: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternatives: 'CONTROLLER_PASSWORD'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -29,7 +29,7 @@ options:
     - name: CONTROLLER_USERNAME
     - name: TOWER_USERNAME
       deprecated:
-        removed_from_collection: 'awx.awx.controller'
+        removed_from_collection: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_USERNAME'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -42,7 +42,7 @@ options:
         removed_from_collection: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
-        alternative: 'CONTROLLER_PASSWORD'
+        alternatives: 'CONTROLLER_PASSWORD'
   oauth_token:
     description:
     - The OAuth token to use.

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -29,7 +29,7 @@ options:
     - name: CONTROLLER_USERNAME
     - name: TOWER_USERNAME
       deprecated:
-        removed_from_collection: 'awx.awx'
+        collection_name: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternatives: 'CONTROLLER_USERNAME'

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -64,7 +64,7 @@ options:
     - name: TOWER_VERIFY_SSL
       deprecated:
         removed_from_collection: 'awx.awx'
-        removed_in: '4.0.0'
+        version: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_VERIFY_SSL'
     aliases: [ validate_certs ]

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -53,7 +53,7 @@ options:
         removed_from_collection: 'awx.awx'
         version: '4.0.0'
         why: Collection name change
-        alternative: 'CONTROLLER_OAUTH_TOKEN'
+        alternatives: 'CONTROLLER_OAUTH_TOKEN'
   verify_ssl:
     description:
     - Specify whether Ansible should verify the SSL certificate of the controller host.

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -66,7 +66,7 @@ options:
         removed_from_collection: 'awx.awx'
         version: '4.0.0'
         why: Collection name change
-        alternative: 'CONTROLLER_VERIFY_SSL'
+        alternatives: 'CONTROLLER_VERIFY_SSL'
     aliases: [ validate_certs ]
 
 notes:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -63,7 +63,7 @@ options:
     - name: CONTROLLER_VERIFY_SSL
     - name: TOWER_VERIFY_SSL
       deprecated:
-        removed_from_collection: 'awx.awx.controller'
+        removed_from_collection: 'awx.awx'
         removed_in: '4.0.0'
         why: Collection name change
         alternative: 'CONTROLLER_VERIFY_SSL'


### PR DESCRIPTION
This was breaking docs build for any plugins that used this fragment

fixes #10776

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
doc_fragment/auth_pliugin
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
latest
```

##### ADDITIONAL NOTES

Current docs has the deprecated entry have priority/precedence over the new one, not sure if that is what was wanted but otherwise I would reverse the order