### PR TITLE
Move AWX_MOUNT_ISOLATED_PATHS_ON_K8S to be closer to other booleans

### DIFF
--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -200,6 +200,10 @@ function JobsEdit() {
                   name="AWX_SHOW_PLAYBOOK_LINKS"
                   config={jobs.AWX_SHOW_PLAYBOOK_LINKS}
                 />
+                <BooleanField
+                  name="AWX_MOUNT_ISOLATED_PATHS_ON_K8S"
+                  config={jobs.AWX_MOUNT_ISOLATED_PATHS_ON_K8S}
+                />
                 <ObjectField
                   name="AD_HOC_COMMANDS"
                   config={jobs.AD_HOC_COMMANDS}
@@ -211,10 +215,6 @@ function JobsEdit() {
                 <ObjectField
                   name="AWX_ISOLATION_SHOW_PATHS"
                   config={jobs.AWX_ISOLATION_SHOW_PATHS}
-                />
-                <BooleanField
-                  name="AWX_MOUNT_ISOLATED_PATHS_ON_K8S"
-                  config={jobs.AWX_MOUNT_ISOLATED_PATHS_ON_K8S}
                 />
                 <ObjectField name="AWX_TASK_ENV" config={jobs.AWX_TASK_ENV} />
                 {submitError && <FormSubmitError error={submitError} />}


### PR DESCRIPTION
Move AWX_MOUNT_ISOLATED_PATHS_ON_K8S to be closer to other booleans on
the layout.

With this change

<img width="1474" alt="image" src="https://user-images.githubusercontent.com/9053044/160897205-6c910123-42c2-4071-9d22-3959cb7ed504.png">

Without

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/9053044/160897437-9d91d514-6d3c-4d18-b65b-40e71736bcf4.png">
