### PR TITLE
Fix newly-added black rules

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -862,7 +862,7 @@ class UnifiedJobSerializer(BaseSerializer):
         if 'elapsed' in ret:
             if obj and obj.pk and obj.started and not obj.finished:
                 td = now() - obj.started
-                ret['elapsed'] = (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10 ** 6) / (10 ** 6 * 1.0)
+                ret['elapsed'] = (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / (10**6 * 1.0)
             ret['elapsed'] = float(ret['elapsed'])
         # Because this string is saved in the db in the source language,
         # it must be marked for translation after it is pulled from the db, not when set

--- a/awxkit/awxkit/utils/__init__.py
+++ b/awxkit/awxkit/utils/__init__.py
@@ -255,7 +255,7 @@ def random_ipv4():
 
 def random_ipv6():
     """Generates a random ipv6 address;; useful for testing."""
-    return ':'.join('{0:x}'.format(random.randint(0, 2 ** 16 - 1)) for i in range(8))
+    return ':'.join('{0:x}'.format(random.randint(0, 2**16 - 1)) for i in range(8))
 
 
 def random_loopback_ip():


### PR DESCRIPTION
I upgraded black on my computer and saw that the upgrade introduced new reformatting behavior.

Implication is that black made a change and we must follow suit.

The new rule will fail checks on all other PRs until we merge this change.