### PR TITLE
Prevents the api label from being added to UI only PRs

### DIFF
--- a/.github/pr_labeler.yml
+++ b/.github/pr_labeler.yml
@@ -1,14 +1,14 @@
 "component:api":
-  - any: ['awx/**/*', '!awx/ui/*']
+  - any: ["awx/**/*", "!awx/ui/**"]
 
 "component:ui":
-  - any: ['awx/ui/**/*']
+  - any: ["awx/ui/**/*"]
 
 "component:docs":
-  - any: ['docs/**/*']
+  - any: ["docs/**/*"]
 
 "component:cli":
-  - any: ['awxkit/**/*']
+  - any: ["awxkit/**/*"]
 
 "component:collection":
-  - any: ['awx_collection/**/*']
+  - any: ["awx_collection/**/*"]


### PR DESCRIPTION


##### SUMMARY
This change prevents the API label from being applied to issues that are ui only

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
-github workflows

##### AWX VERSION