### PR TITLE
detect if job events are tree-like and collapsible

### DIFF
--- a/awx/main/tests/functional/api/test_events.py
+++ b/awx/main/tests/functional/api/test_events.py
@@ -70,11 +70,11 @@ def test_job_job_events_children_summary(get, organization_factory, job_template
         job_id=job.pk, uuid='uuid2', parent_uuid='uuid1', event="playbook_on_play_start", counter=2, stdout='a' * 1024, job_created=job.created
     ).save()
     JobEvent.create_from_data(
-        job_id=job.pk, uuid='uuid3', parent_uuid='uuid2', event="runner_on_start", counter=3, stdout='a' * 1024, job_created=job.created
+        job_id=job.pk, uuid='uuid3', parent_uuid='uuid2', event="playbook_on_task_start", counter=3, stdout='a' * 1024, job_created=job.created
     ).save()
     JobEvent.create_from_data(job_id=job.pk, uuid='uuid4', parent_uuid='', event='verbose', counter=4, stdout='a' * 1024, job_created=job.created).save()
     JobEvent.create_from_data(
-        job_id=job.pk, uuid='uuid5', parent_uuid='uuid1', event="playbook_on_task_start", counter=5, stdout='a' * 1024, job_created=job.created
+        job_id=job.pk, uuid='uuid5', parent_uuid='uuid1', event="playbook_on_play_start", counter=5, stdout='a' * 1024, job_created=job.created
     ).save()
     job.emitted_events = job.get_event_queryset().count()
     job.status = "successful"
@@ -84,3 +84,50 @@ def test_job_job_events_children_summary(get, organization_factory, job_template
     assert response.data["children_summary"] == {1: {"rowNumber": 0, "numChildren": 4}, 2: {"rowNumber": 1, "numChildren": 2}}
     assert response.data["meta_event_nested_uuid"] == {4: "uuid2"}
     assert response.data["event_processing_finished"] == True
+    assert response.data["is_tree"] == True
+
+
+@pytest.mark.django_db
+def test_job_job_events_children_summary_is_tree(get, organization_factory, job_template_factory):
+    '''
+    children_summary should return {is_tree: False} if the event structure is not tree-like
+    '''
+    objs = organization_factory("org", superusers=['admin'])
+    jt = job_template_factory("jt", organization=objs.organization, inventory='test_inv', project='test_proj').job_template
+    job = jt.create_unified_job()
+    url = reverse('api:job_job_events_children_summary', kwargs={'pk': job.pk})
+    response = get(url, user=objs.superusers.admin, expect=200)
+    assert response.data["event_processing_finished"] == False
+    '''
+    E1
+      E2
+        E3
+        E4 (verbose)
+      E5
+        E6 <-- parent is E2, but comes after another "branch" E5
+    '''
+    JobEvent.create_from_data(
+        job_id=job.pk, uuid='uuid1', parent_uuid='', event="playbook_on_start", counter=1, stdout='a' * 1024, job_created=job.created
+    ).save()
+    JobEvent.create_from_data(
+        job_id=job.pk, uuid='uuid2', parent_uuid='uuid1', event="playbook_on_play_start", counter=2, stdout='a' * 1024, job_created=job.created
+    ).save()
+    JobEvent.create_from_data(
+        job_id=job.pk, uuid='uuid3', parent_uuid='uuid2', event="playbook_on_task_start", counter=3, stdout='a' * 1024, job_created=job.created
+    ).save()
+    JobEvent.create_from_data(job_id=job.pk, uuid='uuid4', parent_uuid='', event='verbose', counter=4, stdout='a' * 1024, job_created=job.created).save()
+    JobEvent.create_from_data(
+        job_id=job.pk, uuid='uuid5', parent_uuid='uuid1', event="playbook_on_play_start", counter=5, stdout='a' * 1024, job_created=job.created
+    ).save()
+    JobEvent.create_from_data(
+        job_id=job.pk, uuid='uuid6', parent_uuid='uuid2', event="playbook_on_task_start", counter=6, stdout='a' * 1024, job_created=job.created
+    ).save()
+    job.emitted_events = job.get_event_queryset().count()
+    job.status = "successful"
+    job.save()
+    url = reverse('api:job_job_events_children_summary', kwargs={'pk': job.pk})
+    response = get(url, user=objs.superusers.admin, expect=200)
+    assert response.data["children_summary"] == {}
+    assert response.data["meta_event_nested_uuid"] == {}
+    assert response.data["event_processing_finished"] == True
+    assert response.data["is_tree"] == False

--- a/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
+++ b/awx/ui/src/screens/Job/JobOutput/useJobEvents.js
@@ -56,7 +56,8 @@ export default function useJobEvents(callbacks, jobId, isFlatMode) {
     callbacks
       .fetchChildrenSummary()
       .then((result) => {
-        if (result.data.event_processing_finished === false) {
+        const { event_processing_finished, is_tree } = result.data;
+        if (event_processing_finished === false || is_tree === false) {
           callbacks.setForceFlatMode(true);
           callbacks.setJobTreeReady();
           return;


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "fix missing job events on job output page"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related https://github.com/ansible/awx/issues/12194 and https://github.com/ansible/awx/issues/12233

shoutout to @ybucci for helping us discover the root of the bug!

if the ansible playbook is run with a strategy like free or host_pinned, then the events may no longer follow a tree-like hierarchy

e.g.
```
 E1
    E2
 E3
    E4  <- parent is E3
    E5  <- parent is E1
```
in the above, there is no clear way to collapse E1, because E5 comes after E3, which occurs after E1. Thus the tree view should be disabled.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.0.1.dev144+g783e170e6a
```

