### PR TITLE
Restrict files that trigger a reload

### DIFF
--- a/tools/docker-compose/awx-autoreload
+++ b/tools/docker-compose/awx-autoreload
@@ -11,7 +11,7 @@ last_reload=`date +%s`
 inotifywait -mrq -e create,delete,attrib,close_write,move --exclude '(/awx_devel/awx/ui|/awx_devel/awx/.*/tests)' $1 | while read directory action file; do
    this_reload=`date +%s`
    since_last=$((this_reload-last_reload))
-   if [[ "$file" =~ .*py$ ]] && [[ "$since_last" -gt 1 ]]; then
+   if [[ "$file" =~ ^[^.].*\.py$ ]] && [[ "$since_last" -gt 1 ]]; then
       echo "File changed: $file"
       echo "Running command: $2"
       eval $2


### PR DESCRIPTION
##### SUMMARY
Restrict files that trigger a reload to files explicitly ending in '.py' that do not start with a dot.
This will avoid Emacs lockfiles from triggering the restart.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION

old style:
```
$ file='.#serializers.py'
$ if [[ "$file" =~ .*py$ ]]; then echo "true"; else echo "false"; fi
true
```

new style:
```
$ file='.#serializers.py'
$ if [[ "$file" =~ ^[^.].*\.py$ ]]; then echo "true"; else echo "false"; fi
false
[jrb@fedora awx]$ file2=foo.py
[jrb@fedora awx]$ if [[ "$file2" =~ ^[^.].*\.py$ ]]; then echo "true"; else echo "false"; fi
true
```
