### PR TITLE
fix off-by-one error in job output pagination

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/getEventRequestParams.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/getEventRequestParams.test.js
@@ -44,4 +44,14 @@ describe('getEventRequestParams', () => {
     });
     expect(loadRange).toEqual(range(121, 126));
   });
+
+  it('should return last event only', () => {
+    const [params, loadRange] = getEventRequestParams(job, 72, [72, 72]);
+
+    expect(params).toEqual({
+      page: 72,
+      page_size: 1,
+    });
+    expect(loadRange).toEqual(range(72, 72));
+  });
 });

--- a/awx/ui/src/screens/Job/JobOutput/shared/jobOutputUtils.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/jobOutputUtils.js
@@ -3,7 +3,7 @@ export default function getRowRangePageSize(startIndex, stopIndex) {
   let pageSize;
 
   if (startIndex === stopIndex) {
-    page = startIndex + 1;
+    page = startIndex;
     pageSize = 1;
   } else if (stopIndex >= startIndex + 50) {
     page = Math.floor(startIndex / 50) + 1;

--- a/awx/ui/src/screens/Job/JobOutput/shared/jobOutputUtils.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/shared/jobOutputUtils.test.js
@@ -3,11 +3,20 @@ import getRowRangePageSize from './jobOutputUtils';
 describe('getRowRangePageSize', () => {
   test('handles range of 1', () => {
     expect(getRowRangePageSize(1, 1)).toEqual({
-      page: 2,
+      page: 1,
       pageSize: 1,
-      firstIndex: 1,
+      firstIndex: 0,
     });
   });
+
+  test('handles range of 1 at a higher number', () => {
+    expect(getRowRangePageSize(72, 72)).toEqual({
+      page: 72,
+      pageSize: 1,
+      firstIndex: 71,
+    });
+  });
+
   test('handles range larger than 50 rows', () => {
     expect(getRowRangePageSize(55, 125)).toEqual({
       page: 2,
@@ -15,6 +24,7 @@ describe('getRowRangePageSize', () => {
       firstIndex: 50,
     });
   });
+
   test('handles small range', () => {
     expect(getRowRangePageSize(47, 53)).toEqual({
       page: 6,
@@ -22,6 +32,7 @@ describe('getRowRangePageSize', () => {
       firstIndex: 45,
     });
   });
+
   test('handles perfect range', () => {
     expect(getRowRangePageSize(5, 9)).toEqual({
       page: 2,
@@ -29,6 +40,7 @@ describe('getRowRangePageSize', () => {
       firstIndex: 5,
     });
   });
+
   test('handles range with 0 startIndex', () => {
     expect(getRowRangePageSize(0, 50)).toEqual({
       page: 1,


### PR DESCRIPTION
##### SUMMARY
Fixes off-by-one error when calculating job output pagination when fetching a single event.

Addresses #12101

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI
