### PR TITLE
Add setuptools_scm[toml] and pkgconfig to requirements file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg2,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==58.2.0 wheel==0.36.2
+VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==58.2.0 setuptools_scm[toml]==6.4.2 wheel==0.36.2
 
 NAME ?= awx
 

--- a/docs/licenses/pkgconfig.txt
+++ b/docs/licenses/pkgconfig.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/licenses/setuptools-scm.txt
+++ b/docs/licenses/setuptools-scm.txt
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/docs/licenses/tomli.txt
+++ b/docs/licenses/tomli.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Taneli Hukkinen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -105,7 +105,7 @@ Upgrading to 4.0.0 causes error because imports changed.
 ImportError: cannot import name 'KeyVaultClient'
 ```
 
-### pip and setuptools
+### pip, setuptools and setuptools_scm
 
 The offline installer needs to have functionality confirmed before upgrading these.
 Versions need to match the versions used in the pip bootstrapping step

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -58,6 +58,9 @@ uwsgitop
 wheel
 pip==21.2.4  # see UPGRADE BLOCKERs
 setuptools==58.2.0  # see UPGRADE BLOCKERs
+setuptools_scm[toml]>=3.4  # see UPGRADE BLOCKERs, xmlsec build dep
+lxml>=3.8 # xmlsec build dep
+pkgconfig>=1.5.1 # xmlsec build dep
 
 # Temporarily added to use ansible-runner from git branch, to be removed
 # when ansible-runner moves from requirements_git.txt to here

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -192,6 +192,7 @@ lockfile==0.12.2
     # via python-daemon
 lxml==4.7.0
     # via
+    #   -r /awx_devel/requirements/requirements.in
     #   python3-saml
     #   xmlsec
 markdown==3.2.1
@@ -225,13 +226,17 @@ oauthlib==3.2.0
 openshift==0.11.0
     # via -r /awx_devel/requirements/requirements.in
 packaging==21.3
-    # via ansible-runner
+    # via
+    #   ansible-runner
+    #   setuptools-scm
 pbr==5.6.0
     # via -r /awx_devel/requirements/requirements.in
 pexpect==4.7.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   ansible-runner
+pkgconfig==1.5.5
+    # via -r /awx_devel/requirements/requirements.in
 prometheus-client==0.7.1
     # via -r /awx_devel/requirements/requirements.in
 psutil==5.8.0
@@ -339,6 +344,8 @@ schedule==0.6.0
     # via -r /awx_devel/requirements/requirements.in
 service-identity==18.1.0
     # via twisted
+setuptools-scm[toml]==6.4.2
+    # via -r /awx_devel/requirements/requirements.in
 six==1.14.0
     # via
     #   ansible-runner
@@ -380,6 +387,8 @@ tempora==2.1.0
     # via
     #   irc
     #   jaraco-logging
+tomli==2.0.1
+    # via setuptools-scm
 twilio==6.37.0
     # via -r /awx_devel/requirements/requirements.in
 twisted[tls]==20.3.0
@@ -421,4 +430,5 @@ setuptools==58.2.0
     #   kubernetes
     #   markdown
     #   python-daemon
+    #   setuptools-scm
     #   zope-interface


### PR DESCRIPTION
Follow up for https://github.com/ansible/awx/pull/11654

As a part of the django update, xmlsec was updated. The new version added setup_requires and offline rpm build is now failing becuse those dependencies are missing in the requirements file.

I'm not sure where in the file those build deps should be added, so I added toward the end of the file where pip/setuptools are.