### PR TITLE
Move reaper logic into worker, avoiding bottlenecks

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -16,6 +16,7 @@ from queue import Full as QueueFull, Empty as QueueEmpty
 from django.conf import settings
 from django.db import connection as django_connection, connections
 from django.core.cache import cache as django_cache
+from django.utils.timezone import now as tz_now
 from django_guid import set_guid
 from jinja2 import Template
 import psutil
@@ -437,18 +438,17 @@ class AutoscalePool(WorkerPool):
             idx = random.choice(range(len(self.workers)))
             self.write(idx, m)
 
-        # if the database says a job is running or queued on this node, but it's *not*,
-        # then reap it
-        running_uuids = []
-        for worker in self.workers:
-            worker.calculate_managed_tasks()
-            running_uuids.extend(list(worker.managed_tasks.keys()))
-
-        # if we are not in the dangerous situation of queue backup then clear old waiting jobs
-        if self.workers and max(len(w.managed_tasks) for w in self.workers) <= 1:
-            reaper.reap_waiting(excluded_uuids=running_uuids)
-
-        reaper.reap(excluded_uuids=running_uuids)
+    def add_bind_kwargs(self, body):
+        bind_kwargs = body.pop('bind_kwargs', [])
+        body.setdefault('kwargs', {})
+        if 'dispatch_time' in bind_kwargs:
+            body['kwargs']['dispatch_time'] = tz_now().isoformat()
+        if 'active_task_ids' in bind_kwargs:
+            active_task_ids = []
+            for worker in self.workers:
+                worker.calculate_managed_tasks()
+                active_task_ids.extend(list(worker.managed_tasks.keys()))
+            body['kwargs']['active_task_ids'] = active_task_ids
 
     def up(self):
         if self.full:
@@ -463,9 +463,8 @@ class AutoscalePool(WorkerPool):
         if 'guid' in body:
             set_guid(body['guid'])
         try:
-            # when the cluster heartbeat occurs, clean up internally
-            if isinstance(body, dict) and 'cluster_node_heartbeat' in body['task']:
-                self.cleanup()
+            if isinstance(body, dict) and body.get('bind_kwargs'):
+                self.add_bind_kwargs(body)
             if self.should_grow:
                 self.up()
             # we don't care about "preferred queue" round robin distribution, just

--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -441,12 +441,12 @@ class AutoscalePool(WorkerPool):
         body.setdefault('kwargs', {})
         if 'dispatch_time' in bind_kwargs:
             body['kwargs']['dispatch_time'] = tz_now().isoformat()
-        if 'active_task_ids' in bind_kwargs:
-            active_task_ids = []
+        if 'worker_tasks' in bind_kwargs:
+            worker_tasks = {}
             for worker in self.workers:
                 worker.calculate_managed_tasks()
-                active_task_ids.extend(list(worker.managed_tasks.keys()))
-            body['kwargs']['active_task_ids'] = active_task_ids
+                worker_tasks[worker.pid] = list(worker.managed_tasks.keys())
+            body['kwargs']['worker_tasks'] = worker_tasks
 
     def up(self):
         if self.full:

--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -378,8 +378,6 @@ class AutoscalePool(WorkerPool):
         1.  Discover worker processes that exited, and recover messages they
             were handling.
         2.  Clean up unnecessary, idle workers.
-        3.  Check to see if the database says this node is running any tasks
-            that aren't actually running.  If so, reap them.
 
         IMPORTANT: this function is one of the few places in the dispatcher
         (aside from setting lookups) where we talk to the database.  As such,
@@ -465,6 +463,9 @@ class AutoscalePool(WorkerPool):
         try:
             if isinstance(body, dict) and body.get('bind_kwargs'):
                 self.add_bind_kwargs(body)
+            # when the cluster heartbeat occurs, clean up internally
+            if isinstance(body, dict) and 'cluster_node_heartbeat' in body['task']:
+                self.cleanup()
             if self.should_grow:
                 self.up()
             # we don't care about "preferred queue" round robin distribution, just

--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -50,13 +50,21 @@ class task:
     @task(queue='tower_broadcast')
     def announce():
         print("Run this everywhere!")
+
+    # The special parameter bind_kwargs tells the main dispatcher process to add certain kwargs
+
+    @task(bind_kwargs=['dispatch_time'])
+    def print_time(dispatch_time=None):
+        print(f"Time I was dispatched: {dispatch_time}")
     """
 
-    def __init__(self, queue=None):
+    def __init__(self, queue=None, bind_kwargs=None):
         self.queue = queue
+        self.bind_kwargs = bind_kwargs
 
     def __call__(self, fn=None):
         queue = self.queue
+        bind_kwargs = self.bind_kwargs
 
         class PublisherMixin(object):
 
@@ -80,6 +88,8 @@ class task:
                 guid = get_guid()
                 if guid:
                     obj['guid'] = guid
+                if bind_kwargs:
+                    obj['bind_kwargs'] = bind_kwargs
                 obj.update(**kw)
                 if callable(queue):
                     queue = queue()

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -199,10 +199,7 @@ class TestAutoScaling:
         assert len(self.pool) == 10
 
         # cleanup should scale down to 8 workers
-        with mock.patch('awx.main.dispatch.reaper.reap') as reap:
-            with mock.patch('awx.main.dispatch.reaper.reap_waiting') as reap:
-                self.pool.cleanup()
-        reap.assert_called()
+        self.pool.cleanup()
         assert len(self.pool) == 2
 
     def test_max_scale_up(self):
@@ -250,10 +247,7 @@ class TestAutoScaling:
         time.sleep(1)  # wait a moment for sigterm
 
         # clean up and the dead worker
-        with mock.patch('awx.main.dispatch.reaper.reap') as reap:
-            with mock.patch('awx.main.dispatch.reaper.reap_waiting') as reap:
-                self.pool.cleanup()
-        reap.assert_called()
+        self.pool.cleanup()
         assert len(self.pool) == 1
         assert self.pool.workers[0].pid == alive_pid
 


### PR DESCRIPTION
##### SUMMARY
I'm hoping that this can be the final piece of the puzzle to address all the reports of bad behavior by the reaper with jobs in the "waiting" status.

Another piece is up at https://github.com/ansible/awx/pull/12573

With this change, we will still sometimes see slowness as `self.pool.up()` is called to expand the worker pool, but we will remove the risky behavior of running (potentially slow) database queries periodically from the main dispatcher process.

It is believed that slowness in the main dispatcher process can cause a pileup of incoming messages, which is what leaves jobs in the waiting state.

This moves the `.cleanup()` logic out of the main process and into a worker process, and runs at the same period it did before. Local reaper will be a side-effect of the cluster_node_heartbeat task, that was true before and will stay the same here. Instead of having the main dispatcher process _run_ the logic, it will instead attach a number of necessary parameters, so it will can be ran in the main body of the task.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
This will have conflicts as other merges happen. That's fine, there shouldn't be any problem resolving them.
