### PR TITLE
Fix Source Control Type label in project form

### DIFF
--- a/awx/ui/src/screens/Project/shared/ProjectForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.js
@@ -211,7 +211,7 @@ function ProjectFormFields({
         validated={
           !scmTypeMeta.touched || !scmTypeMeta.error ? 'default' : 'error'
         }
-        label={t`Source Control Credential Type`}
+        label={t`Source Control Type`}
       >
         <AnsibleSelect
           {...scmTypeField}

--- a/awx/ui/src/screens/Project/shared/ProjectForm.test.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.test.js
@@ -121,9 +121,9 @@ describe('<ProjectForm />', () => {
     expect(wrapper.find('FormGroup[label="Name"]').length).toBe(1);
     expect(wrapper.find('FormGroup[label="Description"]').length).toBe(1);
     expect(wrapper.find('FormGroup[label="Organization"]').length).toBe(1);
-    expect(
-      wrapper.find('FormGroup[label="Source Control Credential Type"]').length
-    ).toBe(1);
+    expect(wrapper.find('FormGroup[label="Source Control Type"]').length).toBe(
+      1
+    );
     expect(wrapper.find('FormGroup[label="Ansible Environment"]').length).toBe(
       0
     );
@@ -291,7 +291,7 @@ describe('<ProjectForm />', () => {
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
 
     const scmTypeSelect = wrapper.find(
-      'FormGroup[label="Source Control Credential Type"] FormSelect'
+      'FormGroup[label="Source Control Type"] FormSelect'
     );
     await act(async () => {
       scmTypeSelect.invoke('onChange')('svn', {


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fix Source Control Type field label in Project form"
-->

##### SUMMARY
<img width="1397" alt="Screen Shot 2022-03-22 at 9 38 47 AM" src="https://user-images.githubusercontent.com/9889020/159494804-b9832ff8-daef-4b9e-b3e8-de27888273f2.png">

Changed `Source Control Credential Type` to `Source Control Type`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
