### PR TITLE
update awx.awx collection to allow archived project.

### DIFF
--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -45,7 +45,7 @@ options:
     scm_type:
       description:
         - Type of SCM resource.
-      choices: ["manual", "git", "svn", "insights"]
+      choices: ["manual", "git", "svn", "insights", "archive"]
       default: "manual"
       type: str
     scm_url:
@@ -256,7 +256,7 @@ def main():
         new_name=dict(),
         copy_from=dict(),
         description=dict(),
-        scm_type=dict(choices=['manual', 'git', 'svn', 'insights'], default='manual'),
+        scm_type=dict(choices=['manual', 'git', 'svn', 'insights', 'archive'], default='manual'),
         scm_url=dict(),
         local_path=dict(),
         scm_branch=dict(),

--- a/awx_collection/tests/integration/targets/project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project/tasks/main.yml
@@ -195,6 +195,20 @@
         that:
           - result.changed
 
+    - name: Set project to remote archive and test that it updates correctly.
+      project:
+        name: "{{ project_name3 }}"
+        organization: Default
+        scm_type: archive
+        scm_url: https://github.com/ansible/test-playbooks/archive/refs/tags/1.0.0.tar.gz
+        wait: true
+        update_project: true
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
   always:
     - name: Delete the test job_template
       job_template:


### PR DESCRIPTION
<!--- changelog-entry
---
msg: "update awx.awx collection to allow archived project."
-->

##### SUMMARY
update awx.awx collection to allow archived project.
Adds option to use the remote archive option in the GUI/API
https://docs.ansible.com/automation-controller/latest/html/userguide/projects.html#scm-type-remote-archive

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
20.1.0
```


##### ADDITIONAL INFORMATION
To remove a link to my personal archive, a release needs to be made on 
https://github.com/ansible/test-playbooks

