### PR TITLE
update workflow module for schema node creation to look for type when finding unified job template

### DIFF
--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -261,7 +261,7 @@ options:
             type:
               description:
                 - Name of unified job template type to run in the workflow.
-                - Can be a job_template, project, inventory_source, system_job, workflow_approval, workflow_job_template.
+                - Can be a job_template, project, inventory_source, system_job_template, workflow_approval, workflow_job_template.
               type: str
             timeout:
               description:
@@ -489,6 +489,7 @@ def create_workflow_nodes(module, response, workflow_nodes, workflow_id):
         if workflow_node['unified_job_template']['name']:
             if workflow_node['unified_job_template']['type'] is None:
                 module.fail_json(msg='Could not find unified job template type in workflow_nodes {1}'.format(workflow_node))
+            search_fields['type'] = workflow_node['unified_job_template']['type']
             if workflow_node['unified_job_template']['type'] == 'inventory_source':
                 if 'inventory' in workflow_node['unified_job_template']:
                     if 'organization' in workflow_node['unified_job_template']['inventory']:

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -110,6 +110,20 @@
         that:
           - "result is changed"
 
+    - name: Create a 3rd Demo Project in another org with inventory source name
+      project:
+        name: "{{ project_inv_source }}"
+        organization: "{{ org_name }}"
+        state: present
+        scm_type: git
+        scm_url: https://github.com/ansible/ansible-tower-samples.git
+        scm_credential: "{{ scm_cred_name }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
     - name: Add an inventory
       inventory:
         description: Test inventory
@@ -573,8 +587,8 @@
           - identifier: node202
             unified_job_template:
               organization:
-                name: Default
-              name: "{{ demo_project_name }}"
+                name: "{{ org_name }}"
+              name: "{{ project_inv_source }}"
               type: project
           - all_parents_must_converge: false
             identifier: node301
@@ -586,7 +600,7 @@
           - identifier: Cleanup Job
             unified_job_template:
               name: Cleanup Activity Stream
-              type: system_job
+              type: system_job_template
       register: result
 
     - assert:
@@ -754,6 +768,16 @@
     - name: Delete the 2nd Demo Project
       project:
         name: "{{ demo_project_name_2 }}"
+        organization: "{{ org_name }}"
+        scm_type: git
+        scm_url: https://github.com/ansible/ansible-tower-samples.git
+        scm_credential: "{{ scm_cred_name }}"
+        state: absent
+      ignore_errors: True
+
+    - name: Delete the 3rd Demo Project
+      project:
+        name: "{{ project_inv_source }}"
         organization: "{{ org_name }}"
         scm_type: git
         scm_url: https://github.com/ansible/ansible-tower-samples.git


### PR DESCRIPTION
##### SUMMARY
Fix the workflow job template collection module to account for unified job template type when searching since it is a required field.
#12596

Also fixed docs and test as it had the wrong system job type name as an example.

##### ISSUE TYPE
 - Bug or Docs Fix

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
21.3.0
```
