### PR TITLE
Fix bug where node alias is not remaining after changing the template on a wf node

### DIFF
--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Visualizer.js
@@ -53,14 +53,7 @@ const Wrapper = styled.div`
 `;
 
 const replaceIdentifier = (node) => {
-  if (stringIsUUID(node.originalNodeObject.identifier) && node.identifier) {
-    return true;
-  }
-
-  if (
-    !stringIsUUID(node.originalNodeObject.identifier) &&
-    node.identifier !== node.originalNodeObject.identifier
-  ) {
+  if (stringIsUUID(node.originalNodeObject.identifier) || node.identifier) {
     return true;
   }
 

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.js
@@ -170,14 +170,14 @@ function VisualizerNode({
 
   let nodeName;
 
-  if (
-    node?.identifier ||
-    (node?.originalNodeObject?.identifier &&
-      !stringIsUUID(node.originalNodeObject.identifier))
+  if (node?.identifier && node.identifier !== '') {
+    nodeName = node.identifier;
+  } else if (
+    node?.identifier !== '' &&
+    node?.originalNodeObject?.identifier &&
+    !stringIsUUID(node.originalNodeObject.identifier)
   ) {
-    nodeName = node?.identifier
-      ? node?.identifier
-      : node?.originalNodeObject?.identifier;
+    nodeName = node?.originalNodeObject?.identifier;
   } else {
     nodeName =
       node?.fullUnifiedJobTemplate?.name ||

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.test.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/VisualizerNode.test.js
@@ -270,6 +270,31 @@ describe('VisualizerNode', () => {
     });
   });
 
+  describe('Node with empty string alias', () => {
+    test('Displays unified job template name inside node', () => {
+      const wrapper = mountWithContexts(
+        <svg>
+          <WorkflowStateContext.Provider value={mockedContext}>
+            <VisualizerNode
+              node={{
+                id: 2,
+                identifier: '',
+                fullUnifiedJobTemplate: {
+                  name: 'foobar',
+                },
+              }}
+              readOnly={false}
+              updateHelpText={() => {}}
+              updateNodeHelp={() => {}}
+            />
+          </WorkflowStateContext.Provider>
+        </svg>
+      );
+      expect(wrapper).toHaveLength(1);
+      expect(wrapper.find('NodeResourceName').text()).toBe('foobar');
+    });
+  });
+
   describe('Node should display convergence label', () => {
     test('Should display ALL convergence label', async () => {
       const wrapper = mountWithContexts(


### PR DESCRIPTION
##### SUMMARY
Changing the underlying unified job template on a node would wipe the alias out.  I fixed this along with another bug where clearing out the alias `''` would result in the old alias still being displayed on the node (rather than the UJT name).

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - UI
