### PR TITLE
Avoid Project..get_or_create() in create_preload_data

### DIFF
--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -25,13 +25,17 @@ class Command(BaseCommand):
                 if not Organization.objects.exists():
                     o, _ = Organization.objects.get_or_create(name='Default')
 
-                    p, _ = Project.objects.get_or_create(
-                        name='Demo Project',
-                        scm_type='git',
-                        scm_url='https://github.com/ansible/ansible-tower-samples',
-                        scm_update_on_launch=True,
-                        scm_update_cache_timeout=0,
-                    )
+                    # Avoid calling directly the get_or_create() to bypass project update
+                    p = Project.objects.filter(name='Demo Project', scm_type='git').first()
+                    if not p:
+                        p = Project(
+                            name='Demo Project',
+                            scm_type='git',
+                            scm_url='https://github.com/ansible/ansible-tower-samples',
+                            scm_update_on_launch=True,
+                            scm_update_cache_timeout=0,
+                        )
+
                     p.organization = o
                     p.save(skip_update=True)
 


### PR DESCRIPTION
Django ORM method get_or_create() does not call save() directly, but it calls the create() [1].

https://github.com/django/django/blob/0f6946495a8ec955b471ca1baaf408ceb53d4796/django/db/models/query.py#L678


The create method ignores the `skip_update=True` option, which then will trigger a project update, however, the EE was not yet created in the database.

To avoid this problem, we just check the existence of the default project and create it with save(skip_update=True) manually.

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```

Related: https://github.com/ansible/awx/issues/11584

##### ADDITIONAL INFORMATION
Testing it:
```
awx-manage shell_plus --quiet
In [2]: JobTemplate.objects.all().delete()
   ...: Credential.objects.all().delete()
   ...: Project.objects.all().delete()
   ...: Inventory.objects.all().delete()
   ...: Organization.objects.all().delete()
   ...: ExecutionEnvironment.objects.all().delete()
   ...: 

Out[2]: 
(4,
 {'main.ActivityStream_execution_environment': 2,
  'main.ExecutionEnvironment': 2})
bash-4.4$ awx-manage create_preload_data
Default organization added.
Demo Credential, Inventory, and Job Template added.
(changed: True)
bash-4.4$ awx-manage register_default_execution_environments
'AWX EE (latest)' Default Execution Environment registered.
'AWX EE (latest)' Default Execution Environment updated.
Control Plane Execution Environment registered.
(changed: True)
```

No project updates were triggered 
```
In [1]: ProjectUpdate.objects.count()
Out[1]: 0

In [2]: Project.objects.all()
Out[2]: <PolymorphicQuerySet [<Project: Demo Project-25>]>

```