### PR TITLE
Wait 60 seconds before scaling down a worker

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -71,9 +71,11 @@ class PoolWorker(object):
         self.messages_finished = 0
         self.managed_tasks = collections.OrderedDict()
         self.finished = MPQueue(queue_size) if self.track_managed_tasks else NoOpResultQueue()
+        self.last_finished = None
         self.queue = MPQueue(queue_size)
         self.process = Process(target=target, args=(self.queue, self.finished) + args)
         self.process.daemon = True
+        self.scale_down_in = settings.DISPATCHER_SCALE_DOWN_WAIT_TIME
 
     def start(self):
         self.process.start()
@@ -144,6 +146,9 @@ class PoolWorker(object):
                 # state of which events are *currently* being processed.
                 logger.warning('Event UUID {} appears to be have been duplicated.'.format(uuid))
 
+        if finished:
+            self.last_finished = time.time()
+
     @property
     def current_task(self):
         if not self.track_managed_tasks:
@@ -188,6 +193,14 @@ class PoolWorker(object):
     @property
     def idle(self):
         return not self.busy
+
+    @property
+    def lazy(self):
+        if self.busy:
+            return False
+        if self.last_finished is None:
+            return True
+        return time.time() - self.last_finished > self.scale_down_in
 
 
 class StatefulPoolWorker(PoolWorker):
@@ -249,7 +262,7 @@ class WorkerPool(object):
         except Exception:
             logger.exception('could not fork')
         else:
-            logger.debug('scaling up worker pid:{}'.format(worker.pid))
+            logger.info(f'scaling up worker pid:{worker.pid} total:{len(self.workers)}')
         return idx, worker
 
     def debug(self, *args, **kwargs):
@@ -385,12 +398,12 @@ class AutoscalePool(WorkerPool):
                             logger.exception('failed to reap job UUID {}'.format(w.current_task['uuid']))
                 orphaned.extend(w.orphaned_tasks)
                 self.workers.remove(w)
-            elif w.idle and len(self.workers) > self.min_workers:
+            elif w.lazy and len(self.workers) > self.min_workers:
                 # the process has an empty queue (it's idle) and we have
                 # more processes in the pool than we need (> min)
                 # send this process a message so it will exit gracefully
                 # at the next opportunity
-                logger.debug('scaling down worker pid:{}'.format(w.pid))
+                logger.info(f'scaling down worker pid:{w.pid} from:{len(self.workers)}')
                 w.quit()
                 self.workers.remove(w)
             if w.alive:

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -438,6 +438,10 @@ EXECUTION_NODE_REMEDIATION_CHECKS = 60 * 30  # once every 30 minutes check if an
 # Amount of time dispatcher will try to reconnect to database for jobs and consuming new work
 DISPATCHER_DB_DOWNTOWN_TOLLERANCE = 40
 
+# Minimum time to wait after last job finished before scaling down a worker
+# A higher value will free up memory more agressively, but a lower value will require less forking
+DISPATCHER_SCALE_DOWN_WAIT_TIME = 60
+
 BROKER_URL = 'unix:///var/run/redis/redis.sock'
 CELERYBEAT_SCHEDULE = {
     'tower_scheduler': {'task': 'awx.main.tasks.system.awx_periodic_scheduler', 'schedule': timedelta(seconds=30), 'options': {'expires': 20}},


### PR DESCRIPTION
##### SUMMARY
From analysis in scale testing, we have found that `pool.up()` can take on the order of 2 seconds in extremely stressed systems. This kind of number shouldn't be normal, but it is something that occupies time in the main dispatcher process and increases the time taken to process and run a task.

This introduces a new constraint that we don't scale down workers until it has been over 60 seconds since the worker completed its last task. This assures that during temporary churn (scheduled tasks), some idle workers are kept around so scaling up isn't necessary before starting a task.

In practice, it can take significantly longer than this because work allocation is random. This seems okay to me for now.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
How to see this behavior:

 - create a JT that sleeps for a few minutes, allow concurrent jobs
 - increase the log level of the "scaling" up and down logs so you can see them
 - create a workflow with about 5 root nodes from that JT, corresponding to the min_workers number
 - launch it

In devel, you see a constant flurry of scaling up and down in this scenario.

With this patch, we only scale up workers when starting, and aside from very occasional noise, don't have any scaling up or down events until the workflow finishes.

The noise is due to the system periodic tasks, which come and go by design. With this, we will effectively keep around spare workers so that we don't generally have to scale up a worker to run those periodic tasks. The idea here is to reduce the amount of _unrelated_ heavy work the system has to do while running resource intensive playbooks. Scaling up a worker will consume many 100s of addition MBs of memory, so we can avoid that here.
