### PR TITLE
Fixes search drop down items for job output search

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.js
@@ -93,9 +93,12 @@ function JobOutputSearch({
       key: 'stdout__icontains',
       isDefault: true,
     },
-    {
+  ];
+
+  if (job.type !== 'system_job' && job.type !== 'inventory_update') {
+    columns.push({
       name: t`Event`,
-      key: 'event',
+      key: 'or__event',
       options: [
         ['runner_on_failed', t`Host Failed`],
         ['runner_on_start', t`Host Started`],
@@ -129,9 +132,9 @@ function JobOutputSearch({
         ['system_warning', t`System Warning`],
         ['error', t`Error`],
       ],
-    },
-    { name: t`Advanced`, key: 'advanced' },
-  ];
+    });
+  }
+  columns.push({ name: t`Advanced`, key: 'advanced' });
   const isDisabled = isJobRunning(job.status);
 
   return (

--- a/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutputSearch.test.js
@@ -23,6 +23,7 @@ describe('JobOutputSearch', () => {
       <JobOutputSearch
         job={{
           status: 'successful',
+          type: 'project',
         }}
         qsConfig={{
           defaultParams: { page: 1 },
@@ -42,7 +43,59 @@ describe('JobOutputSearch', () => {
     await act(async () => {
       wrapper.find(searchBtn).simulate('click');
     });
-
+    expect(wrapper.find('Search').prop('columns')).toHaveLength(3);
+    expect(wrapper.find('Search').prop('columns').at(0).name).toBe('Stdout');
+    expect(wrapper.find('Search').prop('columns').at(1).name).toBe('Event');
+    expect(wrapper.find('Search').prop('columns').at(2).name).toBe('Advanced');
     expect(history.location.search).toEqual('?stdout__icontains=99');
+  });
+  test('Should not have Event key in search drop down for system job', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/jobs/playbook/1/output'],
+    });
+
+    const wrapper = mountWithContexts(
+      <JobOutputSearch
+        job={{
+          status: 'successful',
+          type: 'system_job',
+        }}
+        qsConfig={{
+          defaultParams: { page: 1 },
+          integerFields: ['page', 'page_size'],
+        }}
+      />,
+      {
+        context: { router: { history } },
+      }
+    );
+    expect(wrapper.find('Search').prop('columns')).toHaveLength(2);
+    expect(wrapper.find('Search').prop('columns').at(0).name).toBe('Stdout');
+    expect(wrapper.find('Search').prop('columns').at(1).name).toBe('Advanced');
+  });
+
+  test('Should not have Event key in search drop down for inventory update job', () => {
+    const history = createMemoryHistory({
+      initialEntries: ['/jobs/playbook/1/output'],
+    });
+
+    const wrapper = mountWithContexts(
+      <JobOutputSearch
+        job={{
+          status: 'successful',
+          type: 'inventory_update',
+        }}
+        qsConfig={{
+          defaultParams: { page: 1 },
+          integerFields: ['page', 'page_size'],
+        }}
+      />,
+      {
+        context: { router: { history } },
+      }
+    );
+    expect(wrapper.find('Search').prop('columns')).toHaveLength(2);
+    expect(wrapper.find('Search').prop('columns').at(0).name).toBe('Stdout');
+    expect(wrapper.find('Search').prop('columns').at(1).name).toBe('Advanced');
   });
 });


### PR DESCRIPTION

##### SUMMARY
This addresses #10281 
This adds the `or` operator to the Job Output Event filter as the option items are mutually exclusive.  Also fixes an undiscovered bug where someone would try to filter events on an inventory_update job or a system_job and the page would crash.  This work here removes the Event option from the search drop down when `job.type === inventory_update || job.type === system_job`
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI

##### AWX VERSION


##### ADDITIONAL INFORMATION

![jobfiltering](https://user-images.githubusercontent.com/39280967/155025930-37cadefe-0f64-465e-8315-1b2d58c92966.gif)

