### PR TITLE
Inherit from our own APIView, not rest framework

### DIFF
--- a/awx/api/views/debug.py
+++ b/awx/api/views/debug.py
@@ -4,7 +4,7 @@ from django.conf import settings
 
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
-from rest_framework.views import APIView
+from awx.api.generics import APIView
 
 from awx.main.scheduler import TaskManager, DependencyManager, WorkflowManager
 


### PR DESCRIPTION
##### SUMMARY
This seems to be causing the schema generator to fail. Because these new views went too far up the inheritance chain, into DRF, it didn't have the expected properties that we put into our base views. This also applies the standard headers that responses from other views will have.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

