### PR TITLE
Avoid dependency manager for jobs with no deps

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -600,6 +600,19 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
     def get_ui_url(self):
         return urljoin(settings.TOWER_URL_BASE, "/#/jobs/playbook/{}".format(self.pk))
 
+    def _set_default_dependencies_processed(self):
+        """
+        This sets the initial value of dependencies_processed
+        and here we use this as a shortcut to avoid the DependencyManager for jobs that do not need it
+        """
+        if (not self.project) or self.project.scm_update_on_launch:
+            self.dependencies_processed = False
+        elif (not self.inventory) or self.inventory.inventory_sources.filter(update_on_launch=True).exists():
+            self.dependencies_processed = False
+        else:
+            # No dependencies to process
+            self.dependencies_processed = True
+
     @property
     def event_class(self):
         if self.has_unpartitioned_events:


### PR DESCRIPTION
##### SUMMARY
This is motivated by comments I remember that @rebeccahhh made in the final review of @fosterseth's task manager refactor.

The time from hitting the launch button until the ansible-playbook subprocess starts seems to have increased marginally, depending on the scenario. When I looked at other scenarios with devel, I found that jobs were going through both the dependency manager and the task manager.

I have several other PRs that are trying to avoid delays from a pg_notify NOTIFY action to the worker process running the code. That should help with the round-trip efficiency scheduling a task, running, and scheduling a new task.

But for jobs, we should still try to reduce the number of tasks in the lifecycle. This fast-tracks jobs like the stock Demo Job Template, meaning that the related project / inventory has no update-on-launch.

My evaluation is that this should increase query count on creation by 1 - the `.exists()` on inventory sources. The project and inventory should already be in memory (it'd be crazy if they weren't, right?)

The cost of 1 additional query should compare favorably to the benefit of fast-tracking here. All evidence suggests that, with this change, we should _always_ be faster to run jobs than before, even small jobs ran on a quiet system.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API



##### ADDITIONAL INFORMATION

![Screenshot from 2022-08-17 08-52-48](https://user-images.githubusercontent.com/1385596/185139916-ed88f7b9-f5d4-40d8-8f67-7870a02eda2d.png)

You can see here that the dependency manager timings are pretty constant, because I'm only launching fast-tracked jobs. Dependency manager is not doing any work in the timeline here.
