### PR TITLE
Correct help text for job idle timeout

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -446,7 +446,7 @@ register(
     label=_('Default Job Idle Timeout'),
     help_text=_(
         'If no output is detected from ansible in this number of seconds the execution will be terminated. '
-        'Use value of 0 to used default idle_timeout is 600s.'
+        'Use value of 0 to indicate that no idle timeout should be imposed.'
     ),
     category=_('Jobs'),
     category_slug='jobs',


### PR DESCRIPTION
##### SUMMARY
I established experimentally that this help text was wrong. Steps to show this:
 - run a job that has a `command:` task sleep for 700 seconds
   - find that it is successful
 - PATCH the /api/v2/settings/jobs/ page to set `DEFAULT_JOB_IDLE_TIMEOUT` to 600
 - re-launch the job
   - find that it fails with a timeout

Looking into the origin of this, it seems that someone mistook the ansible-runner _example_ data for the default value. Following the ansible-runner code, it's pretty clear that providing no value of `idle_timeout` results in no idle timeout being enforced. AWX has code that will not provide the `idle_timeout` param if the setting's value is 0.

https://github.com/ansible/awx/blob/78660ad0a22798ace9210b37ba5be9429603e49d/awx/main/tasks/jobs.py#L518-L520

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

