### PR TITLE
Give the system a bit more time to finish

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -729,7 +729,7 @@ def handle_work_error(task_id, *args, **kwargs):
 def handle_success_and_failure_notifications(job_id):
     uj = UnifiedJob.objects.get(pk=job_id)
     retries = 0
-    while retries < 5:
+    while retries < 15:
         if uj.finished:
             uj.send_notification_templates('succeeded' if uj.status == 'successful' else 'failed')
             return


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This will fix notification not being sent due to slow(er) communications between all moving parts.

See #11422 (and probably #2982 too)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- Tasks

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 19.2.2 +
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
2022-02-16 03:03:20,511 DEBUG    [48f333404b7c495eb4a1839b1d2a3cce] awx.main.dispatch task f2dd1a9f-7302-4dfc-90f9-ef1052369c1c starting awx.main.tasks.handle_success_and_failure_notifications(*[56095])
2022-02-16 03:03:25,577 WARNING  [48f333404b7c495eb4a1839b1d2a3cce] awx.main.tasks Failed to even try to send notifications for job '2022-02-16 02:40:16.081250+00:00-56095-running' due to job not being in finished state.
2022-02-16 03:03:26,689 INFO     [07479b253ab9461f8995e77fc9eb7cbf] awx.main.commands.run_callback_receiver Event processing is finished for Job 56095, sending notifications
2022-02-16 03:03:26,689 INFO     [07479b253ab9461f8995e77fc9eb7cbf] awx.main.commands.run_callback_receiver Event processing is finished for Job 56095, sending notifications
```
