### PR TITLE
Allow for passing multiple items for values and roles when configuring SAML auth

### DIFF
--- a/awx/sso/conf.py
+++ b/awx/sso/conf.py
@@ -1535,12 +1535,12 @@ register(
     category_slug='saml',
     placeholder=[
         ('is_superuser_attr', 'saml_attr'),
-        ('is_superuser_value', 'value'),
-        ('is_superuser_role', 'saml_role'),
+        ('is_superuser_value', ['value']),
+        ('is_superuser_role', ['saml_role']),
         ('remove_superusers', True),
         ('is_system_auditor_attr', 'saml_attr'),
-        ('is_system_auditor_value', 'value'),
-        ('is_system_auditor_role', 'saml_role'),
+        ('is_system_auditor_value', ['value']),
+        ('is_system_auditor_role', ['saml_role']),
         ('remove_system_auditors', True),
     ],
 )

--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -741,12 +741,12 @@ class SAMLTeamAttrField(HybridDictField):
 class SAMLUserFlagsAttrField(HybridDictField):
 
     is_superuser_attr = fields.CharField(required=False, allow_null=True)
-    is_superuser_value = fields.CharField(required=False, allow_null=True)
-    is_superuser_role = fields.CharField(required=False, allow_null=True)
+    is_superuser_value = fields.StringListField(required=False, allow_null=True)
+    is_superuser_role = fields.StringListField(required=False, allow_null=True)
     remove_superusers = fields.BooleanField(required=False, allow_null=True)
     is_system_auditor_attr = fields.CharField(required=False, allow_null=True)
-    is_system_auditor_value = fields.CharField(required=False, allow_null=True)
-    is_system_auditor_role = fields.CharField(required=False, allow_null=True)
+    is_system_auditor_value = fields.StringListField(required=False, allow_null=True)
+    is_system_auditor_role = fields.StringListField(required=False, allow_null=True)
     remove_system_auditors = fields.BooleanField(required=False, allow_null=True)
 
     child = _Forbidden()

--- a/awx/sso/migrations/0003_convert_saml_string_to_list.py
+++ b/awx/sso/migrations/0003_convert_saml_string_to_list.py
@@ -1,0 +1,58 @@
+from django.db import migrations, connection
+import json
+
+_values_to_change = ['is_superuser_value', 'is_superuser_role', 'is_system_auditor_value', 'is_system_auditor_role']
+
+
+def _get_setting():
+    with connection.cursor() as cursor:
+        cursor.execute(f'SELECT value FROM conf_setting WHERE key= %s', ['SOCIAL_AUTH_SAML_USER_FLAGS_BY_ATTR'])
+        row = cursor.fetchone()
+        if row == None:
+            return {}
+        existing_setting = row[0]
+
+    try:
+        existing_json = json.loads(existing_setting)
+    except json.decoder.JSONDecodeError as e:
+        print("Failed to decode existing json setting:")
+        print(existing_setting)
+        raise e
+
+    return existing_json
+
+
+def _set_setting(value):
+    with connection.cursor() as cursor:
+        cursor.execute(f'UPDATE conf_setting SET value = %s WHERE key = %s', [json.dumps(value), 'SOCIAL_AUTH_SAML_USER_FLAGS_BY_ATTR'])
+
+
+def forwards(app, schema_editor):
+    # The Operation should use schema_editor to apply any changes it
+    # wants to make to the database.
+    existing_json = _get_setting()
+    for key in _values_to_change:
+        if existing_json.get(key, None) and isinstance(existing_json.get(key), str):
+            existing_json[key] = [existing_json.get(key)]
+    _set_setting(existing_json)
+
+
+def backwards(app, schema_editor):
+    existing_json = _get_setting()
+    for key in _values_to_change:
+        if existing_json.get(key, None) and not isinstance(existing_json.get(key), str):
+            try:
+                existing_json[key] = existing_json.get(key).pop()
+            except IndexError:
+                existing_json[key] = ""
+    _set_setting(existing_json)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sso', '0002_expand_provider_options'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/awx/sso/tests/functional/test_pipeline.py
+++ b/awx/sso/tests/functional/test_pipeline.py
@@ -446,6 +446,10 @@ class TestSAMLUserFlags:
                 (False, False),
                 False,
             ),
+            # NOTE: The first handful of tests test role/value as string instead of lists.
+            #       This was from the initial implementation of these fields but the code should be able to handle this
+            #       There are a couple tests at the end of this which will validate arrays in these values.
+            #
             # In this case we will give the user a group to make them an admin
             (
                 {'is_superuser_role': 'test-role-1'},
@@ -516,6 +520,30 @@ class TestSAMLUserFlags:
             (
                 {'is_superuser_attr': 'name_id', 'is_superuser_value': 'junk', 'remove_superusers': False},
                 (True, False),
+                True,
+            ),
+            # Positive test for multiple values for is_superuser_value
+            (
+                {'is_superuser_attr': 'is_superuser', 'is_superuser_value': ['junk', 'junk2', 'else', 'junk']},
+                (True, True),
+                False,
+            ),
+            # Negative test for multiple values for is_superuser_value
+            (
+                {'is_superuser_attr': 'is_superuser', 'is_superuser_value': ['junk', 'junk2', 'junk']},
+                (False, True),
+                True,
+            ),
+            # Positive test for multiple values of is_superuser_role
+            (
+                {'is_superuser_role': ['junk', 'junk2', 'something', 'junk']},
+                (True, True),
+                False,
+            ),
+            # Negative test for multiple values of is_superuser_role
+            (
+                {'is_superuser_role': ['junk', 'junk2', 'junk']},
+                (False, True),
                 True,
             ),
         ],

--- a/awx/sso/tests/unit/test_fields.py
+++ b/awx/sso/tests/unit/test_fields.py
@@ -121,12 +121,12 @@ class TestSAMLUserFlagsAttrField:
         [
             {},
             {'is_superuser_attr': 'something'},
-            {'is_superuser_value': 'value'},
-            {'is_superuser_role': 'my_peeps'},
+            {'is_superuser_value': ['value']},
+            {'is_superuser_role': ['my_peeps']},
             {'remove_superusers': False},
             {'is_system_auditor_attr': 'something_else'},
-            {'is_system_auditor_value': 'value2'},
-            {'is_system_auditor_role': 'other_peeps'},
+            {'is_system_auditor_value': ['value2']},
+            {'is_system_auditor_role': ['other_peeps']},
             {'remove_system_auditors': False},
         ],
     )
@@ -147,7 +147,13 @@ class TestSAMLUserFlagsAttrField:
                     'is_system_auditor_value': 'value2',
                     'is_system_auditor_role': 'other_peeps',
                 },
-                {'junk': ['Invalid field.']},
+                {
+                    'junk': ['Invalid field.'],
+                    'is_superuser_role': ['Expected a list of items but got type "str".'],
+                    'is_superuser_value': ['Expected a list of items but got type "str".'],
+                    'is_system_auditor_role': ['Expected a list of items but got type "str".'],
+                    'is_system_auditor_value': ['Expected a list of items but got type "str".'],
+                },
             ),
             (
                 {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
 
This PR fixes [#12521](https://github.com/ansible/awx/issues/12521) by changing the following values from strings to arrays:
 * is_superuser_value
 * is_system_auditor_value
 * is_superuser_role
 * is_system_auditor_role

These have become `or` values meaning if the value of a users attribute matches any of the values in the setting or a user has one or more of the roles they will gain the flag.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.2.1.dev71+g7db39719a4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
