### PR TITLE
[feature-project-integrity] add new managed credential type for gpg pub key

### DIFF
--- a/awx/main/migrations/0165_added_contentsigning_to_project_model.py
+++ b/awx/main/migrations/0165_added_contentsigning_to_project_model.py
@@ -3,6 +3,14 @@
 from django.db import migrations, models
 import django.db.models.deletion
 
+from awx.main.models import CredentialType
+from awx.main.utils.common import set_current_apps
+
+
+def setup_tower_managed_defaults(apps, schema_editor):
+    set_current_apps(apps)
+    CredentialType.setup_tower_managed_defaults(apps)
+
 
 class Migration(migrations.Migration):
 
@@ -28,4 +36,5 @@ class Migration(migrations.Migration):
                 to='main.credential',
             ),
         ),
+        migrations.RunPython(setup_tower_managed_defaults),
     ]

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -1171,6 +1171,25 @@ ManagedCredentialType(
     },
 )
 
+ManagedCredentialType(
+    namespace='gpg_public_key',
+    kind='cryptography',
+    name=gettext_noop('GPG Public Key'),
+    inputs={
+        'fields': [
+            {
+                'id': 'gpg_public_key',
+                'label': gettext_noop('GPG Public Key'),
+                'type': 'string',
+                'secret': True,
+                'multiline': True,
+                'help_text': gettext_noop('GPG Public Key used to validate content signatures.'),
+            },
+        ],
+        'required': ['gpg_public_key'],
+    },
+)
+
 
 class CredentialInputSource(PrimordialModel):
     class Meta:

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -74,34 +74,37 @@ GLqbpJyX2r3p/Rmo6mLY71SqpA==
 
 @pytest.mark.django_db
 def test_default_cred_types():
-    assert sorted(CredentialType.defaults.keys()) == [
-        'aim',
-        'aws',
-        'azure_kv',
-        'azure_rm',
-        'centrify_vault_kv',
-        'conjur',
-        'controller',
-        'galaxy_api_token',
-        'gce',
-        'github_token',
-        'gitlab_token',
-        'hashivault_kv',
-        'hashivault_ssh',
-        'insights',
-        'kubernetes_bearer_token',
-        'net',
-        'openstack',
-        'registry',
-        'rhv',
-        'satellite6',
-        'scm',
-        'ssh',
-        'thycotic_dsv',
-        'thycotic_tss',
-        'vault',
-        'vmware',
-    ]
+    assert sorted(CredentialType.defaults.keys()) == sorted(
+        [
+            'aim',
+            'aws',
+            'azure_kv',
+            'azure_rm',
+            'centrify_vault_kv',
+            'conjur',
+            'controller',
+            'galaxy_api_token',
+            'gce',
+            'github_token',
+            'gitlab_token',
+            'gpg_public_key',
+            'hashivault_kv',
+            'hashivault_ssh',
+            'insights',
+            'kubernetes_bearer_token',
+            'net',
+            'openstack',
+            'registry',
+            'rhv',
+            'satellite6',
+            'scm',
+            'ssh',
+            'thycotic_dsv',
+            'thycotic_tss',
+            'vault',
+            'vmware',
+        ]
+    )
 
     for type_ in CredentialType.defaults.values():
         assert type_().managed is True


### PR DESCRIPTION
##### SUMMARY
related to https://github.com/ansible/awx/issues/12536

add new managed credential type for gpg public key use for content signature validation.

TODO: 
- [x] validate gpg public key is added to a new instance
   - in docker-compose dev environment validated that with new environment the gpg public key credential type is added
- [x] validate gpg public key credential type is added on update 
   - setup new docker-compose dev environment from parent branch https://github.com/ansible/awx/tree/feature-project-integrity 
   - validate that the gpg public key credential type does not exist 
   - switch to PR branch and ran `awx-manage migration` (to simulate upgrade) 
   - validate that the gpg public key credential type exist
- [x] validate gpg public key credential type can not be deleted
  - in docker-composed dev environment validated that awx cli and UI is not able to delete the managed credential type 
  - validate if force deleted from shell_plus `awx-manage setup_managed_credential_types` will add it back

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API


##### AWX VERSION
```
awx: 21.3.1.dev18+ga1a0fc28c9
```


##### ADDITIONAL INFORMATION



```
HTTP 200 OK
Allow: GET, PUT, PATCH, DELETE, HEAD, OPTIONS
Content-Type: application/json
Vary: Accept
X-API-Node: awx_1
X-API-Product-Name: AWX
X-API-Product-Version: 21.3.1.dev5+gcba685f655.d20220712
X-API-Query-Count: 1
X-API-Query-Time: 0.001s
X-API-Time: 0.008s

{
    "id": 19,
    "type": "credential_type",
    "url": "[/api/v2/credential_types/19/](https://localhost:8043/api/v2/credential_types/19/)",
    "related": {
        "named_url": "[/api/v2/credential_types/GPG Public Key+cryptography/](https://localhost:8043/api/v2/credential_types/GPG%20Public%20Key+cryptography/)",
        "credentials": "[/api/v2/credential_types/19/credentials/](https://localhost:8043/api/v2/credential_types/19/credentials/)",
        "activity_stream": "[/api/v2/credential_types/19/activity_stream/](https://localhost:8043/api/v2/credential_types/19/activity_stream/)"
    },
    "summary_fields": {
        "user_capabilities": {
            "edit": true,
            "delete": true
        }
    },
    "created": "2022-07-18T20:16:32.984533Z",
    "modified": "2022-07-18T20:16:32.984533Z",
    "name": "GPG Public Key",
    "description": "",
    "kind": "cryptography",
    "namespace": "gpg_public_key",
    "managed": true,
    "inputs": {
        "fields": [
            {
                "id": "gpg_public_key",
                "label": "GPG Public Key",
                "type": "string",
                "secret": true,
                "multiline": true,
                "help_text": "GPG Public Key used to validate content signatures."
            }
        ],
        "required": [
            "gpg_public_key"
        ]
    },
    "injectors": {}
}
```
