### PR TITLE
Fix typo in application module example

### DIFF
--- a/awx_collection/plugins/modules/application.py
+++ b/awx_collection/plugins/modules/application.py
@@ -79,7 +79,7 @@ EXAMPLES = '''
     organization: "test"
     state: present
     authorization_grant_type: password
-    client-type: public
+    client_type: public
 
 - name: Add Foo application
   application:
@@ -88,7 +88,7 @@ EXAMPLES = '''
     organization: "test"
     state: present
     authorization_grant_type: authorization-code
-    client-type: confidential
+    client_type: confidential
     redirect_uris:
       - http://tower.com/api/v2/
 '''


### PR DESCRIPTION

---
msg: "Fixed typo in application module example"


##### SUMMARY
Issue AAP-3176
Module Link - https://console.redhat.com/ansible/automation-hub/repo/published/ansible/controller/content/module/application


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
n/a
```


##### ADDITIONAL INFORMATION
Issue AAP-3176
Fix typos in the example section in the `application` module: https://github.com/ansible/awx/blob/devel/awx_collection/plugins/modules/application.py

Before:
```
client-type: public

client-type: confidential
```

After:
```
client_type: public

client_type: confidential
```
