### PR TITLE
Task manager refactor revert pending wfs change

### DIFF
--- a/awx/main/scheduler/dependency_graph.py
+++ b/awx/main/scheduler/dependency_graph.py
@@ -96,7 +96,11 @@ class DependencyGraph(object):
 
     def workflow_job_blocked_by(self, job):
         if job.allow_simultaneous is False:
-            return self.get_item(self.WORKFLOW_JOB_TEMPLATES_JOBS, job.workflow_job_template_id)
+            if job.workflow_job_template_id:
+                return self.get_item(self.WORKFLOW_JOB_TEMPLATES_JOBS, job.workflow_job_template_id)
+            elif job.unified_job_template_id:
+                # Sliced jobs are WorkflowJob type but do not have a workflow_job_template_id
+                return self.get_item(self.WORKFLOW_JOB_TEMPLATES_JOBS, job.unified_job_template_id)
         return None
 
     def system_job_blocked_by(self, job):

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -275,12 +275,12 @@ class WorkflowManager(TaskBase):
                 task.save(update_fields=['status', 'job_explanation', 'timed_out'])
 
     @timeit
-    def get_tasks(self):
-        self.all_tasks = [wf for wf in WorkflowJob.objects.filter(status='running')]
+    def get_tasks(self, filter_args):
+        self.all_tasks = [wf for wf in WorkflowJob.objects.filter(**filter_args)]
 
     @timeit
     def _schedule(self):
-        self.get_tasks()
+        self.get_tasks(dict(status__in=["running"], dependencies_processed=True))
         if len(self.all_tasks) > 0:
             self.spawn_workflow_graph_jobs()
             self.timeout_approval_node()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
We agreed last week that we want the TaskManager to deal with all pending tasks to keep all "soft blocking" logic contained to the DependencyGraph.

This does:
- [x] fix blocked_by logic for sliced jobs in depedency graph that was looking at wrong template ID
- [x] cherry-pick a fix @AlanCoding has for a fix to adding sliced jobs to the DepedencyGraph
- [x] move logic for moving pending workflows to running back to task manager
- [x] filter WorkflowApproval jobs out of the main get_tasks query so we are not grabbing them in DepdencyManager and TaskManager 
- [x] make get_tasks and related member functions set the lists of tasks as attributes on the classes and stop passing around the list of tasks
- [x] move calls to add newly running jobs to DepedencyGraph to start_task so we do it the same way for everything.

What I've tested (manually):
- [x] WorkflowJobs respect allow_simultaneous
- [x] SlicedJobs respect allow_simultaneous
- [x] regular jobs still start correctly
- [x] project update_on_launch still working 