### PR TITLE
Narrow down the inotifywait criteria for reloading the dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ uwsgi: collectstatic
 	    --logformat "%(addr) %(method) %(uri) - %(proto) %(status)"
 
 awx-autoreload:
-	@/awx_devel/tools/docker-compose/awx-autoreload /awx_devel "$(DEV_RELOAD_COMMAND)"
+	@/awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx "$(DEV_RELOAD_COMMAND)"
 
 daphne:
 	@if [ "$(VENV_BASE)" ]; then \

--- a/tools/docker-compose/awx-autoreload
+++ b/tools/docker-compose/awx-autoreload
@@ -8,7 +8,7 @@ fi
 
 last_reload=`date +%s`
 
-inotifywait -mrq -e create,delete,attrib,close_write,move --exclude '/awx_devel/awx/ui' $1 | while read directory action file; do
+inotifywait -mrq -e create,delete,attrib,close_write,move --exclude '(/awx_devel/awx/ui|/awx_devel/awx/.*/tests)' $1 | while read directory action file; do
    this_reload=`date +%s`
    since_last=$((this_reload-last_reload))
    if [[ "$file" =~ .*py$ ]] && [[ "$since_last" -gt 1 ]]; then


### PR DESCRIPTION
##### SUMMARY
- listen specifically within awx/awx, so that changes in awxkit or
  awx_collection don't trigger spurious reloads
- expand the exclude pattern to ignore the test directories

related #12054 

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.1.1
```


##### ADDITIONAL INFORMATION
I pulled up a separate terminal and did the following commands while watching the docker logs terminal for reloads.  The goal was for none of these to trigger the reload.

Starting in top-level `awx/`, not `awx/awx/`:
```
touch foo.py; rm foo.py

pushd awx/ui/
touch foo.py; rm foo.py
popd

pushd awx/main/tests/
touch foo.py; rm foo.py
popd

pushd awxkit/awxkit/
touch foo.py; rm foo.py
popd

pushd awx_collection/plugins/modules/
touch foo.py; rm foo.py
popd
```
