### PR TITLE
SAML superuse/auditor working with lists

### DIFF
--- a/awx/sso/pipeline.py
+++ b/awx/sso/pipeline.py
@@ -263,9 +263,14 @@ def _check_flag(user, flag, attributes, user_flags_settings):
         if user_flags_settings.get(is_value_key, None):
             # If so, check and see if the value of the attr matches the required value
             attribute_value = attributes.get(attr_setting, None)
+            attribute_matches = False
             if isinstance(attribute_value, (list, tuple)):
-                attribute_value = attribute_value[0]
-            if attribute_value == user_flags_settings.get(is_value_key):
+                if user_flags_settings.get(is_value_key) in attribute_value:
+                    attribute_matches = True
+            elif attribute_value == user_flags_settings.get(is_value_key):
+                attribute_matches = True
+
+            if attribute_matches:
                 logger.debug("Giving %s %s from attribute %s with matching value" % (user.username, flag, attr_setting))
                 new_flag = True
             # if they don't match make sure that new_flag is false

--- a/awx/sso/tests/functional/test_pipeline.py
+++ b/awx/sso/tests/functional/test_pipeline.py
@@ -447,6 +447,16 @@ class TestSAMLUserFlags:
                 {'is_superuser_role': 'test-role-1', 'is_superuser_attr': 'is_superuser', 'is_superuser_value': 'true'},
                 (True, True),
             ),
+            # In this test case we will validate that a single attribute (instead of a list) still works
+            (
+                {'is_superuser_attr': 'name_id', 'is_superuser_value': 'test_id'},
+                (True, True),
+            ),
+            # This will be a negative test for a single atrribute
+            (
+                {'is_superuser_attr': 'name_id', 'is_superuser_value': 'junk'},
+                (False, False),
+            ),
         ],
     )
     def test__check_flag(self, user_flags_settings, expected):
@@ -457,10 +467,10 @@ class TestSAMLUserFlags:
         attributes = {
             'email': ['noone@nowhere.com'],
             'last_name': ['Westcott'],
-            'is_superuser': ['true'],
+            'is_superuser': ['something', 'else', 'true'],
             'username': ['test_id'],
             'first_name': ['John'],
-            'Role': ['test-role-1'],
+            'Role': ['test-role-1', 'something', 'different'],
             'name_id': 'test_id',
         }
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In the SAML settings for giving someone superuser/system auditor we previously only evaluated the first entry in a list. This change will now handle a list by searching the entirety of a list instead of just the first entry. 

This is a refinement of https://github.com/ansible/awx/pull/11619

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev154+gc7a1fb67d0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
