### PR TITLE
Add column org to template list

### DIFF
--- a/awx/ui/src/components/TemplateList/TemplateList.js
+++ b/awx/ui/src/components/TemplateList/TemplateList.js
@@ -241,6 +241,7 @@ function TemplateList({ defaultParams }) {
             <HeaderRow qsConfig={qsConfig} isExpandable>
               <HeaderCell sortKey="name">{t`Name`}</HeaderCell>
               <HeaderCell sortKey="type">{t`Type`}</HeaderCell>
+              <HeaderCell sortKey="organization">{t`Organization`}</HeaderCell>
               <HeaderCell sortKey="last_job_run">{t`Last Ran`}</HeaderCell>
               <HeaderCell>{t`Actions`}</HeaderCell>
             </HeaderRow>

--- a/awx/ui/src/components/TemplateList/TemplateListItem.js
+++ b/awx/ui/src/components/TemplateList/TemplateListItem.js
@@ -182,6 +182,15 @@ function TemplateListItem({
           )}
         </TdBreakWord>
         <Td dataLabel={t`Type`}>{toTitleCase(template.type)}</Td>
+        <Td dataLabel={t`Organization`}>
+          {summaryFields.organization ? (
+            <Link
+              to={`/organizations/${summaryFields.organization.id}/details`}
+            >
+              {summaryFields.organization.name}
+            </Link>
+          ) : null}
+        </Td>
         <Td dataLabel={t`Last Ran`}>{lastRun}</Td>
         <ActionsTd dataLabel={t`Actions`}>
           <ActionItem
@@ -270,19 +279,6 @@ function TemplateListItem({
                   dataCy={`template-${template.id}-activity`}
                 />
               ) : null}
-              {summaryFields.organization && (
-                <Detail
-                  label={t`Organization`}
-                  value={
-                    <Link
-                      to={`/organizations/${summaryFields.organization.id}/details`}
-                    >
-                      {summaryFields.organization.name}
-                    </Link>
-                  }
-                  dataCy={`template-${template.id}-organization`}
-                />
-              )}
               {summaryFields.inventory ? (
                 <Detail
                   label={t`Inventory`}

--- a/awx/ui/src/components/TemplateList/TemplateListItem.test.js
+++ b/awx/ui/src/components/TemplateList/TemplateListItem.test.js
@@ -10,6 +10,50 @@ import TemplateListItem from './TemplateListItem';
 jest.mock('../../api');
 
 describe('<TemplateListItem />', () => {
+  test('should display expected data', () => {
+    const wrapper = mountWithContexts(
+      <table>
+        <tbody>
+          <TemplateListItem
+            isSelected={false}
+            template={{
+              id: 1,
+              name: 'Template 1',
+              url: '/templates/job_template/1',
+              type: 'job_template',
+              summary_fields: {
+                organization: {
+                  id: 1,
+                  name: 'Foo',
+                },
+                user_capabilities: {
+                  start: true,
+                },
+                recent_jobs: [
+                  {
+                    id: 123,
+                    name: 'Template 1',
+                    status: 'failed',
+                    finished: '2020-02-26T22:38:41.037991Z',
+                  },
+                ],
+              },
+            }}
+          />
+        </tbody>
+      </table>
+    );
+    expect(wrapper.find('Td[dataLabel="Name"]').text()).toBe('Template 1');
+    expect(wrapper.find('Td[dataLabel="Type"]').text()).toBe('Job Template');
+    expect(wrapper.find('Td[dataLabel="Organization"]').text()).toBe('Foo');
+    expect(
+      wrapper.find('Td[dataLabel="Organization"]').find('Link').prop('to')
+    ).toBe('/organizations/1/details');
+    expect(wrapper.find('Td[dataLabel="Last Ran"]').text()).toBe(
+      '2/26/2020, 10:38:41 PM'
+    );
+  });
+
   test('launch button shown to users with start capabilities', () => {
     const wrapper = mountWithContexts(
       <table>
@@ -401,7 +445,6 @@ describe('<TemplateListItem />', () => {
     }
 
     assertDetail('Description', 'mock description');
-    assertDetail('Organization', "Mike's Org");
     assertDetail('Inventory', "Mike's Inventory");
     assertDetail('Project', "Mike's Project");
     assertDetail('Execution Environment', 'Mock EE 1.2.3');
@@ -420,9 +463,6 @@ describe('<TemplateListItem />', () => {
         .find('Detail[label="Labels"]')
         .containsAllMatchingElements([<span>L_91o2</span>])
     ).toEqual(true);
-    expect(wrapper.find('Detail[label="Organization"] dd a').prop('href')).toBe(
-      '/organizations/1/details'
-    );
     expect(wrapper.find(`Detail[label="Activity"] Sparkline`)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Add column org to template list

This change was added based on the feedback from @trahman73 .

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/9053044/173441472-0b540904-9b7a-4938-9666-82db91be1f0e.png">


See: https://github.com/ansible/awx/issues/11795
