### PR TITLE
Remove an old metrics field and add a new one to dashboard

### DIFF
--- a/tools/grafana/dashboards/demo_dashboard.json
+++ b/tools/grafana/dashboards/demo_dashboard.json
@@ -244,18 +244,6 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "task_manager_generate_dependencies_seconds",
-          "hide": false,
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "editorMode": "builder",
           "expr": "task_manager_get_tasks_seconds",
           "hide": false,
           "legendFormat": "__auto",
@@ -268,7 +256,19 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "task_manager_spawn_workflow_graph_jobs_seconds",
+          "expr": "task_manager_commit_seconds",
+          "hide": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "task_manager__schedule_seconds",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,


### PR DESCRIPTION
##### SUMMARY
This is from just starting up and using the dashboard. Change summarized:

 - the metric `task_manager_generate_dependencies_seconds` has been removed, so it is removed here
 - `task_manager_spawn_workflow_graph_jobs_seconds` was also removed
 - the metric `task_manager__schedule_seconds` was in the metrics, but not in the dashboard, so it is added here
 - I thought I already added `task_manager_commit_seconds`, but maybe I failed to save it? Trying to fix that here.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
