### PR TITLE
Duplication of PR of Jinga 2 Rendering 

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4480,7 +4480,10 @@ class NotificationTemplateSerializer(BaseSerializer):
                 body = messages[event].get('body', {})
                 if body:
                     try:
-                        potential_body = json.loads(body)
+                        rendered_body = (
+                            sandbox.ImmutableSandboxedEnvironment(undefined=DescriptiveUndefined).from_string(body).render(JobNotificationMixin.context_stub())
+                        )
+                        potential_body = json.loads(rendered_body)
                         if not isinstance(potential_body, dict):
                             error_list.append(
                                 _("Webhook body for '{}' should be a json dictionary. Found type '{}'.".format(event, type(potential_body).__name__))


### PR DESCRIPTION
Cherry picked changes to merge community PR. https://github.com/ansible/awx/pull/11366

Switch Jinja2 environment for rendering before testing JSON to ImmutbleSandboxedEnvironment

Render Jinja template before checking for valid JSON

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Render Jinja template before checking for valid JSON"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
original issue: https://github.com/ansible/awx/issues/10961 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.0.1

```

