### PR TITLE
[task_manager_refactor] Optimize task manager with debug toolbar, adjust prefetch

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -92,7 +92,7 @@ class TaskBase:
             .exclude(launch_type='sync')
             .exclude(polymorphic_ctype_id=wf_approval_ctype_id)
             .order_by('created')
-            .prefetch_related('instance_group')
+            .prefetch_related('dependent_jobs')
         )
         self.all_tasks = [t for t in qs]
 


### PR DESCRIPTION
##### SUMMARY
I turned on the debug toolbar and visited

https://localhost:8043/api/debug/task_manager/

This patch basically changes what that tells me to change.

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION

Scenario:
 - create an empty instance group
 - create a JT and associate that IG
 - launch a bunch of jobs, like 100, they all stay in pending


some data...

from the metrics endpoint, before:

```
task_manager_get_tasks_seconds{node="awx_1"} 0.03567666403250769
task_manager_start_task_seconds{node="awx_1"} 0.0
task_manager_process_running_tasks_seconds{node="awx_1"} 9.110081009566784e-07
task_manager_process_pending_tasks_seconds{node="awx_1"} 0.1499260279815644
task_manager__schedule_seconds{node="awx_1"} 0.21376737294485793
```


after:

```
task_manager_get_tasks_seconds{node="awx_1"} 0.04179912700783461
task_manager_start_task_seconds{node="awx_1"} 0.0
task_manager_process_running_tasks_seconds{node="awx_1"} 1.034000888466835e-06
task_manager_process_pending_tasks_seconds{node="awx_1"} 0.022089578968007118
task_manager__schedule_seconds{node="awx_1"} 0.0897223959909752
```

endpoint data, before:
	134 queries
	61.68 ms

with fix:
	35 queries
	23 ms