### PR TITLE
Fix notification template details for system auditors

### DIFF
--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
@@ -38,7 +38,7 @@ function NotificationTemplate({ setBreadcrumb }) {
       setBreadcrumb(detail.data);
       return {
         template: detail.data,
-        defaultMessages: options.data.actions.POST.messages,
+        defaultMessages: options.data.actions?.POST?.messages,
       };
     }, [templateId, setBreadcrumb]),
     { template: null, defaultMessages: null }
@@ -53,7 +53,7 @@ function NotificationTemplate({ setBreadcrumb }) {
       <PageSection>
         <Card>
           <ContentError error={error}>
-            {error.response.status === 404 && (
+            {error.response?.status === 404 && (
               <span>
                 {t`Notification Template not found.`}{' '}
                 <Link to="/notification_templates">

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.js
@@ -99,7 +99,7 @@ function NotificationTemplateDetail({ template, defaultMessages }) {
   );
 
   const { error, dismissError } = useDismissableError(deleteError || testError);
-  const typeMessageDefaults = defaultMessages[template.notification_type];
+  const typeMessageDefaults = defaultMessages?.[template?.notification_type];
   return (
     <CardBody>
       <DetailList gutter="sm">
@@ -384,13 +384,14 @@ function NotificationTemplateDetail({ template, defaultMessages }) {
           date={modified}
           user={summary_fields?.modified_by}
         />
-        {hasCustomMessages(messages, typeMessageDefaults) && (
+        {typeMessageDefaults &&
+        hasCustomMessages(messages, typeMessageDefaults) ? (
           <CustomMessageDetails
             messages={messages}
             defaults={typeMessageDefaults}
             type={template.notification_type}
           />
-        )}
+        ) : null}
       </DetailList>
       <CardActionsRow>
         {summary_fields.user_capabilities?.edit && (

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateDetail/NotificationTemplateDetail.test.js
@@ -70,7 +70,11 @@ const mockTemplate = {
 describe('<NotificationTemplateDetail />', () => {
   let wrapper;
 
-  beforeEach(async () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should render Details', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <NotificationTemplateDetail
@@ -80,13 +84,29 @@ describe('<NotificationTemplateDetail />', () => {
       );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+    function assertDetail(label, value) {
+      expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
+      expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);
+    }
+    assertDetail('Name', mockTemplate.name);
+    assertDetail('Description', mockTemplate.description);
+    expect(
+      wrapper
+        .find('Detail[label="Email Options"]')
+        .containsAllMatchingElements([<li>Use SSL</li>, <li>Use TLS</li>])
+    ).toEqual(true);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test('should render Details', () => {
+  test('should render Details when defaultMessages is missing', async () => {
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <NotificationTemplateDetail
+          template={mockTemplate}
+          defaultMessages={null}
+        />
+      );
+    });
+    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     function assertDetail(label, value) {
       expect(wrapper.find(`Detail[label="${label}"] dt`).text()).toBe(label);
       expect(wrapper.find(`Detail[label="${label}"] dd`).text()).toBe(value);


### PR DESCRIPTION
Fix notification template details for system auditors

<img width="1784" alt="image" src="https://user-images.githubusercontent.com/9053044/163458147-c8ccae90-a5ba-4ef8-b09f-669ab2e7f799.png">


See: https://github.com/ansible/awx/issues/11770
