### PR TITLE
Variablizing the awx_template_version

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build collection and publish to galaxy
         run: |
-          COLLECTION_NAMESPACE=${{ env.collection_namespace }} make build_collection
+          COLLECTION_TEMPLATE_VERSION=true COLLECTION_NAMESPACE=${{ env.collection_namespace }} make build_collection
           ansible-galaxy collection publish \
             --token=${{ secrets.GALAXY_TOKEN }} \
             awx_collection_build/${{ env.collection_namespace }}-awx-${{ github.event.release.tag_name }}.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -288,6 +288,7 @@ COLLECTION_TEST_TARGET ?=
 COLLECTION_PACKAGE ?= awx
 COLLECTION_NAMESPACE ?= awx
 COLLECTION_INSTALL = ~/.ansible/collections/ansible_collections/$(COLLECTION_NAMESPACE)/$(COLLECTION_PACKAGE)
+COLLECTION_TEMPLATE_VERSION ?= false
 
 test_collection:
 	rm -f $(shell ls -d $(VENV_BASE)/awx/lib/python* | head -n 1)/no-global-site-packages.txt
@@ -315,7 +316,7 @@ awx_collection_build: $(shell find awx_collection -type f)
 	  -e collection_package=$(COLLECTION_PACKAGE) \
 	  -e collection_namespace=$(COLLECTION_NAMESPACE) \
 	  -e collection_version=$(COLLECTION_VERSION) \
-	  -e '{"awx_template_version":false}'
+	  -e '{"awx_template_version": $(COLLECTION_TEMPLATE_VERSION)}'
 	ansible-galaxy collection build awx_collection_build --force --output-path=awx_collection_build
 
 build_collection: awx_collection_build


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This should enable the release process to update the version in the module_util.
If you look at the last promote release process it is correctly getting the correct version for the release:
```
Run COLLECTION_NAMESPACE=awx make build_collection
/home/runner/work/awx/awx/.eggs/setuptools_scm-6.4.2-py3.9.egg/setuptools_scm/git.py:105: UserWarning: "/home/runner/work/awx/awx" is shallow and may cause errors
  warnings.warn(f'"{wd.path}" is shallow and may cause errors')
/home/runner/work/awx/awx/.eggs/setuptools_scm-6.4.2-py3.9.egg/setuptools_scm/git.py:105: UserWarning: "/home/runner/work/awx/awx" is shallow and may cause errors
  warnings.warn(f'"{wd.path}" is shallow and may cause errors')
ansible-playbook -i localhost, awx_collection/tools/template_galaxy.yml \
  -e collection_package=awx \
  -e collection_namespace=awx \
  -e collection_version=21.0.0 \
```

However, in the ansible it was skipping the task which updates the version in the collections module_utils file:
```
TASK [template_galaxy : Set the collection version in the controller_api.py file] ***
skipping: [localhost]
```

We had hardcoded the setting the Makefile to prevent a make build from updating that release number so it would stay at devel. When this process moved to a GH action it was never able to update the required file to prevent the error. This change modifies the make file to variablize the option.

Another solution which I am tossing around is just never skipping the step. This step is the only place we ever set that field 

Fixes https://github.com/ansible/awx/issues/12060
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.0.1.dev120+ge7514e4547.d20220517
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
