### PR TITLE
Fixing import of projects issue due to local_path

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -243,6 +243,10 @@ class ApiV2(base.Base):
                         # JTs have valid options for playbook names
                         _page.wait_until_completed()
                 else:
+                    # If we are an existing project and our scm_tpye is not changing don't try and import the local_path setting
+                    if asset['natural_key']['type'] == 'project' and 'local_path' in post_data and _page['scm_type'] == post_data['scm_type']:
+                        del post_data['local_path']
+
                     _page = _page.put(post_data)
                     changed = True
             except (exc.Common, AssertionError) as e:


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Awxkit import now allows for multiple imports of the same project without failures"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Addresses https://github.com/ansible/awx/issues/11883

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev218+g282cceae8e
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Given an import file of:
```
{
     "projects": [
          {
               "name": "Demo Project",
               "description": "",
               "local_path": "_6__demo_project",
               "scm_type": "git",
               "scm_url": "https://github.com/ansible/ansible-tower-samples",
               "scm_branch": "",
               "scm_refspec": "",
               "scm_clean": false,
               "scm_track_submodules": false,
               "scm_delete_on_update": false,
               "credential": null,
               "timeout": 0,
               "scm_update_on_launch": true,
               "scm_update_cache_timeout": 0,
               "allow_override": false,
               "default_environment": null,
               "organization": {
                    "name": "Default",
                    "type": "organization"
               },
               "related": {
                    "schedules": [],
                    "notification_templates_started": [],
                    "notification_templates_success": [],
                    "notification_templates_error": []
               },
               "natural_key": {
                    "organization": {
                         "name": "Default",
                         "type": "organization"
                    },
                    "name": "Demo Project",
                    "type": "project"
               }
          }
    ]
}
```

Importing the project once would succeed but running a second time would error with:
`Object import failed: Bad Request (400) received - {'local_path': ['Cannot change local_path for git-based projects']}.`

Post change, it will re-import without out a failure. 