### PR TITLE
Respect optional fully qualified collection name (ansible.builtin.) for playbook identification

### DIFF
--- a/awx/main/tests/data/ansible_utils/playbooks/valid/import_fqcn.yml
+++ b/awx/main/tests/data/ansible_utils/playbooks/valid/import_fqcn.yml
@@ -1,0 +1,2 @@
+---
+- ansible.builtin.import_playbook: foo

--- a/awx/main/tests/data/ansible_utils/playbooks/valid/include_fqcn.yml
+++ b/awx/main/tests/data/ansible_utils/playbooks/valid/include_fqcn.yml
@@ -1,0 +1,2 @@
+---
+- ansible.builtin.include: foo

--- a/awx/main/utils/ansible.py
+++ b/awx/main/utils/ansible.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('awx.main.utils.ansible')
 __all__ = ['skip_directory', 'could_be_playbook', 'could_be_inventory']
 
 
-valid_playbook_re = re.compile(r'^\s*?-?\s*?(?:hosts|include|import_playbook):\s*?.*?$')
+valid_playbook_re = re.compile(r'^\s*?-?\s*?(?:hosts|(ansible\.builtin\.)?include|(ansible\.builtin\.)?import_playbook):\s*?.*?$')
 valid_inventory_re = re.compile(r'^[a-zA-Z0-9_.=\[\]]')
 
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
During a project sync we look for yaml/yml files and look at their contents for specific keywords including `hosts`, `include` and `import`. The `include` and `import` modules can now be fully qualified like `ansible.builtin.include` so we need to add those optional prefixes to the search requirements. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 20.1.1.dev93+ge31115d18e
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
