### PR TITLE
add ADMIN_PASSWORD env var for `make docker-compose`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,8 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e enable_ldap=$(LDAP) \
 	    -e enable_splunk=$(SPLUNK) \
 	    -e enable_prometheus=$(PROMETHEUS) \
-	    -e enable_grafana=$(GRAFANA)
+	    -e enable_grafana=$(GRAFANA) \
+	    -e admin_password=$(ADMIN_PASSWORD)
 
 
 docker-compose: awx/projects docker-compose-sources

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -21,6 +21,7 @@ services:
       RECEPTORCTL_SOCKET: {{ receptor_socket_file }}
       CONTROL_PLANE_NODE_COUNT: {{ control_plane_node_count|int }}
       EXECUTION_NODE_COUNT: {{ execution_node_count|int }}
+      ADMIN_PASSWORD: {{ admin_password }}
 {% if loop.index == 1 %}
       RUN_MIGRATIONS: 1
 {% endif %}

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -21,7 +21,10 @@ fi
 
 if output=$(awx-manage createsuperuser --noinput --username=admin --email=admin@localhost 2> /dev/null); then
     echo $output
-    admin_password=$(openssl rand -base64 12)
+    admin_password=$ADMIN_PASSWORD
+    if [[ -z "$ADMIN_PASSWORD" ]]; then
+        admin_password=$(openssl rand -base64 12)
+    fi
     echo "Admin password: ${admin_password}"
     awx-manage update_password --username=admin --password=${admin_password}
 fi


### PR DESCRIPTION
Signed-off-by: Hao Liu <haoli@redhat.com>

##### SUMMARY
add `ADMIN_PASSWORD` environment variable for `make docker-compose` target to allow user to specify a default admin password when deploying awx development environment using `make docker-compose`

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.4.1.dev58+g664d9bd6d9
```


##### ADDITIONAL INFORMATION
build procedure for the PR:
- build new awx_devel image 
```bash
export DEV_DOCKER_TAG_BASE=<your image registry, example `quay.io/haoliu`>
make docker-compose-build
docker push $DEV_DOCKER_TAG_BASE/awx_devel:$COMPOSE_TAG
```

test scenario 1: with no ADMIN_PASSWORD env var set a random password is generated
```bash
make docker-clean-volumes
export DEV_DOCKER_TAG_BASE=<your image registry, example `quay.io/haoliu`>
unset ADMIN_PASSWORD
make docker-compose
```
- validate random password is generated 
```
...
tools_awx_1     |   Applying sso.0003_convert_saml_string_to_list... OK
tools_awx_1     |   Applying taggit.0004_alter_taggeditem_content_type_alter_taggeditem_tag... OK
tools_awx_1     | Superuser created successfully.
tools_awx_1     | Admin password: Xf3Oc5JB9L0/kNSw
...
```


test scenario 2: with ADMIN_PASSWORD env var set a admin password is set to the value of the env var
```bash
make docker-clean-volumes
export DEV_DOCKER_TAG_BASE=<your image registry, example `quay.io/haoliu`>
export ADMIN_PASSWORD=yolo
make docker-compose
```
- validate admin password is set to the `yolo`
```
tools_awx_1     |   Applying sso.0003_convert_saml_string_to_list... OK
tools_awx_1     |   Applying taggit.0004_alter_taggeditem_content_type_alter_taggeditem_tag... OK
tools_awx_1     | Superuser created successfully.
tools_awx_1     | Admin password: yolo
```
- validate able to login to awx with the password
