### PR TITLE
Add help text popovers to /#/credentials details fields

### DIFF
--- a/awx/ui/src/screens/Credential/CredentialDetail/CredentialDetail.js
+++ b/awx/ui/src/screens/Credential/CredentialDetail/CredentialDetail.js
@@ -100,12 +100,19 @@ function CredentialDetail({ credential }) {
 
   const { error, dismissError } = useDismissableError(deleteError);
 
-  const renderDetail = ({ id, label, type, ask_at_runtime }) => {
+  const renderDetail = ({
+    id,
+    label,
+    type,
+    ask_at_runtime,
+    help_text = '',
+  }) => {
     if (inputSources[id]) {
       return (
         <React.Fragment key={id}>
           <Detail
             dataCy={`credential-${id}-detail`}
+            helpText={help_text}
             id={`credential-${id}-detail`}
             fullWidth
             label={<span>{label} *</span>}
@@ -151,6 +158,7 @@ function CredentialDetail({ credential }) {
           key={id}
           label={label}
           value={t`Encrypted`}
+          helpText={help_text}
           isEncrypted
         />
       );
@@ -160,6 +168,7 @@ function CredentialDetail({ credential }) {
       return (
         <Detail
           dataCy={`credential-${id}-detail`}
+          helpText={help_text}
           id={`credential-${id}-detail`}
           key={id}
           label={label}
@@ -175,6 +184,7 @@ function CredentialDetail({ credential }) {
         key={id}
         label={label}
         value={inputs[id]}
+        helpText={help_text}
       />
     );
   };


### PR DESCRIPTION
Add help text popovers to /#/credentials details fields

See: https://github.com/ansible/awx/issues/11862

For the credentials we get most of the strings from the backend. I needed to surface this data on the details page.

I created one credential for each type available on the API and any of them that displayed a text help_text during add/edit now display the same help_text on the details page.

To show a few:

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/9053044/166556680-aa793f9e-1861-461e-82d5-b685721e08a6.png">

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/9053044/166556728-42755780-a671-48da-93ae-6865c34778e5.png">

<img width="1493" alt="image" src="https://user-images.githubusercontent.com/9053044/166556774-bc328e55-4a39-489d-825a-878fb258cdfb.png">

<img width="1502" alt="image" src="https://user-images.githubusercontent.com/9053044/166556816-fbdde0d0-3741-49c4-a347-adca7d99ea47.png">

<img width="1483" alt="image" src="https://user-images.githubusercontent.com/9053044/166556874-30e4ed74-6435-41af-9abb-93e7ae8d276c.png">


<img width="1474" alt="image" src="https://user-images.githubusercontent.com/9053044/166557263-b238d86e-bace-4a9c-b3de-151fbc654f42.png">


