### PR TITLE
Remove hardcoded public schema in cleanup_jobs.py

### DIFF
--- a/awx/main/management/commands/cleanup_jobs.py
+++ b/awx/main/management/commands/cleanup_jobs.py
@@ -103,7 +103,7 @@ class DeleteMeta:
 
         with connection.cursor() as cursor:
             query = "SELECT inhrelid::regclass::text AS child FROM pg_catalog.pg_inherits"
-            query += f" WHERE inhparent = 'public.{tbl_name}'::regclass"
+            query += f" WHERE inhparent = '{tbl_name}'::regclass"
             query += f" AND TO_TIMESTAMP(LTRIM(inhrelid::regclass::text, '{tbl_name}_'), 'YYYYMMDD_HH24') < '{self.cutoff}'"
             query += " ORDER BY inhrelid::regclass::text"
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fix cleanup_jobs.py when using external postgres database"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

related https://github.com/ansible/awx/issues/10838

This removes the hardcoded reference to the public schema when looking for table partitions to clean up. I'm -pretty- sure this works fine, and I have successfully tested it on my AWX instance which uses an external DB with a  schema named 'awx' instead of 'public'.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Management Job

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 19.3.1.dev1076+g3d5f302d10
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
