### PR TITLE
Enable django debug toolbar by default in development environment

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -56,9 +56,9 @@
     path: "{{ playbook_dir }}/../../../awx/settings/local_settings.py"
     state: absent
 
-- name: Copy local_settings.py
-  copy:
-    src: "local_settings.py"
+- name: Template local_settings.py
+  template:
+    src: "local_settings.py.j2"
     dest: "{{ sources_dest }}/local_settings.py"
 
 - name: Get OS info for sdb

--- a/tools/docker-compose/ansible/roles/sources/templates/local_settings.py.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/local_settings.py.j2
@@ -15,8 +15,7 @@
 # Enable the following lines and install the browser extension to use Django debug toolbar
 # if your deployment method is not VMWare of Docker-for-Mac you may
 # need a different IP address from request.META['REMOTE_ADDR']
-# INTERNAL_IPS = ('172.19.0.1', '172.18.0.1', '192.168.100.1')
-# ALLOWED_HOSTS = ['*']
+INTERNAL_IPS = {{ internal_ips }}
 
 # The UUID of the system, for HA.
 SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'

--- a/tools/docker-compose/ansible/roles/sources/vars_plugins/internal_ips.py
+++ b/tools/docker-compose/ansible/roles/sources/vars_plugins/internal_ips.py
@@ -1,0 +1,14 @@
+import socket
+
+
+def internal_ips():
+    # Pulled from https://django-debug-toolbar.readthedocs.io/en/latest/installation.html#configure-internal-ips
+    hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
+    internal_ips = [ip[: ip.rfind(".")] + ".1" for ip in ips] + ["127.0.0.1", "10.0.2.2"]
+
+    return internal_ips
+
+
+class VarsModule(object):
+    def get_vars(self, loader, path, entities):
+        return {'internal_ips': internal_ips()}


### PR DESCRIPTION
This PR: 

- Enables Django Debug Toolbar by default in the development environment. 
  - Is there any reason not to do this?
- Uses an Ansible [vars plugin](https://docs.ansible.com/ansible/latest/plugins/vars.html) to automatically set the `INTERNAL_IPS` setting (used by DDT)