### PR TITLE
Remove ssh_key_data pipe if it exists

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -339,7 +339,7 @@ class AWXReceptorJob:
             shutil.rmtree(artifact_dir)
 
         # If we happen to leave around any pipes that could cause hangs when unstreaming
-        key_data_file = os.path.join(self.runner_params['private_data_dir'], 'artifacts', str(self.task.instance.id))
+        key_data_file = os.path.join(self.runner_params['private_data_dir'], 'artifacts', str(self.task.instance.id), 'ssh_key_data')
         if os.path.exists(key_data_file):
             os.remove(key_data_file)
 

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -338,6 +338,11 @@ class AWXReceptorJob:
         if os.path.exists(artifact_dir):
             shutil.rmtree(artifact_dir)
 
+        # If we happen to leave around any pipes that could cause hangs when unstreaming
+        key_data_file = os.path.join(self.runner_params['private_data_dir'], 'artifacts', str(self.task.instance.id))
+        if os.path.exists(key_data_file):
+            os.remove(key_data_file)
+
         resultsock, resultfile = receptor_ctl.get_work_results(self.unit_id, return_socket=True, return_sockfile=True)
         # Both "processor" and "cancel_watcher" are spawned in separate threads.
         # We wait for the first one to return. If cancel_watcher returns first,


### PR DESCRIPTION
##### SUMMARY
We have made a discovery that `unstream_dir` from ansible-runner can hang if one of the files it sends overlaps with a pipe of that same name on the host machine. I have confirmed this with a test in ansible-runner:

```python
def test_unstream_hits_pipe(tmp_path):
    source_dir = tmp_path / 'source'
    source_dir.mkdir()

    (source_dir / 'my_text_file.txt').write_text('foobar')

    dest_dir = tmp_path / 'dest'
    dest_dir.mkdir()

    os.mkfifo(str(dest_dir / 'my_text_file.txt'))

    # prepare the buffer with data to write
    buffer = io.BytesIO()
    buffer.name = 'not_stdout'
    stream_dir(source_dir, buffer)
    buffer.seek(0)

    # write the data to the destination
    size_data = json.loads(buffer.readline().strip())
    unstream_dir(buffer, size_data['zipfile'], dest_dir)  # assure this does not hang
```

However, ansible-runner appears to be the wrong place to make the fix, because you... shouldn't do this to begin with.

So to stop hanging jobs, we will remove that specific path if it exists.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

