### PR TITLE
Adding option to enable and configure an OpenLDAP server next to AWX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ COMPOSE_TAG ?= $(GIT_BRANCH)
 MAIN_NODE_TYPE ?= hybrid
 # If set to true docker-compose will also start a keycloak instance
 KEYCLOAK ?= false
+# If set to true docker-compose will also start an ldap instance
+LDAP ?= false
 
 VENV_BASE ?= /var/lib/awx/venv
 
@@ -453,7 +455,8 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e control_plane_node_count=$(CONTROL_PLANE_NODE_COUNT) \
 	    -e execution_node_count=$(EXECUTION_NODE_COUNT) \
 	    -e minikube_container_group=$(MINIKUBE_CONTAINER_GROUP) \
-	    -e enable_keycloak=$(KEYCLOAK)
+	    -e enable_keycloak=$(KEYCLOAK) \
+	    -e enable_ldap=$(LDAP)
 
 
 docker-compose: awx/projects docker-compose-sources

--- a/tools/docker-compose/ansible/plumb_ldap.yml
+++ b/tools/docker-compose/ansible/plumb_ldap.yml
@@ -1,0 +1,32 @@
+---
+- name: Plumb an ldap instance
+  hosts: localhost
+  connection: local
+  gather_facts: False
+  vars:
+    awx_host: "https://localhost:8043"
+  tasks:
+    - name: Load existing and new LDAP settings
+      set_fact:
+        existing_ldap: "{{ lookup('awx.awx.controller_api', 'settings/ldap', host=awx_host, verify_ssl=false) }}"
+        new_ldap: "{{ lookup('template', 'ldap_settings.json.j2') }}"
+
+    - name: Display existing LDAP configuration
+      debug:
+        msg:
+          - "Here is your existing LDAP configuration for reference:"
+          - "{{ existing_ldap }}"
+
+    - pause:
+        prompt: "Continuing to run this will replace your existing ldap settings (displayed above). They will all be captured. Be sure that is backed up before continuing"
+
+    - name: Write out the existing content
+      copy:
+        dest: "../_sources/existing_ldap_adapter_settings.json"
+        content: "{{ existing_ldap }}"
+
+    - name: Configure AWX LDAP adapter
+      awx.awx.settings:
+        settings: "{{ new_ldap }}"
+        controller_host: "{{ awx_host }}"
+        validate_certs: False

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -18,3 +18,12 @@ work_sign_private_keyfile: "{{ work_sign_key_dir }}/work_private_key.pem"
 work_sign_public_keyfile: "{{ work_sign_key_dir }}/work_public_key.pem"
 
 enable_keycloak: false
+
+enable_ldap: false
+ldap_public_key_file_name: 'ldap.cert'
+ldap_private_key_file_name: 'ldap.key'
+ldap_cert_dir: '{{ sources_dest }}/ldap_certs'
+ldap_diff_dir: '{{ sources_dest }}/ldap_diffs'
+ldap_public_key_file: '{{ ldap_cert_dir }}/{{ ldap_public_key_file_name }}'
+ldap_private_key_file: '{{ ldap_cert_dir }}/{{ ldap_private_key_file_name }}'
+ldap_cert_subject: "/C=US/ST=NC/L=Durham/O=awx/CN="

--- a/tools/docker-compose/ansible/roles/sources/files/ldap.ldif
+++ b/tools/docker-compose/ansible/roles/sources/files/ldap.ldif
@@ -1,0 +1,86 @@
+dn: dc=example,dc=org
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: example
+
+dn: ou=users,dc=example,dc=org
+ou: users
+objectClass: organizationalUnit
+
+dn: cn=awx_ldap_admin,ou=users,dc=example,dc=org
+mail: admin@example.org
+sn: LdapAdmin
+cn: awx_ldap_admin
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+userPassword: admin123
+givenName: awx
+
+dn: cn=awx_ldap_auditor,ou=users,dc=example,dc=org
+mail: auditor@example.org
+sn: LdapAuditor
+cn: awx_ldap_auditor
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+userPassword: audit123
+givenName: awx
+
+dn: cn=awx_ldap_unpriv,ou=users,dc=example,dc=org
+mail: unpriv@example.org
+sn: LdapUnpriv
+cn: awx_ldap_unpriv
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+givenName: awx
+userPassword: unpriv123
+
+dn: ou=groups,dc=example,dc=org
+ou: groups
+objectClass: top
+objectClass: organizationalUnit
+
+dn: cn=awx_users,ou=groups,dc=example,dc=org
+cn: awx_users
+objectClass: top
+objectClass: groupOfNames
+member: cn=awx_ldap_admin,ou=users,dc=example,dc=org
+member: cn=awx_ldap_auditor,ou=users,dc=example,dc=org
+member: cn=awx_ldap_unpriv,ou=users,dc=example,dc=org
+member: cn=awx_ldap_org_admin,ou=users,dc=example,dc=org
+
+dn: cn=awx_admins,ou=groups,dc=example,dc=org
+cn: awx_admins
+objectClass: top
+objectClass: groupOfNames
+member: cn=awx_ldap_admin,ou=users,dc=example,dc=org
+
+dn: cn=awx_auditors,ou=groups,dc=example,dc=org
+cn: awx_auditors
+objectClass: top
+objectClass: groupOfNames
+member: cn=awx_ldap_auditor,ou=users,dc=example,dc=org
+
+dn: cn=awx_ldap_org_admin,ou=users,dc=example,dc=org
+mail: org.admin@example.org
+sn: LdapOrgAdmin
+cn: awx_ldap_org_admin
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+givenName: awx
+userPassword: orgadmin123
+
+dn: cn=awx_org_admins,ou=groups,dc=example,dc=org
+cn: awx_org_admins
+objectClass: top
+objectClass: groupOfNames
+member: cn=awx_ldap_org_admin,ou=users,dc=example,dc=org
+

--- a/tools/docker-compose/ansible/roles/sources/tasks/ldap.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/ldap.yml
@@ -1,0 +1,18 @@
+---
+- name: Create LDAP cert directory
+  file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "{{ ldap_cert_dir }}"
+    - "{{ ldap_diff_dir }}"
+
+- name: General LDAP cert
+  command: 'openssl req -new -x509 -days 365 -nodes -out {{ ldap_public_key_file }} -keyout {{ ldap_private_key_file }} -subj "{{ ldap_cert_subject }}"'
+  args:
+    creates: "{{ ldap_public_key_file }}"
+
+- name: Copy ldap.diff
+  copy:
+    src: "ldap.ldif"
+    dest: "{{ ldap_diff_dir }}/ldap.ldif"

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -91,6 +91,10 @@
   args:
     creates: "{{ work_sign_public_keyfile }}"
 
+- name: Include LDAP tasks if enabled
+  include_tasks: ldap.yml
+  when: enable_ldap | bool
+
 - name: Render Docker-Compose
   template:
     src: docker-compose.yml.j2

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -100,6 +100,29 @@ services:
     depends_on:
       - postgres
 {% endif %}
+{% if enable_ldap|bool %}
+  ldap:
+    image: bitnami/openldap:2
+    container_name: tools_ldap_1
+    hostname: ldap
+    user: "{{ ansible_user_uid }}"
+    ports:
+      - "389:1389"
+      - "636:1636"
+    environment:
+      LDAP_ADMIN_USERNAME: admin
+      LDAP_ADMIN_PASSWORD: admin
+      LDAP_CUSTOM_LDIF_DIR: /opt/bitnami/openldap/ldiffs
+      LDAP_ENABLE_TLS: "yes"
+      LDAP_LDAPS_PORT_NUMBER: 1636
+      LDAP_TLS_CERT_FILE: /opt/bitnami/openldap/certs/{{ ldap_public_key_file_name }}
+      LDAP_TLS_CA_FILE: /opt/bitnami/openldap/certs/{{ ldap_public_key_file_name }}
+      LDAP_TLS_KEY_FILE: /opt/bitnami/openldap/certs/{{ ldap_private_key_file_name }}
+    volumes:
+      - 'openldap_data:/bitnami/openldap'
+      - '../../docker-compose/_sources/ldap_certs:/opt/bitnami/openldap/certs'
+      - '../../docker-compose/_sources/ldap_diffs:/opt/bitnami/openldap/ldiffs'
+{% endif %}
   # A useful container that simply passes through log messages to the console
   # helpful for testing awx/tower logging
   # logstash:
@@ -157,6 +180,11 @@ volumes:
   redis_socket_{{ container_postfix }}:
     name: tools_redis_socket_{{ container_postfix }}
 {% endfor -%}
+{% if enable_ldap %}
+  openldap_data:
+    name: tools_ldap_1
+    driver: local
+{% endif %}
 {% if minikube_container_group|bool %}
 networks:
   default:

--- a/tools/docker-compose/ansible/templates/ldap_settings.json.j2
+++ b/tools/docker-compose/ansible/templates/ldap_settings.json.j2
@@ -1,0 +1,52 @@
+{
+    "AUTH_LDAP_1_SERVER_URI": "ldap://{{ container_reference }}:389",
+    "AUTH_LDAP_1_BIND_DN": "cn=admin,dc=example,dc=org",
+    "AUTH_LDAP_1_BIND_PASSWORD": "admin",
+    "AUTH_LDAP_1_START_TLS": false,
+    "AUTH_LDAP_1_CONNECTION_OPTIONS": {
+        "OPT_REFERRALS": 0,
+        "OPT_NETWORK_TIMEOUT": 30
+    },
+    "AUTH_LDAP_1_USER_SEARCH": [
+        "ou=users,dc=example,dc=org",
+        "SCOPE_SUBTREE",
+        "(cn=%(user)s)"
+    ],
+    "AUTH_LDAP_1_USER_DN_TEMPLATE": "cn=%(user)s,ou=users,dc=example,dc=org",
+    "AUTH_LDAP_1_USER_ATTR_MAP": {
+        "first_name": "givenName",
+        "last_name": "sn",
+        "email": "mail"
+    },
+    "AUTH_LDAP_1_GROUP_SEARCH": [
+        "ou=groups,dc=example,dc=org",
+        "SCOPE_SUBTREE",
+        "(objectClass=groupOfNames)"
+    ],
+    "AUTH_LDAP_1_GROUP_TYPE": "MemberDNGroupType",
+    "AUTH_LDAP_1_GROUP_TYPE_PARAMS": {
+        "member_attr": "member",
+        "name_attr": "cn"
+    },
+    "AUTH_LDAP_1_REQUIRE_GROUP": "cn=awx_users,ou=groups,dc=example,dc=org",
+    "AUTH_LDAP_1_DENY_GROUP": null,
+    "AUTH_LDAP_1_USER_FLAGS_BY_GROUP": {
+        "is_superuser": [
+            "cn=awx_admins,ou=groups,dc=example,dc=org"
+        ],
+        "is_system_auditor": [
+            "cn=awx_auditors,ou=groups,dc=example,dc=org"
+        ]
+    },
+    "AUTH_LDAP_1_ORGANIZATION_MAP": {
+        "LDAP Organization": {
+            "users": true,
+            "remove_admins": false,
+            "remove_users": true,
+            "admins": [
+                "cn=awx_org_admins,ou=groups,dc=example,dc=org"
+            ]
+        }
+    },
+    "AUTH_LDAP_1_TEAM_MAP": {}
+}


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A user can now run `LDAP=true make docker-compose` and get an LDAP container along side AWX. They can then run `ansible-playbook plumb_ldap.yml` to configure the AWX adapter. This is for testing/troubleshooting purposes.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - docker_compose
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev184+ge919fad14a
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
