### PR TITLE
Do not remove artifacts for local work

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -326,7 +326,7 @@ class AWXReceptorJob:
         # Artifacts are an output, but sometimes they are an input as well
         # this is the case with fact cache, where clearing facts deletes a file, and this must be captured
         artifact_dir = os.path.join(self.runner_params['private_data_dir'], 'artifacts')
-        if os.path.exists(artifact_dir):
+        if self.work_type != 'local' and os.path.exists(artifact_dir):
             shutil.rmtree(artifact_dir)
 
         resultsock, resultfile = receptor_ctl.get_work_results(self.unit_id, return_socket=True, return_sockfile=True)


### PR DESCRIPTION
##### SUMMARY
This is cherry-picking a fix from https://github.com/ansible/awx/pull/11641 because that work got stranded and this is still not fixed.

Connect https://github.com/ansible/awx/issues/11842, which describes (predictably) unrelated fallout which is a consequence of this.

What's going on - `only_transmit_kwargs` is used as a parameter to ansible-runner when running local work. This means that the private_data_dir is not streamed to the receptor process, and the one on disk is used in-place. However, this does not turn off streaming of artifacts back from receptor (maybe it should). The artifacts directory is _inside_ of the private_data_dir. This line deletes the artifacts directory so that any file deletions on the remote node will be picked up. But this doesn't work when it's running locally. It "streams" the artifacts back, but... from the same directory it started in. So deleting stuff before the job run deletes the stuff in the context where the job runs.

But this issue has also made it clear that we don't have test coverage for certs... which we should also do.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API


