### PR TITLE
Add force_basic_auth to allow basic authentication without creating t…

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -32,6 +32,12 @@ options:
     - If value not set, will try environment variable C(CONTROLLER_PASSWORD) and then config files
     type: str
     aliases: [ tower_password ]
+  controller_force_basic_auth:
+    description:
+    - Force the sending of the Basic authentication header.
+    - This can be used only if C(controller_oauthtoken) is not set, otherwise it will be ignored.
+    type: bool
+    aliases: [ tower_force_basic_auth ]
   controller_oauthtoken:
     description:
     - The OAuth token to use.

--- a/awx_collection/tests/integration/targets/user/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/user/tasks/main.yml
@@ -90,8 +90,8 @@
   user:
     first_name: Joe
     last_name: Super
-    username: "{{ username }}"
-    password: "{{ 65535 | random | to_uuid }}"
+    username: "{{ username }}-admin"
+    password: "{{ username }}-admin"
     email: joe@example.org
     state: present
     superuser: true
@@ -101,9 +101,41 @@
     that:
       - "result is changed"
 
+- name: Create a Superuser as {{ username }} with force_basic_authentication
+  user:
+    controller_username: "{{ username }}-admin"
+    controller_password: "{{ username }}-admin"
+    controller_force_basic_auth: true
+    first_name: John
+    last_name: Super
+    username: "{{ username }}-manager"
+    password: "{{ 65535 | random | to_uuid }}"
+    email: john@example.org
+    state: present
+    superuser: true
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
+- name: Delete a Superuser as {{ username }} with force_basic_authentication
+  user:
+    controller_username: "{{ username }}-admin"
+    controller_password: "{{ username }}-admin"
+    controller_force_basic_auth: true
+    username: "{{ username }}-manager"
+    email: john@example.org
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
 - name: Delete a Superuser
   user:
-    username: "{{ username }}"
+    username: "{{ username }}-admin"
     email: joe@example.org
     state: absent
   register: result


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Add controller_force_basic_auth to allow basic authentication without creating a token"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This is "related https://github.com/ansible/awx/issues/10243"

The code changes add the `controller_force_basic_auth` option to allow basic authentication without the need of creating tokens.
Additionally the token feature could be disabled, which breaks the functionality of this collection at the moment.

**Reasons**
* Depending on the implementation, if a user is blocked in the external authentication system (e.g. LDAP), the token would still be valid. For that reason, sometimes there are policies against using tokens.
* Besides other ansible modules and the AWX API itself already support basic authentications.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
20.0.2.dev52+g70dfb68976
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
It is my first time contributing to this project, so please, let me know, if I am missing something