### PR TITLE
Falling back to project.status if the last project sync job was deleted

### DIFF
--- a/awx/ui/src/screens/Project/ProjectList/ProjectListItem.js
+++ b/awx/ui/src/screens/Project/ProjectList/ProjectListItem.js
@@ -195,7 +195,7 @@ function ProjectListItem({
           )}
         </TdBreakWord>
         <Td dataLabel={t`Status`}>
-          {job && (
+          {job ? (
             <Tooltip
               position="top"
               content={generateLastJobTooltip(job)}
@@ -204,6 +204,14 @@ function ProjectListItem({
               <Link to={`/jobs/project/${job.id}`}>
                 <StatusLabel status={job.status} />
               </Link>
+            </Tooltip>
+          ) : (
+            <Tooltip
+              position="top"
+              content={t`Unable to load last job update`}
+              key={project.id}
+            >
+              <StatusLabel status={project?.status} />
             </Tooltip>
           )}
         </Td>


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Co authored with @nixocio 

Modify the project list UI so that its status will be displayed in the UI if the last project sync job is missing. 
Pre change:
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/32551173/167898732-e8c495b6-7145-4a6a-92e4-660d73dd156e.png">

Post change:
<img width="1449" alt="image" src="https://user-images.githubusercontent.com/32551173/167896752-8c22c219-ead2-42d5-a96a-a248d52e7d23.png">

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.0.1.dev89+g3976c4fedb
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
