### PR TITLE
Adding ability to run user level pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ reference-schema.json
 .tags
 .tags1
 
+# User level pre-commit hooks
+pre-commit-user
+
 # Tower
 awx-dev
 awx/settings/local_*.py*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ When you attempt to perform a `git commit` there will be a pre-commit hook that 
 
 While you can use environment variables to skip the pre-commit hooks GitHub will run similar tests and prevent merging of PRs if the tests do not pass.
 
- If you would like to add additional commit hooks for your own usage you can create a directory in the root of the repository called `pre-commit-user`. Any executable "*.sh" file in that directory will be executed as part of the pre-commit hooks. If any of the pre-commit checks fail the commit will be halted. For your convenience in user scripts, a variable called `CHANGED_FILES` will be set with any changed files present in the commit.
+ If you would like to add additional commit hooks for your own usage you can create a directory in the root of the repository called `pre-commit-user`. Any executable file in that directory will be executed as part of the pre-commit hooks. If any of the pre-commit checks fail the commit will be halted. For your convenience in user scripts, a variable called `CHANGED_FILES` will be set with any changed files present in the commit.
 
 ## What should I work on?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Have questions about this document or anything not covered here? Come chat with 
   - [Building API Documentation](#building-api-documentation)
   - [Accessing the AWX web interface](#accessing-the-awx-web-interface)
   - [Purging containers and images](#purging-containers-and-images)
+  - [Pre commit hooks](#pre-commit-hooks)
 - [What should I work on?](#what-should-i-work-on)
 - [Submitting Pull Requests](#submitting-pull-requests)
 - [PR Checks run by Zuul](#pr-checks-run-by-zuul)
@@ -103,6 +104,14 @@ When necessary, remove any AWX containers and images by running the following:
 ```bash
 (host)$ make docker-clean
 ```
+
+### Pre commit hooks
+
+When you attempt to perform a `git commit` there will be a pre-commit hook that gets run before the commit is allowed to your local repository. For example, python's [black](https://pypi.org/project/black/) will be run to test the formatting of any python files.
+
+While you can use environment variables to skip the pre-commit hooks GitHub will run similar tests and prevent merging of PRs if the tests do not pass.
+
+ If you would like to add additional commit hooks for your own usage you can create a directory in the root of the repository called `pre-commit-user`. Any executable "*.sh" file in that directory will be executed as part of the pre-commit hooks. If any of the pre-commit checks fail the commit will be halted. For your convenience in user scripts, a variable called `CHANGED_FILES` will be set with any changed files present in the commit.
 
 ## What should I work on?
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -6,3 +6,11 @@ if [ -z $AWX_IGNORE_BLACK ] ; then
         	exit 1)
 	fi
 fi
+
+if [ -z $AWX_IGNORE_USER ] ; then
+	if [ -d ./pre-commit-user ] ; then
+		for SCRIPT in `find ./pre-commit-user -name "*.sh" -executable` ; do
+			$SCRIPT || exit 1
+		done
+	fi
+fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -13,11 +13,13 @@ if [ -z $AWX_IGNORE_USER ] ; then
 	if [ -d ./pre-commit-user ] ; then
 		for SCRIPT in `find ./pre-commit-user -name "*.sh" -executable` ; do
 			echo "Running user pre-commit hook $SCRIPT"
-			$SCRIPT || (echo "User test $SCRIPT failed" && FAIL=1)
-			echo "fail is $FAIL"
+			$SCRIPT
+			if [ $? != 0 ] ; then
+				echo "User test $SCRIPT failed"
+			       	FAIL=1
+			fi
 		done
 	fi
-	echo "Final fail $FAIL"
 	if [ $FAIL == 1 ] ; then
 		echo "One or more user tests failed, see messages above"
 		exit 1

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -8,9 +8,18 @@ if [ -z $AWX_IGNORE_BLACK ] ; then
 fi
 
 if [ -z $AWX_IGNORE_USER ] ; then
+	FAIL=0
+	export CHANGED_FILES=$(git diff --cached --name-only --diff-filter=AM)
 	if [ -d ./pre-commit-user ] ; then
 		for SCRIPT in `find ./pre-commit-user -name "*.sh" -executable` ; do
-			$SCRIPT || exit 1
+			echo "Running user pre-commit hook $SCRIPT"
+			$SCRIPT || (echo "User test $SCRIPT failed" && FAIL=1)
+			echo "fail is $FAIL"
 		done
+	fi
+	echo "Final fail $FAIL"
+	if [ $FAIL == 1 ] ; then
+		echo "One or more user tests failed, see messages above"
+		exit 1
 	fi
 fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -11,7 +11,7 @@ if [ -z $AWX_IGNORE_USER ] ; then
 	FAIL=0
 	export CHANGED_FILES=$(git diff --cached --name-only --diff-filter=AM)
 	if [ -d ./pre-commit-user ] ; then
-		for SCRIPT in `find ./pre-commit-user -name "*.sh" -executable` ; do
+		for SCRIPT in `find ./pre-commit-user -executable -type f` ; do
 			echo "Running user pre-commit hook $SCRIPT"
 			$SCRIPT
 			if [ $? != 0 ] ; then


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change allows users to place additional pre-commit hook scripts in a directory called pre-commit-user. These files will be ignored by git.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.5.2.dev308+g74198d26f0.d20220318
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
