### PR TITLE
Only do substitutions for container path conversions with resolved paths

### DIFF
--- a/awx/main/utils/execution_environments.py
+++ b/awx/main/utils/execution_environments.py
@@ -58,9 +58,12 @@ def to_container_path(path, private_data_dir):
     """
     if not os.path.isabs(private_data_dir):
         raise RuntimeError('The private_data_dir path must be absolute')
-    if private_data_dir != path and Path(private_data_dir) not in Path(path).resolve().parents:
+    # due to how tempfile.mkstemp works, we are probably passed a resolved path, but unresolved private_data_dir
+    resolved_path = Path(path).resolve()
+    resolved_pdd = Path(private_data_dir).resolve()
+    if private_data_dir != path and resolved_pdd not in resolved_path.parents:
         raise RuntimeError(f'Cannot convert path {path} unless it is a subdir of {private_data_dir}')
-    return path.replace(private_data_dir, CONTAINER_ROOT, 1)
+    return str(resolved_path).replace(str(resolved_pdd), CONTAINER_ROOT, 1)
 
 
 def to_host_path(path, private_data_dir):

--- a/awx/main/utils/execution_environments.py
+++ b/awx/main/utils/execution_environments.py
@@ -61,17 +61,6 @@ def to_container_path(path, private_data_dir):
     # due to how tempfile.mkstemp works, we are probably passed a resolved path, but unresolved private_data_dir
     resolved_path = Path(path).resolve()
     resolved_pdd = Path(private_data_dir).resolve()
-    if private_data_dir != path and resolved_pdd not in resolved_path.parents:
-        raise RuntimeError(f'Cannot convert path {path} unless it is a subdir of {private_data_dir}')
+    if resolved_pdd != resolved_path and resolved_pdd not in resolved_path.parents:
+        raise RuntimeError(f'Cannot convert path {resolved_path} unless it is a subdir of {resolved_pdd}')
     return str(resolved_path).replace(str(resolved_pdd), CONTAINER_ROOT, 1)
-
-
-def to_host_path(path, private_data_dir):
-    """Given a path inside of the EE container, this gives the absolute path
-    on the host machine within the private_data_dir
-    """
-    if not os.path.isabs(private_data_dir):
-        raise RuntimeError('The private_data_dir path must be absolute')
-    if CONTAINER_ROOT != path and Path(CONTAINER_ROOT) not in Path(path).resolve().parents:
-        raise RuntimeError(f'Cannot convert path {path} unless it is a subdir of {CONTAINER_ROOT}')
-    return path.replace(CONTAINER_ROOT, private_data_dir, 1)


### PR DESCRIPTION
##### SUMMARY
We have a report that, on some systems, there is a symlink `/var/run -> ../run`

I've added tests here that create a symlink for case-in-point like `/tmp/dst -> /tmp/src`

Before this change, running jobs with `AWX_ISOLATION_BASE_PATH` set to a symlink of this pattern would error like:

```
Traceback (most recent call last):
  File "/awx_devel/awx/main/tasks/jobs.py", line 469, in run
    credential.credential_type.inject_credential(credential, env, self.safe_cred_env, args, private_data_dir)
  File "/awx_devel/awx/main/models/credential/__init__.py", line 507, in inject_credential
    container_path = to_container_path(path, private_data_dir)
  File "/awx_devel/awx/main/utils/execution_environments.py", line 62, in to_container_path
    raise RuntimeError(f'Cannot convert path {path} unless it is a subdir of {private_data_dir}')
RuntimeError: Cannot convert path /tmp/foobar/awx_117_j_ds0t3g/env/tmpw093dey9 unless it is a subdir of /tmp/foobar/awx_117_j_ds0t3g
```

After this change, that works fine.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - API
