### PR TITLE
set max dispatch workers to same as max forks

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -22,7 +22,7 @@ import psutil
 
 from awx.main.models import UnifiedJob
 from awx.main.dispatch import reaper
-from awx.main.utils.common import convert_mem_str_to_bytes
+from awx.main.utils.common import convert_mem_str_to_bytes, get_mem_effective_capacity
 
 if 'run_callback_receiver' in sys.argv:
     logger = logging.getLogger('awx.main.commands.run_callback_receiver')
@@ -324,8 +324,9 @@ class AutoscalePool(WorkerPool):
                 total_memory_gb = convert_mem_str_to_bytes(settings_absmem) // 2**30
             else:
                 total_memory_gb = (psutil.virtual_memory().total >> 30) + 1  # noqa: round up
-            # 5 workers per GB of total memory
-            self.max_workers = total_memory_gb * 5
+
+            # Get same number as max forks based on memory, this function takes memory as bytes
+            self.max_workers = get_mem_effective_capacity(total_memory_gb * 2**30)
 
         # max workers can't be less than min_workers
         self.max_workers = max(self.min_workers, self.max_workers)


### PR DESCRIPTION
Right now, without this, we end up with a different number for max_workers than max_forks. For example, on a control node with 16 Gi of RAM,
  max_mem_capacity  w/ 100 MB/fork = (16*1024)/100 --> 164
  max_workers = 5 * 16 --> 80

This means we would allow that control node to control up to 164 jobs, but all jobs after the 80th job will be stuck in `waiting` waiting for a dispatch worker to free up to run the job.

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "set max dispatch workers to the same number as max forks based on memory to allow controlling as many jobs as we assert we can based on memory"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Have max_workers == max forks based on memory capacity to prevent situations where we start jobs because we believe there is enough capacity to control the job, but there are not enough dispatch workers available to actually do so. In cases where a user decides to use the "capacity adjustment" or otherwise limit how many jobs a control node can control, we
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
@jainnikhil30 noticed jobs hanging out in waiting for a long time when he was running many concurrent jobs, @AlanCoding helped identify how the max number of dispatch workers factors into that.