### PR TITLE
Only display usable inventories for launch prompt

### DIFF
--- a/awx/ui/src/components/LaunchPrompt/steps/InventoryStep.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/InventoryStep.js
@@ -21,6 +21,7 @@ const QS_CONFIG = getQSConfig('inventory', {
   page: 1,
   page_size: 5,
   order_by: 'name',
+  role_level: 'use_role',
 });
 
 function InventoryStep({ warningMessage = null }) {


### PR DESCRIPTION
##### SUMMARY
Prompted job launch attempts fail when the user only has read or update access to the selected inventory. This PR updates the inventory prompt list request parameters so that only usable inventories are displayed.


