### PR TITLE
Fix typerror cannot read property of null

### DIFF
--- a/awx/ui/src/components/AddDropDownButton/AddDropDownButton.js
+++ b/awx/ui/src/components/AddDropDownButton/AddDropDownButton.js
@@ -12,7 +12,7 @@ function AddDropDownButton({ dropdownItems, ouiaId }) {
 
   useEffect(() => {
     const toggle = (e) => {
-      if (!isKebabified && (!element || !element.current.contains(e.target))) {
+      if (!isKebabified && (!element || !element.current?.contains(e.target))) {
         setIsOpen(false);
       }
     };


### PR DESCRIPTION
```
> x = null
null
> x?.contains
undefined
> x.contains
Uncaught TypeError: Cannot read property 'contains' of null
```

See: https://github.com/ansible/awx/issues/11582
