### PR TITLE
[task_manager_refactor] ensure system can complete work without periodic scheduler

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -46,6 +46,7 @@ from awx.main.utils.common import (
     parse_yaml_or_json,
     getattr_dne,
     ScheduleDependencyManager,
+    ScheduleTaskManager,
     get_event_partition_epoch,
     get_capacity_type,
 )
@@ -1375,7 +1376,10 @@ class UnifiedJob(
         self.update_fields(start_args=json.dumps(kwargs), status='pending')
         self.websocket_emit_status("pending")
 
-        ScheduleDependencyManager().schedule()
+        if self.dependencies_processed:
+            ScheduleTaskManager().schedule()
+        else:
+            ScheduleDependencyManager().schedule()
 
         # Each type of unified job has a different Task class; get the
         # appropirate one.

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -430,8 +430,9 @@ class DependencyManager(TaskBase):
         return created_dependencies
 
     def process_tasks(self):
-        self.generate_dependencies(self.all_tasks)
-        self.subsystem_metrics.inc(f"{self.prefix}_pending_processed", len(self.all_tasks))
+        deps = self.generate_dependencies(self.all_tasks)
+        self.generate_dependencies(deps)
+        self.subsystem_metrics.inc(f"{self.prefix}_pending_processed", len(self.all_tasks) + len(deps))
 
     @timeit
     def _schedule(self):
@@ -572,6 +573,8 @@ class TaskManager(TaskBase):
     @timeit
     def process_running_tasks(self, running_tasks):
         for task in running_tasks:
+            if type(task) is WorkflowJob:
+                ScheduleWorkflowManager().schedule()
             self.dependency_graph.add_job(task)
 
     @timeit

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -449,7 +449,6 @@ CELERYBEAT_SCHEDULE = {
     'gather_analytics': {'task': 'awx.main.tasks.system.gather_analytics', 'schedule': timedelta(minutes=5)},
     'task_manager': {'task': 'awx.main.scheduler.tasks.task_manager', 'schedule': timedelta(seconds=20), 'options': {'expires': 20}},
     'dependency_manager': {'task': 'awx.main.scheduler.tasks.dependency_manager', 'schedule': timedelta(seconds=20), 'options': {'expires': 20}},
-    'workflow_manager': {'task': 'awx.main.scheduler.tasks.workflow_manager', 'schedule': timedelta(seconds=20), 'options': {'expires': 20}},
     'k8s_reaper': {'task': 'awx.main.tasks.system.awx_k8s_reaper', 'schedule': timedelta(seconds=60), 'options': {'expires': 50}},
     'receptor_reaper': {'task': 'awx.main.tasks.system.awx_receptor_workunit_reaper', 'schedule': timedelta(seconds=60)},
     'send_subsystem_metrics': {'task': 'awx.main.analytics.analytics_tasks.send_subsystem_metrics', 'schedule': timedelta(seconds=20)},


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I disabled the periodic schedulers listed in defaults.py and launched a job. The system _should_
 be able to run the job (and its dependencies) to completion. Of course we'll keep the periodic schedulers in, but it is nice to have the system be responsive on its own and progress work forward.

This commit adds Schedule*Manager.schedule() calls in appropriate places to ensure the system can keep propelling forward. 

Tested with Job and dependencies project update A,  inventory update,  project update B
Tested with workflows
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.3.1.dev34+g92739e2d9e

```
