### PR TITLE
Fix errors in websocket code due to missing template

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1289,7 +1289,8 @@ class UnifiedJob(
 
             if self.spawned_by_workflow:
                 status_data['group_name'] = "workflow_events"
-                status_data['workflow_job_template_id'] = self.unified_job_template.id
+                if self.workflow_job:
+                    status_data['workflow_job_template_id'] = self.workflow_job.workflow_job_template_id
                 emit_channel_notification('workflow_events-' + str(self.workflow_job_id), status_data)
         except IOError:  # includes socket errors
             logger.exception('%s failed to emit channel msg about status change', self.log_format)


### PR DESCRIPTION
##### SUMMARY
In our full test runs, we have 9 errors from this:

```
2022-08-18 15:20:47,150 ERROR    [9a3cb6f5e884486a8e25e4e96fccf81e] awx.main.dispatch Worker failed to run task awx.main.tasks.jobs.RunJob(*[3042], **{}
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/dispatch/worker/task.py", line 102, in perform_work
    result = self.run_callable(body)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/dispatch/worker/task.py", line 77, in run_callable
    return _call(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/jobs.py", line 90, in _wrapped
    return f(self, *args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/signals.py", line 58, in _wrapped
    return f(*args, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/jobs.py", line 654, in run
    self.instance.websocket_emit_status(status)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/models/unified_jobs.py", line 1298, in websocket_emit_status
    connection.on_commit(lambda: self._websocket_emit_status(status))
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/base/base.py", line 645, in on_commit
    func()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/models/unified_jobs.py", line 1298, in <lambda>
    connection.on_commit(lambda: self._websocket_emit_status(status))
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/models/unified_jobs.py", line 1292, in _websocket_emit_status
    status_data['workflow_job_template_id'] = self.unified_job_template.id
AttributeError: 'NoneType' object has no attribute 'id'
```

This is because of deletion cascades that happen while jobs are running. We have a null `unified_job_template` in that case.

But looking at this field, the entire thing didn't make any sense. I also can't find any place where the UI even uses this channel, `workflow_events-N`.

But I really just want to stop these errors.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

