### PR TITLE
Chaning API version from v1beta1 to v1

### DIFF
--- a/tools/docker-compose-minikube/minikube/templates/rbac.yml.j2
+++ b/tools/docker-compose-minikube/minikube/templates/rbac.yml.j2
@@ -24,7 +24,7 @@ rules:
   resources: ["secrets"]
   verbs: ["get", "create", "delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ minikube_service_account_name }}


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When running `make docker-compose-container-group` an error was thrown:
```
TASK [minikube : Create ServiceAccount and clusterRoleBinding] *************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to find exact match for rbac.authorization.k8s.io/v1beta1.RoleBinding by [kind, name, singularName, shortNames]"}
```

The v1beta1 has been moved to just v1. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev165+g4d47f24dd4.d20220224
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
