### PR TITLE
Deal properly with comments in requirements_git.txt

### DIFF
--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -14,17 +14,19 @@ _cleanup() {
 generate_requirements() {
   venv="`pwd`/venv"
   echo $venv
-  /usr/bin/python3.8 -m venv "${venv}"
+  /usr/bin/python3 -m venv "${venv}"
   # shellcheck disable=SC1090
   source ${venv}/bin/activate
 
-  ${venv}/bin/python3.8 -m pip install -U pip pip-tools
+  ${venv}/bin/python3 -m pip install -U pip pip-tools
 
-  ${pip_compile} --output-file requirements.txt "${requirements_in}" "${requirements_git}"
+  ${pip_compile} "${requirements_in}" "${requirements_git}" --output-file requirements.txt
   # consider the git requirements for purposes of resolving deps
   # Then remove any git+ lines from requirements.txt
   while IFS= read -r line; do
-    sed -i "\!${line%#*}!d" requirements.txt
+    if [[ $line != \#* ]]; then  # ignore comments
+      sed -i "\!${line%#*}!d" requirements.txt
+    fi
   done < "${requirements_git}"
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Deal properly with comments in requirements_git.txt

The updater.sh script was expecting that _every_ line in this file was
a repo reference.

Also, this script was hardcoded to use Python 3.8, and the containers now have Python 3.9 instead.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
