### PR TITLE
Fix subsystem metrics sync-only operation in async context

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -136,7 +136,7 @@ class HistogramM(BaseM):
 
 
 class Metrics:
-    def __init__(self, auto_pipe_execute=True):
+    def __init__(self, auto_pipe_execute=True, instance_name=None):
         self.pipe = redis.Redis.from_url(settings.BROKER_URL).pipeline()
         self.conn = redis.Redis.from_url(settings.BROKER_URL)
         self.last_pipe_execute = time.time()
@@ -150,7 +150,10 @@ class Metrics:
         # the calling function should call .pipe_execute() explicitly
         self.auto_pipe_execute = auto_pipe_execute
         Instance = apps.get_model('main', 'Instance')
-        self.instance_name = Instance.objects.me().hostname
+        if instance_name:
+            self.instance_name = instance_name
+        else:
+            self.instance_name = Instance.objects.me().hostname
 
         # metric name, help_text
         METRICSLIST = [

--- a/awx/main/wsbroadcast.py
+++ b/awx/main/wsbroadcast.py
@@ -71,7 +71,7 @@ class WebsocketTask:
         self.protocol = protocol
         self.verify_ssl = verify_ssl
         self.channel_layer = None
-        self.subsystem_metrics = s_metrics.Metrics()
+        self.subsystem_metrics = s_metrics.Metrics(instance_name=name)
 
     async def run_loop(self, websocket: aiohttp.ClientWebSocketResponse):
         raise RuntimeError("Implement me")


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

## The Issue
I see this log

`django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.`

this is the culprit line

`self.instance_name = Instance.objects.me().hostname`

This particular instance of subsystem metrics is being called in an async context from the websocket broadcast manager.

I assume this was brought on by the django 3 upgrade

## The Fix
Just pass the hostname into init of Metrics(), so we can avoid calling this code.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 20.0.2.dev97+gc9853f0359

```
