### PR TITLE
Fix awx collection project module

### DIFF
--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -169,6 +169,18 @@ options:
       required: False
       default: 2
       type: float
+    signature_validation:
+      description:
+        - Whether to validate the signature during project update.
+      required: False
+      default: False
+      type: bool
+    signature_validation_credential:
+      description:
+        - Name of the credential to use for signature validation.
+        - Required if C(signature_validation=True)
+      type: str
+
 extends_documentation_fragment: awx.awx.auth
 '''
 
@@ -279,10 +291,17 @@ def main():
         wait=dict(type='bool', default=True),
         update_project=dict(default=False, type='bool'),
         interval=dict(default=2.0, type='float'),
+        signature_validation=dict(type='bool', default=False),
+        signature_validation_credential=dict(type='str'),
     )
 
     # Create a module for ourselves
-    module = ControllerAPIModule(argument_spec=argument_spec)
+    module = ControllerAPIModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ("signature_validation", True, ["signature_validation_credential"]),
+        ],
+    )
 
     # Extract our parameters
     name = module.params.get('name')
@@ -300,6 +319,8 @@ def main():
     state = module.params.get('state')
     wait = module.params.get('wait')
     update_project = module.params.get('update_project')
+
+    signature_validation_credential = module.params.get('signature_validation_credential')
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
     lookup_data = {}
@@ -330,6 +351,9 @@ def main():
     if credential is not None:
         credential = module.resolve_name_to_id('credentials', credential)
 
+    if signature_validation_credential is not None:
+        signature_validation_credential = module.resolve_name_to_id('credentials', signature_validation_credential)
+
     # Attempt to look up associated field items the user specified.
     association_fields = {}
 
@@ -358,6 +382,7 @@ def main():
         'organization': org_id,
         'scm_update_on_launch': scm_update_on_launch,
         'scm_update_cache_timeout': scm_update_cache_timeout,
+        'signature_validation_credential': signature_validation_credential,
     }
 
     for field_name in (
@@ -372,6 +397,7 @@ def main():
         'custom_virtualenv',
         'description',
         'allow_override',
+        'signature_validation',
     ):
         field_val = module.params.get(field_name)
         if field_val is not None:


### PR DESCRIPTION
##### SUMMARY
- added input arg for `signature_validation`
- added input arg for `signature_validation_credential`


##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
awx: 21.3.1.dev41+g44e64d9401
```


##### ADDITIONAL INFORMATION
created a playbook to tested the following scenario 
- adding project without `signature_validation` enabled (validate project is created as expected)
- added project with `signature_validation` enabled without `signature_validation_credential `(validated project creation failed due to missing credential)
- added project with both `signature_validation` and `signature_validation_credential` (validated project created successfully with both value set correctly)

