### PR TITLE
removed 'check_migrations' condition in _citi_db_wrapper

### DIFF
--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -81,17 +81,16 @@ def _ctit_db_wrapper(trans_safe=False):
         yield
     except DBError as exc:
         if trans_safe:
-            if 'migrate' not in sys.argv and 'check_migrations' not in sys.argv:
-                level = logger.exception
-                if isinstance(exc, ProgrammingError):
-                    if 'relation' in str(exc) and 'does not exist' in str(exc):
-                        # this generally means we can't fetch Tower configuration
-                        # because the database hasn't actually finished migrating yet;
-                        # this is usually a sign that a service in a container (such as ws_broadcast)
-                        # has come up *before* the database has finished migrating, and
-                        # especially that the conf.settings table doesn't exist yet
-                        level = logger.debug
-                level('Database settings are not available, using defaults.')
+            level = logger.exception
+            if isinstance(exc, ProgrammingError):
+                if 'relation' in str(exc) and 'does not exist' in str(exc):
+                    # this generally means we can't fetch Tower configuration
+                    # because the database hasn't actually finished migrating yet;
+                    # this is usually a sign that a service in a container (such as ws_broadcast)
+                    # has come up *before* the database has finished migrating, and
+                    # especially that the conf.settings table doesn't exist yet
+                    level = logger.debug
+            level('Database settings are not available, using defaults.')
         else:
             logger.exception('Error modifying something related to database settings.')
     finally:


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Linked issue : https://github.com/ansible/tower/issues/5692 
After the Django upgrade these migration check are no longer needed. 
```
