### PR TITLE
return event_status on push, tag push, and merge gitlab webhook events

### DIFF
--- a/awx/api/views/webhooks.py
+++ b/awx/api/views/webhooks.py
@@ -204,8 +204,6 @@ class GitlabWebhookReceiver(WebhookReceiverBase):
         return h.hexdigest()
 
     def get_event_status_api(self):
-        if self.get_event_type() != 'Merge Request Hook':
-            return
         project = self.request.data.get('project', {})
         repo_url = project.get('web_url')
         if not repo_url:

--- a/awx/api/views/webhooks.py
+++ b/awx/api/views/webhooks.py
@@ -204,6 +204,8 @@ class GitlabWebhookReceiver(WebhookReceiverBase):
         return h.hexdigest()
 
     def get_event_status_api(self):
+        if self.get_event_type() not in self.ref_keys.keys():
+            return
         project = self.request.data.get('project', {})
         repo_url = project.get('web_url')
         if not repo_url:


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Enable gitlab webhook event status for more types than Merge Request webhooks"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Enables webhook event status to be visible in gitlab on e.g. push events so that we can view the status from the job launch in gitlab.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related: #12268 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.0.1.dev130+gf02212b1fe

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Simply removed these two lines from webhook.py:
```
 if self.get_event_type() != 'Merge Request Hook':
            return
```
<!--- Paste verbatim command output below, e.g. before and after your change --