### PR TITLE
[task_manager_refactor] add schedule dependency and workflow managers

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -93,7 +93,7 @@ from awx.main.utils import (
     get_object_or_400,
     getattrd,
     get_pk_from_dict,
-    schedule_task_manager,
+    ScheduleWorkflowManager,
     ignore_inventory_computed_fields,
 )
 from awx.main.utils.encryption import encrypt_value
@@ -3391,7 +3391,7 @@ class WorkflowJobCancel(RetrieveAPIView):
         obj = self.get_object()
         if obj.can_cancel:
             obj.cancel()
-            schedule_task_manager()
+            ScheduleWorkflowManager().schedule()
             return Response(status=status.HTTP_202_ACCEPTED)
         else:
             return self.http_method_not_allowed(request, *args, **kwargs)

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -45,7 +45,7 @@ from awx.main.utils.common import (
     get_type_for_model,
     parse_yaml_or_json,
     getattr_dne,
-    schedule_task_manager,
+    ScheduleDependencyManager,
     get_event_partition_epoch,
     get_capacity_type,
 )
@@ -1357,7 +1357,7 @@ class UnifiedJob(
         self.update_fields(start_args=json.dumps(kwargs), status='pending')
         self.websocket_emit_status("pending")
 
-        schedule_task_manager()
+        ScheduleDependencyManager().schedule()
 
         # Each type of unified job has a different Task class; get the
         # appropirate one.

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -40,7 +40,7 @@ from awx.main.models.mixins import (
 from awx.main.models.jobs import LaunchTimeConfigBase, LaunchTimeConfig, JobTemplate
 from awx.main.models.credential import Credential
 from awx.main.redact import REPLACE_STR
-from awx.main.utils import schedule_task_manager
+from awx.main.utils import ScheduleWorkflowManager
 
 
 __all__ = [
@@ -809,7 +809,7 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
         self.save()
         self.send_approval_notification('approved')
         self.websocket_emit_status(self.status)
-        schedule_task_manager()
+        ScheduleWorkflowManager().schedule()
         return reverse('api:workflow_approval_approve', kwargs={'pk': self.pk}, request=request)
 
     def deny(self, request=None):
@@ -818,7 +818,7 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
         self.save()
         self.send_approval_notification('denied')
         self.websocket_emit_status(self.status)
-        schedule_task_manager()
+        ScheduleWorkflowManager().schedule()
         return reverse('api:workflow_approval_deny', kwargs={'pk': self.pk}, request=request)
 
     def signal_start(self, **kwargs):

--- a/awx/main/scheduler/tasks.py
+++ b/awx/main/scheduler/tasks.py
@@ -13,38 +13,23 @@ from awx.main.dispatch import get_local_queuename
 logger = logging.getLogger('awx.main.scheduler')
 
 
-@task(queue=get_local_queuename)
-def task_manager():
-    prefix = 'task'
+def run_manager(manager, prefix):
     if MODE == 'development' and settings.AWX_DISABLE_TASK_MANAGERS:
         logger.debug(f"Not running {prefix} manager, AWX_DISABLE_TASK_MANAGERS is True. Trigger with GET to /api/debug/{prefix}_manager/")
         return
+    manager().schedule()
 
-    TaskManager().schedule()
+
+@task(queue=get_local_queuename)
+def task_manager():
+    run_manager(TaskManager, "task")
 
 
 @task(queue=get_local_queuename)
 def dependency_manager():
-    prefix = 'dependency'
-    if MODE == 'development' and settings.AWX_DISABLE_TASK_MANAGERS:
-        logger.debug(f"Not running {prefix} manager, AWX_DISABLE_TASK_MANAGERS is True. Trigger with GET to /api/debug/{prefix}_manager/")
-        return
-    DependencyManager().schedule()
+    run_manager(DependencyManager, "dependency")
 
 
 @task(queue=get_local_queuename)
 def workflow_manager():
-    prefix = 'workflow'
-    if MODE == 'development' and settings.AWX_DISABLE_TASK_MANAGERS:
-        logger.debug(f"Not running {prefix} manager, AWX_DISABLE_TASK_MANAGERS is True. Trigger with GET to /api/debug/{prefix}_manager/")
-        return
-    WorkflowManager().schedule()
-
-
-def run_task_manager():
-    if MODE == 'development' and settings.AWX_DISABLE_TASK_MANAGERS:
-        logger.debug("Not running task managers, AWX_DISABLE_TASK_MANAGERS is True. Trigger with GET to /api/debug/{prefix}_manager/")
-        return
-    task_manager()
-    dependency_manager()
-    workflow_manager()
+    run_manager(WorkflowManager, "workflow")

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -53,7 +53,7 @@ from awx.main.dispatch import get_local_queuename, reaper
 from awx.main.utils.common import (
     ignore_inventory_computed_fields,
     ignore_inventory_group_removal,
-    schedule_task_manager,
+    ScheduleWorkflowManager,
 )
 
 from awx.main.utils.external_logging import reconfigure_rsyslog
@@ -671,7 +671,7 @@ def handle_work_success(task_actual):
     if not instance:
         return
 
-    schedule_task_manager()
+    ScheduleWorkflowManager().schedule()
 
 
 @task(queue=get_local_queuename)
@@ -713,7 +713,7 @@ def handle_work_error(task_id, *args, **kwargs):
     # what the job complete message handler does then we may want to send a
     # completion event for each job here.
     if first_instance:
-        schedule_task_manager()
+        ScheduleWorkflowManager().schedule()
         pass
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
change all of the `schedule_task_manager` calls in the code to invoke the one of the 3 managers

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### Notes

the bulk reschedule seems to work fine inside of the class

here is a script I ran in awx shell to demonstrate that the flags are set correctly outside and inside the context manager

```
In [13]: print(ScheduleTaskManager().manager_threading_local.__dict__)
{'bulk_reschedule': False, 'needs_scheduling': False}

In [14]: with ScheduleTaskManager().task_manager_bulk_reschedule():
    ...:     print(ScheduleTaskManager().manager_threading_local.__dict__)
    ...:     ScheduleTaskManager().schedule()
    ...:     print(ScheduleTaskManager().manager_threading_local.__dict__)
    ...: 
{'bulk_reschedule': True, 'needs_scheduling': False}
2022-07-08 16:16:03,432 DEBUG    [-] awx.main.utils returning
{'bulk_reschedule': True, 'needs_scheduling': True}
```