### PR TITLE
Optimize object creation by getting fewer empty relationships

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -29,7 +29,6 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.encoding import force_str
 from django.utils.text import capfirst
 from django.utils.timezone import now
-from django.utils.functional import cached_property
 
 # Django REST Framework
 from rest_framework.exceptions import ValidationError, PermissionDenied

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5008,8 +5008,7 @@ class ActivityStreamSerializer(BaseSerializer):
     object_association = serializers.SerializerMethodField(help_text=_("When present, shows the field name of the role or relationship that changed."))
     object_type = serializers.SerializerMethodField(help_text=_("When present, shows the model on which the role or relationship was defined."))
 
-    @cached_property
-    def _local_summarizable_fk_fields(self):
+    def _local_summarizable_fk_fields(self, obj):
         summary_dict = copy.copy(SUMMARIZABLE_FK_FIELDS)
         # Special requests
         summary_dict['group'] = summary_dict['group'] + ('inventory_id',)
@@ -5029,7 +5028,13 @@ class ActivityStreamSerializer(BaseSerializer):
             ('workflow_approval', ('id', 'name', 'unified_job_id')),
             ('instance', ('id', 'hostname')),
         ]
-        return field_list
+        # Optimization - do not attempt to summarize all fields, pair down to only relations that exist
+        if not obj:
+            return field_list
+        existing_association_types = [obj.object1, obj.object2]
+        if 'user' in existing_association_types:
+            existing_association_types.append('role')
+        return [entry for entry in field_list if entry[0] in existing_association_types]
 
     class Meta:
         model = ActivityStream
@@ -5113,7 +5118,7 @@ class ActivityStreamSerializer(BaseSerializer):
         data = {}
         if obj.actor is not None:
             data['actor'] = self.reverse('api:user_detail', kwargs={'pk': obj.actor.pk})
-        for fk, __ in self._local_summarizable_fk_fields:
+        for fk, __ in self._local_summarizable_fk_fields(obj):
             if not hasattr(obj, fk):
                 continue
             m2m_list = self._get_related_objects(obj, fk)
@@ -5170,7 +5175,7 @@ class ActivityStreamSerializer(BaseSerializer):
 
     def get_summary_fields(self, obj):
         summary_fields = OrderedDict()
-        for fk, related_fields in self._local_summarizable_fk_fields:
+        for fk, related_fields in self._local_summarizable_fk_fields(obj):
             try:
                 if not hasattr(obj, fk):
                     continue

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -409,7 +409,7 @@ def emit_activity_stream_change(instance):
     from awx.api.serializers import ActivityStreamSerializer
 
     actor = None
-    if instance.actor:
+    if instance.actor_id:
         actor = instance.actor.username
     summary_fields = ActivityStreamSerializer(instance).get_summary_fields(instance)
     analytics_logger.info(

--- a/awx/main/tests/unit/api/serializers/test_activity_stream_serializer.py
+++ b/awx/main/tests/unit/api/serializers/test_activity_stream_serializer.py
@@ -20,7 +20,7 @@ def test_activity_stream_related():
     """
     serializer_related = set(
         ActivityStream._meta.get_field(field_name).related_model
-        for field_name, stuff in ActivityStreamSerializer()._local_summarizable_fk_fields
+        for field_name, stuff in ActivityStreamSerializer()._local_summarizable_fk_fields(None)
         if hasattr(ActivityStream, field_name)
     )
 


### PR DESCRIPTION
##### SUMMARY
Making changes to objects unintentionally winds up being a very heavy operation in this app.

The first reason for this is that an activity stream entry has to be created. This requires 1 query at a minimum, but we will probably not bother with optimization if it comes in under around 10 queries.

Unexpectedly, the _main_ performance bottleneck when modifying an object is that we run the `ActivityStreamSerializer` in order to send to the `analytics_logger`, which very few users are going to have turned on in the first place. This winds up being notoriously inefficient, as it maintains a many-to-many relationship with virtually every model type that exists, on the order of ~25. To fully serialize, we make requests to all of those, even though only 3 at most will ever be used.

This manifests in unexpected places, like `create_unified_job`, which has caught my interest because https://github.com/ansible/awx/pull/12503 will add more operations to that method, decreasing the POST response times.

This is an offer to pay down some of our performance debt as a counter-balance to those additions.

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
I must address the difficult question "is this correct?"

I ran this script over all 3147 activity stream entries that I had:

```python
for o in ActivityStream.objects.all():
  for t in ActivityStreamSerializer(o)._local_summarizable_fk_fields:
    if not hasattr(o, t[0]):
      continue
    rel_items = list(getattr(o, t[0]).all())
    if not rel_items:
      continue
    if t[0] not in (o.object1, o.object2):
      print(f'Found counter example {o}, {t[0]}, {o.object1}, {o.object2}')
```

From that, I was able to find that roles were the only exception to the rule that `object1` or `object2` will correspond to the name of a many-to-many object manager that is populated with something.

Confirm for yourself, that our signals add to the relationship named by the object1 or 2 fields:

https://github.com/ansible/awx/blob/bff49f2a5fd8929808b2890bc2d16279c523cc53/awx/main/signals.py#L450

https://github.com/ansible/awx/blob/bff49f2a5fd8929808b2890bc2d16279c523cc53/awx/main/signals.py#L478

https://github.com/ansible/awx/blob/bff49f2a5fd8929808b2890bc2d16279c523cc53/awx/main/signals.py#L560-L561

https://github.com/ansible/awx/blob/bff49f2a5fd8929808b2890bc2d16279c523cc53/awx/main/signals.py#L574

the one possible exception there is:

https://github.com/ansible/awx/blob/bff49f2a5fd8929808b2890bc2d16279c523cc53/awx/main/signals.py#L571-L572

But if this didn't match the other field name, normal (non-RBAC) entries wouldn't show up right either. Filtering on `/api/v2/activity_stream/?object_relationship_type__endswith=_role`, this does seem to work right, with each entry summarizing 4 items typically.
