### PR TITLE
Mark committed_capacity field for removal

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4873,7 +4873,7 @@ class InstanceGroupSerializer(BaseSerializer):
 
     show_capabilities = ['edit', 'delete']
 
-    committed_capacity = serializers.SerializerMethodField()
+    committed_capacity = serializers.SerializerMethodField(help_text=_('This resource has been deprecated and will be removed in a future release'))
     consumed_capacity = serializers.SerializerMethodField()
     percent_capacity_remaining = serializers.SerializerMethodField()
     jobs_running = serializers.IntegerField(


### PR DESCRIPTION
##### SUMMARY
Explaining why this field exists:

This app used to use celery and RabbitMQ as the messaging system.

In that old design, the instance groups corresponded to literal queues in RabbitMQ. When the task manager dispatched a task, it submitted it to its instance group queue. This meant that we had no control over which node (inside of the group) received the job, because all nodes in the group would be pulling from that queue.

This was redesigned entirely, we don't use RabbitMQ, replacing it with the postgres message bus. Instead of having queues for instance groups, every instance had a queue. Instead of the task manager selecting an instance group alone, it now selects the `instance_group`, `controller_node`, and `execution_node`, and sends the message to the controller_node queue.

The construct of "committed" capacity is for jobs with "waiting" status which have already been submitted to the instance group queue (the type of queue that no longer exists).

In the modern system, all capacity use is committed to a particular instance. The consumed capacity for an instance group is just the consumed capacity of the instances in that group, added up.

This field is archaic at this point.

OPTIONS with this change

```json
            "committed_capacity": {
                "type": "field",
                "label": "Committed capacity",
                "help_text": "This resource has been deprecated and will be removed in a future release",
                "filterable": false
            },
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API
