### PR TITLE
add execution_environment_admin to role module

### DIFF
--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -34,7 +34,7 @@ options:
         - The role type to grant/revoke.
       required: True
       choices: ["admin", "read", "member", "execute", "adhoc", "update", "use", "approval", "auditor", "project_admin", "inventory_admin", "credential_admin",
-                "workflow_admin", "notification_admin", "job_template_admin"]
+                "workflow_admin", "notification_admin", "job_template_admin", "execution_environment_admin"]
       type: str
     target_team:
       description:
@@ -173,6 +173,7 @@ def main():
                 "workflow_admin",
                 "notification_admin",
                 "job_template_admin",
+                "execution_environment_admin",
             ],
             required=True,
         ),

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -85,6 +85,21 @@
         that:
           - "result is changed"
 
+    - name: Add Joe as execution admin to Default Org.
+      role:
+        user: "{{ username }}"
+        role: execution_environment_admin
+        organizations: Default
+        state: "{{ item }}"
+      register: result
+      with_items:
+        - "present"
+        - "absent"
+
+    - assert:
+        that:
+          - "result is changed"
+
     - name: Create a workflow
       workflow_job_template:
         name: test-role-workflow


### PR DESCRIPTION
<!--- changelog-entry
---
msg: "Added execution_environment_admin to role module in the awx collection"
-->

##### SUMMARY
Found that the execution_environment_admin role was missing from the role module

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
19.5.1
```