### PR TITLE
Make awx-autoreloader work faster for large code changes

### DIFF
--- a/tools/docker-compose/awx-autoreload
+++ b/tools/docker-compose/awx-autoreload
@@ -6,10 +6,15 @@ if [ $# -lt 2 ]; then
     exit 1
 fi
 
+last_reload=`date +%s`
+
 inotifywait -mrq -e create,delete,attrib,close_write,move --exclude '/awx_devel/awx/ui' $1 | while read directory action file; do
-   if [[ "$file" =~ .*py$ ]]; then
+   this_reload=`date +%s`
+   since_last=$((this_reload-last_reload))
+   if [[ "$file" =~ .*py$ ]] && [[ "$since_last" -gt 1 ]]; then
       echo "File changed: $file"
       echo "Running command: $2"
       eval $2
+      last_reload=`date +%s`
    fi
 done


### PR DESCRIPTION
##### SUMMARY
I found that if I switched from a large branch to `devel` and back again, this would kick off _multiple_ supervisor reload commands. They would all queue up, and you would have to wait for it to complete that number of restarts (imagine, ballpark of 20 restarts, for 20 file changes) before you could use the server again.

This tracks the time of the last code reload, so that if it was less than a second ago, we don't issue another reload command. Initial testing seems to show it working well.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - API


