### PR TITLE
Use ternary rather than &&

### DIFF
--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
@@ -109,12 +109,12 @@ function NotificationTemplateDetail({ template, defaultMessages }) {
           value={template.description}
           dataCy="nt-detail-description"
         />
-        {summary_fields.recent_notifications.length && (
+        {summary_fields.recent_notifications.length ? (
           <Detail
             label={t`Status`}
             value={<StatusLabel status={testStatus} />}
           />
-        )}
+        ) : null}
         {summary_fields.organization ? (
           <Detail
             label={t`Organization`}


### PR DESCRIPTION
Use ternary rather than && to avoid display 0.

With this change

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/9053044/154566562-d5107959-6400-4499-8739-0b8d3b9dc9e6.png">

Without this change

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/9053044/154566658-d5f64151-80c5-4ed1-b2ea-6b3543564f0a.png">


 