### PR TITLE
Changing session cookie name and added a way for clients to know what the name is #11413

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -99,6 +99,7 @@ class LoggedLoginView(auth_views.LoginView):
             current_user = smart_text(JSONRenderer().render(current_user.data))
             current_user = urllib.parse.quote('%s' % current_user, '')
             ret.set_cookie('current_user', current_user, secure=settings.SESSION_COOKIE_SECURE or None)
+            ret.setdefault('X-API-Session-Cookie-Name', getattr(settings, 'SESSION_COOKIE_NAME', 'awx_sessionid'))
 
             return ret
         else:

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -252,6 +252,10 @@ SESSION_COOKIE_SECURE = True
 # Note: This setting may be overridden by database settings.
 SESSION_COOKIE_AGE = 1800
 
+# Name of the cookie that contains the session information.
+# Note: Changing this value may require changes to any clients.
+SESSION_COOKIE_NAME = 'awx_sessionid'
+
 # Maximum number of per-user valid, concurrent sessions.
 # -1 is unlimited
 # Note: This setting may be overridden by database settings.

--- a/awx/sso/views.py
+++ b/awx/sso/views.py
@@ -46,6 +46,7 @@ class CompleteView(BaseRedirectView):
             current_user = smart_text(JSONRenderer().render(current_user.data))
             current_user = urllib.parse.quote('%s' % current_user, '')
             response.set_cookie('current_user', current_user, secure=settings.SESSION_COOKIE_SECURE or None)
+            response.setdefault('X-API-Session-Cookie-Name', getattr(settings, 'SESSION_COOKIE_NAME', 'awx_sessionid'))
         return response
 
 

--- a/awxkit/awxkit/api/client.py
+++ b/awxkit/awxkit/api/client.py
@@ -33,6 +33,10 @@ class Connection(object):
     def __init__(self, server, verify=False):
         self.server = server
         self.verify = verify
+        # Note: We use the old sessionid here incase someone is trying to connect to an older AWX version
+        # There is a check below so that if AWX returns an X-API-Session-Cookie-Name we will grab it and
+        # connect with the new session cookie name.
+        self.session_cookie_name = 'sessionid'
 
         if not self.verify:
             requests.packages.urllib3.disable_warnings()
@@ -49,8 +53,10 @@ class Connection(object):
             _next = kwargs.get('next')
             if _next:
                 headers = self.session.headers.copy()
-                self.post('/api/login/', headers=headers, data=dict(username=username, password=password, next=_next))
-                self.session_id = self.session.cookies.get('sessionid')
+                response = self.post('/api/login/', headers=headers, data=dict(username=username, password=password, next=_next))
+                if 'X-API-Session-Cookie-Name' in response.headers:
+                    self.session_cookie_name = response.headers.get('X-API-Session-Cookie-Name')
+                self.session_id = self.session.cookies.get(self.session_cookie_name)
                 self.uses_session_cookie = True
             else:
                 self.session.auth = (username, password)
@@ -61,7 +67,7 @@ class Connection(object):
 
     def logout(self):
         if self.uses_session_cookie:
-            self.session.cookies.pop('sessionid', None)
+            self.session.cookies.pop(self.session_cookie_name, None)
         else:
             self.session.auth = None
 

--- a/awxkit/awxkit/awx/utils.py
+++ b/awxkit/awxkit/awx/utils.py
@@ -95,12 +95,12 @@ def as_user(v, username, password=None):
             # requests doesn't provide interface for retrieving
             # domain segregated cookies other than iterating.
             for cookie in connection.session.cookies:
-                if cookie.name == 'sessionid':
+                if cookie.name == connection.session_cookie_name:
                     session_id = cookie.value
                     domain = cookie.domain
                     break
             if session_id:
-                del connection.session.cookies['sessionid']
+                del connection.session.cookies[connection.session_cookie_name]
             if access_token:
                 kwargs = dict(token=access_token)
             else:
@@ -114,9 +114,9 @@ def as_user(v, username, password=None):
         if config.use_sessions:
             if access_token:
                 connection.session.auth = None
-            del connection.session.cookies['sessionid']
+            del connection.session.cookies[connection.session_cookie_name]
             if session_id:
-                connection.session.cookies.set('sessionid', session_id, domain=domain)
+                connection.session.cookies.set(connection.session_cookie_name, session_id, domain=domain)
         else:
             connection.session.auth = previous_auth
 

--- a/awxkit/awxkit/ws.py
+++ b/awxkit/awxkit/ws.py
@@ -51,7 +51,9 @@ class WSClient(object):
 
     # Subscription group types
 
-    def __init__(self, token=None, hostname='', port=443, secure=True, session_id=None, csrftoken=None, add_received_time=False):
+    def __init__(
+        self, token=None, hostname='', port=443, secure=True, session_id=None, csrftoken=None, add_received_time=False, session_cookie_name='awx_sessionid'
+    ):
         # delay this import, because this is an optional dependency
         import websocket
 
@@ -78,7 +80,7 @@ class WSClient(object):
         if self.token is not None:
             auth_cookie = 'token="{0.token}";'.format(self)
         elif self.session_id is not None:
-            auth_cookie = 'sessionid="{0.session_id}"'.format(self)
+            auth_cookie = '{1}="{0.session_id}"'.format(self, session_cookie_name)
             if self.csrftoken:
                 auth_cookie += ';csrftoken={0.csrftoken}'.format(self)
         else:

--- a/docs/auth/session.md
+++ b/docs/auth/session.md
@@ -6,9 +6,9 @@ Session authentication is a safer way of utilizing HTTP(S) cookies. Theoreticall
 `Cookie` header, but this method is vulnerable to cookie hijacks, where crackers can see and steal user
 information from the cookie payload.
 
-Session authentication, on the other hand, sets a single `session_id` cookie. The `session_id`
-is *a random string which will be mapped to user authentication informations by server*. Crackers who
-hijack cookies will only get the `session_id` itself, which does not imply any critical user info, is valid only for
+Session authentication, on the other hand, sets a single `awx_sessionid` cookie. The `awx_sessionid`
+is *a random string which will be mapped to user authentication information by the server*. Crackers who
+hijack cookies will only get the `awx_sessionid` itself, which does not imply any critical user info, is valid only for
 a limited time, and can be revoked at any time.
 
 > Note: The CSRF token will by default allow HTTP.  To increase security, the `CSRF_COOKIE_SECURE` setting should
@@ -34,22 +34,27 @@ be provided in the form:
 * `next`: The path of the redirect destination, in API browser `"/api/"` is used.
 * `csrfmiddlewaretoken`: The CSRF token, usually populated by using Django template `{% csrf_token %}`.
 
-The `session_id` is provided as a return `Set-Cookie` header. Here is a typical one:
+The `awx_session_id` is provided as a return `Set-Cookie` header. Here is a typical one:
 ```
-Set-Cookie: sessionid=lwan8l5ynhrqvps280rg5upp7n3yp6ds; expires=Tue, 21-Nov-2017 16:33:13 GMT; httponly; Max-Age=1209600; Path=/
+Set-Cookie: awx_sessionid=lwan8l5ynhrqvps280rg5upp7n3yp6ds; expires=Tue, 21-Nov-2017 16:33:13 GMT; httponly; Max-Age=1209600; Path=/
 ```
+
+In addition, when the `awx_sessionid` a header called `X-API-Session-Cookie-Name` this header will only be displayed once on a successful logging and denotes the name of the session cookie name. By default this is `awx_sessionid` but can be changed (see below).
+
 Any client should follow the standard rules of [cookie protocol](https://tools.ietf.org/html/rfc6265) to
-parse that header to obtain information about the session, such as session cookie name (`session_id`),
+parse that header to obtain information about the session, such as session cookie name (`awx_sessionid`),
 session cookie value, expiration date, duration, etc.
+
+The name of the cookie is configurable by Tower Configuration setting `SESSION_COOKIE_NAME` under the category `authentication`. It is a string. The default session cookie name is `awx_sessionid`.
 
 The duration of the cookie is configurable by Tower Configuration setting `SESSION_COOKIE_AGE` under
 category `authentication`. It is an integer denoting the number of seconds the session cookie should
 live. The default session cookie age is two weeks.  
 
-After a valid session is acquired, a client should provide the `session_id` as a cookie for subsequent requests
+After a valid session is acquired, a client should provide the `awx_sessionid` as a cookie for subsequent requests
 in order to be authenticated. For example:
 ```
-Cookie: sessionid=lwan8l5ynhrqvps280rg5upp7n3yp6ds; ...
+Cookie: awx_sessionid=lwan8l5ynhrqvps280rg5upp7n3yp6ds; ...
 ```
 
 User should use the `/api/logout/` endpoint to log out. In the API browser, a logged-in user can do that by


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "*Breaking Change:* sessionid cookie has been renamed to awx_sessionid"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This changes the name of the cookie which holds the users session from `sessionid` to `awx_sessionid` to help distinguish the AWX session cooke from other django applications. The name of the cookie is defined in `awx/settings/defaults.py`. In case this gets changed we have also modified the login logic to set a header `X-API-Session-Cookie-Name` which will have a value of the session cookie name. This way, if a integration point is referencing the cookie, they remote integration will be informed of the name of the cooke on a successful login. In addition we have updated awxkit to reference this new session cookie as well as the header. In awxkit there is the interactive client as well as a WebSocket (WS) programatic interface. The WS code has a new parameter for specifying the cookie name. However, the WS interface does not have access to a Connection object before the session cookie name may be needed so if you are using the WS interface to an AWX instance and change the default cookie name (or use the latest WS to connect to an older AWX instance) you must be sure to add the cookie name parameter for a proper connection.

WARNING: If you have a client that depends on the sessionid cookie you will need to modify the client.

Related #11413

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
- awxkit

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev75+gd62bc1a798
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
