### PR TITLE
Prevent duplicate query in local health check

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -263,7 +263,11 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.mark_offline(perform_save=False, errors=errors)
         update_fields.extend(['cpu_capacity', 'mem_capacity', 'capacity', 'errors'])
 
-        self.save(update_fields=update_fields)
+        # disabling activity stream will avoid extra queries, which is important for heatbeat actions
+        from awx.main.signals import disable_activity_stream
+
+        with disable_activity_stream():
+            self.save(update_fields=update_fields)
 
     def local_health_check(self):
         """Only call this method on the instance that this record represents"""


### PR DESCRIPTION
Using the Django debug toolbar, I found this query being issued from:

https://github.com/ansible/awx/blob/627bde9e9e83a97683d4ee8935dbadfd8134cdd0/awx/main/signals.py#L463

#### Explanation

When performing a save, we may have to create an activity stream entry to track it. So in the pre-save signal, we take as an argument the new version of an object, and load the current version of the object from the database. Then we compare the two to determine if we need to insert an activity stream entry.

#### Why we don't need this

All of the fields that `local_health_check` modifies (memory, cpu, errors, capacity) are non-editable from the API, and we never record changes in non-editable fields, because such changes are never initiated by a user via the API.

#### Why I care

The `cluster_node_heartbeat` runs this logic and runs on a 20 second schedule for all nodes in the cluster. This is a top priority for streamlining because any database activity it does adds to the general background noise.
