### PR TITLE
Expose host trusted cert store to EEs by default

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -156,8 +156,12 @@ class BaseTask(object):
         if pull:
             params['container_options'].append(f'--pull={pull}')
 
+        params['container_volume_mounts'] = []
+        if settings.DEFAULT_CONTAINER_VOLUME_MOUNTS:
+            for this_path in settings.DEFAULT_CONTAINER_VOLUME_MOUNTS:
+                params['container_volume_mounts'].append(this_path)
+
         if settings.AWX_ISOLATION_SHOW_PATHS:
-            params['container_volume_mounts'] = []
             for this_path in settings.AWX_ISOLATION_SHOW_PATHS:
                 # Verify if a mount path and SELinux context has been passed
                 # Using z allows the dir to be mounted by multiple containers

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1001,3 +1001,8 @@ DEFAULT_CONTROL_PLANE_QUEUE_NAME = 'controlplane'
 # For example, to disable SELinux in containers for podman
 # DEFAULT_CONTAINER_RUN_OPTIONS = ['--security-opt', 'label=disable']
 DEFAULT_CONTAINER_RUN_OPTIONS = ['--network', 'slirp4netns:enable_ipv6=true']
+
+# List of default exposed container volume mounts
+# This is useful when the EE container needs to access host/node information
+# like /etc/pki/ca-trust/source/anchors
+DEFAULT_CONTAINER_VOLUME_MOUNTS = ['/etc/pki/ca-trust:/etc/pki/ca-trust:O', '/usr/share/pki:/usr/share/pki:O']


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Expose host trusted cert store to EEs by default"
-->

##### SUMMARY
Expose host trusted cert store to EEs by default

Related: https://github.com/ansible/awx/issues/10787

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```

