### PR TITLE
Update logout/login redirect for different users

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -101,9 +101,9 @@ const AuthorizedRoutes = ({ routeConfig }) => {
 export function ProtectedRoute({ children, ...rest }) {
   const {
     authRedirectTo,
-    setAuthRedirectTo,
-    loginRedirectOverride,
     isUserBeingLoggedOut,
+    loginRedirectOverride,
+    setAuthRedirectTo,
   } = useSession();
   const location = useLocation();
 

--- a/awx/ui/src/constants.js
+++ b/awx/ui/src/constants.js
@@ -11,3 +11,4 @@ export const JOB_TYPE_URL_SEGMENTS = {
 export const SESSION_TIMEOUT_KEY = 'awx-session-timeout';
 export const SESSION_REDIRECT_URL = 'awx-redirect-url';
 export const PERSISTENT_FILTER_KEY = 'awx-persistent-filter';
+export const SESSION_USER_ID = 'awx-session-user-id';

--- a/awx/ui/src/contexts/Session.js
+++ b/awx/ui/src/contexts/Session.js
@@ -11,7 +11,7 @@ import { DateTime } from 'luxon';
 import { RootAPI, MeAPI } from 'api';
 import { isAuthenticated } from 'util/auth';
 import useRequest from 'hooks/useRequest';
-import { SESSION_TIMEOUT_KEY } from '../constants';
+import { SESSION_TIMEOUT_KEY, SESSION_USER_ID } from '../constants';
 
 // The maximum supported timeout for setTimeout(), in milliseconds,
 // is the highest number you can represent as a signed 32bit
@@ -101,6 +101,7 @@ function SessionProvider({ children }) {
     setIsUserBeingLoggedOut(true);
     if (!isSessionExpired.current) {
       setAuthRedirectTo('/logout');
+      window.localStorage.setItem(SESSION_USER_ID, null);
     }
     sessionStorage.clear();
     await RootAPI.logout();
@@ -167,21 +168,21 @@ function SessionProvider({ children }) {
 
   const sessionValue = useMemo(
     () => ({
-      isUserBeingLoggedOut,
-      loginRedirectOverride,
       authRedirectTo,
       handleSessionContinue,
       isSessionExpired,
+      isUserBeingLoggedOut,
+      loginRedirectOverride,
       logout,
       sessionCountdown,
       setAuthRedirectTo,
     }),
     [
-      isUserBeingLoggedOut,
-      loginRedirectOverride,
       authRedirectTo,
       handleSessionContinue,
       isSessionExpired,
+      isUserBeingLoggedOut,
+      loginRedirectOverride,
       logout,
       sessionCountdown,
       setAuthRedirectTo,

--- a/awx/ui/src/util/auth.js
+++ b/awx/ui/src/util/auth.js
@@ -6,3 +6,29 @@ export function isAuthenticated(cookie) {
   }
   return false;
 }
+
+export function getCurrentUserId(cookie) {
+  if (!isAuthenticated(cookie)) {
+    return null;
+  }
+  const name = 'current_user';
+  let userId = null;
+  if (cookie && cookie !== '') {
+    const cookies = cookie.split(';');
+    for (let i = 0; i < cookies.length; i++) {
+      const parsedCookie = cookies[i].trim();
+      if (parsedCookie.substring(0, name.length + 1) === `${name}=`) {
+        userId = parseUserId(
+          decodeURIComponent(parsedCookie.substring(name.length + 1))
+        );
+        break;
+      }
+    }
+  }
+  return userId;
+}
+
+function parseUserId(decodedUserData) {
+  const userData = JSON.parse(decodedUserData);
+  return userData.id;
+}

--- a/awx/ui/src/util/auth.test.js
+++ b/awx/ui/src/util/auth.test.js
@@ -1,4 +1,4 @@
-import { isAuthenticated } from './auth';
+import { isAuthenticated, getCurrentUserId } from './auth';
 
 const invalidCookie = 'invalid';
 const validLoggedOutCookie =
@@ -17,5 +17,19 @@ describe('isAuthenticated', () => {
 
   test('returns true for valid authenticated cookie', () => {
     expect(isAuthenticated(validLoggedInCookie)).toEqual(true);
+  });
+});
+
+describe('getCurrentUserId', () => {
+  test('returns null for invalid cookie', () => {
+    expect(getCurrentUserId(invalidCookie)).toEqual(null);
+  });
+
+  test('returns null for expired cookie', () => {
+    expect(getCurrentUserId(validLoggedOutCookie)).toEqual(null);
+  });
+
+  test('returns current user id for valid authenticated cookie', () => {
+    expect(getCurrentUserId(validLoggedInCookie)).toEqual(1);
   });
 });


### PR DESCRIPTION
* Logout as User A and Login as User B redirects to `/home`
* Logout as User A and Login as User A redirects to `/home`
* Allow session to timeout as User A and Login as User A redirects to User A's last location

In order to test this change session to expire in `Idle Time Force Log Out` to be 61s. Create 2 users, A and B.

<img width="462" alt="image" src="https://user-images.githubusercontent.com/9053044/171652403-63bf4c12-0896-417d-aa2d-fa7871f1fa07.png">


See: https://github.com/ansible/awx/issues/11167
