### PR TITLE
Adding GOOGLE_APPLICATION_CREDENTIALS env var

### DIFF
--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -35,6 +35,7 @@ def gce(cred, env, private_data_dir):
     container_path = to_container_path(path, private_data_dir)
     env['GCE_CREDENTIALS_FILE_PATH'] = container_path
     env['GCP_SERVICE_ACCOUNT_FILE'] = container_path
+    env['GOOGLE_APPLICATION_CREDENTIALS'] = container_path
 
     # Handle env variables for new module types.
     # This includes gcp_compute inventory plugin and

--- a/awx/main/tests/data/inventory/plugins/gce/env.json
+++ b/awx/main/tests/data/inventory/plugins/gce/env.json
@@ -2,6 +2,7 @@
     "ANSIBLE_JINJA2_NATIVE": "True",
     "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "GCE_CREDENTIALS_FILE_PATH": "{{ file_reference }}",
+    "GOOGLE_APPLICATION_CREDENTIALS": "{{ file_reference }}",
     "GCP_AUTH_KIND": "serviceaccount",
     "GCP_ENV_TYPE": "tower",
     "GCP_PROJECT": "fooo",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Per my understanding of #12211 the `gcloud` executable requires an environment variable of `GOOGLE_APPLICATION_CREDENTIALS` pointing to the same file that we currently point `GCE_CREDENTIALS_FILE_PATH` too. This will allow a `shell` module call to `gcloud` to function with a `Google Compute Engine` credential type. 

I am looking for someone with more Google Cloud experience than me to confirm that the two file syntaxes are the same and also that adding this additional variable will not have an ill effect on the modules or anything else. In the man time, this PR can be tested.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug or Docs Fix

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.1.1.dev108+g76847c8af0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
