### PR TITLE
[not devel][task_manager_refactor] If we are about to timeout, bailout

### DIFF
--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -2,7 +2,6 @@
 # All Rights Reserved.
 
 from __future__ import absolute_import, unicode_literals
-from django.conf import settings
 from django.urls import include, re_path
 
 from awx import MODE

--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -406,8 +406,8 @@ class AutoscalePool(WorkerPool):
                             w.managed_tasks[current_task['uuid']]['started'] = time.time()
                         age = time.time() - current_task['started']
                         w.managed_tasks[current_task['uuid']]['age'] = age
-                        if age > (60 * 5):
-                            logger.error(f'run_task_manager has held the advisory lock for >5m, sending SIGTERM to {w.pid}')  # noqa
+                        if age > (settings.TASK_MANAGER_TIMEOUT + settings.TASK_MANAGER_TIMEOUT_GRACE_PERIOD):
+                            logger.error(f'run_task_manager has held the advisory lock for {age}, sending SIGTERM to {w.pid}')  # noqa
                             os.kill(w.pid, signal.SIGTERM)
 
         for m in orphaned:

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -19,14 +19,12 @@ from django.conf import settings
 # AWX
 from awx.main.dispatch.reaper import reap_job
 from awx.main.models import (
-    AdHocCommand,
     Instance,
     InventorySource,
     InventoryUpdate,
     Job,
     Project,
     ProjectUpdate,
-    SystemJob,
     UnifiedJob,
     WorkflowApproval,
     WorkflowJob,

--- a/awx/main/scheduler/tasks.py
+++ b/awx/main/scheduler/tasks.py
@@ -43,7 +43,7 @@ def workflow_manager():
 
 def run_task_manager():
     if MODE == 'development' and settings.AWX_DISABLE_TASK_MANAGERS:
-        logger.debug(f"Not running task managers, AWX_DISABLE_TASK_MANAGERS is True. Trigger with GET to /api/debug/{prefix}_manager/")
+        logger.debug("Not running task managers, AWX_DISABLE_TASK_MANAGERS is True. Trigger with GET to /api/debug/{prefix}_manager/")
         return
     task_manager()
     dependency_manager()

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -248,6 +248,11 @@ SUBSYSTEM_METRICS_TASK_MANAGER_RECORD_INTERVAL = 15
 # The maximum allowed jobs to start on a given task manager cycle
 START_TASK_LIMIT = 100
 
+# Time out task managers if they take longer than this many seconds, plus TASK_MANAGER_TIMEOUT_GRACE_PERIOD
+# We have the grace period so the task manager can bail out before the timeout.
+TASK_MANAGER_TIMEOUT = 300
+TASK_MANAGER_TIMEOUT_GRACE_PERIOD = 60
+
 # Disallow sending session cookies over insecure connections
 SESSION_COOKIE_SECURE = True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Discussion in https://github.com/ansible/awx/pull/12475 has gotten complicated around how we are dealing with pending workflow jobs. tl;dr we either need to do more to deal with them correctly in WorkflowManager or we need to revert some changes and go back to letting the TaskManager deal with pending WorkflowJobs

I wanted to seperate out this timeout logic from that decision as it is smaller and less controversial.

This change keeps track of our start time and looks during potentially slow loops to see if we have timed out. If so, we exit the loop early, to preserve whatever progress we have made. We have until the grace period to actually exit before the process will get a signal to get killed.