### PR TITLE
Use select_related on db queries to reduce db calls

### DIFF
--- a/awx/api/views/mesh_visualizer.py
+++ b/awx/api/views/mesh_visualizer.py
@@ -19,7 +19,7 @@ class MeshVisualizer(APIView):
 
         data = {
             'nodes': InstanceNodeSerializer(Instance.objects.all(), many=True).data,
-            'links': InstanceLinkSerializer(InstanceLink.objects.all(), many=True).data,
+            'links': InstanceLinkSerializer(InstanceLink.objects.select_related('target', 'source'), many=True).data,
         }
 
         return Response(data)


### PR DESCRIPTION

##### SUMMARY
Addresses #11712.  Without use `select_related('target', 'source')` we were making `n+1` sequel queries which is a performance issue.  This change reduces that number to just `n`.
##### ISSUE TYPE
-enhancement

##### COMPONENT NAME
 - API

##### AWX VERSION

##### ADDITIONAL INFORMATION
