### PR TITLE
Add a graph to show database connections being used

### DIFF
--- a/tools/grafana/dashboards/demo_dashboard.json
+++ b/tools/grafana/dashboards/demo_dashboard.json
@@ -363,6 +363,95 @@
       ],
       "title": "job status",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "awx_database_connections_total",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Database",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",


### PR DESCRIPTION
##### SUMMARY
Followup from https://github.com/ansible/awx/pull/12427

Adds a graph of database connections to the dev environment preloaded dashboard.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION
Testing that this works:

```
docker volume rm tools_prometheus_storage
docker volume rm tools_grafana_storage
```

...also blew away a bunch of unrelated stuff.

Then restart everything, login and find the graphs. Run a scenario of a bunch of sleep jobs...

this is what we get

![Screenshot from 2022-07-28 13-04-54](https://user-images.githubusercontent.com/1385596/181596405-0dc79e8e-3efe-4e45-89b3-3b4835cbe367.png)

Ping @jainnikhil30 because I can't directly request a review.
