### PR TITLE
Add several changes to Instance Groups

### DIFF
--- a/awx/api/permissions.py
+++ b/awx/api/permissions.py
@@ -4,8 +4,6 @@
 # Python
 import logging
 
-from django.conf import settings
-
 # Django REST Framework
 from rest_framework.exceptions import MethodNotAllowed, PermissionDenied
 from rest_framework import permissions
@@ -248,13 +246,6 @@ class IsSystemAdminOrAuditor(permissions.BasePermission):
         if request.method == 'GET':
             return request.user.is_superuser or request.user.is_system_auditor
         return request.user.is_superuser
-
-
-class InstanceGroupTowerPermission(ModelAccessPermission):
-    def has_object_permission(self, request, view, obj):
-        if request.method == 'DELETE' and obj.name in [settings.DEFAULT_EXECUTION_QUEUE_NAME, settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME]:
-            return False
-        return super(InstanceGroupTowerPermission, self).has_object_permission(request, view, obj)
 
 
 class WebhookKeyPermission(permissions.BasePermission):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4947,6 +4947,9 @@ class InstanceGroupSerializer(BaseSerializer):
         return res
 
     def validate_policy_instance_list(self, value):
+        if self.instance and self.instance.name in [settings.DEFAULT_EXECUTION_QUEUE_NAME, settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME]:
+            if self.instance.policy_instance_list != value:
+                raise serializers.ValidationError(_('%s instance group policy_instance_list may not be changed.' % self.instance.name))
         for instance_name in value:
             if value.count(instance_name) > 1:
                 raise serializers.ValidationError(_('Duplicate entry {}.').format(instance_name))
@@ -4957,6 +4960,11 @@ class InstanceGroupSerializer(BaseSerializer):
         return value
 
     def validate_policy_instance_percentage(self, value):
+        if self.instance and self.instance.name in [settings.DEFAULT_EXECUTION_QUEUE_NAME, settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME]:
+            if value != self.instance.policy_instance_percentage:
+                raise serializers.ValidationError(
+                    _('%s instance group policy_instance_percentage may not be changed from the initial value set by the installer.' % self.instance.name)
+                )
         if value and self.instance and self.instance.is_container_group:
             raise serializers.ValidationError(_('Containerized instances may not be managed via the API'))
         return value
@@ -4972,6 +4980,13 @@ class InstanceGroupSerializer(BaseSerializer):
 
         if self.instance and self.instance.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME and value != settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME:
             raise serializers.ValidationError(_('%s instance group name may not be changed.' % settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME))
+
+        return value
+
+    def validate_is_container_group(self, value):
+        if self.instance and self.instance.name in [settings.DEFAULT_EXECUTION_QUEUE_NAME, settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME]:
+            if value != self.instance.is_container_group:
+                raise serializers.ValidationError(_('%s instance group is_container_group may not be changed.' % self.instance.name))
 
         return value
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -105,7 +105,6 @@ from awx.api.permissions import (
     ProjectUpdatePermission,
     InventoryInventorySourcesUpdatePermission,
     UserPermission,
-    InstanceGroupTowerPermission,
     VariableDataPermission,
     WorkflowApprovalPermission,
     IsSystemAdminOrAuditor,
@@ -480,7 +479,6 @@ class InstanceGroupDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAP
     name = _("Instance Group Detail")
     model = models.InstanceGroup
     serializer_class = serializers.InstanceGroupSerializer
-    permission_classes = (InstanceGroupTowerPermission,)
 
     def update_raw_data(self, data):
         if self.get_object().is_container_group:

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -465,7 +465,7 @@ class BaseAccess(object):
             if display_method == 'schedule':
                 user_capabilities['schedule'] = user_capabilities['start']
                 continue
-            elif display_method == 'delete' and not isinstance(obj, (User, UnifiedJob, CredentialInputSource, ExecutionEnvironment)):
+            elif display_method == 'delete' and not isinstance(obj, (User, UnifiedJob, CredentialInputSource, ExecutionEnvironment, InstanceGroup)):
                 user_capabilities['delete'] = user_capabilities['edit']
                 continue
             elif display_method == 'copy' and isinstance(obj, (Group, Host)):
@@ -573,6 +573,11 @@ class InstanceGroupAccess(BaseAccess):
         return self.user.is_superuser
 
     def can_change(self, obj, data):
+        return self.user.is_superuser
+
+    def can_delete(self, obj):
+        if obj.name in [settings.DEFAULT_EXECUTION_QUEUE_NAME, settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME]:
+            return False
         return self.user.is_superuser
 
 

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroup.js
@@ -13,7 +13,7 @@ import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 
 import useRequest from 'hooks/useRequest';
-import { InstanceGroupsAPI, SettingsAPI } from 'api';
+import { InstanceGroupsAPI } from 'api';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';
@@ -30,28 +30,15 @@ function ContainerGroup({ setBreadcrumb }) {
     isLoading,
     error: contentError,
     request: fetchInstanceGroups,
-    result: { instanceGroup, defaultControlPlane, defaultExecution },
+    result: { instanceGroup },
   } = useRequest(
     useCallback(async () => {
-      const [
-        { data },
-        {
-          data: {
-            DEFAULT_EXECUTION_QUEUE_NAME,
-            DEFAULT_CONTROL_PLANE_QUEUE_NAME,
-          },
-        },
-      ] = await Promise.all([
-        InstanceGroupsAPI.readDetail(id),
-        SettingsAPI.readAll(),
-      ]);
+      const { data } = await InstanceGroupsAPI.readDetail(id);
       return {
         instanceGroup: data,
-        defaultControlPlane: DEFAULT_CONTROL_PLANE_QUEUE_NAME,
-        defaultExecution: DEFAULT_EXECUTION_QUEUE_NAME,
       };
     }, [id]),
-    { instanceGroup: null, defaultExecution: '' }
+    { instanceGroup: null }
   );
 
   useEffect(() => {
@@ -125,17 +112,10 @@ function ContainerGroup({ setBreadcrumb }) {
             {instanceGroup && (
               <>
                 <Route path="/instance_groups/container_group/:id/edit">
-                  <ContainerGroupEdit
-                    instanceGroup={instanceGroup}
-                    defaultControlPlane={defaultControlPlane}
-                    defaultExecution={defaultExecution}
-                  />
+                  <ContainerGroupEdit instanceGroup={instanceGroup} />
                 </Route>
                 <Route path="/instance_groups/container_group/:id/details">
-                  <ContainerGroupDetails
-                    instanceGroup={instanceGroup}
-                    defaultExecution={defaultExecution}
-                  />
+                  <ContainerGroupDetails instanceGroup={instanceGroup} />
                 </Route>
                 <Route path="/instance_groups/container_group/:id/jobs">
                   <JobList

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupAdd/ContainerGroupAdd.js
@@ -11,7 +11,7 @@ import { jsonToYaml, isJsonString } from 'util/yaml';
 
 import ContainerGroupForm from '../shared/ContainerGroupForm';
 
-function ContainerGroupAdd({ defaultExecution, defaultControlPlane }) {
+function ContainerGroupAdd() {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
 
@@ -93,8 +93,6 @@ function ContainerGroupAdd({ defaultExecution, defaultControlPlane }) {
       <Card>
         <CardBody>
           <ContainerGroupForm
-            defaultControlPlane={defaultControlPlane}
-            defaultExecution={defaultExecution}
             initialPodSpec={initialPodSpec}
             onSubmit={handleSubmit}
             submitError={submitError}

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupDetails/ContainerGroupDetails.js
@@ -15,7 +15,7 @@ import { jsonToYaml, isJsonString } from 'util/yaml';
 import { InstanceGroupsAPI } from 'api';
 import { relatedResourceDeleteRequests } from 'util/getRelatedResourceDeleteDetails';
 
-function ContainerGroupDetails({ instanceGroup, defaultExecution }) {
+function ContainerGroupDetails({ instanceGroup }) {
   const { id, name } = instanceGroup;
 
   const history = useHistory();
@@ -99,8 +99,7 @@ function ContainerGroupDetails({ instanceGroup, defaultExecution }) {
               {t`Edit`}
             </Button>
           )}
-        {name !== defaultExecution &&
-          instanceGroup.summary_fields.user_capabilities &&
+        {instanceGroup.summary_fields.user_capabilities &&
           instanceGroup.summary_fields.user_capabilities.delete && (
             <DeleteButton
               ouiaId="container-group-detail-delete-button"

--- a/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.js
+++ b/awx/ui/src/screens/InstanceGroup/ContainerGroupEdit/ContainerGroupEdit.js
@@ -9,11 +9,7 @@ import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';
 import ContainerGroupForm from '../shared/ContainerGroupForm';
 
-function ContainerGroupEdit({
-  instanceGroup,
-  defaultControlPlane,
-  defaultExecution,
-}) {
+function ContainerGroupEdit({ instanceGroup }) {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
   const detailsIUrl = `/instance_groups/container_group/${instanceGroup.id}/details`;
@@ -77,8 +73,6 @@ function ContainerGroupEdit({
   return (
     <CardBody>
       <ContainerGroupForm
-        defaultControlPlane={defaultControlPlane}
-        defaultExecution={defaultExecution}
         instanceGroup={instanceGroup}
         initialPodSpec={initialPodSpec}
         onSubmit={handleSubmit}

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
@@ -13,7 +13,7 @@ import { CaretLeftIcon } from '@patternfly/react-icons';
 import { Card, PageSection } from '@patternfly/react-core';
 
 import useRequest from 'hooks/useRequest';
-import { InstanceGroupsAPI, SettingsAPI } from 'api';
+import { InstanceGroupsAPI } from 'api';
 import RoutedTabs from 'components/RoutedTabs';
 import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';
@@ -31,29 +31,16 @@ function InstanceGroup({ setBreadcrumb }) {
     isLoading,
     error: contentError,
     request: fetchInstanceGroups,
-    result: { instanceGroup, defaultControlPlane, defaultExecution },
+    result: { instanceGroup },
   } = useRequest(
     useCallback(async () => {
-      const [
-        { data },
-        {
-          data: {
-            DEFAULT_CONTROL_PLANE_QUEUE_NAME,
-            DEFAULT_EXECUTION_QUEUE_NAME,
-          },
-        },
-      ] = await Promise.all([
-        InstanceGroupsAPI.readDetail(id),
-        SettingsAPI.readAll(),
-      ]);
+      const { data } = await InstanceGroupsAPI.readDetail(id);
 
       return {
         instanceGroup: data,
-        defaultControlPlane: DEFAULT_CONTROL_PLANE_QUEUE_NAME,
-        defaultExecution: DEFAULT_EXECUTION_QUEUE_NAME,
       };
     }, [id]),
-    { instanceGroup: null, defaultControlPlane: '', defaultExecution: '' }
+    { instanceGroup: null }
   );
 
   useEffect(() => {
@@ -133,18 +120,10 @@ function InstanceGroup({ setBreadcrumb }) {
             {instanceGroup && (
               <>
                 <Route path="/instance_groups/:id/edit">
-                  <InstanceGroupEdit
-                    instanceGroup={instanceGroup}
-                    defaultExecution={defaultExecution}
-                    defaultControlPlane={defaultControlPlane}
-                  />
+                  <InstanceGroupEdit instanceGroup={instanceGroup} />
                 </Route>
                 <Route path="/instance_groups/:id/details">
-                  <InstanceGroupDetails
-                    defaultExecution={defaultExecution}
-                    defaultControlPlane={defaultControlPlane}
-                    instanceGroup={instanceGroup}
-                  />
+                  <InstanceGroupDetails instanceGroup={instanceGroup} />
                 </Route>
                 <Route path="/instance_groups/:id/instances">
                   <Instances

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupAdd/InstanceGroupAdd.js
@@ -6,7 +6,7 @@ import { CardBody } from 'components/Card';
 import { InstanceGroupsAPI } from 'api';
 import InstanceGroupForm from '../shared/InstanceGroupForm';
 
-function InstanceGroupAdd({ defaultExecution, defaultControlPlane }) {
+function InstanceGroupAdd() {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
 
@@ -28,8 +28,6 @@ function InstanceGroupAdd({ defaultExecution, defaultControlPlane }) {
       <Card>
         <CardBody>
           <InstanceGroupForm
-            defaultControlPlane={defaultControlPlane}
-            defaultExecution={defaultExecution}
             onSubmit={handleSubmit}
             submitError={submitError}
             onCancel={handleCancel}

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupDetails/InstanceGroupDetails.js
@@ -23,11 +23,7 @@ const Unavailable = styled.span`
   color: var(--pf-global--danger-color--200);
 `;
 
-function InstanceGroupDetails({
-  instanceGroup,
-  defaultControlPlane,
-  defaultExecution,
-}) {
+function InstanceGroupDetails({ instanceGroup }) {
   const { id, name } = instanceGroup;
 
   const history = useHistory();
@@ -46,8 +42,6 @@ function InstanceGroupDetails({
   const { error, dismissError } = useDismissableError(deleteError);
   const deleteDetailsRequests =
     relatedResourceDeleteRequests.instanceGroup(instanceGroup);
-  const isDefaultInstanceGroup =
-    name === defaultControlPlane || name === defaultExecution;
   return (
     <CardBody>
       <DetailList>
@@ -115,8 +109,7 @@ function InstanceGroupDetails({
               {t`Edit`}
             </Button>
           )}
-        {!isDefaultInstanceGroup &&
-          instanceGroup.summary_fields.user_capabilities &&
+        {instanceGroup.summary_fields.user_capabilities &&
           instanceGroup.summary_fields.user_capabilities.delete && (
             <DeleteButton
               ouiaId="instance-group-detail-delete-button"

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.js
@@ -5,11 +5,7 @@ import { CardBody } from 'components/Card';
 import { InstanceGroupsAPI } from 'api';
 import InstanceGroupForm from '../shared/InstanceGroupForm';
 
-function InstanceGroupEdit({
-  instanceGroup,
-  defaultControlPlane,
-  defaultExecution,
-}) {
+function InstanceGroupEdit({ instanceGroup }) {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
   const detailsUrl = `/instance_groups/${instanceGroup.id}/details`;
@@ -31,8 +27,6 @@ function InstanceGroupEdit({
     <CardBody>
       <InstanceGroupForm
         instanceGroup={instanceGroup}
-        defaultControlPlane={defaultControlPlane}
-        defaultExecution={defaultExecution}
         onSubmit={handleSubmit}
         submitError={submitError}
         onCancel={handleCancel}

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroupEdit/InstanceGroupEdit.test.js
@@ -55,10 +55,7 @@ describe('<InstanceGroupEdit>', () => {
     history = createMemoryHistory();
     await act(async () => {
       wrapper = mountWithContexts(
-        <InstanceGroupEdit
-          defaultControlPlane="controlplane"
-          instanceGroup={instanceGroupData}
-        />,
+        <InstanceGroupEdit instanceGroup={instanceGroupData} />,
         {
           context: { router: { history } },
         }
@@ -68,27 +65,6 @@ describe('<InstanceGroupEdit>', () => {
 
   afterAll(() => {
     jest.clearAllMocks();
-  });
-
-  test('controlplane instance group name can not be updated', async () => {
-    let towerWrapper;
-    await act(async () => {
-      towerWrapper = mountWithContexts(
-        <InstanceGroupEdit
-          defaultControlPlane="controlplane"
-          instanceGroup={{ ...instanceGroupData, name: 'controlplane' }}
-        />,
-        {
-          context: { router: { history } },
-        }
-      );
-    });
-    expect(
-      towerWrapper.find('input#instance-group-name').prop('disabled')
-    ).toBeTruthy();
-    expect(
-      towerWrapper.find('input#instance-group-name').prop('value')
-    ).toEqual('controlplane');
   });
 
   test('handleSubmit should call the api and redirect to details page', async () => {

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { InstanceGroupsAPI } from 'api';
 import InstanceGroups from './InstanceGroups';
+import { useUserProfile } from 'contexts/Config';
 
 const mockUseLocationValue = {
   pathname: '',
@@ -11,6 +12,19 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => mockUseLocationValue,
 }));
+
+beforeEach(() => {
+  useUserProfile.mockImplementation(() => {
+    return {
+      isSuperUser: true,
+      isSystemAuditor: false,
+      isOrgAdmin: false,
+      isNotificationAdmin: false,
+      isExecEnvAdmin: false,
+    };
+  });
+});
+
 describe('<InstanceGroups/>', () => {
   test('should set breadcrumbs', () => {
     mockUseLocationValue.pathname = '/instance_groups';

--- a/awx/ui/src/screens/InstanceGroup/shared/ContainerGroupForm.js
+++ b/awx/ui/src/screens/InstanceGroup/shared/ContainerGroupForm.js
@@ -11,7 +11,7 @@ import FormField, {
   CheckboxField,
 } from 'components/FormField';
 import FormActionGroup from 'components/FormActionGroup';
-import { combine, required, protectedResourceName } from 'util/validators';
+import { required } from 'util/validators';
 import {
   FormColumnLayout,
   FormFullWidthLayout,
@@ -21,20 +21,10 @@ import {
 import CredentialLookup from 'components/Lookup/CredentialLookup';
 import { VariablesField } from 'components/CodeEditor';
 
-function ContainerGroupFormFields({
-  instanceGroup,
-  defaultControlPlane,
-  defaultExecution,
-}) {
+function ContainerGroupFormFields({ instanceGroup }) {
   const { setFieldValue, setFieldTouched } = useFormikContext();
   const [credentialField, credentialMeta, credentialHelpers] =
     useField('credential');
-
-  const [, { initialValue }] = useField('name');
-
-  const isProtected =
-    initialValue === `${defaultControlPlane}` ||
-    initialValue === `${defaultExecution}`;
 
   const [overrideField] = useField('override');
 
@@ -50,21 +40,10 @@ function ContainerGroupFormFields({
     <>
       <FormField
         name="name"
-        helperText={
-          isProtected
-            ? t`This is a protected Instance Group. The name cannot be changed.`
-            : ''
-        }
         id="container-group-name"
         label={t`Name`}
         type="text"
-        validate={combine([
-          required(null),
-          protectedResourceName(
-            t`This is a protected name for Container Groups. Please use a different name.`,
-            [defaultControlPlane, defaultExecution]
-          ),
-        ])}
+        validate={required(null)}
         isRequired
       />
       <CredentialLookup

--- a/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.js
+++ b/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.js
@@ -1,49 +1,25 @@
 import React from 'react';
 import { func, shape } from 'prop-types';
-import { Formik, useField } from 'formik';
+import { Formik } from 'formik';
 
 import { t } from '@lingui/macro';
 import { Form } from '@patternfly/react-core';
 
 import FormField, { FormSubmitError } from 'components/FormField';
 import FormActionGroup from 'components/FormActionGroup';
-import {
-  combine,
-  required,
-  protectedResourceName,
-  minMaxValue,
-} from 'util/validators';
+import { required, minMaxValue } from 'util/validators';
 import { FormColumnLayout } from 'components/FormLayout';
 
-function InstanceGroupFormFields({ defaultControlPlane, defaultExecution }) {
-  const [, { initialValue }] = useField('name');
-  const isProtected =
-    initialValue === `${defaultControlPlane}` ||
-    initialValue === `${defaultExecution}`;
-
-  const validators = combine([
-    required(null),
-    protectedResourceName(
-      t`This is a protected name for Instance Groups. Please use a different name.`,
-      [defaultControlPlane, defaultExecution]
-    ),
-  ]);
-
+function InstanceGroupFormFields() {
   return (
     <>
       <FormField
         name="name"
-        helperText={
-          isProtected
-            ? t`This is a protected Instance Group. The name cannot be changed.`
-            : ''
-        }
         id="instance-group-name"
         label={t`Name`}
         type="text"
-        validate={validators}
+        validate={required(null)}
         isRequired
-        isDisabled={isProtected}
       />
       <FormField
         id="instance-group-policy-instance-minimum"

--- a/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.test.js
+++ b/awx/ui/src/screens/InstanceGroup/shared/InstanceGroupForm.test.js
@@ -117,44 +117,4 @@ describe('<InstanceGroupForm/>', () => {
     wrapper.find('button[aria-label="Cancel"]').invoke('onClick')();
     expect(onCancel).toBeCalled();
   });
-
-  test('Name field should be disabled, default', async () => {
-    let defaultInstanceGroupWrapper;
-    await act(async () => {
-      defaultInstanceGroupWrapper = mountWithContexts(
-        <InstanceGroupForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          defaultControlPlane="controlplane"
-          defaultExecution="default"
-          instanceGroup={{ ...instanceGroup, name: 'default' }}
-        />
-      );
-    });
-    expect(
-      defaultInstanceGroupWrapper
-        .find('TextInput[name="name"]')
-        .prop('isDisabled')
-    ).toBe(true);
-  });
-
-  test('Name field should be disabled, controlplane', async () => {
-    let defaultInstanceGroupWrapper;
-    await act(async () => {
-      defaultInstanceGroupWrapper = mountWithContexts(
-        <InstanceGroupForm
-          onCancel={onCancel}
-          onSubmit={onSubmit}
-          defaultControlPlane="controlplane"
-          defaultExecution="default"
-          instanceGroup={{ ...instanceGroup, name: 'controlplane' }}
-        />
-      );
-    });
-    expect(
-      defaultInstanceGroupWrapper
-        .find('TextInput[name="name"]')
-        .prop('isDisabled')
-    ).toBe(true);
-  });
 });

--- a/awx/ui/src/setupTests.js
+++ b/awx/ui/src/setupTests.js
@@ -93,6 +93,7 @@ jest.doMock('./contexts/Config', () => ({
   Config: MockConfigContext.Consumer,
   useConfig: () => React.useContext(MockConfigContext),
   useAuthorizedPath: jest.fn(),
+  useUserProfile: jest.fn(),
 }));
 
 // ?


### PR DESCRIPTION
Add several changes to API and UI related to Instance Groups.

* Update summary_fields for DEFAULT_CONTROL_PLANE_QUEUE_NAME, and
  DEFAULT_EXECUTION_QUEUE_NAME. Rely on API validation for those fields.

* Fix Instance Group list RBAC

* Add validation for a couple of fields on the Instance Groups endpoint
	1. is_container_group
	2. policy_instance_percentage
	3. policy_instance_list

See: https://github.com/ansible/awx/issues/11130
Also: https://github.com/ansible/awx/issues/11718

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Add several changes to Instance Groups"
-->
