### PR TITLE
Add loop label with docker-compose playbook

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -26,6 +26,8 @@
     mode: '0600'
   when: not lookup('vars', item.item, default='') and not item.stat.exists
   loop: "{{ secrets.results }}"
+  loop_control:
+    label: '{{ item.stat.path }}'
 
 - name: Include generated secrets unless they are explicitly passed in
   include_vars: "{{ sources_dest }}/secrets/{{ item.item }}.yml"


### PR DESCRIPTION
I want to make the startup logs less verbose.

### before

```
TASK [sources : Detect secrets] **************************************************************************************************************************
ok: [localhost] => (item=pg_password)
ok: [localhost] => (item=secret_key)
ok: [localhost] => (item=broadcast_websocket_secret)

TASK [sources : Generate secrets if needed] **************************************************************************************************************
skipping: [localhost] => (item={'changed': False, 'stat': {'exists': True, 'path': '../_sources/secrets/pg_password.yml', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 36, 'inode': 9437215, 'dev': 64771, 'nlink': 1, 'atime': 1644851215.0532753, 'mtime': 1644082690.456649, 'ctime': 1644082690.7586505, 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False, 'blocks': 8, 'block_size': 4096, 'device_type': 0, 'readable': True, 'writeable': True, 'executable': False, 'pw_name': 'alancoding', 'gr_name': 'alancoding', 'checksum': 'b2b0a680a354fbc808e6558a6aaea3d139a6f55b', 'mimetype': 'text/plain', 'charset': 'us-ascii', 'version': '1057165904', 'attributes': ['extents'], 'attr_flags': 'e'}, 'invocation': {'module_args': {'path': '../_sources/secrets/pg_password.yml', 'follow': False, 'get_md5': False, 'get_checksum': True, 'get_mime': True, 'get_attributes': True, 'checksum_algorithm': 'sha1'}}, 'failed': False, 'item': 'pg_password', 'ansible_loop_var': 'item'}) 
skipping: [localhost] => (item={'changed': False, 'stat': {'exists': True, 'path': '../_sources/secrets/secret_key.yml', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 35, 'inode': 9437216, 'dev': 64771, 'nlink': 1, 'atime': 1644851215.2592762, 'mtime': 1644082690.9706516, 'ctime': 1644082691.1356523, 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False, 'blocks': 8, 'block_size': 4096, 'device_type': 0, 'readable': True, 'writeable': True, 'executable': False, 'pw_name': 'alancoding', 'gr_name': 'alancoding', 'checksum': '3cd341fd534e34e976fc020e97f101c5a2f5f336', 'mimetype': 'text/plain', 'charset': 'us-ascii', 'version': '1132154883', 'attributes': ['extents'], 'attr_flags': 'e'}, 'invocation': {'module_args': {'path': '../_sources/secrets/secret_key.yml', 'follow': False, 'get_md5': False, 'get_checksum': True, 'get_mime': True, 'get_attributes': True, 'checksum_algorithm': 'sha1'}}, 'failed': False, 'item': 'secret_key', 'ansible_loop_var': 'item'}) 
skipping: [localhost] => (item={'changed': False, 'stat': {'exists': True, 'path': '../_sources/secrets/broadcast_websocket_secret.yml', 'mode': '0600', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 1000, 'gid': 1000, 'size': 51, 'inode': 9437218, 'dev': 64771, 'nlink': 1, 'atime': 1644851215.4522767, 'mtime': 1644082691.3566535, 'ctime': 1644082691.5246542, 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': False, 'xgrp': False, 'woth': False, 'roth': False, 'xoth': False, 'isuid': False, 'isgid': False, 'blocks': 8, 'block_size': 4096, 'device_type': 0, 'readable': True, 'writeable': True, 'executable': False, 'pw_name': 'alancoding', 'gr_name': 'alancoding', 'checksum': '3320f638b06c073d2c4b0baecaaa77ec8ba5e5e0', 'mimetype': 'text/plain', 'charset': 'us-ascii', 'version': '1315648085', 'attributes': ['extents'], 'attr_flags': 'e'}, 'invocation': {'module_args': {'path': '../_sources/secrets/broadcast_websocket_secret.yml', 'follow': False, 'get_md5': False, 'get_checksum': True, 'get_mime': True, 'get_attributes': True, 'checksum_algorithm': 'sha1'}}, 'failed': False, 'item': 'broadcast_websocket_secret', 'ansible_loop_var': 'item'}) 

TASK [sources : Include generated secrets unless they are explicitly passed in] **************************************************************************
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost]
```

(terminal will wrap that text)

### after

```
TASK [sources : Detect secrets] **************************************************************************************************************************
ok: [localhost] => (item=pg_password)
ok: [localhost] => (item=secret_key)
ok: [localhost] => (item=broadcast_websocket_secret)

TASK [sources : Generate secrets if needed] **************************************************************************************************************
skipping: [localhost] => (item=../_sources/secrets/pg_password.yml) 
skipping: [localhost] => (item=../_sources/secrets/secret_key.yml) 
skipping: [localhost] => (item=../_sources/secrets/broadcast_websocket_secret.yml) 

TASK [sources : Include generated secrets unless they are explicitly passed in] **************************************************************************
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost] => (item=None)
ok: [localhost]
```