### PR TITLE
Let an organization admin to add new users to it's tower organization

### DIFF
--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -67,8 +67,8 @@ no_api_parameter_ok = {
     'ad_hoc_command': ['interval', 'timeout', 'wait'],
     # group parameters to perserve hosts and children.
     'group': ['preserve_existing_children', 'preserve_existing_hosts'],
-    # user parameters to rename a user.
-    'user': ['new_username'],
+    # new_username parameter to rename a user and organization allows for org admin user creation
+    'user': ['new_username', 'organization'],
     # workflow_approval parameters that do not apply when approving an approval node.
     'workflow_approval': ['action', 'interval', 'timeout', 'workflow_job_id'],
 }

--- a/awx_collection/tests/integration/targets/user/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/user/tasks/main.yml
@@ -129,3 +129,173 @@
     that:
       - "'Unable to resolve controller_host' in result.msg or
         'Can not verify ssl with non-https protocol' in result.exception"
+
+- block:
+    - name: Generate a test ID
+      set_fact:
+        test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+
+    - name: Generate an org name
+      set_fact:
+        org_name: "AWX-Collection-tests-organization-org-{{ test_id }}"
+
+    - name: Make sure {{ org_name }} is not there
+      organization:
+        name: "{{ org_name }}"
+        state: absent
+      register: result
+
+    - name: Create a new Organization
+      organization:
+        name: "{{ org_name }}"
+        galaxy_credentials:
+          - Ansible Galaxy
+      register: result
+
+    - assert:
+        that: "result is changed"
+
+    - name: Create a User to become admin of an organization {{ org_name }}
+      user:
+        username: "{{ username }}-orgadmin"
+        password: "{{ username }}-orgadmin"
+        state: present
+        organization: "{{ org_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Add the user {{ username }}-orgadmin as an admin of the organization {{ org_name }}
+      role:
+        user: "{{ username }}-orgadmin"
+        role: admin
+        organization: "{{ org_name }}"
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a User as {{ username }}-orgadmin without using an organization (must fail)
+      user:
+        controller_username: "{{ username }}-orgadmin"
+        controller_password: "{{ username }}-orgadmin"
+        username: "{{ username }}"
+        first_name: Joe
+        password: "{{ 65535 | random | to_uuid }}"
+        state: present
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - "result is failed"
+
+    - name: Create a User as {{ username }}-orgadmin using an organization
+      user:
+        controller_username: "{{ username }}-orgadmin"
+        controller_password: "{{ username }}-orgadmin"
+        username: "{{ username }}"
+        first_name: Joe
+        password: "{{ 65535 | random | to_uuid }}"
+        state: present
+        organization: "{{ org_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Change a User as {{ username }}-orgadmin by ID using an organization
+      user:
+        controller_username: "{{ username }}-orgadmin"
+        controller_password: "{{ username }}-orgadmin"
+        username: "{{ result.id }}"
+        last_name: User
+        email: joe@example.org
+        state: present
+        organization: "{{ org_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Check idempotency as {{ username }}-orgadmin using an organization
+      user:
+        controller_username: "{{ username }}-orgadmin"
+        controller_password: "{{ username }}-orgadmin"
+        username: "{{ username }}"
+        first_name: Joe
+        last_name: User
+        organization: "{{ org_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Rename a User as {{ username }}-orgadmin using an organization
+      user:
+        controller_username: "{{ username }}-orgadmin"
+        controller_password: "{{ username }}-orgadmin"
+        username: "{{ username }}"
+        new_username: "{{ username }}-renamed"
+        email: joe@example.org
+        organization: "{{ org_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Delete a User as {{ username }}-orgadmin using an organization
+      user:
+        controller_username: "{{ username }}-orgadmin"
+        controller_password: "{{ username }}-orgadmin"
+        username: "{{ username }}-renamed"
+        email: joe@example.org
+        state: absent
+        organization: "{{ org_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Remove the user {{ username }}-orgadmin as an admin of the organization {{ org_name }}
+      role:
+        user: "{{ username }}-orgadmin"
+        role: admin
+        organization: "{{ org_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Delete the User {{ username }}-orgadmin
+      user:
+        username: "{{ username }}-orgadmin"
+        password: "{{ username }}-orgadmin"
+        state: absent
+        organization: "{{ org_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Delete the Organization {{ org_name }}
+      organization:
+        name: "{{ org_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that: "result is changed"
+...


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Let an organization admin to add new users to it's tower organization"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Let an organization admin to add new users to it's tower organization. An organization admin must be able to create new users to it's organization (and Tower)
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
Ansible Automation Platform Controller 4.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE:
```
    - name: Configure Tower local users
      ansible.controller.tower_user:
        tower_username: "{{ configure_tower_username }}"
        tower_password: "{{ configure_tower_password }}"
        tower_host: "{{ configure_tower_server_url }}"
        validate_certs: "{{ configure_tower_validate_certs }}"
        username: "userorg2"
        password: "passorg2"
```
```
 👒 ivan@iamlabp1 -  ✝  iam/Orgs/organization2   dev±  ansible-playbook  test.yml --vault-password-file .vault_pass.txt
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *****************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Configure Tower local users] ***********************************************************************************************************************************************************************************************************
[WARNING]: You are using the controller version of this collection but connecting to Red Hat Ansible Tower
fatal: [localhost]: FAILED! => {"changed": false, "msg": "You don't have permission to POST to /api/v2/users/ (HTTP 403)."}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```

AFTER:
```
    - name: Configure Tower local users
      ansible.controller.tower_user:
        tower_username: "{{ configure_tower_username }}"
        tower_password: "{{ configure_tower_password }}"
        tower_host: "{{ configure_tower_server_url }}"
        validate_certs: "{{ configure_tower_validate_certs }}"
        username: "BBB"
        password: "BBB"
        organization: "organization1"
```
```
 👒 ivan@iamlabp1 -  ✘  ✝  iam/Orgs/organization2   dev±  cd ../organization1 
 👒 ivan@iamlabp1 -  ✝  iam/Orgs/organization1   dev±  ansible-playbook  test.yml --vault-password-file .vault_pass.txt
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [localhost] *****************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Configure Tower local users] ***********************************************************************************************************************************************************************************************************
[WARNING]: You are using the controller version of this collection but connecting to Red Hat Ansible Tower
[WARNING]: The field password of user 77 has encrypted data and may inaccurately report task is changed.
changed: [localhost]

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   


```
