### PR TITLE
Add user-defined environment variables to ansible-galaxy commands

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -283,6 +283,19 @@ register(
 )
 
 register(
+    'GALAXY_TASK_ENV',
+    field_class=fields.KeyValueField,
+    label=_('Environment Variables for Galaxy Commands'),
+    help_text=_(
+        'Additional environment variables set for invocations of ansible-galaxy within project updates. '
+        'Useful if you must use a proxy server for ansible-galaxy but not git.'
+    ),
+    category=_('Jobs'),
+    category_slug='jobs',
+    placeholder={'HTTP_PROXY': 'myproxy.local:8080'},
+)
+
+register(
     'INSIGHTS_TRACKING_STATE',
     field_class=fields.BooleanField,
     default=False,

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1160,6 +1160,7 @@ class RunProjectUpdate(BaseTask):
                 'scm_track_submodules': project_update.scm_track_submodules,
                 'roles_enabled': galaxy_creds_are_defined and settings.AWX_ROLES_ENABLED,
                 'collections_enabled': galaxy_creds_are_defined and settings.AWX_COLLECTIONS_ENABLED,
+                'galaxy_task_env': settings.GALAXY_TASK_ENV,
             }
         )
         # apply custom refspec from user for PR refs and the like

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -15,6 +15,7 @@
 # scm_track_submodules: true/false
 # roles_enabled: Value of the global setting to enable roles downloading
 # collections_enabled: Value of the global setting to enable collections downloading
+# galaxy_task_env: environment variables to use specifically for ansible-galaxy commands
 # awx_version: Current running version of the awx or tower as a string
 # awx_license_type: "open" for AWX; else presume Tower
 
@@ -154,18 +155,27 @@
   gather_facts: false
   connection: local
   name: Install content with ansible-galaxy command if necessary
+  vars:
+    galaxy_task_env:  # configure in settings
+    additional_collections_env:
+      # These environment variables are used for installing collections, in addition to galaxy_task_env
+      # setting the collections paths silences warnings
+      ANSIBLE_COLLECTIONS_PATHS: "{{projects_root}}/.__awx_cache/{{local_path}}/stage/requirements_collections"
+      # Put the local tmp directory in same volume as collection destination
+      # otherwise, files cannot be moved accross volumes and will cause error
+      ANSIBLE_LOCAL_TEMP: "{{projects_root}}/.__awx_cache/{{local_path}}/stage/tmp"
   tasks:
 
     - name: Check content sync settings
-      debug:
-        msg: "Collection and role syncing disabled. Check the AWX_ROLES_ENABLED and AWX_COLLECTIONS_ENABLED settings and Galaxy credentials on the project's organization."
-      when: not roles_enabled|bool and not collections_enabled|bool
-      tags:
-        - install_roles
-        - install_collections
+      block:
+      - debug:
+          msg: >
+            Collection and role syncing disabled. Check the AWX_ROLES_ENABLED and
+            AWX_COLLECTIONS_ENABLED settings and Galaxy credentials on the project's organization.
 
-    - name:
-      meta: end_play
+      - name:
+        meta: end_play
+
       when: not roles_enabled|bool and not collections_enabled|bool
       tags:
         - install_roles
@@ -184,9 +194,7 @@
             - "{{project_path|quote}}/roles/requirements.yaml"
             - "{{project_path|quote}}/roles/requirements.yml"
           changed_when: "'was installed successfully' in galaxy_result.stdout"
-          environment:
-            ANSIBLE_FORCE_COLOR: false
-            GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
+          environment: "{{ galaxy_task_env }}"
 
       when: roles_enabled|bool
       tags:
@@ -207,13 +215,7 @@
             - "{{project_path|quote}}/requirements.yaml"
             - "{{project_path|quote}}/requirements.yml"
           changed_when: "'Installing ' in galaxy_collection_result.stdout"
-          environment:
-            ANSIBLE_FORCE_COLOR: false
-            ANSIBLE_COLLECTIONS_PATHS: "{{projects_root}}/.__awx_cache/{{local_path}}/stage/requirements_collections"
-            GIT_SSH_COMMAND: "ssh -o StrictHostKeyChecking=no"
-            # Put the local tmp directory in same volume as collection destination
-            # otherwise, files cannot be moved accross volumes and will cause error
-            ANSIBLE_LOCAL_TEMP: "{{projects_root}}/.__awx_cache/{{local_path}}/stage/tmp"
+          environment: "{{ additional_collections_env | combine(galaxy_task_env) }}"
 
       when:
         - "ansible_version.full is version_compare('2.9', '>=')"

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -168,13 +168,12 @@
 
     - name: Check content sync settings
       block:
-      - debug:
-          msg: >
-            Collection and role syncing disabled. Check the AWX_ROLES_ENABLED and
-            AWX_COLLECTIONS_ENABLED settings and Galaxy credentials on the project's organization.
+        - debug:
+            msg: >
+              Collection and role syncing disabled. Check the AWX_ROLES_ENABLED and
+              AWX_COLLECTIONS_ENABLED settings and Galaxy credentials on the project's organization.
 
-      - name:
-        meta: end_play
+        - meta: end_play
 
       when: not roles_enabled|bool and not collections_enabled|bool
       tags:

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -558,6 +558,10 @@ ANSIBLE_INVENTORY_UNPARSED_FAILED = True
 # Additional environment variables to be passed to the ansible subprocesses
 AWX_TASK_ENV = {}
 
+# Additional environment variables to apply when running ansible-galaxy commands
+# to fetch Ansible content - roles and collections
+GALAXY_TASK_ENV = {'ANSIBLE_FORCE_COLOR': 'false', 'GIT_SSH_COMMAND': "ssh -o StrictHostKeyChecking=no"}
+
 # Rebuild Host Smart Inventory memberships.
 AWX_REBUILD_SMART_MEMBERSHIP = False
 

--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -85,6 +85,7 @@ function JobsEdit() {
         form.AWX_ANSIBLE_CALLBACK_PLUGINS
       ),
       AWX_TASK_ENV: formatJson(form.AWX_TASK_ENV),
+      GALAXY_TASK_ENV: formatJson(form.GALAXY_TASK_ENV),
     });
   };
 
@@ -217,6 +218,10 @@ function JobsEdit() {
                   config={jobs.AWX_MOUNT_ISOLATED_PATHS_ON_K8S}
                 />
                 <ObjectField name="AWX_TASK_ENV" config={jobs.AWX_TASK_ENV} />
+                <ObjectField
+                  name="GALAXY_TASK_ENV"
+                  config={jobs.GALAXY_TASK_ENV}
+                />
                 {submitError && <FormSubmitError error={submitError} />}
                 {revertError && <FormSubmitError error={revertError} />}
               </FormColumnLayout>

--- a/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
@@ -232,25 +232,25 @@
         }
       },
       "GALAXY_TASK_ENV": {
-              "type": "nested object",
-               "required": true,
-              "label": "Environment Variables for Galaxy Commands",
-               "help_text": "Additional environment variables set for invocations of ansible-galaxy within project updates. Useful if you must use a proxy server for ansible-galaxy but not git.",
-               "category": "Jobs",
-               "category_slug": "jobs",
-               "placeholder": {
-                    "HTTP_PROXY": "myproxy.local:8080"
-                },
-               "default": {
-                   "ANSIBLE_FORCE_COLOR": "false",
-                    "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
-              },
-                "child": {
-                  "type": "string",
-                    "required": true,
-                  "read_only": false
-              }
-             },
+        "type": "nested object",
+         "required": true,
+        "label": "Environment Variables for Galaxy Commands",
+         "help_text": "Additional environment variables set for invocations of ansible-galaxy within project updates. Useful if you must use a proxy server for ansible-galaxy but not git.",
+         "category": "Jobs",
+         "category_slug": "jobs",
+         "placeholder": {
+              "HTTP_PROXY": "myproxy.local:8080"
+          },
+         "default": {
+             "ANSIBLE_FORCE_COLOR": "false",
+              "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
+        },
+          "child": {
+            "type": "string",
+              "required": true,
+            "read_only": false
+        }
+       },
       "INSIGHTS_TRACKING_STATE": {
         "type": "boolean",
         "required": false,
@@ -3963,25 +3963,25 @@
         }
       },
       "GALAXY_TASK_ENV": {
-              "type": "nested object",
-               "required": true,
-              "label": "Environment Variables for Galaxy Commands",
-               "help_text": "Additional environment variables set for invocations of ansible-galaxy within project updates. Useful if you must use a proxy server for ansible-galaxy but not git.",
-               "category": "Jobs",
-               "category_slug": "jobs",
-               "placeholder": {
-                    "HTTP_PROXY": "myproxy.local:8080"
-                },
-               "default": {
-                   "ANSIBLE_FORCE_COLOR": "false",
-                    "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
-              },
-                "child": {
-                  "type": "string",
-                    "required": true,
-                  "read_only": false
-              }
-             },
+        "type": "nested object",
+         "required": true,
+        "label": "Environment Variables for Galaxy Commands",
+         "help_text": "Additional environment variables set for invocations of ansible-galaxy within project updates. Useful if you must use a proxy server for ansible-galaxy but not git.",
+         "category": "Jobs",
+         "category_slug": "jobs",
+         "placeholder": {
+              "HTTP_PROXY": "myproxy.local:8080"
+          },
+         "default": {
+             "ANSIBLE_FORCE_COLOR": "false",
+              "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
+        },
+          "child": {
+            "type": "string",
+              "required": true,
+            "read_only": false
+        }
+       },
       "INSIGHTS_TRACKING_STATE": {
         "type": "boolean",
         "label": "Gather data for Insights for Ansible Automation Platform",

--- a/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
@@ -231,6 +231,26 @@
           "read_only": false
         }
       },
+      "GALAXY_TASK_ENV": {
+              "type": "nested object",
+               "required": true,
+              "label": "Environment Variables for Galaxy Commands",
+               "help_text": "Additional environment variables set for invocations of ansible-galaxy within project updates. Useful if you must use a proxy server for ansible-galaxy but not git.",
+               "category": "Jobs",
+               "category_slug": "jobs",
+               "placeholder": {
+                    "HTTP_PROXY": "myproxy.local:8080"
+                },
+               "default": {
+                   "ANSIBLE_FORCE_COLOR": "false",
+                    "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
+              },
+                "child": {
+                  "type": "string",
+                    "required": true,
+                  "read_only": false
+              }
+             },
       "INSIGHTS_TRACKING_STATE": {
         "type": "boolean",
         "required": false,
@@ -3942,6 +3962,26 @@
           "type": "string"
         }
       },
+      "GALAXY_TASK_ENV": {
+              "type": "nested object",
+               "required": true,
+              "label": "Environment Variables for Galaxy Commands",
+               "help_text": "Additional environment variables set for invocations of ansible-galaxy within project updates. Useful if you must use a proxy server for ansible-galaxy but not git.",
+               "category": "Jobs",
+               "category_slug": "jobs",
+               "placeholder": {
+                    "HTTP_PROXY": "myproxy.local:8080"
+                },
+               "default": {
+                   "ANSIBLE_FORCE_COLOR": "false",
+                    "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
+              },
+                "child": {
+                  "type": "string",
+                    "required": true,
+                  "read_only": false
+              }
+             },
       "INSIGHTS_TRACKING_STATE": {
         "type": "boolean",
         "label": "Gather data for Insights for Ansible Automation Platform",

--- a/awx/ui/src/screens/Setting/shared/data.allSettings.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettings.json
@@ -38,6 +38,10 @@
   "AWX_ISOLATION_BASE_PATH":"/tmp",
   "AWX_ISOLATION_SHOW_PATHS":[],
   "AWX_TASK_ENV":{},
+  "GALAXY_TASK_ENV": {
+    "ANSIBLE_FORCE_COLOR": "false",
+    "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
+   },
   "INSIGHTS_TRACKING_STATE":false,
   "PROJECT_UPDATE_VVV":false,
   "AWX_ROLES_ENABLED":true,

--- a/awx/ui/src/screens/Setting/shared/data.jobSettings.json
+++ b/awx/ui/src/screens/Setting/shared/data.jobSettings.json
@@ -7,6 +7,10 @@
   "AWX_ISOLATION_BASE_PATH": "/tmp",
   "AWX_ISOLATION_SHOW_PATHS": [],
   "AWX_TASK_ENV": {},
+   "GALAXY_TASK_ENV": {
+     "ANSIBLE_FORCE_COLOR": "false",
+      "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
+     },
   "PROJECT_UPDATE_VVV": false,
   "AWX_ROLES_ENABLED": true,
   "AWX_COLLECTIONS_ENABLED": true,

--- a/awx/ui/src/screens/Setting/shared/data.jobSettings.json
+++ b/awx/ui/src/screens/Setting/shared/data.jobSettings.json
@@ -7,10 +7,10 @@
   "AWX_ISOLATION_BASE_PATH": "/tmp",
   "AWX_ISOLATION_SHOW_PATHS": [],
   "AWX_TASK_ENV": {},
-   "GALAXY_TASK_ENV": {
-     "ANSIBLE_FORCE_COLOR": "false",
+  "GALAXY_TASK_ENV": {
+      "ANSIBLE_FORCE_COLOR": "false",
       "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
-     },
+  },
   "PROJECT_UPDATE_VVV": false,
   "AWX_ROLES_ENABLED": true,
   "AWX_COLLECTIONS_ENABLED": true,


### PR DESCRIPTION
##### SUMMARY
Allows the user to use a proxy server for `ansible-galaxy` commands by letting them set whatever environment variables they want. We already have a set of environment variables we use for this command, and I don't care if the user changes them, so those are absorbed into this new setting.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Here's what OPTIONS look like for this under PUT

```json
            "GALAXY_TASK_ENV": {
                "type": "nested object",
                "required": true,
                "label": "Environment Variables for Galaxy Commands",
                "help_text": "Additional environment variables set for invocations of ansible-galaxy within project updates. Useful if you must use a proxy server for ansible-galaxy but not git.",
                "category": "Jobs",
                "category_slug": "jobs",
                "placeholder": {
                    "HTTP_PROXY": "myproxy.local:8080"
                },
                "default": {
                    "ANSIBLE_FORCE_COLOR": "false",
                    "GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"
                },
                "child": {
                    "type": "string",
                    "required": true,
                    "read_only": false
                }
```

Here's what the UI looks like:

![Screenshot from 2022-03-08 10-32-25](https://user-images.githubusercontent.com/1385596/157270719-99f64710-29d6-4928-9ed2-740addec64db.png)

I've tested this by setting the HTTPS_PROXY to an invalid URl, and it fails exactly as expected.
