### PR TITLE
Replace git shallow clone with shutil.copytree

### DIFF
--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -472,7 +472,7 @@ class TestGenericRun:
         task.model.objects.get = mock.Mock(return_value=job)
         task.build_private_data_files = mock.Mock(side_effect=OSError())
 
-        with mock.patch('awx.main.tasks.jobs.copy_tree'):
+        with mock.patch('awx.main.tasks.jobs.shutil.copytree'):
             with pytest.raises(Exception):
                 task.run(1)
 
@@ -494,7 +494,7 @@ class TestGenericRun:
         task.model.objects.get = mock.Mock(return_value=job)
         task.build_private_data_files = mock.Mock()
 
-        with mock.patch('awx.main.tasks.jobs.copy_tree'):
+        with mock.patch('awx.main.tasks.jobs.shutil.copytree'):
             with pytest.raises(Exception):
                 task.run(1)
 
@@ -1944,7 +1944,7 @@ def test_job_run_no_ee(mock_me):
     task.update_model = mock.Mock(return_value=job)
     task.model.objects.get = mock.Mock(return_value=job)
 
-    with mock.patch('awx.main.tasks.jobs.copy_tree'):
+    with mock.patch('awx.main.tasks.jobs.shutil.copytree'):
         with pytest.raises(RuntimeError) as e:
             task.pre_run_hook(job, private_data_dir)
 


### PR DESCRIPTION
##### SUMMARY
This is a rebase of https://github.com/ansible/awx/pull/7367 (but actually re-applied by hand)

As of opening this:
 - I have some tests running, and don't want to take further action until looking at those
 - I would like to break off a new method `build_project_dir`, for a couple of reasons
   - so we don't erroneously mix `pre_run_hook` error handling into the project error handling
   - due to this change, we need to more clearly demarcate where the `project` folder needs to be created (copytree requires that it does not yet exist)
   - this is more descriptive and move more code out of the catch-all `*_hook` methods

Because of the heavy tie-ins to this change, I believe it's a good time to do that minor refactor after the basic functionality is validated.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
I talked before about removing the GitPython library. For the moment, I am considering that too complex and risky. We have two very narrow uses for that library that remain. The objective here is just to fix the git-related bugs.
