### PR TITLE
Fix false reaper false-positives of waiting jobs that are waiting for worker

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -432,6 +432,10 @@ class AutoscalePool(WorkerPool):
             idx = random.choice(range(len(self.workers)))
             self.write(idx, m)
 
+        # if we are not in the dangerous situation of queue backup then clear old waiting jobs
+        if self.workers and max(len(w.managed_tasks) for w in self.workers) <= 1:
+            reaper.reap_waiting()
+
         # if the database says a job is running on this node, but it's *not*,
         # then reap it
         running_uuids = []

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -500,7 +500,7 @@ class TestGenericRun:
             with pytest.raises(Exception):
                 task.run(1)
 
-        for c in [mock.call(1, status='running', start_args=''), mock.call(1, status='canceled')]:
+        for c in [mock.call(1, start_args='', status='canceled')]:
             assert c in task.update_model.call_args_list
 
     def test_event_count(self, mock_me):


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/11301

I believe this is a relatively complete solution to the problem of waiting jobs getting reaped.

Once I set max_workers to 4, I actually found the problem fairly easy to reproduce.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

