### PR TITLE
Update project status to reflect project sync related to job template

### DIFF
--- a/awx/ui/src/screens/Job/Job.helptext.js
+++ b/awx/ui/src/screens/Job/Job.helptext.js
@@ -18,6 +18,7 @@ const jobHelpText = {
   jobTags: t`Tags are useful when you have a large playbook, and you want to run a specific part of a play or task. Use commas to separate multiple tags. Refer to the documentation for details on the usage of tags.`,
   skipTags: t`Skip tags are useful when you have a large playbook, and you want to skip specific parts of a play or task. Use commas to separate multiple tags. Refer to the documentation for details on the usage of tags.`,
   sourceControlBranch: t`Select a branch for the workflow. This branch is applied to all job template nodes that prompt for a branch.`,
+  projectUpdate: t`Project checkout results`,
   forks: (
     <span>
       {t`The number of parallel or simultaneous processes to use while executing the playbook. An empty value, or a value less than 1 will use the Ansible default which is usually 5. The default number of forks can be overwritten with a change to`}{' '}

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.js
@@ -168,15 +168,14 @@ function JobDetail({ job, inventorySourceLabels }) {
           />
           <Detail
             dataCy="job-project-status"
-            label={t`Project Status`}
+            label={t`Project Update Status`}
+            helpText={jobHelpText.projectUpdate}
             value={
               projectUpdate ? (
                 <Link to={`/jobs/project/${projectUpdate.id}`}>
-                  <StatusLabel status={project.status} />
+                  <StatusLabel status={projectUpdate.status} />
                 </Link>
-              ) : (
-                <StatusLabel status={project.status} />
-              )
+              ) : null
             }
           />
         </>

--- a/awx/ui/src/screens/Job/JobDetail/JobDetail.test.js
+++ b/awx/ui/src/screens/Job/JobDetail/JobDetail.test.js
@@ -103,7 +103,9 @@ describe('<JobDetail />', () => {
     const statusLabel = statusDetail.find('StatusLabel');
     expect(statusLabel.prop('status')).toEqual('successful');
 
-    const projectStatusDetail = wrapper.find('Detail[label="Project Status"]');
+    const projectStatusDetail = wrapper.find(
+      'Detail[label="Project Update Status"]'
+    );
     expect(projectStatusDetail.find('StatusLabel')).toHaveLength(1);
     const projectStatusLabel = statusDetail.find('StatusLabel');
     expect(projectStatusLabel.prop('status')).toEqual('successful');


### PR DESCRIPTION
Update project status to reflect project update sync related to job
template that was launched with branch override.

We were displaying status of project sync itself, not from the project
update job as expected.

Also, rename `Project Status` to be `Project Update Status`.

Launching a Job Template using a Project that allows branch override using a non valid branch name.

Before this change.

`Project Status` was different from the job that is linked to.

<img width="1501" alt="image" src="https://user-images.githubusercontent.com/9053044/172678809-0c4c9166-e406-4172-8bc5-abc381f356de.png">

After clicking `Project Status`

<img width="1486" alt="image" src="https://user-images.githubusercontent.com/9053044/172679056-64b63bbb-9233-46df-b4b7-d7bb6c5cd4b3.png">



After this change

Status for `Project Update Status` is the same as the job that is linked to.

<img width="1469" alt="image" src="https://user-images.githubusercontent.com/9053044/172678476-7edef099-56e5-47ad-a981-a8ec0007775c.png">

After clicking `Project Update Status`


<img width="1492" alt="image" src="https://user-images.githubusercontent.com/9053044/172678550-e74cf02c-a4fe-48b5-84eb-d9bee6ccd0b7.png">






See: https://github.com/ansible/awx/issues/11987
