### PR TITLE
[task_manager_refactor] move consume_capacity to start_task

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -512,6 +512,12 @@ class TaskManager(TaskBase):
             ScheduleTaskManager().schedule()
         from awx.main.tasks.system import handle_work_error, handle_work_success
 
+        # update capacity for control node and execution node
+        if task.controller_node:
+            self.instances[task.controller_node].consume_capacity(settings.AWX_CONTROL_NODE_TASK_IMPACT)
+        if task.execution_node:
+            self.instances[task.execution_node].consume_capacity(task.task_impact)
+
         dependent_tasks = dependent_tasks or []
 
         task_actual = {
@@ -600,6 +606,7 @@ class TaskManager(TaskBase):
             found_acceptable_queue = False
 
             preferred_instance_groups = self.instance_groups.get_instance_groups_from_task_cache(task)
+
             # Determine if there is control capacity for the task
             if task.capacity_type == 'control':
                 control_impact = task.task_impact + settings.AWX_CONTROL_NODE_TASK_IMPACT
@@ -618,7 +625,6 @@ class TaskManager(TaskBase):
             # All task.capacity_type == 'control' jobs should run on control plane, no need to loop over instance groups
             if task.capacity_type == 'control':
                 task.execution_node = control_instance.hostname
-                control_instance.consume_capacity(control_impact)
                 execution_instance = self.instances[control_instance.hostname].obj
                 task.log_lifecycle("controller_node_chosen")
                 task.log_lifecycle("execution_node_chosen")
@@ -649,9 +655,7 @@ class TaskManager(TaskBase):
                         control_instance = execution_instance
                         task.controller_node = execution_instance.hostname
 
-                    control_instance.consume_capacity(settings.AWX_CONTROL_NODE_TASK_IMPACT)
                     task.log_lifecycle("controller_node_chosen")
-                    execution_instance.consume_capacity(task.task_impact)
                     task.log_lifecycle("execution_node_chosen")
                     logger.debug(
                         "Starting {} in group {} instance {} (remaining_capacity={})".format(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
move consume capacity logic to start_task so that it is centralized and not called in various places elsewhere.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.3.1.dev26+g1b5e3ccec4

```