### PR TITLE
Fix bug where translated strings will cause log error to error

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -10,6 +10,7 @@ from datetime import datetime
 # Django
 from django.conf import settings
 from django.utils.timezone import now
+from django.utils.encoding import force_str
 
 # AWX
 from awx.main.exceptions import PostRunError
@@ -42,7 +43,7 @@ class RSysLogHandler(logging.handlers.SysLogHandler):
             msg += exc.splitlines()[-1]
         except Exception:
             msg += exc
-        msg = '\n'.join([msg, str(record.msg), ''])  # str used in case of translated strings
+        msg = '\n'.join([msg, force_str(record.msg), ''])  # force_str used in case of translated strings
         sys.stderr.write(msg)
 
     def emit(self, msg):

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -42,7 +42,7 @@ class RSysLogHandler(logging.handlers.SysLogHandler):
             msg += exc.splitlines()[-1]
         except Exception:
             msg += exc
-        msg = '\n'.join([msg, record.msg, ''])
+        msg = '\n'.join([msg, str(record.msg), ''])  # str used in case of translated strings
         sys.stderr.write(msg)
 
     def emit(self, msg):


### PR DESCRIPTION
##### SUMMARY
This fixes a bug in our error handling code path that will cause another error.

This code path gets ran whenever rsyslog is not running. When might this happen? We intentionally shut down rsyslog before running migrations...

If rsyslog is down while a log is issued with a translated string, then _the log statement itself throws an error_, which will, notably, error the entire migration process.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION
Reproducer:

First, turn on external logging. It doesn't matter what values you give it, or whether there is a functional aggregator receiving those logs.

Create a new migration file with this.

```diff
diff --git a/awx/main/migrations/0159_alan_test.py b/awx/main/migrations/0159_alan_test.py
new file mode 100644
index 0000000000..022af3dc43
--- /dev/null
+++ b/awx/main/migrations/0159_alan_test.py
@@ -0,0 +1,23 @@
+# Generated by Django 2.2.24 on 2022-02-14 17:37
+
+import logging
+
+from django.db import migrations
+from django.utils.translation import ugettext_lazy as _
+
+logger = logging.getLogger('awx.main.models')
+
+
+def test_alan(*args, **kwargs):
+    logger.error(_('alan did this'))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0158_make_instance_cpu_decimal'),
+    ]
+
+    operations = [
+        migrations.RunPython(test_alan, migrations.RunPython.noop),
+    ]
```

Next, shut down rsyslog

```
supervisorctl stop tower-processes:awx-rsyslogd
```

now run in the shell:

```bash
awx-manage migrate main 0158 && awx-manage migrate main
```

Before this change:

```
bash-5.1$ awx-manage migrate main 0158 && awx-manage migrate main
Operations to perform:
  Target specific migration: 0158_make_instance_cpu_decimal, from main
Running migrations:
  Rendering model states... DONE
  Unapplying main.0159_alan_test... OK
Operations to perform:
  Apply all migrations: main
Running migrations:
2022-02-25 19:57:08,139 ERROR    [-] awx.main.models alan did this two
  Applying main.0159_alan_test...Traceback (most recent call last):
  File "/usr/lib64/python3.9/logging/handlers.py", line 965, in emit
    self.socket.send(msg)
OSError: [Errno 9] Bad file descriptor

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.9/logging/handlers.py", line 886, in _connect_unixsocket
    self.socket.connect(address)
FileNotFoundError: [Errno 2] No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.9/logging/handlers.py", line 968, in emit
    self._connect_unixsocket(self.address)
  File "/awx_devel/awx/main/utils/handlers.py", line 23, in _connect_unixsocket
    super(RSysLogHandler, self)._connect_unixsocket(address)
  File "/usr/lib64/python3.9/logging/handlers.py", line 897, in _connect_unixsocket
    self.socket.connect(address)
FileNotFoundError: [Errno 2] No such file or directory

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/awx-manage", line 9, in <module>
    load_entry_point('awx', 'console_scripts', 'awx-manage')()
  File "/awx_devel/awx/__init__.py", line 171, in manage
    execute_from_command_line(sys.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/awx_devel/awx/main/management/commands/migrate.py", line 12, in handle
    return super().handle(*args, **options)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/base.py", line 83, in wrapped
    res = handle_func(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/commands/migrate.py", line 232, in handle
    post_migrate_state = executor.migrate(
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/migrations/executor.py", line 117, in migrate
    state = self._migrate_all_forwards(state, plan, full_plan, fake=fake, fake_initial=fake_initial)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/migrations/executor.py", line 147, in _migrate_all_forwards
    state = self.apply_migration(state, migration, fake=fake, fake_initial=fake_initial)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/migrations/executor.py", line 245, in apply_migration
    state = migration.apply(state, schema_editor)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/migrations/migration.py", line 124, in apply
    operation.database_forwards(self.app_label, schema_editor, old_state, project_state)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/migrations/operations/special.py", line 190, in database_forwards
    self.code(from_state.apps, schema_editor)
  File "/awx_devel/awx/main/migrations/0159_alan_test.py", line 13, in test_alan
    logger.error(_('alan did this two'))
  File "/usr/lib64/python3.9/logging/__init__.py", line 1475, in error
    self._log(ERROR, msg, args, **kwargs)
  File "/usr/lib64/python3.9/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/usr/lib64/python3.9/logging/__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "/usr/lib64/python3.9/logging/__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "/usr/lib64/python3.9/logging/__init__.py", line 952, in handle
    self.emit(record)
  File "/awx_devel/awx/main/utils/handlers.py", line 51, in emit
    return super(RSysLogHandler, self).emit(msg)
  File "/usr/lib64/python3.9/logging/handlers.py", line 975, in emit
    self.handleError(record)
  File "/awx_devel/awx/main/utils/handlers.py", line 45, in handleError
    msg = '\n'.join([msg, record.msg, ''])
TypeError: sequence item 1: expected str instance, __proxy__ found
```

After this change

```
bash-5.1$ awx-manage migrate main 0158 && awx-manage migrate main
Operations to perform:
  Target specific migration: 0158_make_instance_cpu_decimal, from main
Running migrations:
  No migrations to apply.
Operations to perform:
  Apply all migrations: main
Running migrations:
2022-02-25 19:58:36,459 ERROR    [-] awx.main.models alan did this two
2022-02-25 19:58:36 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
alan did this two
  Applying main.0159_alan_test... OK
```

You can still see that we have rsyslog errors, but that's not the primary concern. This addresses the primary concern that migrations will error.

