### PR TITLE
move static methods used by task manager

### DIFF
--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2022 Ansible by Red Hat
+# All Rights Reserved.
+import logging
+
+from django.conf import settings
+
+from awx.main.models import (
+    Instance,
+    InstanceGroup,
+)
+
+logger = logging.getLogger('awx.main.scheduler')
+
+
+class TaskManagerInstance:
+    """A class representing minimal data the task manager needs to represent an Instance."""
+
+    def __init__(self, obj=None, node_type=None, capacity=None, hostname=None):
+        self.obj = obj
+        self.node_type = node_type
+        self.remaining_capacity = capacity
+        self.capacity = capacity
+        self.hostname = hostname
+
+
+class TaskManagerInstances:
+    def __init__(self, active_tasks, instances=None):
+        self.instances_by_hostname = dict()
+        self._remaining_capacity_updated = False
+        if instances is None:
+            instances = (
+                Instance.objects.filter(hostname__isnull=False, enabled=True).exclude(node_type='hop').only('node_type', 'capacity', 'hostname', 'enabled')
+            )
+        instance_list = [
+            TaskManagerInstance(
+                obj=instance,
+                node_type=instance.node_type,
+                capacity=instance.capacity,
+                hostname=instance.hostname,
+            )
+            for instance in instances
+        ]
+        self._update_remaining_capacity(active_tasks)
+        for instance in instance_list:
+            self.instances_by_hostname[instance.hostname] = instance
+
+    def _update_remaining_capacity(self, tasks):
+        """Takes a list of tasks and updates the remaining capacity on our TaskManagerInstance list.
+
+        Computes remaining capacity for all the instances based on currently running and waiting tasks.
+        """
+        if self._remaining_capacity_updated:
+            # Only want to do this once
+            return
+        for task in tasks:
+            if task.status not in ['waiting', 'running']:
+                continue
+            control_instance = self.instances_by_hostname.get(task.controller_node, '')
+            execution_instance = self.instances_by_hostname.get(task.execution_node, '')
+            if execution_instance and execution_instance.node_type in ('hybrid', 'execution'):
+                self.instances_by_hostname[task.execution_node].remaining_capacity -= task.task_impact
+            if control_instance and control_instance.node_type in ('hybrid', 'control'):
+                self.instances_by_hostname[task.controller_node].remaining_capacity -= settings.AWX_CONTROL_NODE_TASK_IMPACT
+
+    def __getitem__(self, hostname):
+        return self.instances_by_hostname.get(hostname)
+
+    def __contains__(self, hostname):
+        return hostname in self.instances_by_hostname
+
+
+class TaskManagerInstanceGroups:
+    """A class representing minimal data the task manager needs to represent an InstanceGroup."""
+
+    def __init__(self, instances_by_hostname=None, instance_groups=None):
+        self.instance_groups = dict()
+        self.controlplane_ig = None
+
+        if instance_groups is not None:  # for testing
+            self.instance_groups = instance_groups
+        else:
+            for instance_group in InstanceGroup.objects.prefetch_related('instances').only('name', 'instances'):
+                if instance_group.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME:
+                    self.controlplane_ig = instance_group
+                self.instance_groups[instance_group.name] = dict(
+                    instances=[
+                        instances_by_hostname[instance.hostname] for instance in instance_group.instances.all() if instance.hostname in instances_by_hostname
+                    ],
+                )
+
+    def fit_task_to_most_remaining_capacity_instance(self, task, instance_group_name, impact=None, capacity_type=None, add_hybrid_control_cost=False):
+        impact = impact if impact else task.task_impact
+        capacity_type = capacity_type if capacity_type else task.capacity_type
+        instance_most_capacity = None
+        most_remaining_capacity = -1
+        instances = self.instance_groups[instance_group_name]['instances']
+
+        for i in instances:
+            if i.node_type not in (capacity_type, 'hybrid'):
+                continue
+            would_be_remaining = i.remaining_capacity - impact
+            # hybrid nodes _always_ control their own tasks
+            if add_hybrid_control_cost and i.node_type == 'hybrid':
+                would_be_remaining -= settings.AWX_CONTROL_NODE_TASK_IMPACT
+            if would_be_remaining >= 0 and (instance_most_capacity is None or would_be_remaining > most_remaining_capacity):
+                instance_most_capacity = i
+                most_remaining_capacity = would_be_remaining
+        return instance_most_capacity
+
+    def find_largest_idle_instance(self, instance_group_name, capacity_type='execution'):
+        largest_instance = None
+        instances = self.instance_groups[instance_group_name]['instances']
+        for i in instances:
+            if i.node_type not in (capacity_type, 'hybrid'):
+                continue
+            if (hasattr(i, 'jobs_running') and i.jobs_running == 0) or i.remaining_capacity == i.capacity:
+                if largest_instance is None:
+                    largest_instance = i
+                elif i.capacity > largest_instance.capacity:
+                    largest_instance = i
+        return largest_instance

--- a/awx/main/tests/unit/models/test_ha.py
+++ b/awx/main/tests/unit/models/test_ha.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from decimal import Decimal
 
 from awx.main.models import InstanceGroup, Instance
+from awx.main.scheduler.task_manager_models import TaskManagerInstanceGroups
 
 
 @pytest.mark.parametrize('capacity_adjustment', [0.0, 0.25, 0.5, 0.75, 1, 1.5, 3])
@@ -59,9 +60,10 @@ class TestInstanceGroup(object):
         ],
     )
     def test_fit_task_to_most_remaining_capacity_instance(self, task, instances, instance_fit_index, reason):
-        ig = InstanceGroup(id=10)
+        InstanceGroup(id=10)
+        tm_igs = TaskManagerInstanceGroups(instance_groups={'controlplane': {'instances': instances}})
 
-        instance_picked = ig.fit_task_to_most_remaining_capacity_instance(task, instances)
+        instance_picked = tm_igs.fit_task_to_most_remaining_capacity_instance(task, 'controlplane')
 
         if instance_fit_index is None:
             assert instance_picked is None, reason
@@ -82,13 +84,14 @@ class TestInstanceGroup(object):
         def filter_offline_instances(*args):
             return filter(lambda i: i.capacity > 0, instances)
 
-        ig = InstanceGroup(id=10)
+        InstanceGroup(id=10)
         instances_online_only = filter_offline_instances(instances)
+        tm_igs = TaskManagerInstanceGroups(instance_groups={'controlplane': {'instances': instances_online_only}})
 
         if instance_fit_index is None:
-            assert ig.find_largest_idle_instance(instances_online_only) is None, reason
+            assert tm_igs.find_largest_idle_instance('controlplane') is None, reason
         else:
-            assert ig.find_largest_idle_instance(instances_online_only) == instances[instance_fit_index], reason
+            assert tm_igs.find_largest_idle_instance('controlplane') == instances[instance_fit_index], reason
 
 
 def test_cleanup_params_defaults():


### PR DESCRIPTION
These static methods were being used to act on Instance-like objects
that were SimpleNamespace objects with the necessary attributes.

This change introduces dedicated classes to replace the SimpleNamespace
objects and moves the formerlly staticmethods to a place where they are
more relevant instead of tacked onto models to which they were only
loosly related.

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
follow up from conversation with @AlanCoding  for some cleanup in the task manager to prepare for more changes down the road.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 
##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
need to test this some more
