### PR TITLE
Improve awxkit import -h

### DIFF
--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -59,6 +59,30 @@ def add_authentication_arguments(parser, env):
     )
 
 
+def add_verbose(formatting, env):
+    formatting.add_argument(
+        '-v',
+        '--verbose',
+        dest='conf.verbose',
+        help='print debug-level logs, including requests made',
+        default=strtobool(env.get('CONTROLLER_VERBOSE', env.get('TOWER_VERBOSE', 'f'))),
+        action="store_true",
+    )
+
+
+def add_formatting_import_export(parser, env):
+    formatting = parser.add_argument_group('input/output formatting')
+    formatting.add_argument(
+        '-f',
+        '--conf.format',
+        dest='conf.format',
+        choices=['json', 'yaml'],
+        default=env.get('CONTROLLER_FORMAT', env.get('TOWER_FORMAT', 'json')),
+        help=('specify a format for the input and output'),
+    )
+    add_verbose(formatting, env)
+
+
 def add_output_formatting_arguments(parser, env):
     formatting = parser.add_argument_group('input/output formatting')
 
@@ -84,14 +108,7 @@ def add_output_formatting_arguments(parser, env):
         default=env.get('CONTROLLER_COLOR', env.get('TOWER_COLOR', 't')),
         type=strtobool,
     )
-    formatting.add_argument(
-        '-v',
-        '--verbose',
-        dest='conf.verbose',
-        help='print debug-level logs, including requests made',
-        default=strtobool(env.get('CONTROLLER_VERBOSE', env.get('TOWER_VERBOSE', 'f'))),
-        action="store_true",
-    )
+    add_verbose(formatting, env)
 
 
 def format_response(response, fmt='json', filter='.', changed=False):

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -7,7 +7,7 @@ from awxkit.exceptions import ImportExportError
 from awxkit.utils import to_str
 from awxkit.api.pages import Page
 from awxkit.api.pages.api import EXPORTABLE_RESOURCES
-from awxkit.cli.format import FORMATTERS, format_response, add_authentication_arguments
+from awxkit.cli.format import FORMATTERS, format_response, add_authentication_arguments, add_formatting_import_export
 from awxkit.cli.utils import CustomRegistryMeta, cprint
 
 
@@ -125,6 +125,10 @@ class Import(CustomCommand):
     help_text = 'import resources into Tower'
 
     def handle(self, client, parser):
+        if parser:
+            parser.usage = 'awx import < exportfile'
+            parser.description = 'import resources from stdin'
+            add_formatting_import_export(parser, {})
         if client.help:
             parser.print_help()
             raise SystemExit()
@@ -159,7 +163,9 @@ class Export(CustomCommand):
 
     def handle(self, client, parser):
         self.extend_parser(parser)
-
+        parser.usage = 'awx export > exportfile'
+        parser.description = 'export resources to stdout'
+        add_formatting_import_export(parser, {})
         if client.help:
             parser.print_help()
             raise SystemExit()


### PR DESCRIPTION
related: https://github.com/ansible/awx/pull/12049

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Improved awxkit import help text"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The import help text should indicate that the resources should be pass in via stdin

before
```
usage: awx import [-h]

options:
  -h, --help  show this help message and exit
```

after
```
usage: awx import < exportfile

import resources from stdin

options:
  -h, --help            show this help message and exit

input/output formatting:
  -f {json,yaml}, --conf.format {json,yaml}
                        specify a format for the input and output
  -v, --verbose         print debug-level logs, including requests made
```



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 20.0.2.dev226+g7c761cd347
```

