### PR TITLE
use haproxy 2.3 with maxconn set to avoid startup failures

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -69,7 +69,7 @@ services:
 {% endfor %}
 {% if control_plane_node_count|int > 1 %}
   haproxy:
-    image: haproxy
+    image: haproxy:2.3
     user: "{{ ansible_user_uid }}"
     volumes:
       - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:Z"

--- a/tools/docker-compose/ansible/roles/sources/templates/haproxy.cfg.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/haproxy.cfg.j2
@@ -1,6 +1,7 @@
 global
     stats socket /tmp/admin.sock
     stats timeout 30s
+    maxconn 1000
 
 defaults
     log     global


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Our local docker cluster setup uses haproxy as the loadbalancer, but fails to startup with the following error
```
sources_haproxy_1 | [ALERT]    (1) : Not enough memory to allocate 1073741815 entries for fdtab!
sources_haproxy_1 | [ALERT]    (1) : No polling mechanism available.
sources_haproxy_1 |   It is likely that haproxy was built with TARGET=generic and that FD_SETSIZE
sources_haproxy_1 |   is too low on this platform to support maxconn and the number of listeners
sources_haproxy_1 |   and servers. You should rebuild haproxy specifying your system using TARGET=
sources_haproxy_1 |   in order to support other polling systems (poll, epoll, kqueue) or reduce the
sources_haproxy_1 |   global maxconn setting to accommodate the system's limitation. For reference,
sources_haproxy_1 |   FD_SETSIZE=1024 on this system, global.maxconn=536870881 resulting in a maximum of
sources_haproxy_1 |   1073741815 file descriptors. You should thus reduce global.maxconn by 536870396. Also,
sources_haproxy_1 |   check build settings using 'haproxy -vv'.
```

this commit fixes the issue for now, but I want to change back to latest image eventually
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.0.1.dev117+gc4979f1b08.d20220517

```
