### PR TITLE
update another part of minikube dev env docs

### DIFF
--- a/docs/development/minikube.md
+++ b/docs/development/minikube.md
@@ -111,10 +111,11 @@ In the root of awx-operator:
 ```
 $ ansible-playbook ansible/instantiate-awx-deployment.yml \
     -e development_mode=yes \
-    -e tower_image=quay.io/awx/awx_kube_devel \
-    -e tower_image_version=${COMPOSE_TAG} \
-    -e tower_image_pull_policy=Always \
-    -e tower_ingress_type=ingress
+    -e image=quay.io/awx/awx_kube_devel \
+    -e image_version=${COMPOSE_TAG} \
+    -e image_pull_policy=Always \
+    -e service_type=nodeport \
+    -e namespace=$NAMESPACE
 ```
 
 To iterate on changes to the Dockerfile, rebuild and push the image, then delete


### PR DESCRIPTION
vars in ansible/instantiate-awx-deployment.yml in awx-operator repo appear to have been updated, because when we used the `tower_...` vars, they did not apply