### PR TITLE
Fixed a bug where the initial form value of verbosity isn't respected

### DIFF
--- a/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { t } from '@lingui/macro';
 import { withFormik, useFormikContext } from 'formik';
 import PropTypes from 'prop-types';
-
-import { VERBOSITY } from 'components/VerbositySelectField';
 import Wizard from '../Wizard';
 import useAdHocLaunchSteps from './useAdHocLaunchSteps';
 
@@ -62,7 +60,7 @@ const FormikApp = withFormik({
       limit: adHocItemStrings || 'all',
       credentials: [],
       module_args: '',
-      verbosity: VERBOSITY()[0].value,
+      verbosity: 0,
       forks: 0,
       diff_mode: false,
       become_enabled: '',

--- a/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCommandsWizard.js
@@ -62,7 +62,7 @@ const FormikApp = withFormik({
       limit: adHocItemStrings || 'all',
       credentials: [],
       module_args: '',
-      verbosity: VERBOSITY()[0],
+      verbosity: VERBOSITY()[0].value,
       forks: 0,
       diff_mode: false,
       become_enabled: '',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It looks like https://github.com/ansible/awx/pull/12378/commits/ef8d4e73ae08b6ea10c495db28d9ede0ddb8a114 from PR https://github.com/ansible/awx/pull/12378 removed this reference to `.value`. I don't fully understand the implications of the commit but putting this value reference back in allows the form to work in it's default state again.  This would seem to fix https://github.com/ansible/awx/issues/12575
<!--- 
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.4.1.dev50+g1ae1da3f9c
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This is currently broken on the latest AWX release 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
