### PR TITLE
Add setting for notification job status retry loop

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -846,7 +846,7 @@ def handle_work_error(task_id, *args, **kwargs):
 def handle_success_and_failure_notifications(job_id):
     uj = UnifiedJob.objects.get(pk=job_id)
     retries = 0
-    while retries < 5:
+    while retries < settings.AWX_NOTIFICATION_JOB_FINISH_MAX_RETRY:
         if uj.finished:
             uj.send_notification_templates('succeeded' if uj.status == 'successful' else 'failed')
             return

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -983,6 +983,9 @@ BROADCAST_WEBSOCKET_NEW_INSTANCE_POLL_RATE_SECONDS = 10
 # How often websocket process will generate stats
 BROADCAST_WEBSOCKET_STATS_POLL_RATE_SECONDS = 5
 
+# Number of times to retry sending a notification when waiting on a job to finish.
+AWX_NOTIFICATION_JOB_FINISH_MAX_RETRY = 5
+
 DJANGO_GUID = {'GUID_HEADER_NAME': 'X-API-Request-Id'}
 
 # Name of the default task queue


### PR DESCRIPTION
This change has already been made downstream, and this is adopting it for `devel`.