### PR TITLE
Fix a ugettext deprecation that snuck back in

### DIFF
--- a/awx/main/tests/unit/tasks/test_runner_callback.py
+++ b/awx/main/tests/unit/tasks/test_runner_callback.py
@@ -1,7 +1,7 @@
 from awx.main.tasks.callback import RunnerCallback
 from awx.main.constants import ANSIBLE_RUNNER_NEEDS_UPDATE_MESSAGE
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 def test_delay_update(mock_me):


### PR DESCRIPTION
##### SUMMARY
at some point after the Django 3.2 upgrade.

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - API
