### PR TITLE
Update role module to provide better error message when an object does not exist

### DIFF
--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -241,6 +241,7 @@ def main():
     # Lookup actor data
     # separate actors from resources
     actor_data = {}
+    missing_items = []
     for key in ('user', 'team'):
         if key in resources:
             if key == 'user':
@@ -248,9 +249,14 @@ def main():
             else:
                 lookup_data_populated = lookup_data
             # Attempt to look up project based on the provided name or ID and lookup data
-            actor_data[key] = module.get_one('{0}s'.format(key), name_or_id=resources[key], data=lookup_data_populated)
-            resources.pop(key)
-
+            data = module.get_one('{0}s'.format(key), name_or_id=resources[key], data=lookup_data_populated)
+            if data is None:
+                module.fail_json(
+                    msg='Unable to find {0} with name: {1}'.format(key, resources[key]), changed=False
+                )
+            else:
+                actor_data[key] = module.get_one('{0}s'.format(key), name_or_id=resources[key], data=lookup_data_populated)
+                resources.pop(key)
     # Lookup Resources
     resource_data = {}
     for key, value in resources.items():
@@ -261,9 +267,15 @@ def main():
                     lookup_data_populated = {}
                 else:
                     lookup_data_populated = lookup_data
-
-            resource_data.setdefault(key, []).append(module.get_one(key, name_or_id=resource, data=lookup_data_populated))
-
+            data = module.get_one(key, name_or_id=resource, data=lookup_data_populated)
+            if data is None:
+                missing_items.append(resource)
+            else:
+                resource_data.setdefault(key, []).append(data)
+    if len(missing_items) > 0:
+        module.fail_json(
+            msg='There were {0} missing items, missing items: {1}'.format(len(missing_items), missing_items), changed=False
+        )
     # build association agenda
     associations = {}
     for actor_type, actor in actor_data.items():

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -121,6 +121,22 @@
         that:
           - "result is changed"
 
+    - name: Add Joe to nonexistant job template execute role
+      role:
+        user: "{{ username }}"
+        role: execute
+        workflow: test-role-workflow
+        job_templates:
+          - non existant temp
+        state: present
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - "'There were 1 missing items, missing items' in result.msg"
+          - "'non existant temp' in result.msg"
+
     - name: Add Joe to workflow execute role, no-op
       role:
         user: "{{ username }}"


### PR DESCRIPTION
##### SUMMARY
Currently if the role plugin fails to find an object to assign a role to, it fails with a python error. If you are submitting for a team and 100 job templates and workflows, this is nigh unworkable to find out which one is missing. This should be fixed.

Follows up issue  #12598

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
 
##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
21.3.0
```

