### PR TITLE
Escape name__regex and name__iregex

### DIFF
--- a/awx/ui/src/components/Lookup/shared/HostFilterUtils.js
+++ b/awx/ui/src/components/Lookup/shared/HostFilterUtils.js
@@ -68,11 +68,12 @@ export function toQueryString(config, searchParams = {}) {
 
 /**
  * Escape a string with double quote in case there was a white space
+ * @param {string} key The key of the value to be parsed
  * @param {string} value A string to be parsed
  * @return {string}  string
  */
-const escapeString = (value) => {
-  if (verifySpace(value)) {
+const escapeString = (key, value) => {
+  if (verifySpace(value) || key.includes('regex')) {
     return `"${value}"`;
   }
   return value;
@@ -95,9 +96,11 @@ export function toHostFilter(searchParams = {}) {
     .sort()
     .flatMap((key) => {
       if (Array.isArray(searchParams[key])) {
-        return searchParams[key].map((val) => `${key}=${escapeString(val)}`);
+        return searchParams[key].map(
+          (val) => `${key}=${escapeString(key, val)}`
+        );
       }
-      return `${key}=${escapeString(searchParams[key])}`;
+      return `${key}=${escapeString(key, searchParams[key])}`;
     });
 
   const filteredSearchParams = flattenSearchParams.filter(

--- a/awx/ui/src/components/Lookup/shared/HostFilterUtils.test.js
+++ b/awx/ui/src/components/Lookup/shared/HostFilterUtils.test.js
@@ -136,6 +136,17 @@ describe('toHostFilter', () => {
     );
   });
 
+  test('should escape name__regex and name__iregex', () => {
+    const object = {
+      or__name__regex: '(t|e)st',
+      or__name__iregex: '(f|o)',
+      or__name: 'foo',
+    };
+    expect(toHostFilter(object)).toEqual(
+      'name=foo or name__iregex="(f|o)" or name__regex="(t|e)st"'
+    );
+  });
+
   test('should return a host filter with or conditional when value is array', () => {
     const object = {
       or__groups__id: ['1', '2'],


### PR DESCRIPTION
Escacpe name__regex and name__iregex. Escaping the value for those
keys when creating a smart inventory is a work around for the
pyparsing code on the API side for special characters. This will just
display an extra escape when showing the host_filter on details page.

This PR is a collaboration with @john-westcott-iv.


Details

<img width="1496" alt="image" src="https://user-images.githubusercontent.com/9053044/160186990-94213177-547a-41e0-abdd-e444ab4cb6de.png">


Smart Inventory host filter being applied

<img width="1488" alt="image" src="https://user-images.githubusercontent.com/9053044/160187060-646bc65e-bbb6-4333-bb73-90e5c94dcf76.png">



