### PR TITLE
add JobOutput screens for empty content

### DIFF
--- a/awx/ui/src/components/ContentEmpty/ContentEmpty.js
+++ b/awx/ui/src/components/ContentEmpty/ContentEmpty.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { t } from '@lingui/macro';
-
 import {
   Title,
   EmptyState,
@@ -9,9 +8,14 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 
-const ContentEmpty = ({ title = '', message = '' }) => (
-  <EmptyState variant="full">
-    <EmptyStateIcon icon={CubesIcon} />
+const ContentEmpty = ({
+  title = '',
+  message = '',
+  icon = CubesIcon,
+  className = '',
+}) => (
+  <EmptyState variant="full" className={className}>
+    <EmptyStateIcon icon={icon} />
     <Title size="lg" headingLevel="h3">
       {title || t`No items found.`}
     </Title>

--- a/awx/ui/src/screens/Job/JobOutput/EmptyOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/EmptyOutput.js
@@ -1,0 +1,36 @@
+import React, { useEffect } from 'react';
+import 'styled-components/macro';
+import { t } from '@lingui/macro';
+import { SearchIcon } from '@patternfly/react-icons';
+import ContentEmpty from 'components/ContentEmpty';
+
+export default function EmptyOutput({
+  hasQueryParams,
+  isJobRunning,
+  onUnmount,
+}) {
+  let title;
+  let message;
+  let icon;
+
+  useEffect(() => onUnmount);
+
+  if (hasQueryParams) {
+    title = t`The search filter did not produce any results…`;
+    message = t`Please try another search using the filter above`;
+    icon = SearchIcon;
+  } else if (isJobRunning) {
+    title = t`Waiting for job output…`;
+  } else {
+    title = t`No output found for this job.`;
+  }
+
+  return (
+    <ContentEmpty
+      css="height: 100%"
+      title={title}
+      message={message}
+      icon={icon}
+    />
+  );
+}

--- a/awx/ui/src/screens/Job/JobOutput/JobEvent.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEvent.js
@@ -17,11 +17,15 @@ function JobEvent({
   isCollapsed,
   onToggleCollapsed,
   hasChildren,
+  jobStatus,
 }) {
   const numOutputLines = lineTextHtml?.length || 0;
   useEffect(() => {
-    measure();
-  }, [numOutputLines, isCollapsed, measure]);
+    const timeout = setTimeout(measure, 0);
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [numOutputLines, isCollapsed, measure, jobStatus]);
 
   let toggleLineIndex = -1;
   if (hasChildren) {


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Added feedback while job output screen is empty due to no search results or job just starting"
-->

##### SUMMARY

Adds feedback screens to the JobOutput page for instances where the output is empty. This includes search query with no results or a job that is just starting and hasn't begun providing output.

Addresses #11409

![Screen Shot 2022-03-07 at 9 59 44 AM](https://user-images.githubusercontent.com/410794/157093110-9cf4c1a8-c3c2-4425-ae6d-a2f763260069.png)

![Screen Shot 2022-03-07 at 9 59 50 AM](https://user-images.githubusercontent.com/410794/157093125-3beb4e80-b01e-4896-bf26-2a3e51523cba.png)


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
