### PR TITLE
Fix job canceling when getting stuck reading or writing receptor socket

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -535,8 +535,6 @@ class BaseTask(object):
             else:
                 receptor_job = AWXReceptorJob(self, params)
                 res = receptor_job.run()
-                self.unit_id = receptor_job.unit_id
-
                 if not res:
                     return
 


### PR DESCRIPTION
##### SUMMARY
On a recent customer case they reported not being able to cancel a running job. After looking at the code, there were 2 additional places (`submit_work` and `get_work_results`) where it is possible to get stuck on a read or write with the receptor socket. This patch introduces a new pattern that will allow us to eject whenever we might be stuck.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
