### PR TITLE
Allow modification of schedule if there are two of the same name

### DIFF
--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -105,7 +105,7 @@ options:
         - 5
     unified_job_template:
       description:
-        - Name of unified job template to schedule.
+        - Name of unified job template to schedule. Used to look up an already existing schedule.
       required: False
       type: str
     organization:
@@ -158,6 +158,12 @@ EXAMPLES = '''
         every: 1
         on_days: 'sunday'
         include: False
+
+- name: Delete 'my_schedule' schedule for my_workflow
+  schedule:
+    name: "my_schedule"
+    state: absent
+    unified_job_template: my_workflow
 '''
 
 from ..module_utils.controller_api import ControllerAPIModule
@@ -214,14 +220,16 @@ def main():
     if inventory:
         inventory_id = module.resolve_name_to_id('inventories', inventory)
     search_fields = {}
+    sched_search_fields = {}
     if organization:
         search_fields['organization'] = module.resolve_name_to_id('organizations', organization)
     unified_job_template_id = None
     if unified_job_template:
         search_fields['name'] = unified_job_template
         unified_job_template_id = module.get_one('unified_job_templates', **{'data': search_fields})['id']
+        sched_search_fields['unified_job_template'] = unified_job_template_id
     # Attempt to look up an existing item based on the provided data
-    existing_item = module.get_one('schedules', name_or_id=name)
+    existing_item = module.get_one('schedules', name_or_id=name, **{'data': sched_search_fields})
 
     association_fields = {}
 

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -163,6 +163,7 @@
     - name: Disable a schedule
       schedule:
         name: "{{ sched1 }}"
+        unified_job_template: "{{ jt1 }}"
         state: present
         enabled: "false"
       register: result
@@ -187,6 +188,29 @@
         unified_job_template: "{{ jt2 }}"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
+
+    - name: Verify we can't find the schedule without the UJT lookup
+      schedule:
+        name: "{{ sched1 }}"
+        state: present
+        rrule: "DTSTART:20201219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - result is failed
+
+    - name: Verify we can find the schedule with the UJT lookup and delete it
+      schedule:
+        name: "{{ sched1 }}"
+        state: absent
+        unified_job_template: "{{ jt2 }}"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
 
   always:
     - name: Delete the schedule


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes issue where you couldn't modify or delete a schedule if two schedules of the same name exist.
related #12406  

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug or Docs Fix

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
