### PR TITLE
Add job execution environment image to analytics data

### DIFF
--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -419,7 +419,7 @@ def unified_jobs_table(since, full_path, until, **kwargs):
     return _copy_table(table='unified_jobs', query=unified_job_query, path=full_path)
 
 
-@register('unified_job_template_table', '1.0', format='csv', description=_('Data on job templates'))
+@register('unified_job_template_table', '1.1', format='csv', description=_('Data on job templates'))
 def unified_job_template_table(since, full_path, **kwargs):
     unified_job_template_query = '''COPY (SELECT main_unifiedjobtemplate.id,
                                  main_unifiedjobtemplate.polymorphic_ctype_id,

--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -376,13 +376,14 @@ def events_table_partitioned_modified(since, full_path, until, **kwargs):
     return _events_table(since, full_path, until, 'main_jobevent', 'modified', project_job_created=True, **kwargs)
 
 
-@register('unified_jobs_table', '1.2', format='csv', description=_('Data on jobs run'), expensive=four_hour_slicing)
+@register('unified_jobs_table', '1.3', format='csv', description=_('Data on jobs run'), expensive=four_hour_slicing)
 def unified_jobs_table(since, full_path, until, **kwargs):
     unified_job_query = '''COPY (SELECT main_unifiedjob.id,
                                  main_unifiedjob.polymorphic_ctype_id,
                                  django_content_type.model,
                                  main_unifiedjob.organization_id,
                                  main_organization.name as organization_name,
+                                 main_executionenvironment.image as execution_environment_image,
                                  main_job.inventory_id,
                                  main_inventory.name as inventory_name,
                                  main_unifiedjob.created,
@@ -407,6 +408,7 @@ def unified_jobs_table(since, full_path, until, **kwargs):
                                  LEFT JOIN main_job ON main_unifiedjob.id = main_job.unifiedjob_ptr_id
                                  LEFT JOIN main_inventory ON main_job.inventory_id = main_inventory.id
                                  LEFT JOIN main_organization ON main_organization.id = main_unifiedjob.organization_id
+                                 LEFT JOIN main_executionenvironment ON main_executionenvironment.id = main_unifiedjob.execution_environment_id
                                  WHERE ((main_unifiedjob.created > '{0}' AND main_unifiedjob.created <= '{1}')
                                        OR (main_unifiedjob.finished > '{0}' AND main_unifiedjob.finished <= '{1}'))
                                        AND main_unifiedjob.launch_type != 'sync'

--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -424,6 +424,7 @@ def unified_job_template_table(since, full_path, **kwargs):
     unified_job_template_query = '''COPY (SELECT main_unifiedjobtemplate.id,
                                  main_unifiedjobtemplate.polymorphic_ctype_id,
                                  django_content_type.model,
+                                 main_executionenvironment.image as execution_environment_image,
                                  main_unifiedjobtemplate.created,
                                  main_unifiedjobtemplate.modified,
                                  main_unifiedjobtemplate.created_by_id,
@@ -436,7 +437,8 @@ def unified_job_template_table(since, full_path, **kwargs):
                                  main_unifiedjobtemplate.next_job_run,
                                  main_unifiedjobtemplate.next_schedule_id,
                                  main_unifiedjobtemplate.status
-                                 FROM main_unifiedjobtemplate, django_content_type
+                                 FROM main_unifiedjobtemplate
+                                 LEFT JOIN main_executionenvironment ON main_executionenvironment.id = main_unifiedjobtemplate.execution_environment_id, django_content_type
                                  WHERE main_unifiedjobtemplate.polymorphic_ctype_id = django_content_type.id
                                  ORDER BY main_unifiedjobtemplate.id ASC) TO STDOUT WITH CSV HEADER'''
     return _copy_table(table='unified_job_template', query=unified_job_template_query, path=full_path)


### PR DESCRIPTION
##### SUMMARY
It is desired to track what image a job used. That's what this does.

There's still a pending request that we add the image for JTs. This makes less sense to me, but it may be added to this still.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API


