### PR TITLE
Disable isCreatable on Advanced Search

### DIFF
--- a/awx/ui/src/components/Search/AdvancedSearch.js
+++ b/awx/ui/src/components/Search/AdvancedSearch.js
@@ -260,7 +260,6 @@ function AdvancedSearch({
         selections={keySelection}
         isOpen={isKeyDropdownOpen}
         placeholderText={t`Key`}
-        isCreatable
         isGrouped
         onCreateOption={setKeySelection}
         maxHeight={maxSelectHeight}


### PR DESCRIPTION
Disable isCreatable on Advanced Search

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/9053044/163256936-6d7e89a5-07bf-4b96-857c-21a1bf5d2d80.png">


See: https://github.com/ansible/awx/issues/12046
