### PR TITLE
Modifying Makefile so you can specify an alternate branch for runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ DEV_DOCKER_TAG_BASE ?= quay.io/awx
 DEVEL_IMAGE_NAME ?= $(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG)
 
 RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
+CUSTOM_RUNNER ?= 
 
 # Python packages to install only from source (not from binary wheels)
 # Comma separated list
@@ -487,7 +488,7 @@ docker-compose-container-group-clean:
 
 # Base development image build
 docker-compose-build:
-	ansible-playbook tools/ansible/dockerfile.yml -e build_dev=True -e receptor_image=$(RECEPTOR_IMAGE)
+	ansible-playbook tools/ansible/dockerfile.yml -e build_dev=True -e receptor_image=$(RECEPTOR_IMAGE) -e custom_runner='${CUSTOM_RUNNER}'
 	DOCKER_BUILDKIT=1 docker build -t $(DEVEL_IMAGE_NAME) \
 	    --build-arg BUILDKIT_INLINE_CACHE=1 \
 	    --cache-from=$(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG) .

--- a/docs/ansible_runner_integration.md
+++ b/docs/ansible_runner_integration.md
@@ -17,3 +17,13 @@ The callbacks and handlers are:
 If you want to debug `ansible-runner`, then set `AWX_CLEANUP_PATHS=False`, run a job, observe the job's `AWX_PRIVATE_DATA_DIR` property, and go the node where the job was executed and inspect that directory.
 
 If you want to debug the process that `ansible-runner` invoked (_i.e._, Ansible or `ansible-playbook`), then observe the Job's `job_env`, `job_cwd`, and `job_args` parameters.
+
+### Changing
+
+If you want to change the version of ansible-runner built into the awx_tools_1 container you can add a variable to the `make docker-compose-build` command like:
+```
+CUSTOM_RUNNER=git+https://github.com/<your fork>/ansible-runner.git@<your branch>#egg=ansible-runner make docker-compose-build
+```
+This will pull down that version of ansible-runner at the container build time.
+
+Note: This will only apply to the version of running within the container. If you run a job on a remote receptor node the version there will not be changed by making this modification.

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -278,6 +278,11 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 {% endif %}
 
+{% if custom_runner %}
+RUN /var/lib/awx/venv/awx/bin/pip uninstall -y ansible-runner
+RUN /var/lib/awx/venv/awx/bin/pip install {{ custom_runner }}
+{% endif %}
+
 ENV HOME="/var/lib/awx"
 ENV PATH="/usr/pgsql-12/bin:${PATH}"
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
With this chance you can modify the version of ansible-runner built into the awx_tools_1 container with a variable to `make docker-compose-build` like:
```
CUSTOM_RUNNER=git+https://github.com/<your fork>/ansible-runner.git@<your branch>#egg=ansible-runner make docker-compose-build
```

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Makefile
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev135+g3ec0861ab0.d20220216
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
