### PR TITLE
Adding GitHub check to ensure PRs have the proper X/Y/Z flags

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,7 +25,7 @@ Instead use the bug or feature request.
 <!--- Pick one below and delete the rest: -->
  - Breaking Change
  - New or Enhanced Feature
- - Bug or Docs Fix
+ - Bug, Docs Fix or other nominal change
 
 
 ##### COMPONENT NAME

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ the change does.
 <!--- Pick one below and delete the rest: -->
  - Breaking Change 
  - New or Enhanced Feature
- - Bug or Docs Fix
+ - Bug, Docs Fix or other nominal change
 
 ##### COMPONENT NAME
 <!--- Name of the module/plugin/module/task -->

--- a/.github/workflows/pr_body_check.yml
+++ b/.github/workflows/pr_body_check.yml
@@ -25,7 +25,7 @@ jobs:
       # We want to write these out individually just incase the options were joined on a single line
       - name: Check for each of the lines
         run: |
-          grep "Bug or Docs Fix" pr.body > Z
+          grep "Bug, Docs Fix or other nominal change" pr.body > Z
           grep "New or Enhanced Feature" pr.body > Y
           grep "Breaking Change" pr.body > X
           exit 0
@@ -36,8 +36,9 @@ jobs:
       - name: Check for exactly one item
         run: |
           if [ $(cat X Y Z | wc -l) != 1 ] ; then
-            echo "The PR body must contain exactly one of [ 'Bug or Docs Fix', 'New or Enhanced Feature', 'Breaking Change' ]"
+            echo "The PR body must contain exactly one of [ 'Bug, Docs Fix or other nominal change', 'New or Enhanced Feature', 'Breaking Change' ]"
             echo "We counted $(cat X Y Z | wc -l)"
+            echo "See the default PR body for examples"
             exit 255;
           else
             exit 0;

--- a/.github/workflows/pr_body_check.yml
+++ b/.github/workflows/pr_body_check.yml
@@ -1,0 +1,44 @@
+---
+name: PR Check
+env:
+  BRANCH: ${{ github.base_ref || 'devel' }}
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+jobs:
+  pr-check:
+    name: Check PR for X,Y,Z properties
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Write PR body to a file
+        run: |
+          cat >> pr.body << __SOME_RANDOM_PR_EOF__
+          ${{ github.event.pull_request.body }}
+          __SOME_RANDOM_PR_EOF__
+
+      - name: Display the received body for troubleshooting
+        run: cat pr.body
+
+      # We want to write these out individually just incase the options were joined on a single line
+      - name: Check for each of the lines
+        run: |
+          grep "Bug or Docs Fix" pr.body > Z
+          grep "New or Enhanced Feature" pr.body > Y
+          grep "Breaking Change" pr.body > X
+          exit 0
+        # We exit 0 and set the shell to prevent the returns from the greps from failing this step
+        # See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+        shell: bash {0}
+
+      - name: Check for exactly one item
+        run: |
+          if [ $(cat X Y Z | wc -l) != 1 ] ; then
+            echo "The PR body must contain exactly one of [ 'Bug or Docs Fix', 'New or Enhanced Feature', 'Breaking Change' ]"
+            echo "We counted $(cat X Y Z | wc -l)"
+            exit 255;
+          else
+            exit 0;
+          fi

--- a/.github/workflows/pr_body_check.yml
+++ b/.github/workflows/pr_body_check.yml
@@ -7,7 +7,7 @@ on:
     types: [opened, edited, reopened, synchronize]
 jobs:
   pr-check:
-    name: Check PR for X,Y,Z properties
+    name: Scan PR description for semantic versioning keywords
     runs-on: ubuntu-latest
     permissions:
       packages: write


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding a GitHub workflow that will check the PR bodies for exactly one of the issue types. This adds a check on the PR that looks like:
![image](https://user-images.githubusercontent.com/32551173/181112252-dd425532-77fb-4bb9-ab64-c3a0b2194fc3.png)

If the check fails you can click on details and see a message like:
![image](https://user-images.githubusercontent.com/32551173/181112325-f9ced949-421e-4ae8-a8c0-a0dca7e0b8f3.png)

This will allow us to enforce the X/Y/Z flags in the PR body to automate the selection of the next AWX release number.

Fixes https://github.com/ansible/awx/issues/12507

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.2.1.dev96+g780afcddf3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
