### PR TITLE
Fix fact clearing and updating of fact modification times

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -811,7 +811,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
             timeout = now() - datetime.timedelta(seconds=timeout)
             hosts = hosts.filter(ansible_facts_modified__gte=timeout)
         # Backdate all files to a time in the past and create a reference file to compare to
-        backdate = time.time() - datetime.timedelta(days=2).total_seconds()
+        backdate = time.time() - 30.0
         ref_file = os.path.join(artifacts_dir, 'time_reference_fact_cache.txt')
         with codecs.open(ref_file, 'w', encoding='utf-8') as f:
             os.chmod(f.name, 0o600)

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -815,7 +815,6 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         ref_file = os.path.join(artifacts_dir, 'time_reference_fact_cache.txt')
         with codecs.open(ref_file, 'w', encoding='utf-8') as f:
             os.chmod(f.name, 0o600)
-            f.write('timestamp_reference')
         os.utime(ref_file, times=(backdate, backdate))
         for host in hosts:
             filepath = os.sep.join(map(str, [destination, host.name]))

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -335,7 +335,7 @@ class AWXReceptorJob:
         # Artifacts are an output, but sometimes they are an input as well
         # this is the case with fact cache, where clearing facts deletes a file, and this must be captured
         artifact_dir = os.path.join(self.runner_params['private_data_dir'], 'artifacts')
-        if os.path.exists(artifact_dir):
+        if self.work_type != 'local' and os.path.exists(artifact_dir):
             shutil.rmtree(artifact_dir)
 
         resultsock, resultfile = receptor_ctl.get_work_results(self.unit_id, return_socket=True, return_sockfile=True)

--- a/docs/fact_cache.md
+++ b/docs/fact_cache.md
@@ -30,6 +30,17 @@ modification times that have increased (because Ansible updated the file via
 subsequent playbook runs, AWX will _only_ inject cached facts that are _newer_
 than `settings.ANSIBLE_FACT_CACHE_TIMEOUT` seconds.
 
+### Pitfalls
+The AWX setting `ANSIBLE_FACT_CACHE_TIMEOUT` is intended to _replace_ the use
+of the Ansible core setting of `fact_caching_timeout`, which can be
+given as an environment variable as `ANSIBLE_CACHE_PLUGIN_TIMEOUT`.
+In AWX, the ultimate source of truth is the database, but in the analog
+CLI use of Ansible, the ultimate sources of truth are json files laid
+down by the jsonfile fact cache plugin.
+The Ansible core setting has a default value of 1 day.
+If the Ansible setting is a very small value (set in `ansible.cfg`, for example),
+then the playbook may still ignore facts from the database.
+
 ## AWX Fact Logging
 New and changed facts will be logged via AWX's logging facility, specifically
 to the `system_tracking` namespace or logger. The logging payload will include


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/11560

This requires https://github.com/ansible/ansible-runner/pull/966 to work completely, which means you need to be using ansible-runner `devel` for now.

Upon creating this as a draft PR, I'm pretty confident in it, but I still haven't addressed unit tests, kicked off final test runs, and gone through a final polishing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION
My original draft of this involved backdating the files to a modification time of 2 days ago. However, I found that this doesn't work with `meta: clear_facts`, and I have documented why in https://github.com/ansible/ansible/issues/76882. Ansible core may or may not care to fix that, but I would not wait on a fix anyway. I just changed the backdating from 2 days to 30 seconds. It only needs to be greater than 2 seconds to fix timing bugs due to the python ZipInfo data rounding to the nearest 2nd second due to a [crazy old standard](https://stackoverflow.com/questions/64048499/zipfile-lib-weird-behaviour-with-seconds-in-modified-time). I could have kept it at 2 days ago if I set `ANSIBLE_CACHE_PLUGIN_TIMEOUT`, but I feel that should be the domain of the user.

This addresses a few articulable bugs, but the main reason I want to do this is to refactor the fact cache start / finished logic to be more self-contained without bleeding over into the main task code. I like the idea that someone could look at the artifacts folder and make a conclusion about why we did or did not update a host's facts.
