### PR TITLE
Revert recent changes make to dev env supervisor config

### DIFF
--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -5,75 +5,79 @@ nodaemon=true
 
 [program:awx-dispatcher]
 command = make dispatcher
+autostart = true
 autorestart = true
-startsecs = 30
+stopwaitsecs = 1
+stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true
+stdout_events_enabled = true
+stderr_events_enabled = true
+
 
 [program:awx-receiver]
 command = make receiver
+autostart = true
 autorestart = true
-startsecs = 30
+stopwaitsecs = 1
+stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-wsbroadcast]
 command = make wsbroadcast
+autostart = true
 autorestart = true
-startsecs = 30
-autorestart = true
+stopwaitsecs = 1
+stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-uwsgi]
 command = make uwsgi
+autostart = true
 autorestart = true
-startsecs = 30
+redirect_stderr=true
+stopwaitsecs = 1
+stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-daphne]
 command = make daphne
+autostart = true
 autorestart = true
-startsecs = 30
+redirect_stderr=true
+stopwaitsecs = 1
+stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-nginx]
 command = make nginx
+autostart = true
 autorestart = true
-startsecs = 30
-stopasgroup=true
-killasgroup=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [program:awx-rsyslogd]
 command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+autostart = true
 autorestart = true
-startsecs = 30
+stopwaitsecs = 5
+stopsignal=TERM
 stopasgroup=true
 killasgroup=true
 redirect_stderr=true
@@ -82,14 +86,14 @@ stderr_events_enabled = true
 
 [program:awx-receptor]
 command = receptor --config /etc/receptor/receptor.conf
+autostart = true
 autorestart = true
-startsecs = 30
-stopasgroup=true
-killasgroup=true
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+stopsignal = KILL
+stopasgroup = true
+killasgroup = true
+redirect_stderr=true
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [group:tower-processes]
 programs=awx-dispatcher,awx-receiver,awx-uwsgi,awx-daphne,awx-nginx,awx-wsbroadcast,awx-rsyslogd


### PR DESCRIPTION
I made these changes in 0cbc802cf4102eefc96397b77d0f6430d60c73a0. They make sense in production (the application has a chance to shut down gracefully), but when using the development environment it takes a painfully long time for the processes to restart.

I noticed this when I was looking at https://github.com/ansible/awx/pull/12052