### PR TITLE
Don't repeatedly traverse workflow nodes when finding ancestors

### DIFF
--- a/awx/ui/src/components/Workflow/workflowReducer.js
+++ b/awx/ui/src/components/Workflow/workflowReducer.js
@@ -548,17 +548,21 @@ function selectSourceForLinking(state, sourceNode) {
       invalidLinkTargetIds.push(link.target.id);
     }
     if (!parentMap[link.target.id]) {
-      parentMap[link.target.id] = [];
+      parentMap[link.target.id] = {
+        parents: [],
+        traversed: false,
+      };
     }
-    parentMap[link.target.id].push(link.source.id);
+    parentMap[link.target.id].parents.push(link.source.id);
   });
 
   const getAncestors = (id) => {
-    if (parentMap[id]) {
-      parentMap[id].forEach((parentId) => {
+    if (parentMap[id] && !parentMap[id].traversed) {
+      parentMap[id].parents.forEach((parentId) => {
         invalidLinkTargetIds.push(parentId);
         getAncestors(parentId);
       });
+      parentMap[id].traversed = true;
     }
   };
 


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fixed bug where workflow visualizer would crash when linking two nodes in a very large workflow"
-->

##### SUMMARY
In this function: https://github.com/ansible/awx/blob/devel/awx/ui/src/components/Workflow/workflowReducer.js#L535-L584 we go through and mark ancestor nodes as disabled to prevent users from building a workflow with a cycle in it.  If you build a workflow with a sufficiently large number of paths back to the start node and then attempt to link one of the very end nodes with another, the visualizer will crash (due to long running recursion).

To fix this, I've marked nodes as "already traversed" to prevent us from traversing the same paths over and over.

![happy_wf](https://user-images.githubusercontent.com/9889020/166510000-e9cd744b-4792-44b6-baff-d27dc6730e3c.gif)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI