### PR TITLE
Use in-memory data structures to correctly reap orphaned tasks

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -20,7 +20,6 @@ from django.contrib.contenttypes.models import ContentType
 # AWX
 from awx.main.dispatch.reaper import reap_job
 from awx.main.models import (
-    Instance,
     InventorySource,
     InventoryUpdate,
     Job,
@@ -692,16 +691,26 @@ class TaskManager(TaskBase):
         logger.debug("{} couldn't be scheduled on graph, waiting for next cycle".format(task.log_format))
 
     def reap_jobs_from_orphaned_instances(self):
-        # discover jobs that are in running state but aren't on an execution node
-        # that we know about; this is a fairly rare event, but it can occur if you,
-        # for example, SQL backup an awx install with running jobs and restore it
-        # elsewhere
-        for j in UnifiedJob.objects.filter(
-            status__in=['pending', 'waiting', 'running'],
-        ).exclude(execution_node__in=Instance.objects.exclude(node_type='hop').values_list('hostname', flat=True)):
-            if j.execution_node and not j.is_container_group_task:
-                logger.error(f'{j.execution_node} is not a registered instance; reaping {j.log_format}')
-                reap_job(j, 'failed')
+        # discover jobs that are in running state but have an unregistered controller node, execution node, or container group
+        # that we know about; it can occur if a running OCP node misses heartbeat and gets deleted,
+        # or, SQL backup an awx install with running jobs and restore it elsewhere
+
+        # TODO: after merging other resillency changes, add job_explanation to all these cases
+        for task in self.all_tasks:
+            if task.controller_node:
+                if task.controller_node not in self.instances:
+                    self.all_tasks.remove(task)
+                    reap_job(task, 'failed')
+
+            if task.execution_node:
+                if task.execution_node not in self.instances:
+                    self.all_tasks.remove(task)
+                    reap_job(task, 'failed')
+            elif task.instance_group_id:
+                # for container group jobs
+                if task.instance_group_id not in self.instance_groups.pk_ig_map:
+                    self.all_tasks.remove(task)
+                    reap_job(task, 'failed')
 
     def process_tasks(self):
         running_tasks = [t for t in self.all_tasks if t.status in ['waiting', 'running']]

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -694,17 +694,15 @@ class TaskManager(TaskBase):
         # discover jobs that are in running state but have an unregistered controller node or execution node
         # that we know about; it can occur if a running OCP node misses heartbeat and gets deleted,
         # or, SQL backup an awx install with running jobs and restore it elsewhere
-
-        # TODO: after merging other resillency changes, add job_explanation to all these cases
         for task in self.all_tasks:
             if task.controller_node:
-                if task.controller_node not in self.instances:
+                if (task.controller_node not in self.instances) and (task.controller_node not in self.instances.all_hostnames):
                     self.all_tasks.remove(task)
                     reap_job(task, 'failed', job_explanation=f'The controller node for this task, {task.controller_node}, has been deleted.')
                     continue
 
             if task.execution_node:
-                if task.execution_node not in self.instances:
+                if (task.execution_node not in self.instances) and (task.controller_node not in self.instances.all_hostnames):
                     self.all_tasks.remove(task)
                     reap_job(task, 'failed', job_explanation=f'The execution node for this task, {task.execution_node}, has been deleted.')
                     continue

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -691,7 +691,7 @@ class TaskManager(TaskBase):
         logger.debug("{} couldn't be scheduled on graph, waiting for next cycle".format(task.log_format))
 
     def reap_jobs_from_orphaned_instances(self):
-        # discover jobs that are in running state but have an unregistered controller node, execution node, or container group
+        # discover jobs that are in running state but have an unregistered controller node or execution node
         # that we know about; it can occur if a running OCP node misses heartbeat and gets deleted,
         # or, SQL backup an awx install with running jobs and restore it elsewhere
 
@@ -700,17 +700,14 @@ class TaskManager(TaskBase):
             if task.controller_node:
                 if task.controller_node not in self.instances:
                     self.all_tasks.remove(task)
-                    reap_job(task, 'failed')
+                    reap_job(task, 'failed', job_explanation=f'The controller node for this task, {task.controller_node}, has been deleted.')
+                    continue
 
             if task.execution_node:
                 if task.execution_node not in self.instances:
                     self.all_tasks.remove(task)
-                    reap_job(task, 'failed')
-            elif task.instance_group_id:
-                # for container group jobs
-                if task.instance_group_id not in self.instance_groups.pk_ig_map:
-                    self.all_tasks.remove(task)
-                    reap_job(task, 'failed')
+                    reap_job(task, 'failed', job_explanation=f'The execution node for this task, {task.execution_node}, has been deleted.')
+                    continue
 
     def process_tasks(self):
         running_tasks = [t for t in self.all_tasks if t.status in ['waiting', 'running']]

--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -3,6 +3,7 @@
 import logging
 
 from django.conf import settings
+from django.utils.functional import cached_property
 
 from awx.main.models import (
     Instance,
@@ -59,6 +60,14 @@ class TaskManagerInstances:
 
     def __contains__(self, hostname):
         return hostname in self.instances_by_hostname
+
+    @cached_property
+    def all_hostnames(self):
+        """
+        This is a somewhat-cheap way to access the full list of hostnames, including the dead or disabled instances
+        the main instance list does not include these, because they will not accept new jobs
+        """
+        return list(Instance.objects.values_list('hostname', flat=True))
 
 
 class TaskManagerInstanceGroups:


### PR DESCRIPTION
##### SUMMARY
This is very much a WIP, because to complete it, we need a good deal of other things to merge first.

I believe this will help a lot to avoid some real reports from the community that OCP deployments can leave jobs stuck in running/waiting forever. Our reaper just wasn't working because it didn't account for the current job types that we support (like execution node jobs, container group jobs). I'm pretty happy with this overall structure.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION
My single hesitation here is that running/waiting jobs with a cached `task_impact` may not be something that we want to fetch forever. Capacities could be calculated with a Django annotation instead. In that case, we would need a different kind of hook to run this logic. We may have 2 different loops in different places, one for pending jobs and another for running/waiting. Even if we go this route, we should have _correct_ reaping logic, which I think this offers.
