### PR TITLE
Use new children-summary endpoint data to traverse job event tree

### DIFF
--- a/awx/ui/src/api/models/Jobs.js
+++ b/awx/ui/src/api/models/Jobs.js
@@ -19,6 +19,10 @@ class Jobs extends RunnableMixin(Base) {
   readDetail(id) {
     return this.http.get(`${this.baseUrl}${id}/`);
   }
+
+  readChildrenSummary(id) {
+    return this.http.get(`${this.baseUrl}${id}/job_events/children_summary/`);
+  }
 }
 
 export default Jobs;

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -115,8 +115,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
 
   const [jobStatus, setJobStatus] = useState(job.status ?? 'waiting');
   const [forceFlatMode, setForceFlatMode] = useState(false);
-  const isFlatMode =
-    forceFlatMode || isJobRunning(jobStatus) || location.search.length > 1;
+  const isFlatMode = isJobRunning(jobStatus) || location.search.length > 1;
 
   const [isTreeReady, setIsTreeReady] = useState(false);
   const [onReadyEvents, setOnReadyEvents] = useState([]);
@@ -140,7 +139,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
       setJobTreeReady: () => setIsTreeReady(true),
     },
     job.id,
-    isFlatMode
+    isFlatMode || forceFlatMode
   );
   const [wsEvents, setWsEvents] = useState([]);
   const [cssMap, setCssMap] = useState({});
@@ -670,7 +669,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
           onScrollNext={handleScrollNext}
           onScrollPrevious={handleScrollPrevious}
           toggleExpandCollapseAll={handleExpandCollapseAll}
-          isFlatMode={isFlatMode}
+          isFlatMode={isFlatMode || forceFlatMode}
           isTemplateJob={job.type === 'job'}
           isAllCollapsed={isAllCollapsed}
         />

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -169,7 +169,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   useEffect(() => {
     const pendingRequests = Object.values(eventByUuidRequests.current || {});
     setHasContentLoading(true); // prevents "no content found" screen from flashing
-    Promise.all(pendingRequests).then(() => {
+    Promise.allSettled(pendingRequests).then(() => {
       setRemoteRowCount(0);
       clearLoadedEvents();
       loadJobEvents();

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -99,8 +99,6 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const scrollHeight = useRef(0);
   const history = useHistory();
   const eventByUuidRequests = useRef([]);
-  const siblingRequests = useRef([]);
-  const numEventsRequests = useRef([]);
 
   const fetchEventByUuid = async (uuid) => {
     let promise = eventByUuidRequests.current[uuid];
@@ -166,11 +164,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   );
 
   useEffect(() => {
-    const pendingRequests = [
-      ...Object.values(eventByUuidRequests.current || {}),
-      ...Object.values(siblingRequests.current || {}),
-      ...Object.values(numEventsRequests.current || {}),
-    ];
+    const pendingRequests = Object.values(eventByUuidRequests.current || {});
     setHasContentLoading(true); // prevents "no content found" screen from flashing
     Promise.all(pendingRequests).then(() => {
       setRemoteRowCount(0);

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -114,7 +114,9 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   const fetchChildrenSummary = () => JobsAPI.readChildrenSummary(job.id);
 
   const [jobStatus, setJobStatus] = useState(job.status ?? 'waiting');
-  const isFlatMode = isJobRunning(jobStatus) || location.search.length > 1;
+  const [forceFlatMode, setForceFlatMode] = useState(false);
+  const isFlatMode =
+    forceFlatMode || isJobRunning(jobStatus) || location.search.length > 1;
 
   const {
     addEvents,
@@ -131,6 +133,7 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     {
       fetchEventByUuid,
       fetchChildrenSummary,
+      setForceFlatMode,
     },
     job.id,
     isFlatMode

--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { JobsAPI, JobEventsAPI } from 'api';
@@ -26,14 +25,9 @@ const applyJobEventMock = (mockJobEvents) => {
     };
   };
   JobsAPI.readEvents = jest.fn().mockImplementation(mockReadEvents);
-  JobEventsAPI.readChildren = jest.fn().mockResolvedValue({
+  JobsAPI.readChildrenSummary = jest.fn().mockResolvedValue({
     data: {
-      results: [
-        {
-          counter: 20,
-          uuid: 'abc-020',
-        },
-      ],
+      1: [0, 100],
     },
   });
 };

--- a/awx/ui/src/screens/Job/JobOutput/shared/JobEventLine.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/JobEventLine.js
@@ -4,7 +4,6 @@ export default styled.div`
   display: flex;
 
   &:hover {
-    background-color: white;
     cursor: ${(props) => (props.isClickable ? 'pointer' : 'default')};
   }
 

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
@@ -11,16 +11,18 @@ const initialState = {
   // events with parent events that aren't yet loaded.
   // arrays indexed by parent uuid
   eventsWithoutParents: {},
+  // tuple arrays in the form [rowNumber, numChildren] for parent nodes, indexed by counter
+  childrenSummary: {},
   isAllCollapsed: false,
 };
 export const ADD_EVENTS = 'ADD_EVENTS';
 export const TOGGLE_NODE_COLLAPSED = 'TOGGLE_NODE_COLLAPSED';
-export const SET_EVENT_NUM_CHILDREN = 'SET_EVENT_NUM_CHILDREN';
 export const CLEAR_EVENTS = 'CLEAR_EVENTS';
 export const REBUILD_TREE = 'REBUILD_TREE';
 export const TOGGLE_COLLAPSE_ALL = 'TOGGLE_COLLAPSE_ALL';
+export const SET_CHILDREN_SUMMARY = 'SET_CHILDREN_SUMMARY';
 
-export default function useJobEvents(callbacks, isFlatMode) {
+export default function useJobEvents(callbacks, jobId, isFlatMode) {
   const [actionQueue, setActionQueue] = useState([]);
   const enqueueAction = (action) => {
     setActionQueue((queue) => queue.concat(action));
@@ -42,6 +44,18 @@ export default function useJobEvents(callbacks, isFlatMode) {
     });
   }, [actionQueue]);
 
+  useEffect(() => {
+    if (isFlatMode) {
+      return;
+    }
+    callbacks.fetchChildrenSummary().then((result) => {
+      enqueueAction({
+        type: SET_CHILDREN_SUMMARY,
+        childrenSummary: result.data,
+      });
+    });
+  }, [jobId, isFlatMode]); // eslint-disable-line react-hooks/exhaustive-deps
+
   return {
     addEvents: (events) => dispatch({ type: ADD_EVENTS, events }),
     getNodeByUuid: (uuid) => getNodeByUuid(state, uuid),
@@ -53,10 +67,14 @@ export default function useJobEvents(callbacks, isFlatMode) {
     getNodeForRow: (rowIndex) => getNodeForRow(state, rowIndex),
     getTotalNumChildren: (uuid) => {
       const node = getNodeByUuid(state, uuid);
-      return getTotalNumChildren(node);
+      return getTotalNumChildren(node, state.childrenSummary);
     },
     getNumCollapsedEvents: () =>
-      state.tree.reduce((sum, node) => sum + getNumCollapsedChildren(node), 0),
+      state.tree.reduce(
+        (sum, node) =>
+          sum + getNumCollapsedChildren(node, state.childrenSummary),
+        0
+      ),
     getCounterForRow: (rowIndex) => getCounterForRow(state, rowIndex),
     getEvent: (eventIndex) => getEvent(state, eventIndex),
     clearLoadedEvents: () => dispatch({ type: CLEAR_EVENTS }),
@@ -74,12 +92,15 @@ export function jobEventsReducer(callbacks, isFlatMode, enqueueAction) {
         return toggleCollapseAll(state, action.isCollapsed);
       case TOGGLE_NODE_COLLAPSED:
         return toggleNodeIsCollapsed(state, action.uuid);
-      case SET_EVENT_NUM_CHILDREN:
-        return setEventNumChildren(state, action.uuid, action.numChildren);
       case CLEAR_EVENTS:
         return initialState;
       case REBUILD_TREE:
         return rebuildTree(state);
+      case SET_CHILDREN_SUMMARY:
+        return {
+          ...state,
+          childrenSummary: action.childrenSummary,
+        };
       default:
         throw new Error(`Unrecognized action: ${action.type}`);
     }
@@ -113,22 +134,21 @@ export function jobEventsReducer(callbacks, isFlatMode, enqueueAction) {
       let isParentFound;
       [state, isParentFound] = _addNestedLevelEvent(state, event);
       if (!isParentFound) {
-        parentsToFetch[event.parent_uuid] = {
-          childCounter: event.counter,
-          childRowNumber: event.rowNumber,
-        };
+        parentsToFetch[event.parent_uuid] = true;
         state = _addEventWithoutParent(state, event);
       }
     });
 
     Object.keys(parentsToFetch).forEach(async (uuid) => {
-      const { childCounter, childRowNumber } = parentsToFetch[uuid];
       const parent = await callbacks.fetchEventByUuid(uuid);
-      const numPrevSiblings = await callbacks.fetchNumEvents(
-        parent.counter,
-        childCounter
-      );
-      parent.rowNumber = childRowNumber - numPrevSiblings - 1;
+
+      if (!state.childrenSummary[parent.counter]) {
+        // eslint-disable-next-line no-console
+        console.error('No row number found for ', parent);
+      }
+      const [rowNumber] = state.childrenSummary[parent.counter];
+      parent.rowNumber = rowNumber;
+
       enqueueAction({
         type: ADD_EVENTS,
         events: [parent],
@@ -180,7 +200,6 @@ export function jobEventsReducer(callbacks, isFlatMode, enqueueAction) {
     const index = parent.children.findIndex(
       (node) => node.eventIndex >= eventIndex
     );
-    const length = parent.children.length + 1;
     if (index === -1) {
       state = updateNodeByUuid(state, event.parent_uuid, (node) => {
         node.children.push(newNode);
@@ -206,9 +225,6 @@ export function jobEventsReducer(callbacks, isFlatMode, enqueueAction) {
       },
       event.uuid
     );
-    if (length === 1) {
-      _fetchNumChildren(state, parent);
-    }
 
     return [state, true];
   }
@@ -229,45 +245,6 @@ export function jobEventsReducer(callbacks, isFlatMode, enqueueAction) {
         [parentUuid]: eventsList,
       },
     };
-  }
-
-  async function _fetchNumChildren(state, node) {
-    const event = state.events[node.eventIndex];
-    if (!event) {
-      throw new Error(
-        `Cannot fetch numChildren; event ${node.eventIndex} not found`
-      );
-    }
-    const sibling = await _getNextSibling(state, event);
-    const numChildren = await callbacks.fetchNumEvents(
-      event.counter,
-      sibling?.counter
-    );
-    enqueueAction({
-      type: SET_EVENT_NUM_CHILDREN,
-      uuid: event.uuid,
-      numChildren,
-    });
-    if (sibling) {
-      sibling.rowNumber = event.rowNumber + numChildren + 1;
-      enqueueAction({
-        type: ADD_EVENTS,
-        events: [sibling],
-      });
-    }
-  }
-
-  async function _getNextSibling(state, event) {
-    if (!event.parent_uuid) {
-      return callbacks.fetchNextRootNode(event.counter);
-    }
-    const parentNode = getNodeByUuid(state, event.parent_uuid);
-    const parent = state.events[parentNode.eventIndex];
-    const sibling = await callbacks.fetchNextSibling(parent.id, event.counter);
-    if (!sibling) {
-      return _getNextSibling(state, parent);
-    }
-    return sibling;
   }
 
   function _gatherEventsForNewParent(state, parentUuid) {
@@ -303,8 +280,13 @@ function getEventForRow(state, rowIndex) {
   return null;
 }
 
-function getNodeForRow(state, rowToFind) {
-  const { node } = _getNodeForRow(state, rowToFind, state.tree);
+function getNodeForRow(state, rowToFind, childrenSummary) {
+  const { node } = _getNodeForRow(
+    state,
+    rowToFind,
+    state.tree,
+    childrenSummary
+  );
   return node;
 }
 
@@ -329,8 +311,14 @@ function _getNodeForRow(state, rowToFind, nodes) {
     if (event.rowNumber === rowToFind) {
       return { node };
     }
-    const totalNodeDescendants = getTotalNumChildren(node);
-    const numCollapsedChildren = getNumCollapsedChildren(node);
+    const totalNodeDescendants = getTotalNumChildren(
+      node,
+      state.childrenSummary
+    );
+    const numCollapsedChildren = getNumCollapsedChildren(
+      node,
+      state.childrenSummary
+    );
     const nodeChildren = totalNodeDescendants - numCollapsedChildren;
     if (event.rowNumber + nodeChildren >= rowToFind) {
       // requested row is in children/descendants
@@ -391,25 +379,25 @@ function _getLastDescendantNode(nodes) {
   return lastDescendant;
 }
 
-function getTotalNumChildren(node) {
-  if (typeof node.numChildren !== 'undefined') {
-    return node.numChildren;
+function getTotalNumChildren(node, childrenSummary) {
+  if (childrenSummary[node.eventIndex]) {
+    return childrenSummary[node.eventIndex][1];
   }
 
   let estimatedNumChildren = node.children.length;
   node.children.forEach((child) => {
-    estimatedNumChildren += getTotalNumChildren(child);
+    estimatedNumChildren += getTotalNumChildren(child, childrenSummary);
   });
   return estimatedNumChildren;
 }
 
-function getNumCollapsedChildren(node) {
+function getNumCollapsedChildren(node, childrenSummary) {
   if (node.isCollapsed) {
-    return getTotalNumChildren(node);
+    return getTotalNumChildren(node, childrenSummary);
   }
   let sum = 0;
   node.children.forEach((child) => {
-    sum += getNumCollapsedChildren(child);
+    sum += getNumCollapsedChildren(child, childrenSummary);
   });
   return sum;
 }
@@ -512,16 +500,6 @@ function _getNodeByIndex(arr, index) {
     return null;
   }
   return _getNodeByIndex(arr[i - 1].children, index);
-}
-
-function setEventNumChildren(state, uuid, numChildren) {
-  if (!state.uuidMap[uuid]) {
-    return state;
-  }
-  return updateNodeByUuid(state, uuid, (node) => ({
-    ...node,
-    numChildren,
-  }));
 }
 
 function getEvent(state, eventIndex) {

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
@@ -51,7 +51,7 @@ export default function useJobEvents(callbacks, jobId, isFlatMode) {
     if (isFlatMode) {
       return;
     }
-    // TODO: ensure this response is back before adding events
+
     callbacks
       .fetchChildrenSummary()
       .then((result) => {
@@ -63,6 +63,7 @@ export default function useJobEvents(callbacks, jobId, isFlatMode) {
       })
       .catch(() => {
         callbacks.setForceFlatMode(true);
+        callbacks.setJobTreeReady();
       });
   }, [jobId, isFlatMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -107,6 +108,7 @@ export function jobEventsReducer(callbacks, isFlatMode, enqueueAction) {
       case REBUILD_TREE:
         return rebuildTree(state);
       case SET_CHILDREN_SUMMARY:
+        callbacks.setJobTreeReady();
         return {
           ...state,
           childrenSummary: action.childrenSummary || {},

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
@@ -55,6 +55,11 @@ export default function useJobEvents(callbacks, jobId, isFlatMode) {
     callbacks
       .fetchChildrenSummary()
       .then((result) => {
+        if (result.data.event_processing_finished === false) {
+          callbacks.setForceFlatMode(true);
+          callbacks.setJobTreeReady();
+          return;
+        }
         enqueueAction({
           type: SET_CHILDREN_SUMMARY,
           childrenSummary: result.data.children_summary,

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
@@ -54,6 +54,7 @@ export default function useJobEvents(callbacks, jobId, isFlatMode) {
         childrenSummary: result.data,
       });
     });
+    // TODO: catch error -> force isFlatMode to be true?
   }, [jobId, isFlatMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {
@@ -142,9 +143,10 @@ export function jobEventsReducer(callbacks, isFlatMode, enqueueAction) {
     Object.keys(parentsToFetch).forEach(async (uuid) => {
       const parent = await callbacks.fetchEventByUuid(uuid);
 
-      if (!state.childrenSummary[parent.counter]) {
+      if (!state.childrenSummary || !state.childrenSummary[parent.counter]) {
         // eslint-disable-next-line no-console
-        console.error('No row number found for ', parent);
+        console.error('No row number found for ', parent.counter);
+        return;
       }
       const [rowNumber] = state.childrenSummary[parent.counter];
       parent.rowNumber = rowNumber;
@@ -358,8 +360,8 @@ function _getNodeForRow(state, rowToFind, nodes) {
 
 function _getNodeInChildren(state, node, rowToFind) {
   const event = state.events[node.eventIndex];
-  const firstChild = state.events[node.children[0].eventIndex];
-  if (rowToFind < firstChild.rowNumber) {
+  const firstChild = state.events[node.children[0]?.eventIndex];
+  if (!firstChild || rowToFind < firstChild.rowNumber) {
     const rowDiff = rowToFind - event.rowNumber;
     return {
       node: null,

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
@@ -48,13 +48,17 @@ export default function useJobEvents(callbacks, jobId, isFlatMode) {
     if (isFlatMode) {
       return;
     }
-    callbacks.fetchChildrenSummary().then((result) => {
-      enqueueAction({
-        type: SET_CHILDREN_SUMMARY,
-        childrenSummary: result.data,
+    callbacks
+      .fetchChildrenSummary()
+      .then((result) => {
+        enqueueAction({
+          type: SET_CHILDREN_SUMMARY,
+          childrenSummary: result.data,
+        });
+      })
+      .catch(() => {
+        callbacks.setForceFlatMode(true);
       });
-    });
-    // TODO: catch error -> force isFlatMode to be true?
   }, [jobId, isFlatMode]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return {

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
@@ -14,12 +14,16 @@ function Child() {
 function HookTest({
   fetchEventByUuid = () => {},
   fetchChildrenSummary = () => {},
+  setForceFlatMode = () => {},
+  setJobTreeReady = () => {},
   isFlatMode = false,
 }) {
   const hookFuncs = useJobEvents(
     {
       fetchEventByUuid,
       fetchChildrenSummary,
+      setForceFlatMode,
+      setJobTreeReady,
     },
     isFlatMode
   );
@@ -148,6 +152,8 @@ describe('useJobEvents', () => {
     callbacks = {
       fetchEventByUuid: jest.fn(),
       fetchChildrenSummary: jest.fn(),
+      setForceFlatMode: jest.fn(),
+      setJobTreeReady: jest.fn(),
     };
     enqueueAction = jest.fn();
     reducer = jobEventsReducer(callbacks, false, enqueueAction);

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
@@ -8,24 +8,18 @@ import useJobEvents, {
   SET_EVENT_NUM_CHILDREN,
 } from './useJobEvents';
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
 function Child() {
   return <div />;
 }
 function HookTest({
   fetchEventByUuid = () => {},
-  fetchNextSibling = () => {},
-  fetchNextRootNode = () => {},
-  fetchNumEvents = () => {},
+  fetchChildrenSummary = () => {},
   isFlatMode = false,
 }) {
   const hookFuncs = useJobEvents(
     {
       fetchEventByUuid,
-      fetchNextSibling,
-      fetchNextRootNode,
-      fetchNumEvents,
+      fetchChildrenSummary,
     },
     isFlatMode
   );
@@ -153,19 +147,16 @@ describe('useJobEvents', () => {
   beforeEach(() => {
     callbacks = {
       fetchEventByUuid: jest.fn(),
-      fetchNextSibling: jest.fn(),
-      fetchNextRootNode: jest.fn(),
-      fetchNumEvents: jest.fn(),
+      fetchChildrenSummary: jest.fn(),
     };
     enqueueAction = jest.fn();
-    callbacks.fetchNextSibling.mockResolvedValue(eventsList[9]);
-    callbacks.fetchNextRootNode.mockResolvedValue(eventsList[9]);
     reducer = jobEventsReducer(callbacks, false, enqueueAction);
     emptyState = {
       tree: [],
       events: {},
       uuidMap: {},
       eventsWithoutParents: {},
+      childrenSummary: {},
       eventGaps: [],
       isAllCollapsed: false,
     };
@@ -380,10 +371,18 @@ describe('useJobEvents', () => {
       callbacks.fetchEventByUuid.mockResolvedValue({
         counter: 10,
       });
-      const state = reducer(emptyState, {
-        type: ADD_EVENTS,
-        events: eventsList,
-      });
+      const state = reducer(
+        {
+          ...emptyState,
+          childrenSummary: {
+            10: [9, 2],
+          },
+        },
+        {
+          type: ADD_EVENTS,
+          events: eventsList,
+        }
+      );
 
       const newEvents = [
         {
@@ -404,10 +403,18 @@ describe('useJobEvents', () => {
       callbacks.fetchEventByUuid.mockResolvedValue({
         counter: 10,
       });
-      const state = reducer(emptyState, {
-        type: ADD_EVENTS,
-        events: eventsList,
-      });
+      const state = reducer(
+        {
+          ...emptyState,
+          childrenSummary: {
+            10: [9, 2],
+          },
+        },
+        {
+          type: ADD_EVENTS,
+          events: eventsList,
+        }
+      );
 
       const newEvents = [
         {
@@ -437,10 +444,18 @@ describe('useJobEvents', () => {
       callbacks.fetchEventByUuid.mockResolvedValue({
         counter: 10,
       });
-      const state = reducer(emptyState, {
-        type: ADD_EVENTS,
-        events: eventsList,
-      });
+      const state = reducer(
+        {
+          ...emptyState,
+          childrenSummary: {
+            10: [9, 1],
+          },
+        },
+        {
+          type: ADD_EVENTS,
+          events: eventsList,
+        }
+      );
 
       const newEvents = [
         {
@@ -471,10 +486,18 @@ describe('useJobEvents', () => {
       callbacks.fetchEventByUuid.mockResolvedValue({
         counter: 10,
       });
-      const state = reducer(emptyState, {
-        type: ADD_EVENTS,
-        events: eventsList,
-      });
+      const state = reducer(
+        {
+          ...emptyState,
+          childrenSummary: {
+            10: [9, 2],
+          },
+        },
+        {
+          type: ADD_EVENTS,
+          events: eventsList,
+        }
+      );
 
       const newEvents = [
         {
@@ -561,10 +584,19 @@ describe('useJobEvents', () => {
         event_level: 2,
         parent_uuid: 'abc-002',
       };
-      const state = reducer(emptyState, {
-        type: ADD_EVENTS,
-        events: [event3],
-      });
+      const state = reducer(
+        {
+          ...emptyState,
+          childrenSummary: {
+            1: [0, 3],
+            2: [1, 2],
+          },
+        },
+        {
+          type: ADD_EVENTS,
+          events: [event3],
+        }
+      );
       expect(callbacks.fetchEventByUuid).toHaveBeenCalledWith('abc-002');
 
       const event2 = {
@@ -740,154 +772,6 @@ describe('useJobEvents', () => {
         'abc-009': 9,
       });
     });
-
-    describe('fetchNumChildren', () => {
-      test('should find child count for root node', async () => {
-        callbacks.fetchNextRootNode.mockResolvedValue({
-          id: 121,
-          counter: 21,
-          rowNumber: 20,
-          uuid: 'abc-021',
-          event_level: 0,
-          parent_uuid: '',
-        });
-        callbacks.fetchNumEvents.mockResolvedValue(19);
-        reducer(emptyState, {
-          type: ADD_EVENTS,
-          events: [eventsList[0], eventsList[1]],
-        });
-
-        expect(callbacks.fetchNextSibling).toHaveBeenCalledTimes(0);
-        expect(callbacks.fetchNextRootNode).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNextRootNode).toHaveBeenCalledWith(1);
-        await sleep(0);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledWith(1, 21);
-        expect(enqueueAction).toHaveBeenCalledWith({
-          type: SET_EVENT_NUM_CHILDREN,
-          uuid: 'abc-001',
-          numChildren: 19,
-        });
-      });
-
-      test('should find child count for last root node', async () => {
-        callbacks.fetchNextRootNode.mockResolvedValue(null);
-        callbacks.fetchNumEvents.mockResolvedValue(19);
-        reducer(emptyState, {
-          type: ADD_EVENTS,
-          events: [eventsList[0], eventsList[1]],
-        });
-
-        expect(callbacks.fetchNextSibling).toHaveBeenCalledTimes(0);
-        expect(callbacks.fetchNextRootNode).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNextRootNode).toHaveBeenCalledWith(1);
-        await sleep(0);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledWith(1, undefined);
-        expect(enqueueAction).toHaveBeenCalledWith({
-          type: SET_EVENT_NUM_CHILDREN,
-          uuid: 'abc-001',
-          numChildren: 19,
-        });
-      });
-
-      test('should find child count for nested node', async () => {
-        const state = {
-          events: {
-            1: eventsList[0],
-            2: eventsList[1],
-          },
-          tree: [
-            {
-              children: [{ children: [], eventIndex: 2, isCollapsed: false }],
-              eventIndex: 1,
-              isCollapsed: false,
-            },
-          ],
-          uuidMap: {
-            'abc-001': 1,
-            'abc-002': 2,
-          },
-          eventsWithoutParents: {},
-        };
-
-        callbacks.fetchNextSibling.mockResolvedValue({
-          id: 20,
-          counter: 20,
-          rowNumber: 19,
-          uuid: 'abc-020',
-          event_level: 1,
-          parent_uuid: 'abc-001',
-        });
-        callbacks.fetchNumEvents.mockResolvedValue(18);
-        reducer(state, {
-          type: ADD_EVENTS,
-          events: [eventsList[2]],
-        });
-
-        expect(callbacks.fetchNextSibling).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNextSibling).toHaveBeenCalledWith(101, 2);
-        await sleep(0);
-        expect(callbacks.fetchNextRootNode).toHaveBeenCalledTimes(0);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledWith(2, 20);
-        expect(enqueueAction).toHaveBeenCalledWith({
-          type: SET_EVENT_NUM_CHILDREN,
-          uuid: 'abc-002',
-          numChildren: 18,
-        });
-      });
-
-      test('should find child count for nested node, last sibling', async () => {
-        const state = {
-          events: {
-            1: eventsList[0],
-            2: eventsList[1],
-          },
-          tree: [
-            {
-              children: [{ children: [], eventIndex: 2, isCollapsed: false }],
-              eventIndex: 1,
-              isCollapsed: false,
-            },
-          ],
-          uuidMap: {
-            'abc-001': 1,
-            'abc-002': 2,
-          },
-          eventsWithoutParents: {},
-        };
-
-        callbacks.fetchNextSibling.mockResolvedValue(null);
-        callbacks.fetchNextRootNode.mockResolvedValue({
-          id: 121,
-          counter: 21,
-          rowNumber: 20,
-          uuid: 'abc-021',
-          event_level: 0,
-          parent_uuid: '',
-        });
-        callbacks.fetchNumEvents.mockResolvedValue(19);
-        reducer(state, {
-          type: ADD_EVENTS,
-          events: [eventsList[2]],
-        });
-
-        expect(callbacks.fetchNextSibling).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNextSibling).toHaveBeenCalledWith(101, 2);
-        await sleep(0);
-        expect(callbacks.fetchNextRootNode).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNextRootNode).toHaveBeenCalledWith(1);
-        await sleep(0);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledTimes(1);
-        expect(callbacks.fetchNumEvents).toHaveBeenCalledWith(2, 21);
-        expect(enqueueAction).toHaveBeenCalledWith({
-          type: SET_EVENT_NUM_CHILDREN,
-          uuid: 'abc-002',
-          numChildren: 19,
-        });
-      });
-    });
   });
 
   describe('getNodeByUuid', () => {
@@ -965,40 +849,6 @@ describe('useJobEvents', () => {
       );
 
       expect(tree).toEqual(basicTree);
-    });
-  });
-
-  describe('setEventNumChildren', () => {
-    test('should set number of children on root node', () => {
-      const state = reducer(emptyState, {
-        type: ADD_EVENTS,
-        events: eventsList,
-      });
-      expect(state.tree[0].numChildren).toEqual(undefined);
-
-      const { tree } = reducer(state, {
-        type: SET_EVENT_NUM_CHILDREN,
-        uuid: 'abc-001',
-        numChildren: 8,
-      });
-
-      expect(tree[0].numChildren).toEqual(8);
-    });
-
-    test('should set number of children on nested node', () => {
-      const state = reducer(emptyState, {
-        type: ADD_EVENTS,
-        events: eventsList,
-      });
-      expect(state.tree[0].numChildren).toEqual(undefined);
-
-      const { tree } = reducer(state, {
-        type: SET_EVENT_NUM_CHILDREN,
-        uuid: 'abc-006',
-        numChildren: 3,
-      });
-
-      expect(tree[0].children[1].numChildren).toEqual(3);
     });
   });
 
@@ -1266,16 +1116,16 @@ describe('useJobEvents', () => {
     });
 
     test('should get node after gap in loaded children', async () => {
-      const fetchNumEvents = jest.fn();
-      fetchNumEvents.mockImplementation((index) => {
-        const counts = {
-          1: 52,
-          2: 3,
-          6: 47,
-        };
-        return Promise.resolve(counts[index]);
+      const fetchChildrenSummary = jest.fn();
+      fetchChildrenSummary.mockResolvedValue({
+        data: {
+          1: [0, 52],
+          2: [1, 3],
+          6: [5, 47],
+        },
       });
-      wrapper = mount(<HookTest fetchNumEvents={fetchNumEvents} />);
+
+      wrapper = mount(<HookTest fetchChildrenSummary={fetchChildrenSummary} />);
       const laterEvents = [
         {
           id: 151,
@@ -1424,13 +1274,12 @@ describe('useJobEvents', () => {
     });
 
     test('should return estimated counter when node is non-loaded child', async () => {
-      callbacks.fetchNumEvents.mockImplementation((counter) => {
-        const children = {
-          1: 28,
-          2: 3,
-          6: 23,
-        };
-        return children[counter];
+      callbacks.fetchChildrenSummary.mockResolvedValue({
+        data: {
+          1: [0, 28],
+          2: [1, 3],
+          6: [5, 23],
+        },
       });
       const wrapper = mount(<HookTest {...callbacks} />);
       wrapper.update();
@@ -1463,13 +1312,12 @@ describe('useJobEvents', () => {
     });
 
     test('should estimate counter after skipping collapsed subtree', async () => {
-      callbacks.fetchNumEvents.mockImplementation((counter) => {
-        const children = {
-          1: 85,
-          2: 66,
-          69: 17,
-        };
-        return children[counter];
+      callbacks.fetchChildrenSummary.mockResolvedValue({
+        data: {
+          1: [0, 85],
+          2: [1, 66],
+          69: [68, 17],
+        },
       });
       const wrapper = mount(<HookTest {...callbacks} />);
       await act(async () => {
@@ -1497,12 +1345,11 @@ describe('useJobEvents', () => {
     });
 
     test('should estimate counter in gap between loaded events', async () => {
-      callbacks.fetchNumEvents.mockImplementation(
-        (counter) =>
-          ({
-            1: 30,
-          }[counter])
-      );
+      callbacks.fetchChildrenSummary.mockResolvedValue({
+        data: {
+          1: [0, 30],
+        },
+      });
       const wrapper = mount(<HookTest {...callbacks} />);
       await act(async () => {
         wrapper.find('#test').prop('addEvents')([
@@ -1556,12 +1403,11 @@ describe('useJobEvents', () => {
     });
 
     test('should estimate counter in gap before loaded sibling events', async () => {
-      callbacks.fetchNumEvents.mockImplementation(
-        (counter) =>
-          ({
-            1: 30,
-          }[counter])
-      );
+      callbacks.fetchChildrenSummary.mockResolvedValue({
+        data: {
+          1: [0, 30],
+        },
+      });
       const wrapper = mount(<HookTest {...callbacks} />);
       await act(async () => {
         wrapper.find('#test').prop('addEvents')([
@@ -1599,12 +1445,11 @@ describe('useJobEvents', () => {
     });
 
     test('should get counter for node between unloaded siblings', async () => {
-      callbacks.fetchNumEvents.mockImplementation(
-        (counter) =>
-          ({
-            1: 30,
-          }[counter])
-      );
+      callbacks.fetchChildrenSummary.mockResolvedValue({
+        data: {
+          1: [0, 30],
+        },
+      });
       const wrapper = mount(<HookTest {...callbacks} />);
       await act(async () => {
         wrapper.find('#test').prop('addEvents')([

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.test.js
@@ -157,6 +157,7 @@ describe('useJobEvents', () => {
       uuidMap: {},
       eventsWithoutParents: {},
       childrenSummary: {},
+      metaEventParentUuid: {},
       eventGaps: [],
       isAllCollapsed: false,
     };
@@ -772,6 +773,51 @@ describe('useJobEvents', () => {
         'abc-009': 9,
       });
     });
+
+    test('should nest "meta" event based on given parent uuid', () => {
+      const state = reducer(
+        {
+          ...emptyState,
+          childrenSummary: {
+            2: { rowNumber: 1, numChildren: 3 },
+          },
+          metaEventParentUuid: {
+            4: 'abc-002',
+          },
+        },
+        {
+          type: ADD_EVENTS,
+          events: [...eventsList.slice(0, 3)],
+        }
+      );
+      const state2 = reducer(state, {
+        type: ADD_EVENTS,
+        events: [
+          {
+            counter: 4,
+            rowNumber: 3,
+            parent_uuid: '',
+          },
+        ],
+      });
+
+      expect(state2.tree).toEqual([
+        {
+          eventIndex: 1,
+          isCollapsed: false,
+          children: [
+            {
+              eventIndex: 2,
+              isCollapsed: false,
+              children: [
+                { eventIndex: 3, isCollapsed: false, children: [] },
+                { eventIndex: 4, isCollapsed: false, children: [] },
+              ],
+            },
+          ],
+        },
+      ]);
+    });
   });
 
   describe('getNodeByUuid', () => {
@@ -1119,9 +1165,12 @@ describe('useJobEvents', () => {
       const fetchChildrenSummary = jest.fn();
       fetchChildrenSummary.mockResolvedValue({
         data: {
-          1: [0, 52],
-          2: [1, 3],
-          6: [5, 47],
+          children_summary: {
+            1: { rowNumber: 0, numChildren: 52 },
+            2: { rowNumber: 1, numChildren: 3 },
+            6: { rowNumber: 5, numChildren: 47 },
+          },
+          meta_event_nested_uuid: {},
         },
       });
 
@@ -1276,9 +1325,9 @@ describe('useJobEvents', () => {
     test('should return estimated counter when node is non-loaded child', async () => {
       callbacks.fetchChildrenSummary.mockResolvedValue({
         data: {
-          1: [0, 28],
-          2: [1, 3],
-          6: [5, 23],
+          1: { rowNumber: 0, numChildren: 28 },
+          2: { rowNumber: 1, numChildren: 3 },
+          6: { rowNumber: 5, numChidren: 23 },
         },
       });
       const wrapper = mount(<HookTest {...callbacks} />);
@@ -1314,9 +1363,12 @@ describe('useJobEvents', () => {
     test('should estimate counter after skipping collapsed subtree', async () => {
       callbacks.fetchChildrenSummary.mockResolvedValue({
         data: {
-          1: [0, 85],
-          2: [1, 66],
-          69: [68, 17],
+          children_summary: {
+            1: { rowNumber: 0, numChildren: 85 },
+            2: { rowNumber: 1, numChildren: 66 },
+            69: { rowNumber: 68, numChildren: 17 },
+          },
+          meta_event_nested_uuid: {},
         },
       });
       const wrapper = mount(<HookTest {...callbacks} />);
@@ -1347,7 +1399,10 @@ describe('useJobEvents', () => {
     test('should estimate counter in gap between loaded events', async () => {
       callbacks.fetchChildrenSummary.mockResolvedValue({
         data: {
-          1: [0, 30],
+          children_summary: {
+            1: { rowNumber: 0, numChildren: 30 },
+          },
+          meta_event_nested_uuid: {},
         },
       });
       const wrapper = mount(<HookTest {...callbacks} />);
@@ -1405,7 +1460,10 @@ describe('useJobEvents', () => {
     test('should estimate counter in gap before loaded sibling events', async () => {
       callbacks.fetchChildrenSummary.mockResolvedValue({
         data: {
-          1: [0, 30],
+          children_summary: {
+            1: { rowNumber: 0, numChildren: 30 },
+          },
+          meta_event_nested_uuid: {},
         },
       });
       const wrapper = mount(<HookTest {...callbacks} />);
@@ -1447,7 +1505,10 @@ describe('useJobEvents', () => {
     test('should get counter for node between unloaded siblings', async () => {
       callbacks.fetchChildrenSummary.mockResolvedValue({
         data: {
-          1: [0, 30],
+          children_summary: {
+            1: { rowNumber: 0, numChildren: 30 },
+          },
+          meta_event_nested_uuid: {},
         },
       });
       const wrapper = mount(<HookTest {...callbacks} />);


### PR DESCRIPTION
<!--- changelog-entry
msg: "Fix issues/optimize loading job output"
-->

##### SUMMARY
Updates UI to use the new children-summary endpoint (#11928) to determine number of child events & position in the tree. This greatly reduces the number of network requests made by the job output page for playbook jobs while expand/collapse is enabled.

This also addresses certain job events (such as Warnings) that do not fit into the parent/child tree structure of job events the way normal events do, which was breaking the UI's event lookup algorithm. The problem is these events don't have an `parent_uuid` field even though they might occur between two other events that share a parent. The children-summary endpoint provides a "meta_event_nested_uuid" object to place these events under the correct parent node so the lookup algorithm can work as expected.

~~This depends on #11928 and should not be merged until that PR is also merged.~~

Addresses #11818, #11765, #11647 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
