### PR TITLE
Forcing an unbind for a django-auth-ldap sticky session to the LDAP server

### DIFF
--- a/awx/sso/backends.py
+++ b/awx/sso/backends.py
@@ -124,9 +124,9 @@ class LDAPBackend(BaseLDAPBackend):
                 logger.debug("Forcing LDAP connection to close")
                 try:
                     ldap_user.ldap_user._connection.unbind_s()
-                except Exception as unbind_e:
-                    logger.error("Got unexpected exception when forcing disconnect")
-                    logger.error(unbind_e)
+                    ldap_user.ldap_user._connection_bound = False
+                except Exception:
+                    logger.exception(f"Got unexpected LDAP exception when forcing LDAP disconnect for user {ldap_user}, login will still proceed")
             return ldap_user
         except Exception:
             logger.exception("Encountered an error authenticating to LDAP")

--- a/awx/sso/backends.py
+++ b/awx/sso/backends.py
@@ -68,6 +68,7 @@ class LDAPSettings(BaseLDAPSettings):
 
 
 class LDAPBackend(BaseLDAPBackend):
+
     """
     Custom LDAP backend for AWX.
     """
@@ -116,7 +117,17 @@ class LDAPBackend(BaseLDAPBackend):
             for setting_name, type_ in [('GROUP_SEARCH', 'LDAPSearch'), ('GROUP_TYPE', 'LDAPGroupType')]:
                 if getattr(self.settings, setting_name) is None:
                     raise ImproperlyConfigured("{} must be an {} instance.".format(setting_name, type_))
-            return super(LDAPBackend, self).authenticate(request, username, password)
+            ldap_user = super(LDAPBackend, self).authenticate(request, username, password)
+            # If we have an LDAP user and that user we found has an ldap_user internal object and that object has a bound connection
+            # Then we can try and force an unbind to close the sticky connection
+            if ldap_user and ldap_user.ldap_user and ldap_user.ldap_user._connection_bound:
+                logger.debug("Forcing LDAP connection to close")
+                try:
+                    ldap_user.ldap_user._connection.unbind_s()
+                except Exception as unbind_e:
+                    logger.error("Got unexpected exception when forcing disconnect")
+                    logger.error(unbind_e)
+            return ldap_user
         except Exception:
             logger.exception("Encountered an error authenticating to LDAP")
             return None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
django-auth-ldap will use a sticky session if the BIND_DN and BIND_PASS are specified in the LDAP config. This change will modify the behavior to have AWX close the sticky session to free up the uwsgi thread.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.1.1.dev64+gd132e9ec2a
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
