### PR TITLE
Give more specific messages if a job was killed due to SIGTERM or SIGKILL signals

### DIFF
--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -22,7 +22,7 @@ def startup_reaping():
         job_ids.append(j.id)
         j.status = 'failed'
         j.start_args = ''
-        j.job_explanation += 'Task was marked as running on system startup, so it has been marked as failed.'
+        j.job_explanation += 'Task was marked as running at system start up. The system must have previously not shut down properly, so it has been marked as failed.'
         j.save(update_fields=['status', 'start_args', 'job_explanation'])
         if hasattr(j, 'send_notification_templates'):
             j.send_notification_templates('failed')

--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -22,7 +22,7 @@ def startup_reaping():
         job_ids.ids.append(j.id)
         j.status = 'failed'
         j.start_args = ''
-        j.job_explanation += 'Task was stopped due to a service disruption.'
+        j.job_explanation += 'Task was marked as running on system startup, so it has been marked as failed.'
         j.save(update_fields=['status', 'start_args', 'job_explanation'])
         if hasattr(j, 'send_notification_templates'):
             j.send_notification_templates('failed')

--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -19,7 +19,7 @@ def startup_reaping():
     jobs = UnifiedJob.objects.filter(status='running', controller_node=me.hostname)
     job_ids = []
     for j in jobs:
-        job_ids.ids.append(j.id)
+        job_ids.append(j.id)
         j.status = 'failed'
         j.start_args = ''
         j.job_explanation += 'Task was marked as running on system startup, so it has been marked as failed.'

--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -22,7 +22,7 @@ def startup_reaping():
         job_ids.append(j.id)
         j.status = 'failed'
         j.start_args = ''
-        j.job_explanation += 'Task was marked as running at system start up. The system must have previously not shut down properly, so it has been marked as failed.'
+        j.job_explanation += 'Task was marked as running at system start up. The system must have not shut down properly, so it has been marked as failed.'
         j.save(update_fields=['status', 'start_args', 'job_explanation'])
         if hasattr(j, 'send_notification_templates'):
             j.send_notification_templates('failed')

--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -17,7 +17,9 @@ def startup_reaping():
     """
     me = Instance.objects.me()
     jobs = UnifiedJob.objects.filter(status='running', controller_node=me.hostname)
+    job_ids = []
     for j in jobs:
+        job_ids.ids.append(j.id)
         j.status = 'failed'
         j.start_args = ''
         j.job_explanation += 'Task was stopped due to a service disruption.'
@@ -25,7 +27,8 @@ def startup_reaping():
         if hasattr(j, 'send_notification_templates'):
             j.send_notification_templates('failed')
         j.websocket_emit_status('failed')
-    logger.error(f'unified jobs {j.id for j in jobs} were reaped on dispatch startup')
+    if job_ids:
+        logger.error(f'Unified jobs {job_ids} were reaped on dispatch startup')
 
 
 def reap_job(j, status):

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
         # (like the node heartbeat)
         periodic.run_continuously()
 
-        reaper.reap()
+        reaper.startup_reaping()
         consumer = None
 
         try:

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -179,7 +179,11 @@ class RunnerCallback:
         Ansible runner callback to tell the job when/if it is canceled
         """
         unified_job_id = self.instance.pk
-        self.instance = self.update_model(unified_job_id)
+        try:
+            self.instance = self.update_model(unified_job_id)
+        except Exception:
+            logger.exception(f'Encountered error during cancel check for {unified_job_id}, canceling now')
+            return True
         if not self.instance:
             logger.error('unified job {} was deleted while running, canceling'.format(unified_job_id))
             return True

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -181,7 +181,6 @@ class RunnerCallback:
         """
         unified_job_id = self.instance.pk
         if signal_callback():
-            self.delay_update(job_explanation="Aborted job due to receiving shutdown signal")
             return True
         try:
             self.instance = self.update_model(unified_job_id)

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -16,6 +16,7 @@ from awx.main.redact import UriCleaner
 from awx.main.constants import MINIMAL_EVENTS, ANSIBLE_RUNNER_NEEDS_UPDATE_MESSAGE
 from awx.main.utils.update_model import update_model
 from awx.main.queue import CallbackQueueDispatcher
+from awx.main.tasks.signals import signal_callback
 
 logger = logging.getLogger('awx.main.tasks.callback')
 
@@ -179,6 +180,9 @@ class RunnerCallback:
         Ansible runner callback to tell the job when/if it is canceled
         """
         unified_job_id = self.instance.pk
+        if signal_callback():
+            self.delay_update(job_explanation="Aborted job due to receiving shutdown signal")
+            return True
         try:
             self.instance = self.update_model(unified_job_id)
         except Exception:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -551,7 +551,6 @@ class BaseTask(object):
                 self.instance = self.update_model(pk)
                 if self.instance.cancel_flag is False:
                     status = 'failed'
-                    self.runner_callback.delay_update(job_explanation="Aborted job due to receiving shutdown signal")
         except ReceptorNodeNotFound as exc:
             self.runner_callback.delay_update(job_explanation=str(exc))
         except Exception:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -62,6 +62,7 @@ from awx.main.tasks.callback import (
     RunnerCallbackForProjectUpdate,
     RunnerCallbackForSystemJob,
 )
+from awx.main.tasks.signals import with_signal_handling, signal_callback
 from awx.main.tasks.receptor import AWXReceptorJob
 from awx.main.exceptions import AwxTaskError, PostRunError, ReceptorNodeNotFound
 from awx.main.utils.ansible import read_ansible_config
@@ -392,6 +393,7 @@ class BaseTask(object):
                 instance.save(update_fields=['ansible_version'])
 
     @with_path_cleanup
+    @with_signal_handling
     def run(self, pk, **kwargs):
         """
         Run the job/task and capture its output.
@@ -423,7 +425,7 @@ class BaseTask(object):
             private_data_dir = self.build_private_data_dir(self.instance)
             self.pre_run_hook(self.instance, private_data_dir)
             self.instance.log_lifecycle("preparing_playbook")
-            if self.instance.cancel_flag:
+            if self.instance.cancel_flag or signal_callback():
                 self.instance = self.update_model(self.instance.pk, status='canceled')
             if self.instance.status != 'running':
                 # Stop the task chain and prevent starting the job if it has
@@ -545,6 +547,11 @@ class BaseTask(object):
                 self.runner_callback.delay_update(skip_if_already_set=True, job_explanation=f"Job terminated due to {status}")
                 if status == 'timeout':
                     status = 'failed'
+            elif status == 'canceled':
+                self.instance = self.update_model(pk)
+                if self.instance.cancel_flag is False:
+                    status = 'failed'
+                    self.runner_callback.delay_update(job_explanation="Aborted job due to receiving shutdown signal")
         except ReceptorNodeNotFound as exc:
             self.runner_callback.delay_update(job_explanation=str(exc))
         except Exception:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -549,7 +549,8 @@ class BaseTask(object):
                     status = 'failed'
             elif status == 'canceled':
                 self.instance = self.update_model(pk)
-                if self.instance.cancel_flag is False:
+                if (getattr(self.instance, 'cancel_flag', False) is False) and signal_callback():
+                    self.runner_callback.delay_update(job_explanation="Aborted job due to receiving shutdown signal")
                     status = 'failed'
         except ReceptorNodeNotFound as exc:
             self.runner_callback.delay_update(job_explanation=str(exc))

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -550,7 +550,7 @@ class BaseTask(object):
             elif status == 'canceled':
                 self.instance = self.update_model(pk)
                 if (getattr(self.instance, 'cancel_flag', False) is False) and signal_callback():
-                    self.runner_callback.delay_update(job_explanation="Aborted job due to receiving shutdown signal")
+                    self.runner_callback.delay_update(job_explanation="Task was canceled due to receiving a shutdown signal.")
                     status = 'failed'
         except ReceptorNodeNotFound as exc:
             self.runner_callback.delay_update(job_explanation=str(exc))

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -25,6 +25,7 @@ from awx.main.utils.common import (
     cleanup_new_process,
 )
 from awx.main.constants import MAX_ISOLATED_PATH_COLON_DELIMITER
+from awx.main.tasks.signals import sleep_with_signal_handling
 
 # Receptorctl
 from receptorctl.socket_interface import ReceptorControl
@@ -450,7 +451,7 @@ class AWXReceptorJob:
                 result = namedtuple('result', ['status', 'rc'])
                 return result('canceled', 1)
 
-            time.sleep(1)
+            sleep_with_signal_handling(1)
 
     @property
     def pod_definition(self):

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -25,7 +25,6 @@ from awx.main.utils.common import (
     cleanup_new_process,
 )
 from awx.main.constants import MAX_ISOLATED_PATH_COLON_DELIMITER
-from awx.main.tasks.signals import sleep_with_signal_handling
 
 # Receptorctl
 from receptorctl.socket_interface import ReceptorControl
@@ -451,7 +450,7 @@ class AWXReceptorJob:
                 result = namedtuple('result', ['status', 'rc'])
                 return result('canceled', 1)
 
-            sleep_with_signal_handling(1)
+            time.sleep(1)
 
     @property
     def pod_definition(self):

--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -49,13 +49,13 @@ def with_signal_handling(f):
     """
 
     @functools.wraps(f)
-    def _wrapped(self, *args, **kwargs):
+    def _wrapped(*args, **kwargs):
         try:
             this_is_outermost_caller = False
             if not signal_state.is_active:
                 signal_state.connect_signals()
                 this_is_outermost_caller = True
-            return f(self, *args, **kwargs)
+            return f(*args, **kwargs)
         finally:
             if this_is_outermost_caller:
                 signal_state.restore_signals()

--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -1,0 +1,77 @@
+import signal
+import time
+import functools
+
+
+__all__ = ['with_signal_handling', 'sleep_with_signal_handling', 'signal_callback']
+
+
+class SignalState:
+    def reset(self):
+        self.sigterm_flag = False
+        self.is_active = False
+        self.original_sigterm = None
+        self.original_sigint = None
+        self.raise_exception = False
+
+    def __init__(self):
+        self.reset()
+
+    def set_flag(self, *args):
+        """Method to pass into the python signal.signal method to receive signals"""
+        self.sigterm_flag = True
+        if self.raise_exception:
+            raise Exception('Exit signal received')
+
+    def connect_signals(self):
+        self.original_sigterm = signal.getsignal(signal.SIGTERM)
+        self.original_sigint = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGTERM, self.set_flag)
+        signal.signal(signal.SIGINT, self.set_flag)
+        self.is_active = True
+
+    def restore_signals(self):
+        signal.signal(signal.SIGTERM, self.original_sigterm)
+        signal.signal(signal.SIGINT, self.original_sigint)
+        self.reset()
+
+
+signal_state = SignalState()
+
+
+def signal_callback():
+    return signal_state.sigterm_flag
+
+
+def with_signal_handling(f):
+    """
+    Change signal handling to make signal_callback return True in event of SIGTERM or SIGINT.
+    """
+
+    @functools.wraps(f)
+    def _wrapped(self, *args, **kwargs):
+        try:
+            this_is_outermost_caller = False
+            if not signal_state.is_active:
+                signal_state.connect_signals()
+                this_is_outermost_caller = True
+            return f(self, *args, **kwargs)
+        finally:
+            if this_is_outermost_caller:
+                signal_state.restore_signals()
+
+    return _wrapped
+
+
+def sleep_with_signal_handling(seconds):
+    """
+    Method can only be used while @with_signal_handling decorator is active.
+    Will raise an exception if SIGTERM or SIGINT received while sleeping.
+    """
+    if not signal_state.is_active:
+        raise RuntimeError('This method can only be used inside of signal handling decorator')
+    try:
+        signal_state.raise_exception = True
+        time.sleep(seconds)
+    finally:
+        signal_state.raise_exception = False

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -133,10 +133,6 @@ def inform_cluster_of_shutdown():
     try:
         this_inst = Instance.objects.get(hostname=settings.CLUSTER_HOST_ID)
         this_inst.mark_offline(update_last_seen=True, errors=_('Instance received normal shutdown signal'))
-        try:
-            reaper.reap(this_inst)
-        except Exception:
-            logger.exception('failed to reap jobs for {}'.format(this_inst.hostname))
         logger.warning('Normal shutdown signal for instance {}, ' 'removed self from capacity pool.'.format(this_inst.hostname))
     except Exception:
         logger.exception('Encountered problem with normal shutdown signal.')

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -76,24 +76,6 @@ Try upgrading OpenSSH or providing your private key in an different format. \
 '''
 
 
-def startup_reaping():
-    """
-    If this particular instance is starting, then we know that any running jobs are invalid
-    so we will reap those jobs as a special action here
-    """
-    me = Instance.objects.me()
-    jobs = UnifiedJob.objects.filter(status='running', controller_node=me.hostname)
-    for j in jobs:
-        j.status = 'failed'
-        j.start_args = ''
-        j.job_explanation += 'Task was stopped due to a service disruption.'
-        j.save(update_fields=['status', 'start_args', 'job_explanation'])
-        if hasattr(j, 'send_notification_templates'):
-            j.send_notification_templates('failed')
-        j.websocket_emit_status('failed')
-        logger.error(f'unified job {j.id} was reaped on dispatch startup')
-
-
 def dispatch_startup():
     startup_logger = logging.getLogger('awx.main.tasks')
 
@@ -120,7 +102,6 @@ def dispatch_startup():
     # no-op.
     #
     apply_cluster_membership_policies()
-    startup_reaping()
     cluster_node_heartbeat()
     m = Metrics()
     m.reset_values()

--- a/awx/main/tests/unit/tasks/test_signals.py
+++ b/awx/main/tests/unit/tasks/test_signals.py
@@ -1,0 +1,50 @@
+import signal
+
+from awx.main.tasks.signals import signal_state, signal_callback, with_signal_handling
+
+
+def test_outer_inner_signal_handling():
+    """
+    Even if the flag is set in the outer context, its value should persist in the inner context
+    """
+
+    @with_signal_handling
+    def f2():
+        assert signal_callback()
+
+    @with_signal_handling
+    def f1():
+        assert signal_callback() is False
+        signal_state.set_flag()
+        assert signal_callback()
+        f2()
+
+    original_sigterm = signal.getsignal(signal.SIGTERM)
+    assert signal_callback() is False
+    f1()
+    assert signal_callback() is False
+    assert signal.getsignal(signal.SIGTERM) is original_sigterm
+
+
+def test_inner_outer_signal_handling():
+    """
+    Even if the flag is set in the inner context, its value should persist in the outer context
+    """
+
+    @with_signal_handling
+    def f2():
+        assert signal_callback() is False
+        signal_state.set_flag()
+        assert signal_callback()
+
+    @with_signal_handling
+    def f1():
+        assert signal_callback() is False
+        f2()
+        assert signal_callback()
+
+    original_sigterm = signal.getsignal(signal.SIGTERM)
+    assert signal_callback() is False
+    f1()
+    assert signal_callback() is False
+    assert signal.getsignal(signal.SIGTERM) is original_sigterm

--- a/awx/main/utils/update_model.py
+++ b/awx/main/utils/update_model.py
@@ -1,8 +1,9 @@
 from django.db import transaction, DatabaseError, InterfaceError
 
 import logging
+import time
 
-from awx.main.tasks.signals import sleep_with_signal_handling
+from awx.main.tasks.signals import signal_callback
 
 
 logger = logging.getLogger('awx.main.tasks.utils')
@@ -38,7 +39,10 @@ def update_model(model, pk, _attempt=0, _max_attempts=5, select_for_update=False
         # Attempt to retry the update, assuming we haven't already
         # tried too many times.
         if _attempt < _max_attempts:
-            sleep_with_signal_handling(5)
+            for i in range(5):
+                time.sleep(1)
+                if signal_callback():
+                    raise RuntimeError(f'Could not fetch {pk} because of receiving abort signal')
             return update_model(model, pk, _attempt=_attempt + 1, _max_attempts=_max_attempts, **updates)
         else:
             logger.error('Failed to update %s after %d retries.', model._meta.object_name, _attempt)

--- a/awx/main/utils/update_model.py
+++ b/awx/main/utils/update_model.py
@@ -1,7 +1,8 @@
 from django.db import transaction, DatabaseError, InterfaceError
 
 import logging
-import time
+
+from awx.main.tasks.signals import sleep_with_signal_handling
 
 
 logger = logging.getLogger('awx.main.tasks.utils')
@@ -37,7 +38,7 @@ def update_model(model, pk, _attempt=0, _max_attempts=5, select_for_update=False
         # Attempt to retry the update, assuming we haven't already
         # tried too many times.
         if _attempt < _max_attempts:
-            time.sleep(5)
+            sleep_with_signal_handling(5)
             return update_model(model, pk, _attempt=_attempt + 1, _max_attempts=_max_attempts, **updates)
         else:
             logger.error('Failed to update %s after %d retries.', model._meta.object_name, _attempt)


### PR DESCRIPTION
##### SUMMARY
The current behavior is that a dispatcher worker with a running job will not exit on SIGTERM. This means that it runs out the clock for its supervisor grace period and then gets a SIGKILL. Eventually the job still gets reaped anyway, but with potentially missing events and a vague message (it's not self-consistent after a SIGKILL, lost information).

The intent of this change is that we get snappy SIGTERM exits of the dispatcher, writes new messages for the different cases, and does some other minor things to make debugging easier.

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
This is pulling in particular parts of https://github.com/ansible/awx/pull/11745, but not doing the architectural change of changing our canceling mechanism. This processes the SIGTERM and SIGINT signals and cancels jobs with a descriptive message. Those signals can come from a `supervisorctl stop` kind of command, or something else on the machine going rogue doing it by itself.

I've tried to apply everything I've learned in an appropriate manner. PR 11745 has some awkward code because it's passing around the objects related to signal handling. Fundamentally, the python `signal` library works with python globals, so we should also do so, but, take action to limit the context in which they apply. We also have a highly specific an opinionated use case with project syncs before job runs. If you look at `this_is_outermost_caller`, this is some additional work to ensure that nested applications of the decorator work with the same state.
