### PR TITLE
Automatically install setuptools-scm in script called from Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,9 +111,18 @@ jobs:
           repository: ansible/awx-operator
           path: awx-operator
 
+      - name: Get python version from Makefile
+        working-directory: awx
+        run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
+
+      - name: Install python ${{ env.py_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.py_version }}
+
       - name: Install playbook dependencies
         run: |
-          python3 -m pip install docker setuptools_scm
+          python3 -m pip install docker
 
       - name: Build AWX image
         working-directory: awx

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install playbook dependencies
         run: |
-          python3 -m pip install docker setuptools_scm
+          python3 -m pip install docker
 
       - name: Build and stage AWX
         working-directory: awx

--- a/tools/ansible/build.yml
+++ b/tools/ansible/build.yml
@@ -5,15 +5,16 @@
   tasks:
     - name: Get version from SCM if not explicitly provided
       shell: |
-        python3 -m setuptools_scm | cut -d + -f -1
+        make print-VERSION | cut -d + -f -1
       args:
         chdir: '../../'
-      register: setup_py_version
+      register: scm_version
+      failed_when: not scm_version.stdout
       when: awx_version is not defined
 
     - name: Set awx_version
       set_fact:
-        awx_version: "{{ setup_py_version.stdout }}"
+        awx_version: "{{ scm_version.stdout }}"
       when: awx_version is not defined
 
     - include_role:

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -43,7 +43,7 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     xmlsec1-devel \
     xmlsec1-openssl-devel
 
-RUN pip3 install virtualenv setuptools_scm build
+RUN pip3 install virtualenv build
 
 
 # Install & build requirements

--- a/tools/scripts/scm_version.py
+++ b/tools/scripts/scm_version.py
@@ -1,4 +1,18 @@
-from setuptools_scm import get_version
+import os
+import sys
+import subprocess
+import traceback
+
+try:
+    from setuptools_scm import get_version
+except ModuleNotFoundError:
+    sys.stderr.write("Unable to import setuptools-scm, attempting to install now...\n")
+
+    os.environ['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
+    subprocess.check_output([sys.executable, '-m', 'ensurepip'])
+    subprocess.check_output([sys.executable, '-m', 'pip', 'install', 'setuptools-scm'])
+
+    from setuptools_scm import get_version
 
 version = get_version(root='../..', relative_to=__file__)
 print(version)

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,8 @@ isolated_build = True
 
 [testenv:linters]
 deps =
-  make
   black
   flake8
-  setuptools-scm
   yamllint
 allowlist_externals = make
 setenv =


### PR DESCRIPTION
This would normally be a no-no, but in the context of the development environment I think it's ok... mostly because I'm tired of people getting confused.