### PR TITLE
Avoid updating modified_by from None to None

### DIFF
--- a/awx/main/models/base.py
+++ b/awx/main/models/base.py
@@ -316,16 +316,17 @@ class PrimordialModel(HasEditsMixin, CreatedModifiedModel):
         user = get_current_user()
         if user and not user.id:
             user = None
-        if not self.pk and not self.created_by:
+        if (not self.pk) and (user is not None) and (not self.created_by):
             self.created_by = user
             if 'created_by' not in update_fields:
                 update_fields.append('created_by')
         # Update modified_by if any editable fields have changed
         new_values = self._get_fields_snapshot()
         if (not self.pk and not self.modified_by) or self._values_have_edits(new_values):
-            self.modified_by = user
-            if 'modified_by' not in update_fields:
-                update_fields.append('modified_by')
+            if self.modified_by != user:
+                self.modified_by = user
+                if 'modified_by' not in update_fields:
+                    update_fields.append('modified_by')
         super(PrimordialModel, self).save(*args, **kwargs)
         self._prior_values_store = new_values
 

--- a/awx/main/tests/functional/models/test_base.py
+++ b/awx/main/tests/functional/models/test_base.py
@@ -1,0 +1,40 @@
+from unittest import mock
+import pytest
+
+from crum import impersonate
+
+from awx.main.models import Host
+
+
+@pytest.mark.django_db
+def test_modified_by_not_changed(inventory):
+    with impersonate(None):
+        host = Host.objects.create(name='foo', inventory=inventory)
+        assert host.modified_by == None
+        host.variables = {'foo': 'bar'}
+        with mock.patch('django.db.models.Model.save') as save_mock:
+            host.save(update_fields=['variables'])
+            save_mock.assert_called_once_with(update_fields=['variables'])
+
+
+@pytest.mark.django_db
+def test_modified_by_changed(inventory, alice):
+    with impersonate(None):
+        host = Host.objects.create(name='foo', inventory=inventory)
+        assert host.modified_by == None
+    with impersonate(alice):
+        host.variables = {'foo': 'bar'}
+        with mock.patch('django.db.models.Model.save') as save_mock:
+            host.save(update_fields=['variables'])
+            save_mock.assert_called_once_with(update_fields=['variables', 'modified_by'])
+        assert host.modified_by == alice
+
+
+@pytest.mark.django_db
+def test_created_by(inventory, alice):
+    with impersonate(alice):
+        host = Host.objects.create(name='foo', inventory=inventory)
+        assert host.created_by == alice
+    with impersonate(None):
+        host = Host.objects.create(name='bar', inventory=inventory)
+        assert host.created_by == None


### PR DESCRIPTION
##### SUMMARY
Some evidence from the field has suggested that including `modified_by` in database `UPDATE` statements in inventory updates (on imported hosts) may increase the risk of deadlocks with concurrent jobs or other things.

This tries to reduce the risk of deadlock by avoiding adding `modified_by` to `update_fields` when it is obviously not necessary. In inventory updates, the value was `None` before and `None` afterwards, but the current code will still include it in the `update_fields` because unrelated host values changed.

Before:

```sql
UPDATE "main_host"
SET    "modified_by_id" = NULL,
       "variables" =
'{"dynamic_2022_03_02_03_06_37.417769": "host_static_value", "static_key": "host_dynamic_2022_03_02_03_46_52.221230", "dynamic_2022_03_02_03_46_07.240945": "host_static_value", "dynamic_2022_03_02_03_46_52.221230": "host_static_value"}'
WHERE  "main_host"."id" = 53951 
```

After:

```sql
UPDATE "main_host"
SET    "variables" =
'{"dynamic_2022_03_02_03_06_37.417769": "host_static_value", "static_key": "host_dynamic_2022_03_02_03_53_22.808519", "dynamic_2022_03_02_03_46_07.240945": "host_static_value", "dynamic_2022_03_02_03_46_52.221230": "host_static_value", "dynamic_2022_03_02_03_53_22.808519": "host_static_value"}'
WHERE  "main_host"."id" = 53951 
```

This happens in the part of the import that looks like this:

> 7.706 WARNING  host updates took 10 queries for 2 hosts

I'm using a test case, where variables intentionally change based on the current date and time.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

