### PR TITLE
Display all job type events in job output

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -240,7 +240,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
           setWsEvents([]);
           scrollToRow(lastScrollPosition);
         });
-      }, 250);
+      }, 500);
       return;
     }
     let batchTimeout;
@@ -278,7 +278,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
         batchedEvents = [];
       };
 
-      if (data.group_name === 'job_events') {
+      if (data.group_name === `${job.type}_events`) {
         batchedEvents.push(data);
         clearTimeout(batchTimeout);
         if (batchedEvents.length >= 25) {


### PR DESCRIPTION
##### SUMMARY
Fixes bad check on websocket events that was filtering out events for non-playbook job events on the job output screen.

addresses #11628 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
