### PR TITLE
Block sliced workflow jobs on any job type from their JT

### DIFF
--- a/awx/main/scheduler/dependency_graph.py
+++ b/awx/main/scheduler/dependency_graph.py
@@ -99,8 +99,10 @@ class DependencyGraph(object):
             if job.workflow_job_template_id:
                 return self.get_item(self.WORKFLOW_JOB_TEMPLATES_JOBS, job.workflow_job_template_id)
             elif job.unified_job_template_id:
-                # Sliced jobs are WorkflowJob type but do not have a workflow_job_template_id
-                return self.get_item(self.WORKFLOW_JOB_TEMPLATES_JOBS, job.unified_job_template_id)
+                # Sliced jobs can be either Job or WorkflowJob type, and either should block a sliced WorkflowJob
+                return self.get_item(self.WORKFLOW_JOB_TEMPLATES_JOBS, job.unified_job_template_id) or self.get_item(
+                    self.JOB_TEMPLATE_JOBS, job.unified_job_template_id
+                )
         return None
 
     def system_job_blocked_by(self, job):


### PR DESCRIPTION
##### SUMMARY
Prior changes did some work to assure that workflow jobs would be added to the dependency graph, keyed off their `job_template` ForeignKey, in the event that a related `workflow_job_template` was not present. That fixed the big bug, but the expansion of that fix to make blocking of sliced jobs work correctly generally was not totally correct.

If a JT using slicing is launched with `ask_inventory_on_launch`, then it becomes unpredictable what job type those runs will have. They could be workflow jobs or jobs. For sliced jobs, we should never block on other jobs (enforced on creation), but workflow jobs should block (if applicable). This should codify that more completely.

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
To be honest, the whole separate construct of `WORKFLOW_JOB_TEMPLATES_JOBS` vs `JOB_TEMPLATE_JOBS` doesn't make a lot of sense, because the polymorphic models enforce that a WFJT will never share an id with a JT. You could throw all templates into the same data structure, and I am not sure why we don't.
