### PR TITLE
use qs params when fetching new/updated jobs to preserve filters

### DIFF
--- a/awx/ui/src/components/JobList/JobList.js
+++ b/awx/ui/src/components/JobList/JobList.js
@@ -106,8 +106,12 @@ function JobList({
     async (ids) => {
       const params = parseQueryString(qsConfig, location.search);
       params.id__in = ids.join(',');
-      const { data } = await UnifiedJobsAPI.read(params);
-      return data.results;
+      try {
+        const { data } = await UnifiedJobsAPI.read(params);
+        return data.results;
+      } catch (e) {
+        return [];
+      }
     },
     [location.search] // eslint-disable-line react-hooks/exhaustive-deps
   );

--- a/awx/ui/src/components/JobList/JobList.js
+++ b/awx/ui/src/components/JobList/JobList.js
@@ -103,13 +103,13 @@ function JobList({
   }, [fetchJobs]);
 
   const fetchJobsById = useCallback(
-    async (ids, qs = {}) => {
-      const params = parseQueryString(qs, location.search);
+    async (ids) => {
+      const params = parseQueryString(qsConfig, location.search);
       params.id__in = ids.join(',');
       const { data } = await UnifiedJobsAPI.read(params);
       return data.results;
     },
-    [location.search]
+    [location.search] // eslint-disable-line react-hooks/exhaustive-deps
   );
 
   const jobs = useWsJobs(results, fetchJobsById, qsConfig);

--- a/awx/ui/src/components/JobList/useWsJobs.js
+++ b/awx/ui/src/components/JobList/useWsJobs.js
@@ -47,16 +47,9 @@ export default function useWsJobs(initialJobs, fetchJobsById, qsConfig) {
       return;
     }
     const params = parseQueryString(qsConfig, location.search);
-    const filtersApplied = Object.keys(params).length > 4;
-    if (
-      filtersApplied &&
-      !['completed', 'failed', 'error'].includes(lastMessage.status)
-    ) {
-      return;
-    }
-
     const jobId = lastMessage.unified_job_id;
     const index = jobs.findIndex((j) => j.id === jobId);
+
     if (index > -1) {
       setJobs(sortJobs(updateJob(jobs, index, lastMessage), params));
     } else {


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "only show new jobs in job list that meet filter criteria"
-->

##### SUMMARY
Applies active search filters when adding/updating jobs in the job list. This prevents sync jobs or other misc jobs that don't meet the criteria from appearing (and then disappearing if the page is refreshed)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - UI