### PR TITLE
Dependabot runs monthly and only makes prs for production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/awx/ui"
     schedule:
-      interval: "weekly"
-      day: "sunday"
+      interval: "monthly"
     open-pull-requests-limit: 5
     allow:
-      - dependency-type: "direct"
+      - dependency-type: "production"
     reviewers:
       - "AlexSCorey"
       - "keithjgrant"


### PR DESCRIPTION


##### SUMMARY
Updates dependabot so that it only runs monthly, on the first of the month, and limits the prs to only those that are for production depenencies
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - UI
