### PR TITLE
Fix TypeError when running a command on a host in a smart inventory

### DIFF
--- a/awx/ui/src/components/AdHocCommands/AdHocCommands.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommands.js
@@ -59,6 +59,7 @@ function AdHocCommands({
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
   const {
     isLoading: isLaunchLoading,
     error: launchError,
@@ -172,6 +173,8 @@ function AdHocCommands({
 AdHocCommands.propTypes = {
   adHocItems: PropTypes.arrayOf(PropTypes.object).isRequired,
   hasListItems: PropTypes.bool.isRequired,
+  onLaunchLoading: PropTypes.func.isRequired,
+  moduleOptions: PropTypes.arrayOf(PropTypes.array).isRequired,
 };
 
 export default AdHocCommands;

--- a/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommands.test.js
@@ -73,6 +73,10 @@ describe('<AdHocCommands />', () => {
           adHocItems={adHocItems}
           hasListItems
           onLaunchLoading={() => jest.fn()}
+          moduleOptions={[
+            ['command', 'command'],
+            ['shell', 'shell'],
+          ]}
         />
       );
     });

--- a/awx/ui/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.js
@@ -25,25 +25,33 @@ function SmartInventoryHostList({ inventory }) {
   const location = useLocation();
   const [isAdHocLaunchLoading, setIsAdHocLaunchLoading] = useState(false);
   const {
-    result: { hosts, count },
+    result: { hosts, count, moduleOptions },
     error: contentError,
     isLoading,
     request: fetchHosts,
   } = useRequest(
     useCallback(async () => {
       const params = parseQueryString(QS_CONFIG, location.search);
-      const {
-        data: { results, count: hostCount },
-      } = await InventoriesAPI.readHosts(inventory.id, params);
+      const [
+        {
+          data: { results, count: hostCount },
+        },
+        adHocOptions,
+      ] = await Promise.all([
+        InventoriesAPI.readHosts(inventory.id, params),
+        InventoriesAPI.readAdHocOptions(inventory.id),
+      ]);
 
       return {
         hosts: results,
         count: hostCount,
+        moduleOptions: adHocOptions.data.actions.GET.module_name.choices,
       };
     }, [location.search, inventory.id]),
     {
       hosts: [],
       count: 0,
+      moduleOptions: [],
     }
   );
 
@@ -91,6 +99,7 @@ function SmartInventoryHostList({ inventory }) {
                     adHocItems={selected}
                     hasListItems={count > 0}
                     onLaunchLoading={setIsAdHocLaunchLoading}
+                    moduleOptions={moduleOptions}
                   />,
                 ]
               : []

--- a/awx/ui/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.test.js
+++ b/awx/ui/src/screens/Inventory/SmartInventoryHosts/SmartInventoryHostList.test.js
@@ -27,6 +27,21 @@ describe('<SmartInventoryHostList />', () => {
     InventoriesAPI.readHosts.mockResolvedValue({
       data: mockHosts,
     });
+    InventoriesAPI.readAdHocOptions.mockResolvedValue({
+      data: {
+        actions: {
+          GET: {
+            module_name: {
+              choices: [
+                ['command', 'command'],
+                ['shell', 'shell'],
+              ],
+            },
+          },
+          POST: {},
+        },
+      },
+    });
     await act(async () => {
       wrapper = mountWithContexts(
         <SmartInventoryHostList inventory={clonedInventory} />


### PR DESCRIPTION
Fix TypeError when running a command on a host in a smart inventory

<img width="1599" alt="image" src="https://user-images.githubusercontent.com/9053044/154523876-690dc611-3ba4-438b-876f-bc6b867b4938.png">


See: https://github.com/ansible/awx/issues/11611

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fix TypeError when running a command on a host in a smart inventory"
-->

