### PR TITLE
update workflow nodes to allow workflows and system jobs

### DIFF
--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -259,7 +259,7 @@ options:
             type:
               description:
                 - Name of unified job template type to run in the workflow.
-                - Can be a job_template, project, inventory_source, workflow_approval.
+                - Can be a job_template, project, inventory_source, system_job, workflow_approval, workflow_job_template.
               type: str
             timeout:
               description:
@@ -486,13 +486,17 @@ def create_schema_nodes(module, response, schema, workflow_id):
             if workflow_node['unified_job_template']['type'] is None:
                 module.fail_json(msg='Could not find unified job template type in schema {1}'.format(workflow_node))
             if workflow_node['unified_job_template']['type'] == 'inventory_source':
-                organization_id = module.resolve_name_to_id('organizations', workflow_node['unified_job_template']['inventory']['organization']['name'])
-                search_fields['organization'] = organization_id
-            elif workflow_node['unified_job_template']['type'] == 'workflow_approval':
-                pass
-            else:
+                if 'inventory' in workflow_node['unified_job_template']:
+                    if 'organization' in workflow_node['unified_job_template']['inventory']:
+                        organization_id = module.resolve_name_to_id('organizations', workflow_node['unified_job_template']['inventory']['organization']['name'])
+                        search_fields['organization'] = organization_id
+                    else:
+                        pass
+            elif 'organization' in workflow_node['unified_job_template']:
                 organization_id = module.resolve_name_to_id('organizations', workflow_node['unified_job_template']['organization']['name'])
                 search_fields['organization'] = organization_id
+            else:
+                pass
             unified_job_template = module.get_one('unified_job_templates', name_or_id=workflow_node['unified_job_template']['name'], **{'data': search_fields})
             if unified_job_template:
                 workflow_node_fields['unified_job_template'] = unified_job_template['id']

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -586,6 +586,10 @@
             name: Default
           name: "{{ jt2_name }}"
           type: job_template
+      - identifier: Cleanup Job
+        unified_job_template:
+          name: Cleanup Activity Stream
+          type: system_job
   register: result
 
 - assert:
@@ -625,6 +629,12 @@
             organization:
               name: Default
           type: inventory_source
+      - identifier: Workflow inception
+        unified_job_template:
+          name: "{{ wfjt_name }}"
+          organization:
+            name: Default
+          type: workflow_job_template
   register: result
 
 - name: Kick off a workflow and wait for it


### PR DESCRIPTION
<!--- changelog-entry
---
msg: "Updated awx.awx.workflow_job_templates to allow for workflow and system role nodes"
-->

##### SUMMARY
After reviewing the GUI, the system roles and workflow_job_template type were not supported, Updated the lookup knowledge to make org lookup optional if not provided, and added the new types, and tests to account for the changes.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
21.1.0
```