### PR TITLE
Translate contents of Hosts Automated field as a single string

### DIFF
--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
@@ -134,22 +134,23 @@ function SubscriptionDetail() {
             label={t`Hosts imported`}
             value={license_info.current_instances}
           />
-          {typeof automatedInstancesCount !== 'undefined' && (
-            <Detail
-              dataCy="subscription-hosts-automated"
-              label={t`Hosts automated`}
-              value={
-                automated_since ? (
-                  <Trans>
-                    {automatedInstancesCount} since{' '}
-                    {automatedInstancesSinceDateTime}
-                  </Trans>
-                ) : (
-                  automatedInstancesCount
-                )
-              }
-            />
-          )}
+          {typeof automatedInstancesCount !== 'undefined' &&
+            automatedInstancesCount !== null && (
+              <Detail
+                dataCy="subscription-hosts-automated"
+                label={t`Hosts automated`}
+                value={
+                  automated_since ? (
+                    <Trans>
+                      {automatedInstancesCount} since{' '}
+                      {automatedInstancesSinceDateTime}
+                    </Trans>
+                  ) : (
+                    automatedInstancesCount
+                  )
+                }
+              />
+            )}
           <Detail
             dataCy="subscription-hosts-remaining"
             label={t`Hosts remaining`}

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
@@ -35,6 +35,13 @@ function SubscriptionDetail() {
     },
   ];
 
+  const { automated_instances: automatedInstancesCount, automated_since } =
+    license_info;
+
+  const automatedInstancesSinceDateTime = automated_since
+    ? formatDateString(new Date(automated_since * 1000).toISOString())
+    : null;
+
   return (
     <>
       <RoutedTabs tabsArray={tabsArray} />
@@ -127,19 +134,22 @@ function SubscriptionDetail() {
             label={t`Hosts imported`}
             value={license_info.current_instances}
           />
-          <Detail
-            dataCy="subscription-hosts-automated"
-            label={t`Hosts automated`}
-            value={
-              <>
-                {license_info.automated_instances} <Trans>since</Trans>{' '}
-                {license_info.automated_since &&
-                  formatDateString(
-                    new Date(license_info.automated_since * 1000).toISOString()
-                  )}
-              </>
-            }
-          />
+          {typeof automatedInstancesCount !== 'undefined' && (
+            <Detail
+              dataCy="subscription-hosts-automated"
+              label={t`Hosts automated`}
+              value={
+                automated_since ? (
+                  <Trans>
+                    {automatedInstancesCount} since{' '}
+                    {automatedInstancesSinceDateTime}
+                  </Trans>
+                ) : (
+                  automatedInstancesCount
+                )
+              }
+            />
+          )}
           <Detail
             dataCy="subscription-hosts-remaining"
             label={t`Hosts remaining`}

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.js
@@ -82,4 +82,17 @@ describe('<SubscriptionDetail />', () => {
 
     expect(wrapper.find('Button[aria-label="edit"]').length).toBe(1);
   });
+
+  test('should not render Hosts Automated Detail if license_info.automated_instances is undefined', () => {
+    wrapper = mountWithContexts(<SubscriptionDetail />, {
+      context: {
+        config: {
+          ...config,
+          license_info: { ...config.license_info, automated_instances: null },
+        },
+      },
+    });
+
+    expect(wrapper.find(`Detail[label="Hosts automated"]`).length).toBe(0);
+  });
 });


### PR DESCRIPTION
##### SUMMARY
Translate the entire string rather than just 'since'.  This is necessary for languages where the date should come before the number of hosts.

Here's what it looks like in practice.  I don't know Japanese so I just translated 'since' to 'sometranslatedtext':

![hosts_automated](https://user-images.githubusercontent.com/9889020/177829534-8f7b6681-9dd5-49c5-b30d-e85af25cc3ab.gif)

Here's what the sample .po looks like:

<img width="667" alt="Screen Shot 2022-07-07 at 12 42 06 PM" src="https://user-images.githubusercontent.com/9889020/177829585-a76f22d5-e214-4a10-91b2-e6b19aa5e25c.png">


##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - UI
