### PR TITLE
disable uwsgi py autoreload 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ uwsgi: collectstatic
 	    --processes=5 \
 	    --harakiri=120 --master \
 	    --no-orphans \
-	    --py-autoreload 1 \
+	    --py-autoreload 0 \
 	    --max-requests=1000 \
 	    --stats /tmp/stats.socket \
 	    --lazy-apps \


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This has broken recently. we should disable it until we can get a fix / workaround.

you can set up an alias to do a quick restart of services

`alias restartall='docker exec -ti -u0 tools_awx_1 supervisorctl restart all'`

we could also explore using inotifywait to watch for modified/created/deleted python files and restart services automatically, as an alternative to uwsgi py-autoreload 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 20.0.2.dev230+g3abcd1f1ba

```
