### PR TITLE
Avoid running jobs that have already been reaped

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -401,8 +401,7 @@ class BaseTask(object):
             self.instance = self.update_model(self.instance.pk, status='canceled')
         if self.instance.status not in ACTIVE_STATES:
             # Prevent starting the job if it has been reaped or handled by another process.
-            logger.warning(f'Not starting {self.instance.status} task pk={pk}')
-            return
+            raise RuntimeError(f'Not starting {self.instance.status} task pk={pk}')
 
         if self.instance.execution_environment_id is None:
             from awx.main.signals import disable_activity_stream

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -398,7 +398,7 @@ class BaseTask(object):
         """
         self.instance = self.model.objects.get(pk=pk)
         if self.instance.status != 'canceled' and self.instance.cancel_flag:
-            self.instance = self.update_model(self.instance.pk, status='canceled')
+            self.instance = self.update_model(self.instance.pk, start_args='', status='canceled')
         if self.instance.status not in ACTIVE_STATES:
             # Prevent starting the job if it has been reaped or handled by another process.
             raise RuntimeError(f'Not starting {self.instance.status} task pk={pk}')

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -401,7 +401,7 @@ class BaseTask(object):
             self.instance = self.update_model(self.instance.pk, start_args='', status='canceled')
         if self.instance.status not in ACTIVE_STATES:
             # Prevent starting the job if it has been reaped or handled by another process.
-            raise RuntimeError(f'Not starting {self.instance.status} task pk={pk}')
+            raise RuntimeError(f'Not starting {self.instance.status} task pk={pk} because {self.instance.status} is not in a valid active state')
 
         if self.instance.execution_environment_id is None:
             from awx.main.signals import disable_activity_stream

--- a/awx/main/tests/functional/test_tasks.py
+++ b/awx/main/tests/functional/test_tasks.py
@@ -68,7 +68,10 @@ def test_folder_cleanup_running_job(mock_job_folder, mock_me):
 def test_does_not_run_reaped_job(mocker, mock_me):
     job = Job.objects.create(status='failed', job_explanation='This job has been reaped.')
     mock_run = mocker.patch('awx.main.tasks.jobs.ansible_runner.interface.run')
-    RunJob().run(job.id)
+    try:
+        RunJob().run(job.id)
+    except Exception:
+        pass
     job.refresh_from_db()
     assert job.status == 'failed'
     mock_run.assert_not_called()

--- a/awx/main/tests/functional/test_tasks.py
+++ b/awx/main/tests/functional/test_tasks.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import shutil
 
+from awx.main.tasks.jobs import RunJob
 from awx.main.tasks.system import execution_node_health_check, _cleanup_images_and_files
 from awx.main.models import Instance, Job
 
@@ -61,3 +62,13 @@ def test_folder_cleanup_running_job(mock_job_folder, mock_me):
         job.save(update_fields=['status'])
         _cleanup_images_and_files(grace_period=0)
         assert not os.path.exists(mock_job_folder)  # job is finished and no grace period, should delete
+
+
+@pytest.mark.django_db
+def test_does_not_run_reaped_job(mocker, mock_me):
+    job = Job.objects.create(status='failed', job_explanation='This job has been reaped.')
+    mock_run = mocker.patch('awx.main.tasks.jobs.ansible_runner.interface.run')
+    RunJob().run(job.id)
+    job.refresh_from_db()
+    assert job.status == 'failed'
+    mock_run.assert_not_called()

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -498,7 +498,7 @@ class TestGenericRun:
             with pytest.raises(Exception):
                 task.run(1)
 
-        for c in [mock.call(1, status='running', start_args=''), mock.call(1, status='canceled')]:
+        for c in [mock.call(1, start_args='', status='canceled')]:
             assert c in task.update_model.call_args_list
 
     def test_event_count(self, mock_me):


### PR DESCRIPTION
##### SUMMARY
We may reap jobs in the waiting status:

https://github.com/ansible/awx/blob/b6362a63ccc8338b48860cf710be7739c84f6fc5/awx/main/dispatch/reaper.py#L45-L51

It is extremely likely that a job reaped by the second condition there will still be picked up by the dispatcher and will start to run. That's not good.

We should still consider modifying that reaping condition, but this will avoid the self-contradictory situation generally. If a job was moved out of active status by another process, we assume that was done for a reason.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API

