### PR TITLE
[Draft] Consume control node capacity

### DIFF
--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -244,7 +244,7 @@ class InstanceGroupManager(models.Manager):
             # TODO: dock capacity for isolated job management tasks running in queue
             impact = t.task_impact
             control_groups = []
-            if t.controller_node:
+            if hasattr(t, 'controller_node') and t.controller_node:
                 # TODO: what happens if a control node comes online after graph was built?
                 # In k8s nodes need to be able to come/go more often
                 control_groups = instance_ig_mapping.get(t.controller_node, [])

--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -217,7 +217,7 @@ class InstanceGroupManager(models.Manager):
     @staticmethod
     def zero_out_group(graph, name, breakdown):
         if name not in graph:
-            graph[name] = {}
+            graph[name] = {'dependency_graph': None, 'capacity': 0, 'instances': [], 'control_capacity': 0, 'execution_capacity': 0}
         graph[name]['consumed_capacity'] = 0
         for capacity_type in ('execution', 'control'):
             graph[name][f'consumed_{capacity_type}_capacity'] = 0

--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -248,6 +248,8 @@ class InstanceGroupManager(models.Manager):
                 # TODO: what happens if a control node comes online after graph was built?
                 # In k8s nodes need to be able to come/go more often
                 control_groups = instance_ig_mapping.get(t.controller_node, [])
+                if not control_groups:
+                    logger.warn(f"No instance group found for {t.controller_node}, capacity consumed may be innaccurate.")
 
             if t.status == 'waiting' or (not t.execution_node and not t.is_container_group_task):
                 # Subtract capacity from any peer groups that share instances

--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -245,7 +245,9 @@ class InstanceGroupManager(models.Manager):
             impact = t.task_impact
             control_groups = []
             if t.controller_node:
-                control_groups = instance_ig_mapping[t.controller_node]
+                # TODO: what happens if a control node comes online after graph was built?
+                # In k8s nodes need to be able to come/go more often
+                control_groups = instance_ig_mapping.get(t.controller_node, [])
 
             if t.status == 'waiting' or (not t.execution_node and not t.is_container_group_task):
                 # Subtract capacity from any peer groups that share instances

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -146,10 +146,11 @@ class Instance(HasPolicyEditsMixin, BaseModel):
 
     @property
     def consumed_capacity(self):
-        capacity_consumed = sum(
-            x.task_impact
-            for x in UnifiedJob.objects.filter(Q(controller_node=self.hostname) | Q(execution_node=self.hostname) & Q(status__in=('running', 'waiting')))
-        )
+        tasks = [
+            x for x in UnifiedJob.objects.filter(Q(controller_node=self.hostname) | Q(execution_node=self.hostname) & Q(status__in=('running', 'waiting')))
+        ]
+        capacity_consumed = sum(x.task_impact for x in tasks)
+        logger.debug(f"tasks on the host: {[(task.log_format, task.task_impact) for task in tasks]}")
         logger.debug(f"{capacity_consumed} capacity consumed on {self.hostname}")
         return capacity_consumed
 

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -146,11 +146,10 @@ class Instance(HasPolicyEditsMixin, BaseModel):
 
     @property
     def consumed_capacity(self):
-        tasks = [
-            x for x in UnifiedJob.objects.filter((Q(controller_node=self.hostname) | Q(execution_node=self.hostname)) & Q(status__in=('running', 'waiting')))
-        ]
-        capacity_consumed = sum(x.task_impact for x in tasks)
-        logger.debug(f"tasks on the host: {[(task.log_format, task.task_impact) for task in tasks]}")
+        capacity_consumed = sum(
+            x.task_impact
+            for x in UnifiedJob.objects.filter((Q(controller_node=self.hostname) | Q(execution_node=self.hostname)) & Q(status__in=('running', 'waiting')))
+        )
         logger.debug(f"{capacity_consumed} capacity consumed on {self.hostname}")
         return capacity_consumed
 

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -178,9 +178,20 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         )
 
     @staticmethod
-    def choose_control_plane_node_with_sufficient_capacity(task):
-        """Returns the control plane node with most capacity or None if there is none with capacity"""
-        instances = Instance.objects.filter(enabled=True, capacity__gte=task.task_impact).filter(node_type__in=['control', 'hybrid']).all()
+    def choose_control_plane_node_with_sufficient_capacity(task=None):
+        """Return an enabled control node with sufficient capacity.
+
+        Optionally provide a task that will inform the minimum amount of capacity needed,
+        otherwise an instance with remaining capacity greater than or equal to 0 will meet
+        criteria for selection.
+
+        If no instance meets criteria, return None.
+        """
+        # TODO: Replace most uses of choose_online_control_plane_node with this method.
+        impact = 0
+        if task:
+            impact = task.task_impact
+        instances = Instance.objects.filter(enabled=True, capacity__gte=impact).filter(node_type__in=['control', 'hybrid']).all()
         if instances:
             return max(instances, key=lambda i: i.remaining_capacity)
         return None

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -147,7 +147,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
     @property
     def consumed_capacity(self):
         tasks = [
-            x for x in UnifiedJob.objects.filter(Q(controller_node=self.hostname) | Q(execution_node=self.hostname) & Q(status__in=('running', 'waiting')))
+            x for x in UnifiedJob.objects.filter((Q(controller_node=self.hostname) | Q(execution_node=self.hostname)) & Q(status__in=('running', 'waiting')))
         ]
         capacity_consumed = sum(x.task_impact for x in tasks)
         logger.debug(f"tasks on the host: {[(task.log_format, task.task_impact) for task in tasks]}")

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -145,7 +145,10 @@ class Instance(HasPolicyEditsMixin, BaseModel):
 
     @property
     def consumed_capacity(self):
-        return sum(x.task_impact for x in UnifiedJob.objects.filter(execution_node=self.hostname, status__in=('running', 'waiting')))
+        # TODO refactor, we can probably get this done in one query
+        control_capacity_consumed = sum(x.task_impact for x in UnifiedJob.objects.filter(controller_node=self.hostname, status__in=('running', 'waiting')))
+        execution_capacity_consumed = sum(x.task_impact for x in UnifiedJob.objects.filter(execution_node=self.hostname, status__in=('running', 'waiting')))
+        return control_capacity_consumed + execution_capacity_consumed
 
     @property
     def remaining_capacity(self):

--- a/awx/main/scheduler/capacity_utils.py
+++ b/awx/main/scheduler/capacity_utils.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2015 Ansible, Inc.
+# All Rights Reserved
+
+# Python
+import logging
+import heapq
+from types import SimpleNamespace
+
+# Django
+from django.utils.translation import ugettext_lazy as _, gettext_noop
+
+# AWX
+from awx.main.scheduler.dependency_graph import DependencyGraph
+from awx.main.models import (
+    Instance,
+    InstanceGroup,
+)
+
+
+logger = logging.getLogger('awx.main.scheduler')
+
+
+class PrioritizableControlNode:
+    def __init__(self, remaining_capacity, hostname):
+        self.remaining_capacity = remaining_capacity
+        self.hostname = hostname
+
+    def __gt__(self, other):
+        return self.remaining_capacity > other.remaining_capacity
+
+    def __lt__(self, other):
+        return self.remaining_capacity < other.remaining_capacity
+
+    def __eq__(self, other):
+        return self.hostname == other.hostname
+
+    def __hash__(self):
+        return hash(self.hostname)
+
+    def __str__(self):
+        return f"{self.hostname}: {self.remaining_capacity} remaining capacity"
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class PrioritizedControlNodes:
+    def __init__(self):
+        self.control_nodes = set()
+
+    def add(self, node):
+        self.control_nodes.add(node)
+
+    def update(self, node):
+        """The __hash__ function for PrioritizableControlNodes just compares hostnames.
+
+        We can add/remove the node to update object in PrioritizedControlNodes to have right capacity.
+        """
+        self.control_nodes.remove(node)
+        self.control_nodes.add(node)
+
+    # TODO: Maybe rename
+    def assign_task_to_node(self, task, task_manager_instances={}, graph=None):
+        """Find most available control instance and deduct task impact if we find it.
+
+        If no node is available, return False
+        """
+        control_heap = list(self.control_nodes)
+        heapq.heapify(control_heap)
+        best_instance = heapq.nlargest(1, control_heap).pop()
+        if best_instance.remaining_capacity < task.task_impact:
+            return False
+
+        if task_manager_instances and graph:
+            for ig in task_manager_instances[best_instance.hostname].instance_groups:
+                ig_data = graph[ig]
+                # This should really not happen since every time we assign a task to a node, we deduct from its instance group
+                # capacity as well. If we never see this, maybe we can drop this code
+                if not ig_data['control_capacity'] - ig_data['consumed_control_capacity'] >= task.task_impact:
+                    logger.warn(f"Somehow we had capacity on a control node {best_instance} but not on its instance_group {instance_group}")
+                    return False
+        logger.debug(f"chose {best_instance} to run {task.log_format}")
+        best_instance.remaining_capacity -= task.task_impact
+        self.update(best_instance)
+        return best_instance
+
+
+class TaskManagerInstances:
+    def __init__(self):
+        realinstances = Instance.objects.filter(hostname__isnull=False, enabled=True).exclude(node_type='hop').prefetch_related('rampart_groups')
+        self.instances_partial = dict()
+        self.control_nodes = PrioritizedControlNodes()
+
+        for instance in realinstances:
+            self.instances_partial[instance.hostname] = SimpleNamespace(
+                obj=instance,
+                node_type=instance.node_type,
+                remaining_capacity=instance.remaining_capacity,
+                capacity=instance.capacity,
+                jobs_running=instance.jobs_running,
+                hostname=instance.hostname,
+                instance_groups=[ig.name for ig in instance.rampart_groups.all()],
+            )
+            if instance.node_type in ('control', 'hybrid'):
+                self.control_nodes.add(PrioritizableControlNode(remaining_capacity=instance.remaining_capacity, hostname=instance.hostname))
+
+    def __getitem__(self, key):
+        return self.instances_partial.get(key)
+
+    def init_graph(self, graph=dict()):
+        for rampart_group in InstanceGroup.objects.prefetch_related('instances'):
+            graph[rampart_group.name] = dict(
+                graph=DependencyGraph(),
+                execution_capacity=0,
+                control_capacity=0,
+                consumed_capacity=0,
+                consumed_control_capacity=0,
+                consumed_execution_capacity=0,
+                instances=[],
+            )
+            for instance in rampart_group.instances.filter(enabled=True).order_by('hostname'):
+                if instance.hostname in self.instances_partial:
+                    graph[rampart_group.name]['instances'].append(self.instances_partial[instance.hostname])
+                for capacity_type in ('control', 'execution'):
+                    if instance.node_type in (capacity_type, 'hybrid'):
+                        graph[rampart_group.name][f'{capacity_type}_capacity'] += instance.capacity
+        return graph

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -517,10 +517,10 @@ class TaskManager:
                         # If we are deducting capacity, "choose_online_control_plane_node" should only choose control plane nodes
                         # with capacity >0
                         # TODO would be great if this just did the right thing and only chose a control group with enough
-                        # capacity and we didn't need this try/except
+                        # capacity and we didn't need this try/except - maybe replace this with better decision making about capacity
                         task.controller_node = Instance.choose_online_control_plane_node()
                     except IndexError:
-                        task.status = 'pending'
+                        # task.status = 'pending'
                         logger.warning("No control plane nodes available to run containerized job {}, returning to pending".format(task.log_format))
                         found_acceptable_queue = False
                         continue
@@ -528,8 +528,8 @@ class TaskManager:
                     control_instance = Instance.objects.filter(hostname=task.controller_node).first()
                     control_group = control_instance.rampart_groups.first()
                     remaining_capacity = self.get_remaining_capacity(control_group.name, capacity_type='control')
-                    if task.task_impact > 0 and remaining_capacity <= 0:
-                        logger.debug("Skipping group {}, remaining_capacity {} <= 0".format(rampart_group.name, remaining_capacity))
+                    if task.task_impact > 0 and (remaining_capacity - task.task_impact) < 0:
+                        logger.debug("Skipping group {}, not enough capacity.".format(rampart_group.name))
                         continue
 
                     task.log_lifecycle("controller_node_chosen")

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -96,9 +96,9 @@ class TaskManager:
                 consumed_execution_capacity=0,
                 instances=[],
             )
-            for instance in rampart_group.instances.all():
-                if not instance.enabled:
-                    continue
+            for instance in rampart_group.instances.filter(enabled=True).order_by('hostname'):
+                if instance.hostname in instances_by_hostname:
+                    self.graph[rampart_group.name]['instances'].append(instances_by_hostname[instance.hostname])
                 for capacity_type in ('control', 'execution'):
                     if instance.node_type in (capacity_type, 'hybrid'):
                         self.graph[rampart_group.name][f'{capacity_type}_capacity'] += instance.capacity
@@ -109,11 +109,6 @@ class TaskManager:
                             self.control_node_capacity[instance]['instance_groups'] = [rampart_group.name]
                         elif instance.node_type in ('hybrid', 'control'):
                             self.control_node_capacity[instance]['instance_groups'].append(rampart_group.name)
-
-            # This loop down here is strange, because we just looped over the instances
-            for instance in rampart_group.instances.filter(enabled=True).order_by('hostname'):
-                if instance.hostname in instances_by_hostname:
-                    self.graph[rampart_group.name]['instances'].append(instances_by_hostname[instance.hostname])
 
     def get_and_consume_capacity_on_control_node_with_sufficient_capacity(self, task):
         """Find a control node with enough capacity to control a job.

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -669,9 +669,9 @@ class TaskManager:
                 self.graph[instance_group][f'consumed_{capacity_type}_capacity'] += impact
 
     def get_remaining_capacity(self, instance_group, capacity_type='execution'):
-        cap = self.graph[instance_group][f'{capacity_type}_capacity'] - self.graph[instance_group][f'consumed_{capacity_type}_capacity']
+        capacity = self.graph[instance_group][f'{capacity_type}_capacity'] - self.graph[instance_group][f'consumed_{capacity_type}_capacity']
         logger.debug(f'{instance_group} has {cap} remaining capacity of type {capacity_type}')
-        return cap
+        return capacity
 
     def process_tasks(self, all_sorted_tasks):
         running_tasks = [t for t in all_sorted_tasks if t.status in ['waiting', 'running']]

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -130,6 +130,7 @@ class TaskManager:
         }
         logger.debug(f"control nodes with sufficient control node capacity {sufficient} for {task.log_format}")
         if sufficient:
+            # should we additionally consult the graph to find out if the instance group this instance is in also reports that it has enough net capacity.
             best_instance = max(sufficient, key=sufficient.get)
             logger.debug(f"chose {best_instance} to run {task.log_format}")
             self.control_node_capacity[best_instance]['remaining_capacity'] -= task.task_impact

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -102,11 +102,12 @@ class TaskManager:
                 for capacity_type in ('control', 'execution'):
                     if instance.node_type in (capacity_type, 'hybrid'):
                         self.graph[rampart_group.name][f'{capacity_type}_capacity'] += instance.capacity
-                        if instance.hostname not in self.control_node_capacity.keys():
+                        # the below could be condensed into something more elegant
+                        if instance.node_type in ('hybrid', 'control') and instance.hostname not in self.control_node_capacity.keys():
                             self.control_node_capacity[instance] = dict()
                             self.control_node_capacity[instance]['remaining_capacity'] = instance.remaining_capacity
                             self.control_node_capacity[instance]['instance_groups'] = [rampart_group.name]
-                        else:
+                        elif instance.node_type in ('hybrid', 'control'):
                             self.control_node_capacity[instance]['instance_groups'].append(rampart_group.name)
 
             # This loop down here is strange, because we just looped over the instances

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -564,11 +564,6 @@ class TaskManager:
 
                     break
 
-                # TODO: remove this after we have confidence that OCP control nodes are reporting node_type=control
-                if settings.IS_K8S and task.capacity_type == 'execution':
-                    logger.debug("Skipping group {}, task cannot run on control plane".format(rampart_group.name))
-                    continue
-
                 remaining_capacity = self.get_remaining_capacity(rampart_group.name, capacity_type=task.capacity_type)
                 if task.task_impact > 0 and remaining_capacity <= 0:
                     logger.debug("Skipping group {}, remaining_capacity {} <= 0".format(rampart_group.name, remaining_capacity))

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -512,7 +512,7 @@ class TaskManager:
                         found_acceptable_queue = False
                         continue
                     # If there is enough capacity, assign the node to be the execution node and break out of the sub loop
-                    task.execution_node = controller_node
+                    task.execution_node = controller_node.hostname
                     break
 
                 if task.capacity_type == 'execution' and rampart_group.is_container_group:

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -670,7 +670,7 @@ class TaskManager:
 
     def get_remaining_capacity(self, instance_group, capacity_type='execution'):
         capacity = self.graph[instance_group][f'{capacity_type}_capacity'] - self.graph[instance_group][f'consumed_{capacity_type}_capacity']
-        logger.debug(f'{instance_group} has {cap} remaining capacity of type {capacity_type}')
+        logger.debug(f'{instance_group} has {capacity} remaining capacity of type {capacity_type}')
         return capacity
 
     def process_tasks(self, all_sorted_tasks):


### PR DESCRIPTION
I've tested with container groups in a local minikube cluster, but it generally results in desired behavior
of only starting container group jobs when we have a control node with
capacity to run them. 

Read @beeankha 's comment below to explore what remains to implement the same thing completely for all jobs that have a separate control node.

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Consider control node capacity when selecting a controller node, and consume capacity for controller node"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch addresses https://github.com/ansible/awx/issues/10694

For container groups in particular, there is currently no controller-side mechanism to throttle how many jobs get launched. This can lead to overwhelmed control nodes, and control of jobs unevenly spread across cluster (e.g., you have 3 control pods but 1 sits idle while the other two are overtaxed).

Even before we start to see bad things like control pod eviction from resource consumption, things start to happen like jobs sitting in `'waiting'` for over a min, which can lead to the jobs getting "reaped" but then running and succeeding anyway! By counting capacity consumption for controlling jobs, we at least have the "capacity slider" as a tool to have _some_ way to manage how many jobs a control pod will be controlling/proccesing events for at any given time.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

TODO:
  - [ ] add some tests
  - [ ] do some exploratory testing in a production k8s deployment
  - [ ] decide if we want to fully implement same thing for all jobs w/ separate control node in this PR, or in a follow up PR

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 