### PR TITLE
Fix error on timeout with non-job types

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -754,7 +754,7 @@ class BaseTask(object):
 
                 extra_update_fields['job_explanation'] = self.instance.job_explanation
                 # ensure failure notification sends even if playbook_on_stats event is not triggered
-                handle_success_and_failure_notifications.apply_async([self.instance.job.id])
+                handle_success_and_failure_notifications.apply_async([self.instance.id])
 
         except ReceptorNodeNotFound as exc:
             extra_update_fields['job_explanation'] = str(exc)


### PR DESCRIPTION
This logic will not work if something that's not a job times out, because `instance.job` is not a thing for a project update, for instance.

```
Traceback (most recent call last):
  File "/awx_devel/awx/main/tasks/jobs.py", line 757, in run
    handle_success_and_failure_notifications.apply_async([self.instance.job.id])
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/polymorphic/models.py", line 208, in accessor_function
    attr = model._base_objects.get(pk=self.pk)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/models/manager.py", line 82, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/django/db/models/query.py", line 406, in get
    raise self.model.DoesNotExist(
awx.main.models.jobs.Job.DoesNotExist: Job matching query does not exist.
```

Saying "Job" does not exist is meaning that it's querying for a job with the project update's id.