### PR TITLE
Move runner params logic into the awx.main.tasks.jobs module

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -729,14 +729,6 @@ class BaseTask(object):
                 # Disable Ansible fact cache.
                 params['fact_cache_type'] = ''
 
-            if self.instance.is_container_group_task or settings.IS_K8S:
-                params['envvars'].pop('HOME', None)
-            else:
-                ee_params = self.build_execution_environment_params(self.instance, private_data_dir)
-                params.update(ee_params)
-                if self.instance.execution_node == settings.CLUSTER_HOST_ID or self.instance.execution_node == self.instance.controller_node:
-                    params['only_transmit_kwargs'] = True
-
             '''
             Delete parameters if the values are None or empty array
             '''
@@ -757,6 +749,14 @@ class BaseTask(object):
                     **params,
                 )
             else:
+                if self.instance.is_container_group_task or settings.IS_K8S:
+                    params['envvars'].pop('HOME', None)
+                else:
+                    ee_params = self.build_execution_environment_params(self.instance, private_data_dir)
+                    params.update(ee_params)
+                    if self.instance.execution_node == settings.CLUSTER_HOST_ID or self.instance.execution_node == self.instance.controller_node:
+                        params['only_transmit_kwargs'] = True
+
                 receptor_job = AWXReceptorJob(self, params)
                 res = receptor_job.run()
                 self.unit_id = receptor_job.unit_id

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -731,6 +731,11 @@ class BaseTask(object):
 
             if self.instance.is_container_group_task or settings.IS_K8S:
                 params['envvars'].pop('HOME', None)
+            else:
+                ee_params = self.build_execution_environment_params(self.instance, private_data_dir)
+                params.update(ee_params)
+                if self.instance.execution_node == settings.CLUSTER_HOST_ID or self.instance.execution_node == self.instance.controller_node:
+                    params['only_transmit_kwargs'] = True
 
             '''
             Delete parameters if the values are None or empty array

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -263,13 +263,6 @@ class AWXReceptorJob:
         self.runner_params = runner_params
         self.unit_id = None
 
-        if self.task and not self.task.instance.is_container_group_task:
-            execution_environment_params = self.task.build_execution_environment_params(self.task.instance, runner_params['private_data_dir'])
-            self.runner_params.update(execution_environment_params)
-
-        if not settings.IS_K8S and self.work_type == 'local' and 'only_transmit_kwargs' not in self.runner_params:
-            self.runner_params['only_transmit_kwargs'] = True
-
     def run(self):
         # We establish a connection to the Receptor socket
         receptor_ctl = get_receptor_ctl()


### PR DESCRIPTION
Following up from @amolgautam25 refactoring work, it seems pretty clear that ownership of the ansible-runner parameters should be in `BaseTask` derived code. This is an odd-one-out, so I'd like to get it taken care of as we continue to further analyze the code.