### PR TITLE
Fix race condition when update_model is called within threads

### DIFF
--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -14,6 +14,7 @@ from django_guid import get_guid
 from awx.main.redact import UriCleaner
 from awx.main.constants import MINIMAL_EVENTS
 from awx.main.utils.update_model import update_model
+from awx.main.utils.common import cleanup_new_process
 from awx.main.queue import CallbackQueueDispatcher
 
 logger = logging.getLogger('awx.main.tasks.callback')
@@ -143,6 +144,7 @@ class RunnerCallback:
 
         return False
 
+    @cleanup_new_process
     def cancel_callback(self):
         """
         Ansible runner callback to tell the job when/if it is canceled
@@ -171,6 +173,7 @@ class RunnerCallback:
         event_data.setdefault(self.event_data_key, self.instance.id)
         self.dispatcher.dispatch(event_data)
 
+    @cleanup_new_process
     def status_handler(self, status_data, runner_config):
         """
         Ansible runner callback triggered on status transition


### PR DESCRIPTION
I saw this 2 times this week when running some stress tests.

```
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/fields/related_descriptors.py", line 173, in __get__
    rel_obj = self.field.get_cached_value(instance)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/fields/mixins.py", line 15, in get_cached_value
    return instance._state.fields_cache[cache_name]
KeyError: 'unified_job_template'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/jobs.py", line 560, in run
    res = receptor_job.run()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/receptor.py", line 269, in run
    res = self._run_internal(receptor_ctl)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/receptor.py", line 345, in _run_internal
    res = list(first_future.done)[0].result()
  File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 433, in result
    return self.__get_result()
  File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 389, in __get_result
    raise self._exception
  File "/usr/lib64/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/common.py", line 1168, in wrapper_cleanup_new_process
    return func(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/receptor.py", line 401, in processor
    return ansible_runner.interface.run(
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/ansible_runner/interface.py", line 217, in run
    r.run()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/ansible_runner/streaming.py", line 247, in run
    self.status_callback(data)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/ansible_runner/streaming.py", line 205, in status_callback
    self.status_handler(status_data, runner_config=self.config)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/callback.py", line 190, in status_handler
    self.instance = self.update_model(self.instance.pk, job_args=json.dumps(runner_config.command), job_cwd=runner_config.cwd, job_env=job_env)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/callback.py", line 39, in update_model
    return update_model(self.model, pk, _attempt=0, _max_attempts=self.update_attempts, **updates)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/update_model.py", line 28, in update_model
    instance.save(update_fields=update_fields)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/models/unified_jobs.py", line 858, in save
    if self.unified_job_template != self._get_parent_instance():
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/fields/related_descriptors.py", line 187, in __get__
    rel_obj = self.get_object(instance)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/fields/related_descriptors.py", line 154, in get_object
    return qs.get(self.field.get_reverse_related_filter(instance))
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/query.py", line 431, in get
    num = len(clone)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/query.py", line 262, in __len__
    self._fetch_all()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/query.py", line 1324, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/polymorphic/query.py", line 64, in _polymorphic_iterator
    real_results = self.queryset._get_real_instances(base_result_objects)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/polymorphic/query.py", line 457, in _get_real_instances
    real_objects_dict = {
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/query.py", line 280, in __iter__
    self._fetch_all()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/query.py", line 1324, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/query.py", line 51, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/sql/compiler.py", line 1173, in execute_sql
    cursor = self.connection.cursor()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
    return func(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/base/base.py", line 259, in cursor
    return self._cursor()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/base/base.py", line 237, in _cursor
    return self._prepare_cursor(self.create_cursor(name))
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/utils/asyncio.py", line 33, in inner
    return func(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/postgresql/base.py", line 237, in create_cursor
    cursor.tzinfo_factory = self.tzinfo_factory if settings.USE_TZ else None
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/conf/settings.py", line 490, in __getattr_without_cache__
    return getattr(self._wrapped, name)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/cachetools/decorators.py", line 24, in wrapper
    cache[k] = v
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/cachetools/ttl.py", line 88, in __setitem__
    self.expire(time)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/cachetools/ttl.py", line 168, in expire
    cache_delitem(self, curr.key)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/cachetools/cache.py", line 61, in __delitem__
    del self.__data[key]
KeyError: (<SettingsWrapper>, 'USE_TZ')
```

There was another occurrence I forgot to save, but it was the same thing except the error originated in `cancel_callback`.

Before this patch, I saw this error roughly 1 or 2 times every 1000 jobs when the system was under heavy load. With this patch:

```
>>> Job.objects.filter(status="successful").count()
1000
>>> Job.objects.filter(status="error").count()
0
```