### PR TITLE
Fix search toolbar clear all filters

### DIFF
--- a/awx/ui/src/components/DataListToolbar/DataListToolbar.js
+++ b/awx/ui/src/components/DataListToolbar/DataListToolbar.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useLocation } from 'react-router-dom';
 import { t } from '@lingui/macro';
 import {
   Button,
@@ -58,7 +57,6 @@ function DataListToolbar({
   handleIsAnsibleFactsSelected,
   isFilterCleared,
 }) {
-  const { search } = useLocation();
   const showExpandCollapse = onCompact && onExpand;
   const [isKebabOpen, setIsKebabOpen] = useState(false);
   const [isKebabModalOpen, setIsKebabModalOpen] = useState(false);
@@ -93,7 +91,7 @@ function DataListToolbar({
       ouiaId={`${qsConfig.namespace}-list-toolbar`}
       clearAllFilters={clearAllFilters}
       collapseListedFiltersBreakpoint="lg"
-      clearFiltersButtonText={Boolean(search) && t`Clear all filters`}
+      clearFiltersButtonText={t`Clear all filters`}
     >
       <ToolbarContent>
         {onExpandAll && (

--- a/awx/ui/src/components/DataListToolbar/DataListToolbar.test.js
+++ b/awx/ui/src/components/DataListToolbar/DataListToolbar.test.js
@@ -5,14 +5,6 @@ import { mountWithContexts } from '../../../testUtils/enzymeHelpers';
 import DataListToolbar from './DataListToolbar';
 import AddDropDownButton from '../AddDropDownButton/AddDropDownButton';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useLocation: () => ({
-    pathname: '/organizations',
-    search: 'template.name__icontains=name',
-  }),
-}));
-
 describe('<DataListToolbar />', () => {
   let toolbar;
 


### PR DESCRIPTION
### SUMMARY

Issue: https://github.com/ansible/awx/issues/8474

Dynamically removing the ToolbarFilter component threw the Toolbar component’s inner `filterInfo` state out of sync. The filters were responsible for notifying the Toolbar’s context of changes, so by removing them prematurely, the Toolbar was unaware that it needed to remove filters from its state. This PR persists the ToolbarFilter components, which allows the Toolbar to manage showing and hiding the filter list. 

![filter](https://user-images.githubusercontent.com/15881645/159578188-18f461f6-e8ac-4145-a880-36cf37336bca.gif)

### ISSUE TYPE

- Bugfix Pull Request

### COMPONENT NAME

- UI