### PR TITLE
cast bool to str for runner env

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1054,7 +1054,7 @@ class RunProjectUpdate(BaseTask):
         env['TMP'] = settings.AWX_ISOLATION_BASE_PATH
         env['PROJECT_UPDATE_ID'] = str(project_update.pk)
         if settings.GALAXY_IGNORE_CERTS:
-            env['ANSIBLE_GALAXY_IGNORE'] = True
+            env['ANSIBLE_GALAXY_IGNORE'] = str(True)
 
         # build out env vars for Galaxy credentials (in order)
         galaxy_server_list = []

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1346,7 +1346,7 @@ class TestProjectUpdateGalaxyCredentials(TestJobExecution):
         task.instance = project_update
         env = task.build_env(project_update, private_data_dir)
         if ignore:
-            assert env['ANSIBLE_GALAXY_IGNORE'] is True
+            assert env['ANSIBLE_GALAXY_IGNORE'] == 'True'
         else:
             assert 'ANSIBLE_GALAXY_IGNORE' not in env
 


### PR DESCRIPTION
It appears this was causing a fatal error for runner

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
without this we were getting an error but no output...digging in we found
```
('Traceback (most recent call last):\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/ansible_runner/__main__.py", '
 'line 910, in main\r\n'
 '    res = run(**run_options)\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/ansible_runner/interface.py", '
 'line 217, in run\r\n'
 '    r.run()\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/ansible_runner/streaming.py", '
 'line 130, in run\r\n'
 '    r = ansible_runner.interface.run(**self.kwargs)\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/ansible_runner/interface.py", '
 'line 217, in run\r\n'
 '    r.run()\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/ansible_runner/runner.py", '
 'line 299, in run\r\n'
 '    child = pexpect.spawn(\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/pexpect/pty_spawn.py", '
 'line 204, in __init__\r\n'
 '    self._spawn(command, args, preexec_fn, dimensions)\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/pexpect/pty_spawn.py", '
 'line 302, in _spawn\r\n'
 '    self.ptyproc = self._spawnpty(self.args, env=self.env,\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/pexpect/pty_spawn.py", '
 'line 314, in _spawnpty\r\n'
 '    return ptyprocess.PtyProcess.spawn(args, **kwargs)\r\n'
 '  File '
 '"/var/lib/awx/venv/awx/lib64/python3.8/site-packages/ptyprocess/ptyprocess.py", '
 'line 285, in spawn\r\n'
 '    os.execvpe(command, argv, env)\r\n'
 '  File "/usr/lib64/python3.8/os.py", line 577, in execvpe\r\n'
 '    _execvpe(file, args, env)\r\n'
 '  File "/usr/lib64/python3.8/os.py", line 591, in _execvpe\r\n'
 '    exec_func(file, *argrest)\r\n'
 'TypeError: expected str, bytes or os.PathLike object, not bool\r\n')
```
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
