### PR TITLE
Iterate over SAML attribute values

### DIFF
--- a/awx/sso/pipeline.py
+++ b/awx/sso/pipeline.py
@@ -255,17 +255,18 @@ def _check_flag(user, flag, attributes, user_flags_settings):
             # If so, check and see if the value of the attr matches the required value
             attribute_value = attributes.get(attr_setting, None)
             if isinstance(attribute_value, (list, tuple)):
-                attribute_value = attribute_value[0]
-            if attribute_value == user_flags_settings.get(is_value_key):
-                logger.debug("Giving %s %s from attribute %s with matching value" % (user.username, flag, attr_setting))
-                new_flag = True
-            # if they don't match make sure that new_flag is false
-            else:
-                logger.debug(
-                    "Refusing %s for %s because attr %s (%s) did not match value '%s'"
-                    % (flag, user.username, attr_setting, attribute_value, user_flags_settings.get(is_value_key))
-                )
-                new_flag = False
+                for attribute_value in attribute_value:            
+                    if attribute_value == user_flags_settings.get(is_value_key):
+                        logger.debug("Giving %s %s from attribute %s with matching value" % (user.username, flag, attr_setting))
+                        new_flag = True
+                        break
+                    # if they don't match make sure that new_flag is false
+                    else:
+                        logger.debug(
+                            "Refusing %s for %s because attr %s (%s) did not match value '%s'"
+                            % (flag, user.username, attr_setting, attribute_value, user_flags_settings.get(is_value_key))
+                        )
+                        new_flag = False
         # If there was no required value then we can just allow them in because of the attribute
         else:
             logger.debug("Giving %s %s from attribute %s" % (user.username, flag, attr_setting))


### PR DESCRIPTION
Signed-off-by: abenesh <Adam-Daniel.Benesh@t-systems.com>

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Iterate over SAML attribute lists instead of only evaluating the first entry."
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The SSO Pipeline only evaluates the first value in a list of values that are part of a SAML attribute. Granting superuser or auditor permissions would fail if the first list value is not the expected one.

For example you have a SAML attribute "groups" that includes a list of the users group memberships:

```
<saml:Attribute Name="groups" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
  <saml:AttributeValue xsi:type="xs:string">qaadmins</saml:AttributeValue>
  <saml:AttributeValue xsi:type="xs:string">jira-software-users</saml:AttributeValue>
  <saml:AttributeValue xsi:type="xs:string">awx-frontend-admins</saml:AttributeValue>
......
```

This attribute mapping would not work:

```
{
  "is_superuser_attr": "groups",
  "is_superuser_role": "is_superuser",
  "is_superuser_value": "awx-frontend-admins",
  "is_system_auditor_attr": "groups",
  "is_system_auditor_role": "is_system_auditor",
  "is_system_auditor_value": "awx-frontend-auditors"
}
```

Because ```awx-frontend-admins``` is not the first entry in the list.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Related to #5303

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - SSO

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev41+g1b1b2fd4a7
```