### PR TITLE
Automate labels with GHA

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,8 +1,6 @@
 ---
 name: Bug Report
 description: Create a report to help us improve
-labels:
-  - bug
 body:
   - type: markdown
     attributes:
@@ -38,6 +36,15 @@ body:
       description: What version of AWX are you running?
     validations:
       required: true
+
+  - type: checkboxes
+    id: components
+    attributes:
+      label: Select the relevant components
+      options:
+        - label: UI
+        - label: API
+        - label: Docs
 
   - type: dropdown
     id: awx-install-method

--- a/.github/issue_labeler.yml
+++ b/.github/issue_labeler.yml
@@ -1,2 +1,12 @@
 needs_triage:
   - '.*'
+"type:bug":
+  - "Please confirm the following"
+"type:enhancement":
+  - "Feature Idea"
+"component:ui":
+  - "\\[X\\] UI"
+"component:api":
+  - "\\[X\\] API"
+"component:docs":
+  - "\\[X\\] Docs"

--- a/.github/pr_labeler.yml
+++ b/.github/pr_labeler.yml
@@ -1,0 +1,14 @@
+"component:api":
+  - any: ['awx/**/*', '!awx/ui/*']
+
+"component:ui":
+  - any: ['awx/ui/**/*']
+
+"component:docs":
+  - any: ['docs/**/*']
+
+"component:cli":
+  - any: ['awxkit/**/*']
+
+"component:collection":
+  - any: ['awx_collection/**/*']

--- a/.github/workflows/label_issue.yml
+++ b/.github/workflows/label_issue.yml
@@ -1,21 +1,22 @@
-name: Triage
+name: Label Issue
 
 on:
   issues:
     types:
       - opened
+      - reopened
+      - edited
 
 jobs:
   triage:
     runs-on: ubuntu-latest
-    name: Label
+    name: Label Issue
 
     steps:
-      - name: Label issues
+      - name: Label Issue
         uses: github/issue-labeler@v2.4.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           not-before: 2021-12-07T07:00:00Z
           configuration-path: .github/issue_labeler.yml
           enable-versioned-regex: 0
-        if: github.event_name == 'issues'

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -1,0 +1,20 @@
+name: Label PR
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    name: Label PR
+
+    steps:
+      - name: Label PR
+        uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/pr_labeler.yml


### PR DESCRIPTION
My goal here is to replace awxbot (an unmaintained project) with a set of simple GitHub Actions.

- awxbot used to automatically label our issues, but hasn't since we migrated to using an [issue form](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).
- The action for [labeling PRs](https://github.com/actions/labeler) looks at the files that were changed, not the description of the PR. This allows us to automate the `component:` label, but we lose the ability to automate the `type:` label for PRs. I couldn't find an action for PRs that behaves the same way as awxbot does.