### PR TITLE
Only clear hop node errors if they were lost before, not lost now

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -457,8 +457,9 @@ def inspect_execution_nodes(instance_list):
 
             # Only execution nodes should be dealt with by execution_node_health_check
             if instance.node_type == 'hop':
-                logger.warning(f'Hop node {hostname}, has rejoined the receptor mesh')
-                instance.save_health_data(errors='')
+                if was_lost and (not instance.is_lost(ref_time=nowtime)):
+                    logger.warning(f'Hop node {hostname}, has rejoined the receptor mesh')
+                    instance.save_health_data(errors='')
                 continue
 
             if was_lost:


### PR DESCRIPTION
##### SUMMARY
@InnocentK noted that the `errors` for hop nodes were not getting populated right... and when I looked at the logs, it was pretty clear he was right.

```
tools_awx_1     | awx-dispatcher stdout | 2022-03-11 18:06:21,096 WARNING  [f53cca1e] awx.main.tasks.system Hop node receptor-hop, has rejoined the receptor mesh
tools_awx_1     | awx-dispatcher stdout | 
tools_awx_1     | awx-dispatcher stdout | 2022-03-11 18:07:21,261 WARNING  [2a00335f] awx.main.tasks.system Hop node receptor-hop, has rejoined the receptor mesh
tools_awx_1     | awx-dispatcher stdout | 
tools_awx_1     | awx-dispatcher stdout | 2022-03-11 18:08:21,425 WARNING  [aea4f506] awx.main.tasks.system Hop node receptor-hop, has rejoined the receptor mesh
tools_awx_1     | awx-dispatcher stdout | 
tools_awx_1     | awx-dispatcher stdout | 2022-03-11 18:09:21,542 WARNING  [3cfc819a] awx.main.tasks.system Hop node receptor-hop, has rejoined the receptor mesh
tools_awx_1     | awx-dispatcher stdout | 
tools_awx_1     | awx-dispatcher stdout | 2022-03-11 18:10:21,683 WARNING  [c9dae163] awx.main.tasks.system Hop node receptor-hop, has rejoined the receptor mesh
tools_awx_1     | awx-dispatcher stdout | 
```

Every heartbeat it was hitting this log. That's because the logic was considering it a "rejoin" event every time it saw a hop node at all. Rejoining only happens when it _was_ log, but is _not_ lost with the updated information. This follows a similar pattern to execution nodes now.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

