### PR TITLE
Simple patches to make jobs robust to database restarts

### DIFF
--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -171,7 +171,7 @@ class AWXConsumerPG(AWXConsumerBase):
                     self.pg_is_down = True
                 if time.time() - self.pg_down_time > self.pg_max_wait:
                     logger.warning(f"Postgres event consumer has not recovered in {self.pg_max_wait} s, exiting")
-                    return
+                    raise
                 # Wait for a second before next attempt, but still listen for any shutdown signals
                 for i in range(10):
                     if self.should_stop:

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -147,7 +147,7 @@ class RunnerCallback:
         Ansible runner callback to tell the job when/if it is canceled
         """
         unified_job_id = self.instance.pk
-        self.instance.refresh_from_db()
+        self.instance = self.update_model(unified_job_id)
         if not self.instance:
             logger.error('unified job {} was deleted while running, canceling'.format(unified_job_id))
             return True

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -32,9 +32,10 @@ class RunnerCallback:
         self.safe_env = {}
         self.event_ct = 0
         self.model = model
+        self.update_attempts = int(settings.DISPATCHER_DB_DOWNTOWN_TOLLERANCE / 5)
 
     def update_model(self, pk, _attempt=0, **updates):
-        return update_model(self.model, pk, _attempt=0, **updates)
+        return update_model(self.model, pk, _attempt=0, _max_attempts=self.update_attempts, **updates)
 
     def event_handler(self, event_data):
         #

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -113,10 +113,11 @@ class BaseTask(object):
 
     def __init__(self):
         self.cleanup_paths = []
+        self.update_attempts = int(settings.DISPATCHER_DB_DOWNTOWN_TOLLERANCE / 5)
         self.runner_callback = self.callback_class(model=self.model)
 
     def update_model(self, pk, _attempt=0, **updates):
-        return update_model(self.model, pk, _attempt=0, **updates)
+        return update_model(self.model, pk, _attempt=0, _max_attempts=self.update_attempts, **updates)
 
     def get_path_to(self, *args):
         """

--- a/awx/main/utils/update_model.py
+++ b/awx/main/utils/update_model.py
@@ -1,4 +1,4 @@
-from django.db import transaction, DatabaseError
+from django.db import transaction, DatabaseError, InterfaceError
 
 import logging
 import time
@@ -27,7 +27,7 @@ def update_model(model, pk, _attempt=0, **updates):
                         update_fields.append('failed')
                 instance.save(update_fields=update_fields)
             return instance
-    except DatabaseError as e:
+    except (DatabaseError, InterfaceError) as e:
         # Log out the error to the debug logger.
         logger.debug('Database error updating %s, retrying in 5 seconds (retry #%d): %s', model._meta.object_name, _attempt + 1, e)
 

--- a/awx/main/utils/update_model.py
+++ b/awx/main/utils/update_model.py
@@ -7,7 +7,7 @@ import time
 logger = logging.getLogger('awx.main.tasks.utils')
 
 
-def update_model(model, pk, _attempt=0, **updates):
+def update_model(model, pk, _attempt=0, _max_attempts=5, **updates):
     """Reload the model instance from the database and update the
     given fields.
     """
@@ -33,8 +33,8 @@ def update_model(model, pk, _attempt=0, **updates):
 
         # Attempt to retry the update, assuming we haven't already
         # tried too many times.
-        if _attempt < 5:
+        if _attempt < _max_attempts:
             time.sleep(5)
-            return update_model(model, pk, _attempt=_attempt + 1, **updates)
+            return update_model(model, pk, _attempt=_attempt + 1, _max_attempts=_max_attempts, **updates)
         else:
             logger.error('Failed to update %s after %d retries.', model._meta.object_name, _attempt)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -426,6 +426,9 @@ CLUSTER_NODE_HEARTBEAT_PERIOD = 60
 RECEPTOR_SERVICE_ADVERTISEMENT_PERIOD = 60  # https://github.com/ansible/receptor/blob/aa1d589e154d8a0cb99a220aff8f98faf2273be6/pkg/netceptor/netceptor.go#L34
 EXECUTION_NODE_REMEDIATION_CHECKS = 60 * 30  # once every 30 minutes check if an execution node errors have been resolved
 
+# Amount of time dispatcher will try to reconnect to database for jobs and consuming new work
+DISPATCHER_DB_DOWNTOWN_TOLLERANCE = 40
+
 BROKER_URL = 'unix:///var/run/redis/redis.sock'
 CELERYBEAT_SCHEDULE = {
     'tower_scheduler': {'task': 'awx.main.tasks.system.awx_periodic_scheduler', 'schedule': timedelta(seconds=30), 'options': {'expires': 20}},


### PR DESCRIPTION
##### SUMMARY
The goal of this is to make it so that a small amount of downtime from postgres (less than 5 seconds) will not fail long-running jobs (multiple hours).

One time in the distant past, this was a design goal, and this goal is obvious if you read the code of `update_model`. Systems have shifted significantly since that time, and several novel failure points have been introduced.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
My current testing method looks like this:

```bash
echo "select pg_terminate_backend(pid) from pg_stat_activity where datname='awx';" | awx-manage dbshell
```

This is not the _only_ type of database hiccup that might happen, and we should test other things (like a simple restart), this is just my first stop. I have some manual steps, which I will consolidate into an integration test:

 - Launch a job that sleeps for 60 seconds
 - Wait for first lines of output to appear
 - Run the above command to terminate database connections
 - Wait for the rest of the minute to finish
   - **before** this patch the job is marked as failed by the reaper
   - **after** this patch the job completes successfully.

The logs during the event are a little beat up, but the main dispatcher processes remaining running through the whole thing.
