### PR TITLE
Fix workflow job template webhook credential bug

### DIFF
--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -736,7 +736,7 @@ def main():
 
     webhook_credential = module.params.get('webhook_credential')
     if webhook_credential:
-        new_fields['webhook_credential'] = module.resolve_name_to_id('webhook_credential', webhook_credential)
+        new_fields['webhook_credential'] = module.resolve_name_to_id('credentials', webhook_credential)
 
     # Create the data that gets sent for create and update
     new_fields['name'] = new_name if new_name else (module.get_item_name(existing_item) if existing_item else name)


### PR DESCRIPTION
Signed-off-by: tompage1994@hotmail.co.uk <tpage@redhat.com>

<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: "Fix awx.awx.workflow_job_template webhook_credential option"
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related #12324 
Fixes issue in `awx.awx.workflow_job_template` where `webhook_credential` option was not working because the api `/api/v2/webhook_credential` does not exist.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.0.0
```


