### PR TITLE
add job id to the jobs details page

### DIFF
--- a/awx/ui/src/screens/Job/Jobs.js
+++ b/awx/ui/src/screens/Job/Jobs.js
@@ -23,7 +23,7 @@ function Jobs() {
     const typeSegment = JOB_TYPE_URL_SEGMENTS[job.type];
     setBreadcrumbConfig({
       '/jobs': t`Jobs`,
-      [`/jobs/${typeSegment}/${job.id}`]: `${job.name}`,
+      [`/jobs/${typeSegment}/${job.id}`]: `${job.id} - ${job.name}`,
       [`/jobs/${typeSegment}/${job.id}/output`]: t`Output`,
       [`/jobs/${typeSegment}/${job.id}/details`]: t`Details`,
     });


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Add job id on the job details page"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR adds the job id on the job detail screen.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Before this PR:
![job_no_id](https://user-images.githubusercontent.com/16258763/151738260-f99e241e-35a1-4241-8ab1-fc0035d0c44d.png)


After this PR:
![job_id](https://user-images.githubusercontent.com/16258763/151737739-60dcdd9c-7dc3-4584-9c75-7ae88ac12af8.png)

This PR adds the job id on the job details page like we used to have before. That is useful for debugging purposes (don't have to find the job id from the url)
