### PR TITLE
12483 configure content verification

### DIFF
--- a/awx/ui/src/components/PromptDetail/PromptProjectDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptProjectDetail.js
@@ -125,6 +125,21 @@ function PromptProjectDetail({ resource }) {
           }
         />
       )}
+      {summary_fields?.signature_validation_credential?.id && (
+        <Detail
+          label={t`Content Signature Validation Credential`}
+          dataCy={`${prefixCy}-content-signature-validation-credential`}
+          value={
+            <CredentialChip
+              key={resource.summary_fields.signature_validation_credential.id}
+              credential={
+                resource.summary_fields.signature_validation_credential
+              }
+              isReadOnly
+            />
+          }
+        />
+      )}
       {optionsList && (
         <Detail
           label={t`Enabled Options`}

--- a/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
+++ b/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
@@ -18,9 +18,16 @@ function ProjectAdd() {
       // the API might throw an unexpected error if our creation request
       // has a zero-length string as its credential field. As a work-around,
       // normalize falsey credential fields by deleting them.
-      delete values.credential;
-    } else {
+      values.credential = null;
+    } else if (typeof values.credential.id === 'number') {
       values.credential = values.credential.id;
+    }
+    if (values.scm_type === 'git') {
+      if (!values.signature_validation_credential) {
+        values.signature_validation_credential = null;
+      } else if (typeof values.signature_validation_credential.id === 'number') {
+        values.signature_validation_credential = values.signature_validation_credential.id;
+      }
     }
     setFormSubmitError(null);
     try {

--- a/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.js
+++ b/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.js
@@ -4,6 +4,7 @@ import { t } from '@lingui/macro';
 import styled from 'styled-components';
 import {
   Button,
+  Chip,
   ClipboardCopy,
   TextList,
   TextListItem,
@@ -15,6 +16,7 @@ import { Project } from 'types';
 import { Config, useConfig } from 'contexts/Config';
 import AlertModal from 'components/AlertModal';
 import { CardBody, CardActionsRow } from 'components/Card';
+import ChipGroup from 'components/ChipGroup';
 import DeleteButton from 'components/DeleteButton';
 import { DetailList, Detail, UserDateDetail } from 'components/DetailList';
 import ErrorDetail from 'components/ErrorDetail';
@@ -124,7 +126,6 @@ function ProjectDetail({ project }) {
       </TextList>
     );
   }
-
   const generateLastJobTooltip = (job) => (
     <>
       <div>{t`MOST RECENT SYNC`}</div>
@@ -149,6 +150,7 @@ function ProjectDetail({ project }) {
   } else if (summary_fields?.last_job) {
     job = summary_fields.last_job;
   }
+
   const getSourceControlUrlHelpText = () =>
     scm_type === 'git'
       ? projectHelpText.githubSourceControlUrl
@@ -244,6 +246,21 @@ function ProjectDetail({ project }) {
                 isReadOnly
               />
             }
+            isEmpty={summary_fields.credential.length === 0}
+          />
+        )}
+        {summary_fields.signature_validation_credential && (
+          <Detail
+            label={t`Content Signature Validation Credential`}
+            helpText={projectHelpText.signatureValidation}
+            value={
+              <CredentialChip
+                key={summary_fields.signature_validation_credential.id}
+                credential={summary_fields.signature_validation_credential}
+                isReadOnly
+              />
+            }
+            isEmpty={summary_fields.signature_validation_credential.length === 0}
           />
         )}
         <Detail

--- a/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.test.js
+++ b/awx/ui/src/screens/Project/ProjectDetail/ProjectDetail.test.js
@@ -46,6 +46,11 @@ describe('<ProjectDetail />', () => {
         name: 'qux',
         kind: 'scm',
       },
+      signature_validation_credential: {
+        id: 2000,
+        name: 'svc',
+        kind: 'cryptography',
+      },
       last_job: {
         id: 9000,
         status: 'successful',
@@ -78,6 +83,7 @@ describe('<ProjectDetail />', () => {
     scm_delete_on_update: true,
     scm_track_submodules: true,
     credential: 100,
+    signature_validation_credential: 200,
     status: 'successful',
     organization: 10,
     scm_update_on_launch: true,
@@ -107,6 +113,10 @@ describe('<ProjectDetail />', () => {
     assertDetail(
       'Source Control Credential',
       `Scm: ${mockProject.summary_fields.credential.name}`
+    );
+    assertDetail(
+      'Content Signature Validation Credential',
+      `Gpg Public Key: ${mockProject.summary_fields.signature_validation_credential.name}`
     );
     assertDetail(
       'Cache Timeout',

--- a/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
+++ b/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
@@ -18,10 +18,18 @@ function ProjectEdit({ project }) {
       // the API might throw an unexpected error if our creation request
       // has a zero-length string as its credential field. As a work-around,
       // normalize falsey credential fields by deleting them.
-      delete values.credential;
-    } else {
+      values.credential = null;
+    } else if (typeof values.credential.id === 'number') {
       values.credential = values.credential.id;
     }
+    if (values.scm_type === 'git') {
+      if (!values.signature_validation_credential) {
+        values.signature_validation_credential = null;
+      } else if (typeof values.signature_validation_credential.id === 'number') {
+        values.signature_validation_credential = values.signature_validation_credential.id;
+      }
+    }
+
     try {
       const {
         data: { id },

--- a/awx/ui/src/screens/Project/shared/Project.helptext.js
+++ b/awx/ui/src/screens/Project/shared/Project.helptext.js
@@ -105,6 +105,10 @@ const projectHelpTextStrings = {
         you can input tags, commit hashes, and arbitrary refs. Some
         commit hashes and refs may not be available unless you also
         provide a custom refspec.`,
+  signatureValidation: t`Enable content signing to verify that the content 
+                    has remained secure when a project is synced. 
+                    If the content has been tampered with, the 
+                    job will not run.`,
   options: {
     clean: t`Remove any local modifications prior to performing an update.`,
     delete: t`Delete the local repository in its entirety prior to

--- a/awx/ui/src/screens/Project/shared/ProjectForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.js
@@ -37,15 +37,22 @@ const fetchCredentials = async (credential) => {
         results: [insightsCredentialType],
       },
     },
+    {
+      data: {
+        results: [cryptographyCredentialType],
+      },
+    },
   ] = await Promise.all([
     CredentialTypesAPI.read({ kind: 'scm' }),
     CredentialTypesAPI.read({ name: 'Insights' }),
+    CredentialTypesAPI.read({ kind: 'cryptography' }),
   ]);
 
   if (!credential) {
     return {
       scm: { typeId: scmCredentialType.id },
       insights: { typeId: insightsCredentialType.id },
+      cryptography: { typeId: cryptographyCredentialType.id },
     };
   }
 
@@ -60,6 +67,13 @@ const fetchCredentials = async (credential) => {
       value:
         credential_type_id === insightsCredentialType.id ? credential : null,
     },
+    cryptography: {
+      typeId: cryptographyCredentialType.id,
+      value:
+        credential_type_id === cryptographyCredentialType.id
+          ? credential
+          : null,
+    },
   };
 };
 
@@ -69,7 +83,9 @@ function ProjectFormFields({
   project_local_paths,
   formik,
   setCredentials,
+  setSignatureValidationCredentials,
   credentials,
+  signatureValidationCredentials,
   scmTypeOptions,
   setScmSubFormState,
   scmSubFormState,
@@ -79,6 +95,7 @@ function ProjectFormFields({
     scm_branch: '',
     scm_refspec: '',
     credential: '',
+    signature_validation_credential: '',
     scm_clean: false,
     scm_delete_on_update: false,
     scm_track_submodules: false,
@@ -86,7 +103,6 @@ function ProjectFormFields({
     allow_override: false,
     scm_update_cache_timeout: 0,
   };
-
   const { setFieldValue, setFieldTouched } = useFormikContext();
 
   const [scmTypeField, scmTypeMeta, scmTypeHelpers] = useField({
@@ -145,6 +161,19 @@ function ProjectFormFields({
       });
     },
     [credentials, setCredentials]
+  );
+
+  const handleSignatureValidationCredentialSelection = useCallback(
+    (type, value) => {
+      setSignatureValidationCredentials({
+        ...signatureValidationCredentials,
+        [type]: {
+          ...signatureValidationCredentials[type],
+          value,
+        },
+      });
+    },
+    [signatureValidationCredentials, setSignatureValidationCredentials]
   );
 
   const handleOrganizationUpdate = useCallback(
@@ -259,7 +288,9 @@ function ProjectFormFields({
                 git: (
                   <GitSubForm
                     credential={credentials.scm}
+                    signature_validation_credential={signatureValidationCredentials.cryptography}
                     onCredentialSelection={handleCredentialSelection}
+                    onSignatureValidationCredentialSelection={handleSignatureValidationCredentialSelection}
                     scmUpdateOnLaunch={formik.values.scm_update_on_launch}
                   />
                 ),
@@ -295,7 +326,6 @@ function ProjectFormFields({
     </>
   );
 }
-
 function ProjectForm({ project, submitError, ...props }) {
   const { handleCancel, handleSubmit } = props;
   const { summary_fields = {} } = project;
@@ -307,6 +337,7 @@ function ProjectForm({ project, submitError, ...props }) {
     scm_branch: '',
     scm_refspec: '',
     credential: '',
+    signature_validation_credential: '',
     scm_clean: false,
     scm_delete_on_update: false,
     scm_track_submodules: false,
@@ -318,12 +349,19 @@ function ProjectForm({ project, submitError, ...props }) {
   const [credentials, setCredentials] = useState({
     scm: { typeId: null, value: null },
     insights: { typeId: null, value: null },
+    cryptography: { typeId: null, value: null },
+  });
+  const [signatureValidationCredentials, setSignatureValidationCredentials] = useState({
+    scm: { typeId: null, value: null },
+    insights: { typeId: null, value: null },
+    cryptography: { typeId: null, value: null },
   });
 
   useEffect(() => {
     async function fetchData() {
       try {
         const credentialResponse = fetchCredentials(summary_fields.credential);
+        const signatureValidationCredentialResponse = fetchCredentials(summary_fields.signature_validation_credential);
         const {
           data: {
             actions: {
@@ -335,6 +373,7 @@ function ProjectForm({ project, submitError, ...props }) {
         } = await ProjectsAPI.readOptions();
 
         setCredentials(await credentialResponse);
+        setSignatureValidationCredentials(await signatureValidationCredentialResponse);
         setScmTypeOptions(choices);
       } catch (error) {
         setContentError(error);
@@ -344,7 +383,7 @@ function ProjectForm({ project, submitError, ...props }) {
     }
 
     fetchData();
-  }, [summary_fields.credential]);
+  }, [summary_fields.credential, summary_fields.signature_validation_credential]);
 
   if (isLoading) {
     return <ContentLoading />;
@@ -378,6 +417,8 @@ function ProjectForm({ project, submitError, ...props }) {
         scm_update_cache_timeout: project.scm_update_cache_timeout || 0,
         scm_update_on_launch: project.scm_update_on_launch || false,
         scm_url: project.scm_url || '',
+        signature_validation_credential:
+          project.signature_validation_credential || '',
         default_environment:
           project.summary_fields?.default_environment || null,
       }}
@@ -392,7 +433,9 @@ function ProjectForm({ project, submitError, ...props }) {
               project_local_paths={project_local_paths}
               formik={formik}
               setCredentials={setCredentials}
+              setSignatureValidationCredentials={setSignatureValidationCredentials}
               credentials={credentials}
+              signatureValidationCredentials={signatureValidationCredentials}
               scmTypeOptions={scmTypeOptions}
               setScmSubFormState={setScmSubFormState}
               scmSubFormState={scmSubFormState}

--- a/awx/ui/src/screens/Project/shared/ProjectForm.test.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.test.js
@@ -80,6 +80,18 @@ describe('<ProjectForm />', () => {
     },
   };
 
+  const cryptographyCredentialResolve = {
+    data: {
+      results: [
+        {
+          id: 6,
+          name: 'GPG Public Key',
+          kind: 'cryptography',
+        },
+      ],
+    },
+  };
+
   beforeEach(async () => {
     RootAPI.readAssetVariables.mockResolvedValue({
       data: {
@@ -94,6 +106,9 @@ describe('<ProjectForm />', () => {
     );
     await CredentialTypesAPI.read.mockImplementationOnce(
       () => insightsCredentialResolve
+    );
+    await CredentialTypesAPI.read.mockImplementationOnce(
+      () => cryptographyCredentialResolve
     );
   });
 
@@ -155,6 +170,10 @@ describe('<ProjectForm />', () => {
     ).toBe(1);
     expect(
       wrapper.find('FormGroup[label="Source Control Credential"]').length
+    ).toBe(1);
+    expect(
+      wrapper.find('FormGroup[label="Content Signature Validation Credential"]')
+        .length
     ).toBe(1);
     expect(wrapper.find('FormGroup[label="Options"]').length).toBe(1);
   });

--- a/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
@@ -1,6 +1,8 @@
 import 'styled-components/macro';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { t } from '@lingui/macro';
+import { useFormikContext } from 'formik';
+import CredentialLookup from 'components/Lookup/CredentialLookup';
 import FormField from 'components/FormField';
 import getDocsBaseUrl from 'util/getDocsBaseUrl';
 import { useConfig } from 'contexts/Config';
@@ -16,9 +18,22 @@ import projectHelpStrings from '../Project.helptext';
 
 const GitSubForm = ({
   credential,
+  signature_validation_credential,
   onCredentialSelection,
+  onSignatureValidationCredentialSelection,
   scmUpdateOnLaunch,
 }) => {
+  const { setFieldValue, setFieldTouched } = useFormikContext();
+
+  const onCredentialChange = useCallback(
+    (value) => {
+      onSignatureValidationCredentialSelection('cryptography', value);
+      setFieldValue('signature_validation_credential', value);
+      setFieldTouched('signature_validation_credential', true, false);
+    },
+    [onSignatureValidationCredentialSelection, setFieldValue, setFieldTouched]
+  );
+
   const docsURL = `${getDocsBaseUrl(
     useConfig()
   )}/html/userguide/projects.html#manage-playbooks-using-source-control`;
@@ -38,6 +53,12 @@ const GitSubForm = ({
       <ScmCredentialFormField
         credential={credential}
         onCredentialSelection={onCredentialSelection}
+      />
+      <CredentialLookup
+        credentialTypeId={signature_validation_credential.typeId}
+        label={t`Content Signature Validation Credential`}
+        onChange={onCredentialChange}
+        value={signature_validation_credential.value}
       />
       <ScmTypeOptions scmUpdateOnLaunch={scmUpdateOnLaunch} />
     </>

--- a/awx/ui/src/types.js
+++ b/awx/ui/src/types.js
@@ -145,6 +145,7 @@ export const Project = shape({
   summary_fields: shape({
     organization: Organization,
     credential: Credential,
+    signature_validation_credential: Credential,
     last_job: shape({}),
     last_update: shape({}),
     created_by: shape({}),
@@ -163,6 +164,7 @@ export const Project = shape({
   scm_delete_on_update: bool,
   scm_track_submodules: bool,
   credential: number,
+  signature_validation_credential: number,
   status: oneOf([
     'new',
     'pending',


### PR DESCRIPTION
##### SUMMARY
Added the "Content Signature Validation Credential" field to the Project Form page in the Git subform as a credential lookup field. The field only shows users the applicable credentials by filtering by GPG Public Key. Once the form is saved, the selection is reflected in the Project Details view.
Addresses #12483 

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - UI

##### ADDITIONAL INFORMATION
There is a bug in the UI that requires the Source Control Credential to be interacted with in order to submit the form with a Content Signature Verification Credential selected. For instance, if a user wants to submit the form with a Content Signature Verification Credential but not a Source Control Credential, they will still need to open the Source Control Credential lookup and explicitly empty the field before being able to submit. This bug is being tracked in #12589.
