### PR TITLE
drop call that queries all running and waiting jobs in task manager

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -390,7 +390,7 @@ class InstanceGroup(HasPolicyEditsMixin, BaseModel, RelatedJobsMixin):
         for i in instances:
             if i.node_type not in (capacity_type, 'hybrid'):
                 continue
-            if i.jobs_running == 0:
+            if (hasattr(i, 'jobs_running') and i.jobs_running == 0) or i.remaining_capacity == i.capacity:
                 if largest_instance is None:
                     largest_instance = i
                 elif i.capacity > largest_instance.capacity:

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -79,7 +79,6 @@ class TaskManager:
                 node_type=instance.node_type,
                 remaining_capacity=instance.remaining_capacity,
                 capacity=instance.capacity,
-                jobs_running=instance.jobs_running,
                 hostname=instance.hostname,
             )
             for instance in instances
@@ -490,7 +489,6 @@ class TaskManager:
             if task.capacity_type == 'control':
                 task.execution_node = control_instance.hostname
                 control_instance.remaining_capacity = max(0, control_instance.remaining_capacity - control_impact)
-                control_instance.jobs_running += 1
                 self.dependency_graph.add_job(task)
                 execution_instance = self.real_instances[control_instance.hostname]
                 task.log_lifecycle("controller_node_chosen")
@@ -501,7 +499,6 @@ class TaskManager:
 
             for rampart_group in preferred_instance_groups:
                 if rampart_group.is_container_group:
-                    control_instance.jobs_running += 1
                     self.dependency_graph.add_job(task)
                     self.start_task(task, rampart_group, task.get_jobs_fail_chain(), None)
                     found_acceptable_queue = True
@@ -526,10 +523,7 @@ class TaskManager:
 
                     control_instance.remaining_capacity = max(0, control_instance.remaining_capacity - settings.AWX_CONTROL_NODE_TASK_IMPACT)
                     task.log_lifecycle("controller_node_chosen")
-                    if control_instance != execution_instance:
-                        control_instance.jobs_running += 1
                     execution_instance.remaining_capacity = max(0, execution_instance.remaining_capacity - task.task_impact)
-                    execution_instance.jobs_running += 1
                     task.log_lifecycle("execution_node_chosen")
                     logger.debug(
                         "Starting {} in group {} instance {} (remaining_capacity={})".format(


### PR DESCRIPTION
this is to fix one more place in the task manager where we end up
querying all running and waiting jobs.

Partial fix for https://github.com/ansible/awx/issues/11671

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
