### PR TITLE
Automatically mount the system trust store when invoking EEs with podman

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -156,8 +156,12 @@ class BaseTask(object):
         if pull:
             params['container_options'].append(f'--pull={pull}')
 
+        params['container_volume_mounts'] = []
+        if settings.DEFAULT_CONTAINER_VOLUME_MOUNTS:
+            for this_path in settings.DEFAULT_CONTAINER_VOLUME_MOUNTS:
+                params['container_volume_mounts'].append(this_path)
+
         if settings.AWX_ISOLATION_SHOW_PATHS:
-            params['container_volume_mounts'] = []
             for this_path in settings.AWX_ISOLATION_SHOW_PATHS:
                 # Verify if a mount path and SELinux context has been passed
                 # Using z allows the dir to be mounted by multiple containers

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1001,7 +1001,4 @@ DEFAULT_CONTAINER_RUN_OPTIONS = ['--network', 'slirp4netns:enable_ipv6=true']
 # List of default exposed container volume mounts
 # This is useful when the EE container needs to access host/node information
 # like /etc/pki/ca-trust/source/anchors
-DEFAULT_CONTAINER_VOLUME_MOUNTS = [
-    '/etc/pki/ca-trust:/etc/pki/ca-trust:ro',
-    '/usr/share/pki:/usr/share/pki:ro',
-]
+DEFAULT_CONTAINER_VOLUME_MOUNTS = []

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -997,3 +997,11 @@ DEFAULT_CONTROL_PLANE_QUEUE_NAME = 'controlplane'
 # For example, to disable SELinux in containers for podman
 # DEFAULT_CONTAINER_RUN_OPTIONS = ['--security-opt', 'label=disable']
 DEFAULT_CONTAINER_RUN_OPTIONS = ['--network', 'slirp4netns:enable_ipv6=true']
+
+# List of default exposed container volume mounts
+# This is useful when the EE container needs to access host/node information
+# like /etc/pki/ca-trust/source/anchors
+DEFAULT_CONTAINER_VOLUME_MOUNTS = [
+    '/etc/pki/ca-trust:/etc/pki/ca-trust:ro',
+    '/usr/share/pki:/usr/share/pki:ro',
+]

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -91,3 +91,8 @@ except IOError:
 DATABASES.setdefault('default', dict()).setdefault('OPTIONS', dict()).setdefault(
     'application_name', f'{CLUSTER_HOST_ID}-{os.getpid()}-{" ".join(sys.argv)}'[:63]
 )  # noqa
+
+DEFAULT_CONTAINER_VOLUME_MOUNTS = [
+    '/etc/pki/ca-trust:/etc/pki/ca-trust:O',
+    '/usr/share/pki:/usr/share/pki:O',
+]


### PR DESCRIPTION
Related: https://github.com/ansible/awx/issues/10787

Note: This change is only relevant for the downstream product where we support running on virtual machines.
