### PR TITLE
Adding popover for details is showing breaking of words

### DIFF
--- a/awx/ui/src/components/DetailList/Detail.js
+++ b/awx/ui/src/components/DetailList/Detail.js
@@ -21,7 +21,7 @@ const DetailValue = styled(
     <TextListItem {...props} />
   )
 )`
-  word-break: break-all;
+  overflow-wrap: break-word;
   ${(props) =>
     props.fullWidth &&
     `


### PR DESCRIPTION
Now that we are adding popovers for details pages, I noticed a couple of
strings wrapping in odd places, update css to avoid that.

Also `word-break: break-word` was deprecated.

Without this change

![image](https://user-images.githubusercontent.com/9053044/166564796-014ac11f-fd3c-4add-9d9a-49679d1f9f33.png)

With this change

<img width="1491" alt="image" src="https://user-images.githubusercontent.com/9053044/166565117-a70237bb-b940-4449-b674-041326e4bf97.png">


