### PR TITLE
Fixes erroneous disabling of name input field on container and instance group forms

### DIFF
--- a/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
@@ -30,13 +30,16 @@ function ContainerGroup({ setBreadcrumb }) {
     isLoading,
     error: contentError,
     request: fetchInstanceGroups,
-    result: { instanceGroup, defaultExecution },
+    result: { instanceGroup, defaultControlPlane, defaultExecution },
   } = useRequest(
     useCallback(async () => {
       const [
         { data },
         {
-          data: { DEFAULT_EXECUTION_QUEUE_NAME },
+          data: {
+            DEFAULT_EXECUTION_QUEUE_NAME,
+            DEFAULT_CONTROL_PLANE_QUEUE_NAME,
+          },
         },
       ] = await Promise.all([
         InstanceGroupsAPI.readDetail(id),
@@ -44,6 +47,7 @@ function ContainerGroup({ setBreadcrumb }) {
       ]);
       return {
         instanceGroup: data,
+        defaultControlPlane: DEFAULT_CONTROL_PLANE_QUEUE_NAME,
         defaultExecution: DEFAULT_EXECUTION_QUEUE_NAME,
       };
     }, [id]),
@@ -123,6 +127,7 @@ function ContainerGroup({ setBreadcrumb }) {
                 <Route path="/instance_groups/container_group/:id/edit">
                   <ContainerGroupEdit
                     instanceGroup={instanceGroup}
+                    defaultControlPlane={defaultControlPlane}
                     defaultExecution={defaultExecution}
                   />
                 </Route>

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.js
@@ -11,7 +11,7 @@ import { jsonToYaml, isJsonString } from 'util/yaml';
 
 import ContainerGroupForm from '../shared/ContainerGroupForm';
 
-function ContainerGroupAdd() {
+function ContainerGroupAdd({ defaultExecution, defaultControlPlane }) {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
 
@@ -93,6 +93,8 @@ function ContainerGroupAdd() {
       <Card>
         <CardBody>
           <ContainerGroupForm
+            defaultControlPlane={defaultControlPlane}
+            defaultExecution={defaultExecution}
             initialPodSpec={initialPodSpec}
             onSubmit={handleSubmit}
             submitError={submitError}

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.js
@@ -9,7 +9,11 @@ import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';
 import ContainerGroupForm from '../shared/ContainerGroupForm';
 
-function ContainerGroupEdit({ instanceGroup }) {
+function ContainerGroupEdit({
+  instanceGroup,
+  defaultControlPlane,
+  defaultExecution,
+}) {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
   const detailsIUrl = `/instance_groups/container_group/${instanceGroup.id}/details`;
@@ -77,6 +81,8 @@ function ContainerGroupEdit({ instanceGroup }) {
   return (
     <CardBody>
       <ContainerGroupForm
+        defaultControlPlane={defaultControlPlane}
+        defaultExecution={defaultExecution}
         instanceGroup={instanceGroup}
         initialPodSpec={initialPodSpec}
         onSubmit={handleSubmit}

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.js
@@ -6,7 +6,7 @@ import { CardBody } from 'components/Card';
 import { InstanceGroupsAPI } from 'api';
 import InstanceGroupForm from '../shared/InstanceGroupForm';
 
-function InstanceGroupAdd() {
+function InstanceGroupAdd({ defaultExecution, defaultControlPlane }) {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
 
@@ -28,6 +28,8 @@ function InstanceGroupAdd() {
       <Card>
         <CardBody>
           <InstanceGroupForm
+            defaultControlPlane={defaultControlPlane}
+            defaultExecution={defaultExecution}
             onSubmit={handleSubmit}
             submitError={submitError}
             onCancel={handleCancel}

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
@@ -19,13 +19,21 @@ function InstanceGroups() {
     request: settingsRequest,
     isLoading: isSettingsRequestLoading,
     error: settingsRequestError,
-    result: isKubernetes,
+    result: { isKubernetes, defaultControlPlane, defaultExecution },
   } = useRequest(
     useCallback(async () => {
       const {
-        data: { IS_K8S },
+        data: {
+          IS_K8S,
+          DEFAULT_CONTROL_PLANE_QUEUE_NAME,
+          DEFAULT_EXECUTION_QUEUE_NAME,
+        },
       } = await SettingsAPI.readCategory('all');
-      return IS_K8S;
+      return {
+        isKubernetes: IS_K8S,
+        defaultControlPlane: DEFAULT_CONTROL_PLANE_QUEUE_NAME,
+        defaultExecution: DEFAULT_EXECUTION_QUEUE_NAME,
+      };
     }, []),
     { isLoading: true }
   );
@@ -75,16 +83,22 @@ function InstanceGroups() {
       />
       <Switch>
         <Route path="/instance_groups/container_group/add">
-          <ContainerGroupAdd />
+          <ContainerGroupAdd
+            defaultControlPlane={defaultControlPlane}
+            defaultExecution={defaultExecution}
+          />
         </Route>
         <Route path="/instance_groups/container_group/:id">
           <ContainerGroup setBreadcrumb={buildBreadcrumbConfig} />
         </Route>
-        {!isSettingsRequestLoading && !isKubernetes ? (
+        {!isSettingsRequestLoading && !isKubernetes && (
           <Route path="/instance_groups/add">
-            <InstanceGroupAdd />
+            <InstanceGroupAdd
+              defaultControlPlane={defaultControlPlane}
+              defaultExecution={defaultExecution}
+            />
           </Route>
-        ) : null}
+        )}
         <Route path="/instance_groups/:id">
           <InstanceGroup setBreadcrumb={buildBreadcrumbConfig} />
         </Route>

--- a/awx/ui/src/screens/InstanceGroup/shared/ContainerGroupForm.js
+++ b/awx/ui/src/screens/InstanceGroup/shared/ContainerGroupForm.js
@@ -11,7 +11,7 @@ import FormField, {
   CheckboxField,
 } from 'components/FormField';
 import FormActionGroup from 'components/FormActionGroup';
-import { required } from 'util/validators';
+import { combine, required, protectedResourceName } from 'util/validators';
 import {
   FormColumnLayout,
   FormFullWidthLayout,
@@ -21,12 +21,20 @@ import {
 import CredentialLookup from 'components/Lookup/CredentialLookup';
 import { VariablesField } from 'components/CodeEditor';
 
-function ContainerGroupFormFields({ instanceGroup }) {
+function ContainerGroupFormFields({
+  instanceGroup,
+  defaultControlPlane,
+  defaultExecution,
+}) {
   const { setFieldValue, setFieldTouched } = useFormikContext();
   const [credentialField, credentialMeta, credentialHelpers] =
     useField('credential');
 
-  const [nameField] = useField('name');
+  const [, { initialValue }] = useField('name');
+
+  const isProtected =
+    initialValue === `${defaultControlPlane}` ||
+    initialValue === `${defaultExecution}`;
 
   const [overrideField] = useField('override');
 
@@ -42,11 +50,21 @@ function ContainerGroupFormFields({ instanceGroup }) {
     <>
       <FormField
         name="name"
+        helperText={
+          isProtected
+            ? t`This is a protected Instance Group. The name cannot be changed.`
+            : ''
+        }
         id="container-group-name"
         label={t`Name`}
         type="text"
-        validate={required(null)}
-        isDisabled={nameField.value === 'default'}
+        validate={combine([
+          required(null),
+          protectedResourceName(
+            t`This is a protected name for Container Groups. Please use a different name.`,
+            [defaultControlPlane, defaultExecution]
+          ),
+        ])}
         isRequired
       />
       <CredentialLookup

--- a/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.test.js
+++ b/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.test.js
@@ -60,6 +60,7 @@ describe('<InstanceGroupForm/>', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    wrapper.unmount();
   });
 
   test('Initially renders successfully', () => {

--- a/awx/ui/src/util/validators.js
+++ b/awx/ui/src/util/validators.js
@@ -186,3 +186,8 @@ export function regExp() {
     return undefined;
   };
 }
+
+export function protectedResourceName(message, names = []) {
+  return (value) =>
+    names.some((name) => value.trim() === `${name}`) ? message : undefined;
+}

--- a/awx/ui/src/util/validators.test.js
+++ b/awx/ui/src/util/validators.test.js
@@ -12,6 +12,7 @@ import {
   regExp,
   requiredEmail,
   validateTime,
+  protectedResourceName,
 } from './validators';
 
 describe('validators', () => {
@@ -186,5 +187,22 @@ describe('validators', () => {
     expect(validateTime()('12:15: PM')).toEqual('Invalid time format');
     expect(validateTime()('12.15 PM')).toEqual('Invalid time format');
     expect(validateTime()('12;15 PM')).toEqual('Invalid time format');
+  });
+  test('protectedResourceName should validate properly', () => {
+    expect(
+      protectedResourceName('failed validation', ['Alex'])('Apollo')
+    ).toBeUndefined();
+    expect(
+      protectedResourceName('failed validation', ['Alex', 'Athena'])('alex')
+    ).toBeUndefined();
+    expect(
+      protectedResourceName('failed validation', ['Alex', 'Athena'])('Alex')
+    ).toEqual('failed validation');
+    expect(
+      protectedResourceName('failed validation', ['Alex'])('Alex')
+    ).toEqual('failed validation');
+    expect(
+      protectedResourceName('failed validation', ['Alex'])('Alex ')
+    ).toEqual('failed validation');
   });
 });


### PR DESCRIPTION
##### SUMMARY
This addresses #11634 
Instance Groups and Container Groups have names, (`default`, `controlplane`) that are not available to the user when creating/editing an instance or container group.  This PR fixes a case where a user would go to type `default` and the name input would immediately disable which would prevent them from typing something like `default Instance Group`.  

To resolve that both forms do a check to see if the `initialValues === default || controlplane` (which would mean we are in edit mode, and these are protected instance groups so the name input should be disabled. Doing it this way prevents the field from going disabled as soon as the use types `default` or `controlplane` giving them the opportunity to type more than just those names.  I also introduce a validators to throw a form error when the user tries to create IG/CGs of those protected names
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION



##### ADDITIONAL INFORMATION
![Instancegroups](https://user-images.githubusercontent.com/39280967/152836556-3b6f243b-c289-4e0c-ac2b-42f9d5563cc2.gif)