### PR TITLE
Skip pytest 7.0.0

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -4,7 +4,7 @@ django-rest-swagger
 ipython==7.21.0
 unittest2
 black
-pytest
+pytest!=7.0.0
 pytest-cov
 pytest-django
 pytest-pythonpath


### PR DESCRIPTION
A test was failing with:

```
    from importlib.readers import FileReader
E   ModuleNotFoundError: No module named 'importlib.readers'
```

This fixes it.