### PR TITLE
Prevent edit of  vault ID once credential is created.

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2664,6 +2664,13 @@ class CredentialSerializer(BaseSerializer):
 
         return credential_type
 
+    def validate_inputs(self, inputs):
+        if self.instance and self.instance.credential_type.kind == "vault":
+            if 'vault_id' in inputs and inputs['vault_id'] != self.instance.inputs['vault_id']:
+                raise ValidationError(_('We do not permit Vault IDs to be changed after they have been created.'))
+
+        return inputs
+
 
 class CredentialSerializerCreate(CredentialSerializer):
 

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2667,7 +2667,7 @@ class CredentialSerializer(BaseSerializer):
     def validate_inputs(self, inputs):
         if self.instance and self.instance.credential_type.kind == "vault":
             if 'vault_id' in inputs and inputs['vault_id'] != self.instance.inputs['vault_id']:
-                raise ValidationError(_('We do not permit Vault IDs to be changed after they have been created.'))
+                raise ValidationError(_('Vault IDs cannot be changed once they have been created.'))
 
         return inputs
 

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.js
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-no-useless-fragment */
 import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { useField, useFormikContext } from 'formik';
 import { shape, string } from 'prop-types';
 import styled from 'styled-components';
@@ -31,6 +32,7 @@ function CredentialInput({
   fieldOptions,
   isFieldGroupValid,
   credentialKind,
+  isVaultIdDisabled,
   ...rest
 }) {
   const [fileName, setFileName] = useState('');
@@ -148,6 +150,7 @@ function CredentialInput({
       onChange={(value, event) => {
         subFormField.onChange(event);
       }}
+      isDisabled={isVaultIdDisabled}
       validated={isValid ? 'default' : 'error'}
     />
   );
@@ -167,6 +170,7 @@ CredentialInput.defaultProps = {
 
 function CredentialField({ credentialType, fieldOptions }) {
   const { values: formikValues } = useFormikContext();
+  const location = useLocation();
   const requiredFields = credentialType?.inputs?.required || [];
   const isRequired = requiredFields.includes(fieldOptions.id);
   const validateField = () => {
@@ -242,6 +246,15 @@ function CredentialField({ credentialType, fieldOptions }) {
       <BecomeMethodField fieldOptions={fieldOptions} isRequired={isRequired} />
     );
   }
+
+  let disabled = false;
+  if (
+    credentialType.kind === 'vault' &&
+    location.pathname.endsWith('edit') &&
+    fieldOptions.id === 'vault_id'
+  ) {
+    disabled = true;
+  }
   return (
     <CredentialPluginField
       fieldOptions={fieldOptions}
@@ -251,6 +264,7 @@ function CredentialField({ credentialType, fieldOptions }) {
       <CredentialInput
         isFieldGroupValid={isValid}
         fieldOptions={fieldOptions}
+        isVaultIdDisabled={disabled}
       />
     </CredentialPluginField>
   );

--- a/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialFormFields/CredentialField.test.js
@@ -13,6 +13,12 @@ const fieldOptions = {
   secret: true,
 };
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({
+    pathname: '/credentials/3/edit',
+  }),
+}));
 describe('<CredentialField />', () => {
   let wrapper;
   test('renders correctly without initial value', () => {
@@ -112,5 +118,34 @@ describe('<CredentialField />', () => {
     expect(wrapper.find('TextInput').props().isDisabled).toBe(true);
     expect(wrapper.find('TextInput').props().value).toBe('');
     expect(wrapper.find('TextInput').props().placeholder).toBe('ENCRYPTED');
+  });
+  test('Should check to see if the ability to edit vault ID is disabled after creation.', () => {
+    const vaultCredential = credentialTypes.find((type) => type.id === 3);
+    const vaultFieldOptions = {
+      id: 'vault_id',
+      label: 'Vault Identifier',
+      type: 'string',
+      secret: true,
+    };
+    wrapper = mountWithContexts(
+      <Formik
+        initialValues={{
+          passwordPrompts: {},
+          inputs: {
+            password: 'password',
+            vault_id: 'vault_id',
+          },
+        }}
+      >
+        {() => (
+          <CredentialField
+            fieldOptions={vaultFieldOptions}
+            credentialType={vaultCredential}
+          />
+        )}
+      </Formik>
+    );
+    expect(wrapper.find('CredentialInput').props().isDisabled).toBe(true);
+    expect(wrapper.find('KeyIcon').length).toBe(1);
   });
 });


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Vault credentials no longer allow the vault ID to be edited after creation."
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related #9014 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.0.1
```

