### PR TITLE
bulk reschedule context should track each of the 3 managers

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -851,6 +851,25 @@ _dependency_manager = threading.local()
 _workflow_manager = threading.local()
 
 
+@contextlib.contextmanager
+def task_manager_bulk_reschedule():
+    managers = [ScheduleTaskManager(), ScheduleWorkflowManager(), ScheduleDependencyManager()]
+    """Context manager to avoid submitting task multiple times."""
+    try:
+        for m in managers:
+            m.previous_flag = getattr(m.manager_threading_local, 'bulk_reschedule', False)
+            m.previous_value = getattr(m.manager_threading_local, 'needs_scheduling', False)
+            m.manager_threading_local.bulk_reschedule = True
+            m.manager_threading_local.needs_scheduling = False
+        yield
+    finally:
+        for m in managers:
+            m.manager_threading_local.bulk_reschedule = m.previous_flag
+            if m.manager_threading_local.needs_scheduling:
+                m.schedule()
+            m.manager_threading_local.needs_scheduling = m.previous_value
+
+
 class ScheduleManager:
     def __init__(self, manager, manager_threading_local):
         self.manager = manager
@@ -864,21 +883,6 @@ class ScheduleManager:
 
         # runs right away if not in transaction
         connection.on_commit(lambda: self.manager.delay())
-
-    @contextlib.contextmanager
-    def task_manager_bulk_reschedule(self):
-        """Context manager to avoid submitting task multiple times."""
-        try:
-            previous_flag = getattr(self.manager_threading_local, 'bulk_reschedule', False)
-            previous_value = getattr(self.manager_threading_local, 'needs_scheduling', False)
-            self.manager_threading_local.bulk_reschedule = True
-            self.manager_threading_local.needs_scheduling = False
-            yield
-        finally:
-            self.manager_threading_local.bulk_reschedule = previous_flag
-            if self.manager_threading_local.needs_scheduling:
-                self.schedule()
-            self.manager_threading_local.needs_scheduling = previous_value
 
 
 class ScheduleTaskManager(ScheduleManager):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I realized my original try at fixing up the bulk reschedule is incorrect. Right now the context only tracks calls to a single scheduler, but in the task manager, we may be calling _other_ schedulers. For example, we call ScheduleWorkflowManager from within the TaskManager. Therefore, the bulk reschedule context in the TaskManager should be sensitive to each of the 3 types of Schedule managers.

Also, we move the bulk reschedule to _outside_ of the atomic lock, that way if a reschedule happens, that new dispatched manager will be able to grab the lock.

 <!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug or Docs Fix

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
demonstration of the bulk rescheduler tracking each of the 3 managers appropriately

See that TaskManager and DependencyManager are going to be rescheduled, but WorkflowManager is not.

```
In [17]: def print_managers():
    ...:     for m in [ScheduleTaskManager(), ScheduleDependencyManager(), ScheduleWorkflowManager()]:
    ...:         print(m.__class__, m.manager_threading_local.__dict__)
    ...:     print()
    ...: 

In [18]: with task_manager_bulk_reschedule():
    ...:     print_managers()
    ...:     ScheduleTaskManager().schedule()
    ...:     print_managers()
    ...:     ScheduleDependencyManager().schedule()
    ...:     print_managers()
    ...: 
<class 'awx.main.utils.common.ScheduleTaskManager'> {'bulk_reschedule': True, 'needs_scheduling': False}
<class 'awx.main.utils.common.ScheduleDependencyManager'> {'bulk_reschedule': True, 'needs_scheduling': False}
<class 'awx.main.utils.common.ScheduleWorkflowManager'> {'bulk_reschedule': True, 'needs_scheduling': False}

<class 'awx.main.utils.common.ScheduleTaskManager'> {'bulk_reschedule': True, 'needs_scheduling': True}
<class 'awx.main.utils.common.ScheduleDependencyManager'> {'bulk_reschedule': True, 'needs_scheduling': False}
<class 'awx.main.utils.common.ScheduleWorkflowManager'> {'bulk_reschedule': True, 'needs_scheduling': False}

<class 'awx.main.utils.common.ScheduleTaskManager'> {'bulk_reschedule': True, 'needs_scheduling': True}
<class 'awx.main.utils.common.ScheduleDependencyManager'> {'bulk_reschedule': True, 'needs_scheduling': True}
<class 'awx.main.utils.common.ScheduleWorkflowManager'> {'bulk_reschedule': True, 'needs_scheduling': False}
```
