### PR TITLE
security-fix or Django 3.2.14 CVE-2022-34265

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -9,7 +9,7 @@ cryptography>=36.0.2,<37.0.0 # Until paramiko fixes https://github.com/paramiko/
 Cython<3 # Since the bump to PyYAML 5.4.1 this is now a mandatory dep
 daphne
 distro
-django==3.2.13  # see UPGRADE BLOCKERs
+django==3.2.14  # see UPGRADE BLOCKERs
 django-auth-ldap
 django-cors-headers>=3.5.0
 django-crum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -84,7 +84,7 @@ defusedxml==0.6.0
     #   social-auth-core
 distro==1.5.0
     # via -r /awx_devel/requirements/requirements.in
-django==3.2.13
+django==3.2.14
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels


### PR DESCRIPTION
##### SUMMARY
Security-Issue in Django 3.2.13 fixed in 3.2.14
https://access.redhat.com/security/cve/cve-2022-34265

##### ISSUE TYPE
Security Fix

##### COMPONENT NAME
 UI

##### AWX VERSION


##### ADDITIONAL INFORMATION
