### PR TITLE
Do not mount /etc/redhat-access-insights into EEs

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -854,24 +854,6 @@ class RunJob(BaseTask):
                 d[r'Vault password \({}\):\s*?$'.format(vault_id)] = k
         return d
 
-    def build_execution_environment_params(self, instance, private_data_dir):
-        if settings.IS_K8S:
-            return {}
-
-        params = super(RunJob, self).build_execution_environment_params(instance, private_data_dir)
-        # If this has an insights agent and it is not already mounted then show it
-        insights_dir = os.path.dirname(settings.INSIGHTS_SYSTEM_ID_FILE)
-        if instance.use_fact_cache and os.path.exists(insights_dir):
-            logger.info('not parent of others')
-            params.setdefault('container_volume_mounts', [])
-            params['container_volume_mounts'].extend(
-                [
-                    f"{insights_dir}:{insights_dir}:Z",
-                ]
-            )
-
-        return params
-
     def pre_run_hook(self, job, private_data_dir):
         super(RunJob, self).pre_run_hook(job, private_data_dir)
         if job.inventory is None:


### PR DESCRIPTION
##### SUMMARY
Sharing the /etc/redhat-access-insights is no longer
required for EEs. Furthermore, this fixes a SELinux issue
when launching multiple jobs with concurrency and fact_caching enabled.

```
i.e.:
lsetxattr /etc/redhat-access-insights: operation not permitted
```

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```
