### PR TITLE
Minor tweaks to ansible-runner cleanup task arguments

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -186,10 +186,12 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         returns a dict that is passed to the python interface for the runner method corresponding to that command
         any kwargs will override that key=value combination in the returned dict
         """
-        vargs = dict(grace_period=60)  # grace period of 60 minutes, need to set because CLI default will not take effect
+        vargs = dict()
         if settings.AWX_CLEANUP_PATHS:
             vargs['file_pattern'] = os.path.join(settings.AWX_ISOLATION_BASE_PATH, JOB_FOLDER_PREFIX % '*') + '*'
         vargs.update(kwargs)
+        if not isinstance(vargs.get('grace_period'), int):
+            vargs['grace_period'] = 60  # grace period of 60 minutes, need to set because CLI default will not take effect
         if 'exclude_strings' not in vargs and vargs.get('file_pattern'):
             active_pks = list(
                 UnifiedJob.objects.filter(

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -186,12 +186,16 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         returns a dict that is passed to the python interface for the runner method corresponding to that command
         any kwargs will override that key=value combination in the returned dict
         """
-        vargs = dict()
+        vargs = dict(grace_period=60)  # grace period of 60 minutes, need to set because CLI default will not take effect
         if settings.AWX_CLEANUP_PATHS:
             vargs['file_pattern'] = os.path.join(settings.AWX_ISOLATION_BASE_PATH, JOB_FOLDER_PREFIX % '*') + '*'
         vargs.update(kwargs)
         if 'exclude_strings' not in vargs and vargs.get('file_pattern'):
-            active_pks = list(UnifiedJob.objects.filter(execution_node=self.hostname, status__in=('running', 'waiting')).values_list('pk', flat=True))
+            active_pks = list(
+                UnifiedJob.objects.filter(
+                    (models.Q(execution_node=self.hostname) | models.Q(controller_node=self.hostname)) & models.Q(status__in=('running', 'waiting'))
+                ).values_list('pk', flat=True)
+            )
             if active_pks:
                 vargs['exclude_strings'] = [JOB_FOLDER_PREFIX % job_id for job_id in active_pks]
         if 'remove_images' in vargs or 'image_prune' in vargs:

--- a/awx/main/tests/unit/models/test_ha.py
+++ b/awx/main/tests/unit/models/test_ha.py
@@ -93,7 +93,7 @@ class TestInstanceGroup(object):
 
 def test_cleanup_params_defaults():
     inst = Instance(hostname='foobar')
-    assert inst.get_cleanup_task_kwargs(exclude_strings=['awx_423_']) == {'exclude_strings': ['awx_423_'], 'file_pattern': '/tmp/awx_*_*'}
+    assert inst.get_cleanup_task_kwargs(exclude_strings=['awx_423_']) == {'exclude_strings': ['awx_423_'], 'file_pattern': '/tmp/awx_*_*', 'grace_period': 60}
 
 
 def test_cleanup_params_for_image_cleanup():
@@ -104,4 +104,5 @@ def test_cleanup_params_for_image_cleanup():
         'process_isolation_executable': 'podman',
         'remove_images': ['quay.invalid/foo/bar'],
         'image_prune': True,
+        'grace_period': 60,
     }


### PR DESCRIPTION
##### SUMMARY
Fixes a bug reported multiple times, I don't have AWX issue links ready right now.

I believe this was caused by 2 errors both making each other worse. One, `grace_period` not being provided was supposed to use the default of 60 minutes. It didn't. The programmatic interface was not considered deeply here, and the result is that it resulted in _no_ grace period. This should still only surface as very infrequent race conditions.

The other issue is that job ids were not returned if it was using the instance as a controller node. Both the execution and control nodes have the same directory.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API



##### ADDITIONAL INFORMATION
This is still tricky to reproduce, because the task needs to be ran during the period between being dispatched and sending the job off to receptor, which has no explicitly blocking steps. This might be best accomplished by some aggressive unit tests.
