### PR TITLE
Do not truncate strings on activity stream dropdown

### DIFF
--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -1,13 +1,13 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useLocation, useHistory } from 'react-router-dom';
-
+import styled from 'styled-components';
 import { t } from '@lingui/macro';
 import {
   Card,
   PageSection,
   PageSectionVariants,
   SelectGroup,
-  Select,
+  Select as PFSelect,
   SelectVariant,
   SelectOption,
   Title,
@@ -25,6 +25,14 @@ import { getQSConfig, parseQueryString, updateQueryString } from 'util/qs';
 import { ActivityStreamAPI } from 'api';
 
 import ActivityStreamListItem from './ActivityStreamListItem';
+
+const Select = styled(PFSelect)`
+  && {
+    width: auto;
+    white-space: nowrap;
+    max-height: 480px;
+  }
+`;
 
 function ActivityStream() {
   const { light } = PageSectionVariants;
@@ -116,8 +124,6 @@ function ActivityStream() {
           {t`Activity Stream type selector`}
         </span>
         <Select
-          width="250px"
-          maxHeight="480px"
           variant={SelectVariant.single}
           aria-labelledby="grouped-type-select-id"
           typeAheadAriaLabel={t`Select an activity type`}


### PR DESCRIPTION
Do not truncate strings on activity stream dropdown

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/9053044/162229886-3b13e104-fc30-4881-a4e6-218798de56a9.png">

<img width="1492" alt="image" src="https://user-images.githubusercontent.com/9053044/162229999-8c204f02-7112-47cd-a6bb-5e8055492db0.png">


See: https://github.com/ansible/awx/issues/11399
