### PR TITLE
Add documentation around schedule timezone change

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4683,7 +4683,7 @@ class ScheduleSerializer(LaunchConfigurationBaseSerializer, SchedulePreviewSeria
 
     timezone = serializers.SerializerMethodField(
         help_text=_(
-            'The timezone this schedule runs in. This field is extracted from the RRULE. If the timezone in the RRULE is a link to another timezone this field will show the links name.'
+            'The timezone this schedule runs in. This field is extracted from the RRULE. If the timezone in the RRULE is a link to another timezone, the link will be reflected in this field.'
         ),
     )
     until = serializers.SerializerMethodField(

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4681,8 +4681,16 @@ class SchedulePreviewSerializer(BaseSerializer):
 class ScheduleSerializer(LaunchConfigurationBaseSerializer, SchedulePreviewSerializer):
     show_capabilities = ['edit', 'delete']
 
-    timezone = serializers.SerializerMethodField()
-    until = serializers.SerializerMethodField()
+    timezone = serializers.SerializerMethodField(
+        help_text=_(
+            'The timezone this schedule runs in. This field is extracted from the RRULE. If the timezone in the RRULE is a link to another timezone this field will show the links name.'
+        ),
+        read_only=True,
+    )
+    until = serializers.SerializerMethodField(
+        help_text=_('The date this schedule will end. This field is computed from the RRULE. If the schedule does not end an emptry string will be returned'),
+        read_only=True,
+    )
 
     class Meta:
         model = Schedule

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4685,11 +4685,9 @@ class ScheduleSerializer(LaunchConfigurationBaseSerializer, SchedulePreviewSeria
         help_text=_(
             'The timezone this schedule runs in. This field is extracted from the RRULE. If the timezone in the RRULE is a link to another timezone this field will show the links name.'
         ),
-        read_only=True,
     )
     until = serializers.SerializerMethodField(
         help_text=_('The date this schedule will end. This field is computed from the RRULE. If the schedule does not end an emptry string will be returned'),
-        read_only=True,
     )
 
     class Meta:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -578,8 +578,7 @@ class ScheduleZoneInfo(APIView):
     swagger_topic = 'System Configuration'
 
     def get(self, request):
-        zone_info = models.Schedule.get_zoneinfo_with_links()
-        return Response(zone_info)
+        return Response({'zones': models.Schedule.get_zoneinfo(), 'links': models.Schedule.get_zoneinfo_links()})
 
 
 class LaunchConfigCredentialsBase(SubListAttachDetachAPIView):

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -578,8 +578,8 @@ class ScheduleZoneInfo(APIView):
     swagger_topic = 'System Configuration'
 
     def get(self, request):
-        zones = [{'name': zone} for zone in models.Schedule.get_zoneinfo()]
-        return Response(zones)
+        zone_info = models.Schedule.get_zoneinfo_with_links()
+        return Response(zone_info)
 
 
 class LaunchConfigCredentialsBase(SubListAttachDetachAPIView):

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -85,16 +85,16 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
     next_run = models.DateTimeField(null=True, default=None, editable=False, help_text=_("The next time that the scheduled action will run."))
 
     @classmethod
-    def get_zoneinfo(self):
+    def get_zoneinfo(cls):
         return sorted(get_zonefile_instance().zones)
 
     @classmethod
-    def get_zoneinfo_with_links(self):
+    def get_zoneinfo_links(cls):
+        return_val = {}
         zone_instance = get_zonefile_instance()
-        return_val = {'zones': sorted(zone_instance.zones), 'links': {}}
-        for zone_name in return_val['zones']:
+        for zone_name in zone_instance.zones:
             if str(zone_name) != str(zone_instance.zones[zone_name]._filename):
-                return_val['links'][zone_name] = zone_instance.zones[zone_name]._filename
+                return_val[zone_name] = zone_instance.zones[zone_name]._filename
         return return_val
 
     @property

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -88,6 +88,24 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
     def get_zoneinfo(self):
         return sorted(get_zonefile_instance().zones)
 
+    @classmethod
+    def get_zoneinfo_with_links(self):
+        zone_instance = get_zonefile_instance()
+        return_val = {'zones': sorted(zone_instance.zones), 'links': {}}
+        for zone_name in return_val['zones']:
+            if str(zone_name) != str(zone_instance.zones[zone_name]._filename):
+                return_val['links'][zone_name] = zone_instance.zones[zone_name]._filename
+        return return_val
+
+    @classmethod
+    def get_linked_timezone(self, timezone_name):
+        # Returns two values:
+        #    A boolean True means its linked, false means its not a linked timezone
+        #    The name of the link (or the same name if its not a link)
+        zone_instance = get_zonefile_instance()
+        file_name = zone_instance.zones[timezone_name]._filename
+        return file_name != timezone_name, file_name
+
     @property
     def timezone(self):
         utc = tzutc()

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -97,15 +97,6 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
                 return_val['links'][zone_name] = zone_instance.zones[zone_name]._filename
         return return_val
 
-    @classmethod
-    def get_linked_timezone(self, timezone_name):
-        # Returns two values:
-        #    A boolean True means its linked, false means its not a linked timezone
-        #    The name of the link (or the same name if its not a link)
-        zone_instance = get_zonefile_instance()
-        file_name = zone_instance.zones[timezone_name]._filename
-        return file_name != timezone_name, file_name
-
     @property
     def timezone(self):
         utc = tzutc()

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -500,7 +500,7 @@ def test_complex_schedule(post, admin_user, rrule, expected_result):
 def test_zoneinfo(get, admin_user):
     url = reverse('api:schedule_zoneinfo')
     r = get(url, admin_user, expect=200)
-    assert {'name': 'America/New_York'} in r.data
+    assert 'America/New_York' in r.data['zones']
 
 
 @pytest.mark.django_db

--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.js
@@ -89,7 +89,7 @@ const generateRunOnTheDay = (days = []) => {
   return null;
 };
 
-function ScheduleFormFields({ hasDaysToKeepField, zoneOptions }) {
+function ScheduleFormFields({ hasDaysToKeepField, zoneOptions, zoneLinks }) {
   const [timezone, timezoneMeta] = useField({
     name: 'timezone',
     validate: required(t`Select a value for this field`),
@@ -100,6 +100,15 @@ function ScheduleFormFields({ hasDaysToKeepField, zoneOptions }) {
   });
   const [{ name: dateFieldName }] = useField('startDate');
   const [{ name: timeFieldName }] = useField('startTime');
+  const warnLinkedTZ = (event, selected_value) => {
+    console.log(selected_value)
+    console.log(event)
+    if(selected_value in zoneLinks) {
+       console.log("Warning: "+ selected_value +" is a link to "+ zoneLinks[selected_value] +" and will be saved as that.")
+    }
+    timezone.onChange();
+  };
+
   return (
     <>
       <FormField
@@ -135,6 +144,7 @@ function ScheduleFormFields({ hasDaysToKeepField, zoneOptions }) {
           id="schedule-timezone"
           data={zoneOptions}
           {...timezone}
+	  onChange={warnLinkedTZ}
         />
       </FormGroup>
       <FormGroup
@@ -212,7 +222,7 @@ function ScheduleForm({
     request: loadScheduleData,
     error: contentError,
     isLoading: contentLoading,
-    result: { zoneOptions, credentials },
+    result: { zoneOptions, zoneLinks, credentials },
   } = useRequest(
     useCallback(async () => {
       const { data } = await SchedulesAPI.readZoneInfo();
@@ -225,19 +235,21 @@ function ScheduleForm({
         creds = results;
       }
 
-      const zones = data.map((zone) => ({
-        value: zone.name,
-        key: zone.name,
-        label: zone.name,
+      const zones = data.zones.map((zone) => ({
+        value: zone,
+        key: zone,
+        label: zone,
       }));
 
       return {
         zoneOptions: zones,
+        zoneLinks: data.zones.links,
         credentials: creds || [],
       };
     }, [schedule]),
     {
       zonesOptions: [],
+      zoneLinks: {},
       credentials: [],
       isLoading: true,
     }

--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.js
@@ -243,7 +243,7 @@ function ScheduleForm({
         creds = results;
       }
 
-      const zones = data.zones.map((zone) => ({
+      const zones = (data.zones || []).map((zone) => ({
         value: zone,
         key: zone,
         label: zone,


### PR DESCRIPTION
<!--- changelog-entry
# Fill in 'msg' below to have an entry automatically added to the next release changelog.
# Leaving 'msg' blank will not generate a changelog entry for this PR.
# Please ensure this is a simple (and readable) one-line string.
---
msg: ""
-->

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Timezones can be links to other timezones. For example the UTC timezone is a link to Etc/UCT timezone.
When a user selects UTC in the schedule UI and saves the schedule time UI will then display the Etc/UCT timezone.
This behavior was confusing.
This PR modifies the UI to display a warning message that a selected timezone will be replaced with a different timezone on save to warn the user of the behavior:
<img width="505" alt="image" src="https://user-images.githubusercontent.com/32551173/172418309-4079f423-bc70-40b5-8ee6-0d942165fc00.png">

In addition, the API has been updated to give information about the timezone and until fields (from the options page):
```
            "timezone": {
                "type": "field",
                "label": "Timezone",
                "help_text": "The timezone this schedule runs in. This field is extracted from the RRULE. If the timezone in the RRULE is a link to another timezone this field will show the links name.",
                "filterable": false
            },
            "until": {
                "type": "field",
                "label": "Until",
                "help_text": "The date this schedule will end. This field is computed from the RRULE. If the schedule does not end an emptry string will be returned",
                "filterable": false
            }
```

Addresses #12164 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.0.1.dev192+g96eb122aef
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
