### PR TITLE
update awx collection wait interval to 2

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -994,7 +994,7 @@ class ControllerAPIModule(ControllerModule):
         else:
             return True
 
-    def wait_on_url(self, url, object_name, object_type, timeout=30, interval=10):
+    def wait_on_url(self, url, object_name, object_type, timeout=30, interval=2):
         # Grab our start time to compare against for the timeout
         start = time.time()
         result = self.get_endpoint(url)
@@ -1034,7 +1034,7 @@ class ControllerAPIModule(ControllerModule):
         for k in ('id', 'status', 'elapsed', 'started', 'finished'):
             self.json_output[k] = response['json'].get(k)
 
-    def wait_on_workflow_node_url(self, url, object_name, object_type, timeout=30, interval=10, **kwargs):
+    def wait_on_workflow_node_url(self, url, object_name, object_type, timeout=30, interval=2, **kwargs):
         # Grab our start time to compare against for the timeout
         start = time.time()
         result = self.get_endpoint(url, **kwargs)

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -85,7 +85,7 @@ options:
     interval:
       description:
         - The interval to request an update from the controller.
-      default: 1
+      default: 2
       type: float
     timeout:
       description:
@@ -129,7 +129,7 @@ def main():
         become_enabled=dict(type='bool'),
         diff_mode=dict(type='bool'),
         wait=dict(default=False, type='bool'),
-        interval=dict(default=1.0, type='float'),
+        interval=dict(default=2.0, type='float'),
         timeout=dict(default=None, type='int'),
         execution_environment=dict(),
     )

--- a/awx_collection/plugins/modules/ad_hoc_command_wait.py
+++ b/awx_collection/plugins/modules/ad_hoc_command_wait.py
@@ -30,7 +30,7 @@ options:
       description:
         - The interval in sections, to request an update from the controller.
       required: False
-      default: 1
+      default: 2
       type: float
     timeout:
       description:
@@ -90,7 +90,7 @@ def main():
     argument_spec = dict(
         command_id=dict(type='int', required=True),
         timeout=dict(type='int'),
-        interval=dict(type='float', default=1),
+        interval=dict(type='float', default=2),
     )
 
     # Create a module for ourselves

--- a/awx_collection/plugins/modules/inventory_source_update.py
+++ b/awx_collection/plugins/modules/inventory_source_update.py
@@ -46,7 +46,7 @@ options:
       description:
         - The interval to request an update from the controller.
       required: False
-      default: 1
+      default: 2
       type: float
     timeout:
       description:
@@ -93,7 +93,7 @@ def main():
         inventory=dict(required=True),
         organization=dict(),
         wait=dict(default=False, type='bool'),
-        interval=dict(default=1.0, type='float'),
+        interval=dict(default=2.0, type='float'),
         timeout=dict(default=None, type='int'),
     )
 

--- a/awx_collection/plugins/modules/job_launch.py
+++ b/awx_collection/plugins/modules/job_launch.py
@@ -95,7 +95,7 @@ options:
       description:
         - The interval to request an update from the controller.
       required: False
-      default: 1
+      default: 2
       type: float
     timeout:
       description:
@@ -166,7 +166,7 @@ def main():
         diff_mode=dict(type='bool'),
         credential_passwords=dict(type='dict', no_log=False),
         wait=dict(default=False, type='bool'),
-        interval=dict(default=1.0, type='float'),
+        interval=dict(default=2.0, type='float'),
         timeout=dict(default=None, type='int'),
     )
 

--- a/awx_collection/plugins/modules/job_wait.py
+++ b/awx_collection/plugins/modules/job_wait.py
@@ -31,7 +31,7 @@ options:
         - The interval in sections, to request an update from the controller.
         - For backwards compatibility if unset this will be set to the average of min and max intervals
       required: False
-      default: 1
+      default: 2
       type: float
     timeout:
       description:
@@ -96,7 +96,7 @@ def main():
         job_id=dict(type='int', required=True),
         job_type=dict(choices=['project_updates', 'jobs', 'inventory_updates', 'workflow_jobs'], default='jobs'),
         timeout=dict(type='int'),
-        interval=dict(type='float', default=1),
+        interval=dict(type='float', default=2),
     )
 
     # Create a module for ourselves

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -167,7 +167,7 @@ options:
         - The interval to request an update from the controller.
         - Requires wait.
       required: False
-      default: 1
+      default: 2
       type: float
 extends_documentation_fragment: awx.awx.auth
 '''
@@ -278,7 +278,7 @@ def main():
         state=dict(choices=['present', 'absent'], default='present'),
         wait=dict(type='bool', default=True),
         update_project=dict(default=False, type='bool'),
-        interval=dict(default=1.0, type='float'),
+        interval=dict(default=2.0, type='float'),
     )
 
     # Create a module for ourselves

--- a/awx_collection/plugins/modules/project_update.py
+++ b/awx_collection/plugins/modules/project_update.py
@@ -41,7 +41,7 @@ options:
       description:
         - The interval to request an update from the controller.
       required: False
-      default: 1
+      default: 2
       type: float
     timeout:
       description:
@@ -86,7 +86,7 @@ def main():
         name=dict(required=True, aliases=['project']),
         organization=dict(),
         wait=dict(default=True, type='bool'),
-        interval=dict(default=1.0, type='float'),
+        interval=dict(default=2.0, type='float'),
         timeout=dict(default=None, type='int'),
     )
 

--- a/awx_collection/plugins/modules/workflow_launch.py
+++ b/awx_collection/plugins/modules/workflow_launch.py
@@ -57,7 +57,7 @@ options:
       description:
         - The interval to request an update from the controller.
       required: False
-      default: 1
+      default: 2
       type: float
     timeout:
       description:
@@ -104,7 +104,7 @@ def main():
         scm_branch=dict(),
         extra_vars=dict(type='dict'),
         wait=dict(required=False, default=True, type='bool'),
-        interval=dict(required=False, default=1.0, type='float'),
+        interval=dict(required=False, default=2.0, type='float'),
         timeout=dict(required=False, default=None, type='int'),
     )
 


### PR DESCRIPTION
<!--- changelog-entry
---
msg: "update awx collection wait interval to 2"
-->

##### SUMMARY
update awx collection wait interval to 2
As per #12057 we should set a better example for modules by defaulting to a higher timeout.
A higher timeout and users will likely start to complain about speed, but this doubles the default, and helps prevent DDOS of the controller. 

This also adds uniformity across the wait intervals as the python methods were set to 10, and the modules set to 1.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
20.1.0
```

