### PR TITLE
Remove ansible-tower-setup script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,6 @@ setup(
                     "tools/scripts/automation-controller-service",
                     "tools/scripts/failure-event-handler",
                     "tools/scripts/awx-python",
-                    "tools/scripts/ansible-tower-setup",
                 ],
             ),
             ("%s" % sosconfig, ["tools/sosreport/controller.py"]),

--- a/tools/scripts/ansible-tower-setup
+++ b/tools/scripts/ansible-tower-setup
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-exec /var/lib/awx/setup/setup.sh "$@"


### PR DESCRIPTION
The script is no longer used/needed.