### PR TITLE
[bugfix] credential_plugin tss.py (Thycotic Secret Server) return only value of secret

### DIFF
--- a/awx/main/credential_plugins/tss.py
+++ b/awx/main/credential_plugins/tss.py
@@ -49,7 +49,7 @@ def tss_backend(**kwargs):
     secret_dict = secret_server.get_secret(kwargs['secret_id'])
     secret = ServerSecret(**secret_dict)
 
-    return secret.fields[kwargs['secret_field']]
+    return secret.fields[kwargs['secret_field']].value
 
 
 tss_plugin = CredentialPlugin(


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fix Credential Plugin tss.py (Thycotic Secret Server) return value"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The credential plugin tss.py (Thycotic Secret Server) returns the object instead of only the requested value (the password). This breaks the complete credential plugin.
Now only the value is returned.

This is also the way described in the used Thycotic Lib:
https://github.com/thycotic/python-tss-sdk#useage-1

RH Support Case 03178352

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Credential Plugin Thycotic Secret Server

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
Ansible Automation Platform Controller 4.1.1
Thycotic SecretServer Version 11.0
```
Sorry I have no AWX setup available to test that. AAP is using the same credential plugin.


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

###### Before:

I've added a logging statement to troubleshoot that.
```
# vim /var/lib/awx/venv/awx/lib/python3.8/site-packages/awx/main/credential_plugins/tss.py
.....
    secret_dict = secret_server.get_secret(kwargs['secret_id'])
    secret = ServerSecret(**secret_dict)

    logger.debug(secret.fields[kwargs['secret_field']])            <<<<<<<<   only to troubleshooting the problem

    return secret.fields[kwargs['secret_field']]
.....
```

Output in /var/log/tower/tower.log
```
2022-03-29 08:29:45,862 DEBUG    [c9b6bb792bed48cd8b3c7813677b6d1b] awx ServerSecret.Field(item_id=526076, field_id=7, file_attachment_id=None, field_description='The password used to access information.', field_name='Password', filename=None, value='qwefn14314r##+03rJHGFUwd', slug='password')
```

Error in AAP:

![Bildschirmfoto 2022-03-29 um 10 42 28](https://user-images.githubusercontent.com/34544090/160571395-abc5a52e-cefc-4667-aa2e-97942e1ccf40.png)

###### After:
Working in AAP:
![Bildschirmfoto 2022-03-29 um 10 47 41](https://user-images.githubusercontent.com/34544090/160572548-4c36b84b-8181-4547-9f54-38c2dabf6dc7.png)

PS: Password was randomly created for that test :)