### PR TITLE
Fix image push when overriding awx_image_tag

### DIFF
--- a/tools/ansible/roles/image_push/tasks/main.yml
+++ b/tools/ansible/roles/image_push/tasks/main.yml
@@ -12,11 +12,11 @@
 
 - name: Tag and Push Container Images
   docker_image:
-    name: "{{ awx_image }}:{{ awx_version }}"
+    name: "{{ awx_image }}:{{ awx_image_tag }}"
     repository: "{{ registry }}/{{ awx_image }}:{{ item }}"
     force_tag: yes
     push: true
     source: local
   with_items:
     - "latest"
-    - "{{ awx_version }}"
+    - "{{ awx_image_tag }}"


### PR DESCRIPTION
I was running:

```
$ ansible-playbook tools/ansible/build.yml -e awx_image=shanemcd/awx -e awx_image_tag=test -e push=yes
```

and seeing:

```
TASK [image_push : Tag and Push Container Images] ********************************************************
failed: [localhost] (item=latest) => {"ansible_loop_var": "item", "changed": false, "item": "latest", "msg": "Cannot find the image shanemcd/awx:19.5.2.dev115 locally."}
failed: [localhost] (item=19.5.2.dev115) => {"ansible_loop_var": "item", "changed": false, "item": "19.5.2.dev115", "msg": "Cannot find the image shanemcd/awx:19.5.2.dev115 locally."}
```

This fixes it.