### PR TITLE
Allow to copy entity within the minute

### DIFF
--- a/awx/ui/src/util/dates.js
+++ b/awx/ui/src/util/dates.js
@@ -27,7 +27,7 @@ export function secondsToDays(seconds) {
 
 export function timeOfDay() {
   const dateTime = DateTime.local();
-  return dateTime.toFormat('hh:mm a');
+  return dateTime.toFormat('hh:mm:ss:ms a');
 }
 
 export function dateToInputDateTime(dt, tz = null) {


### PR DESCRIPTION
Allow to copy entity within the minute - add seconds as part of the name
of copied entity.

<img width="1494" alt="image" src="https://user-images.githubusercontent.com/9053044/170111623-71bebba3-d7ca-4432-847e-472187823ec2.png">


See: https://github.com/ansible/awx/issues/12279
