### PR TITLE
Only do a warning on 2-cycles for the register_peers command

### DIFF
--- a/awx/main/management/commands/register_peers.py
+++ b/awx/main/management/commands/register_peers.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
@@ -45,7 +47,7 @@ class Command(BaseCommand):
             peers = set(options['peers'] or options['exact'])
             incoming = set(InstanceLink.objects.filter(target=nodes[options['source']]).values_list('source__hostname', flat=True))
             if peers & incoming:
-                raise CommandError(f"Source node {options['source']} cannot link to nodes already peering to it: {peers & incoming}.")
+                warnings.warn(f"Source node {options['source']} should not link to nodes already peering to it: {peers & incoming}.")
 
         if options['peers']:
             missing_peers = set(options['peers']) - set(nodes)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

It has no way of knowing whether a later command will fix the
situation, and this will come up in the installer.  Let's just trust
the pre-flight checks.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
