### PR TITLE
Update when deleted is shown on job details

### DIFF
--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.js
@@ -93,7 +93,11 @@ function JobDetail({ job, inventorySourceLabels }) {
   );
 
   const renderInventoryDetail = () => {
-    if (job.type !== 'project_update') {
+    if (
+      job.type !== 'project_update' &&
+      job.type !== 'system_job' &&
+      job.type !== 'workflow_job'
+    ) {
       return inventory ? (
         <Detail
           dataCy="job-inventory"
@@ -112,6 +116,60 @@ function JobDetail({ job, inventorySourceLabels }) {
         />
       ) : (
         <DeletedDetail label={t`Inventory`} />
+      );
+    }
+    if (job.type === 'workflow_job') {
+      return inventory ? (
+        <Detail
+          dataCy="job-inventory"
+          label={t`Inventory`}
+          value={
+            <Link
+              to={
+                inventory.kind === 'smart'
+                  ? `/inventories/smart_inventory/${inventory.id}`
+                  : `/inventories/inventory/${inventory.id}`
+              }
+            >
+              {inventory.name}
+            </Link>
+          }
+        />
+      ) : null;
+    }
+    return null;
+  };
+
+  const renderProjectDetail = () => {
+    if (
+      job.type !== 'ad_hoc_command' &&
+      job.type !== 'inventory_update' &&
+      job.type !== 'system_job' &&
+      job.type !== 'workflow_job'
+    ) {
+      return project ? (
+        <>
+          <Detail
+            dataCy="job-project"
+            label={t`Project`}
+            value={<Link to={`/projects/${project.id}`}>{project.name}</Link>}
+          />
+          <Detail
+            dataCy="job-project-status"
+            label={t`Project Status`}
+            value={
+              projectUpdate ? (
+                <Link to={`/jobs/project/${projectUpdate.id}`}>
+                  <StatusLabel status={project.status} />
+                </Link>
+              ) : (
+                <StatusLabel status={project.status} />
+              )
+            }
+          />
+        </>
+      ) : (
+        <DeletedDetail label={t`Project`} />
       );
     }
     return null;
@@ -225,30 +283,7 @@ function JobDetail({ job, inventorySourceLabels }) {
             }
           />
         )}
-        {project ? (
-          <>
-            <Detail
-              dataCy="job-project"
-              label={t`Project`}
-              value={<Link to={`/projects/${project.id}`}>{project.name}</Link>}
-            />
-            <Detail
-              dataCy="job-project-status"
-              label={t`Project Status`}
-              value={
-                projectUpdate ? (
-                  <Link to={`/jobs/project/${projectUpdate.id}`}>
-                    <StatusLabel status={project.status} />
-                  </Link>
-                ) : (
-                  <StatusLabel status={project.status} />
-                )
-              }
-            />
-          </>
-        ) : (
-          <DeletedDetail label={t`Project`} />
-        )}
+        {renderProjectDetail()}
         {scmBranch && (
           <Detail
             dataCy="source-control-branch"

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.test.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.test.js
@@ -63,7 +63,6 @@ describe('<JobDetail />', () => {
       'Instance Group',
       mockJobData.summary_fields.instance_group.name
     );
-    assertDetail('Job Slice', '0/1');
     assertDetail('Credentials', 'SSH: Demo Credential');
     assertDetail('Machine Credential', 'SSH: Machine cred');
     assertDetail('Source Control Branch', 'main');
@@ -102,6 +101,23 @@ describe('<JobDetail />', () => {
     expect(projectStatusDetail.find('StatusLabel')).toHaveLength(1);
     const projectStatusLabel = statusDetail.find('StatusLabel');
     expect(projectStatusLabel.prop('status')).toEqual('successful');
+  });
+
+  test('should display Deleted for Inventory and Project for job type run', () => {
+    const job = {
+      ...mockJobData,
+      summary_fields: {
+        ...mockJobData.summary_fields,
+        project: null,
+        inventory: null,
+      },
+      project: null,
+      inventory: null,
+    };
+
+    wrapper = mountWithContexts(<JobDetail job={job} />);
+    expect(wrapper.find(`DeletedDetail[label="Project"]`).length).toBe(1);
+    expect(wrapper.find(`DeletedDetail[label="Inventory"]`).length).toBe(1);
   });
 
   test('should not display finished date', () => {
@@ -146,6 +162,7 @@ describe('<JobDetail />', () => {
     assertDetail('Module Name', 'command');
     assertDetail('Module Arguments', 'echo hello_world');
     assertDetail('Job Type', 'Run Command');
+    expect(wrapper.find(`Detail[label="Project"]`).length).toBe(0);
   });
 
   test('should display source data', () => {
@@ -182,6 +199,7 @@ describe('<JobDetail />', () => {
       />
     );
     assertDetail('Source', 'Sourced from Project');
+    expect(wrapper.find(`Detail[label="Project"]`).length).toBe(0);
   });
 
   test('should show schedule that launched workflow job', async () => {
@@ -215,7 +233,7 @@ describe('<JobDetail />', () => {
     ).toHaveLength(1);
   });
 
-  test('should hide "Launched By" detail for JT launched from a workflow launched by a schedule', async () => {
+  test('should hide "Launched By" detail for JT launched from a workflow launched by a schedule', () => {
     wrapper = mountWithContexts(
       <JobDetail
         job={{
@@ -317,6 +335,7 @@ describe('<JobDetail />', () => {
     expect(
       wrapper.find('Button[aria-label="Cancel Demo Job Template"]')
     ).toHaveLength(0);
+    expect(wrapper.find(`Detail[label="Project"]`).length).toBe(0);
   });
 
   test('should not show cancel job button, job completed', async () => {


### PR DESCRIPTION
Update when deleted is show on job details.

Some job types should not display inventory or projects, update when
showing those fields.

Also, update when displaying information when
those fields where deleted.

ad-hoc command

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/9053044/162804776-ae87c6f6-d845-412b-8ba6-f5ffe4e780a2.png">

inventory source sync

<img width="1466" alt="image" src="https://user-images.githubusercontent.com/9053044/162804827-dd966536-24c6-45ab-8b29-b331706aa8e9.png">

project sync

<img width="1479" alt="image" src="https://user-images.githubusercontent.com/9053044/162804928-593d5b6c-14b1-40e3-b4a4-0489d573e602.png">

workflow job template

<img width="1486" alt="image" src="https://user-images.githubusercontent.com/9053044/162805016-dadc1e85-26d2-4257-b316-a41fc0f95a82.png">

management job

<img width="1488" alt="image" src="https://user-images.githubusercontent.com/9053044/162805081-30c4a34f-0542-469c-8aa4-fe9daf190bfb.png">

playbook run
<img width="1465" alt="image" src="https://user-images.githubusercontent.com/9053044/162805221-335f65bd-a620-4d87-ab7f-10f84d3a73d8.png">


See: https://github.com/ansible/awx/issues/12008
