### PR TITLE
Change Demo Project status to successful

### DIFF
--- a/awx/main/management/commands/create_preload_data.py
+++ b/awx/main/management/commands/create_preload_data.py
@@ -32,8 +32,10 @@ class Command(BaseCommand):
                             name='Demo Project',
                             scm_type='git',
                             scm_url='https://github.com/ansible/ansible-tower-samples',
-                            scm_update_on_launch=True,
                             scm_update_cache_timeout=0,
+                            status='successful',
+                            scm_revision='347e44fea036c94d5f60e544de006453ee5c71ad',
+                            playbook_files=['hello_world.yml'],
                         )
 
                     p.organization = o


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Change the Demo Project to have an initial status of successful, and avoid running an update right after install"
-->

##### SUMMARY
This requires UI changes from https://github.com/ansible/awx/pull/12215, and should not be fully considered until after that has landed.

This will change the user experience for the "Demo Project" created from the `create_preload_data` management command. These changes will avoid kicking off an initial project update, and instead directly populate the `scm_revision` and `playbook_files`. Populating these fields plus the `status` will make this project usable for the "Demo Job Template". For a new install, it will perform a project "sync" for the first launch of the Demo JT, to pull the known revision from github, at that time (it also might pull the controlplane EE).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API

##### AWX VERSION
```
21.0.0
```

