### PR TITLE
Shortcut Instance.objects.me when possible

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -166,11 +166,7 @@ class Metrics:
         elif settings.IS_TESTING():
             self.instance_name = "awx_testing"
         else:
-            try:
-                self.instance_name = Instance.objects.me().hostname
-            except Exception as e:
-                self.instance_name = settings.CLUSTER_HOST_ID
-                logger.info(f'Instance {self.instance_name} seems to be unregistered, error: {e}')
+            self.instance_name = Instance.objects.my_hostname()
 
         # metric name, help_text
         METRICSLIST = [

--- a/awx/main/management/commands/run_wsbroadcast.py
+++ b/awx/main/management/commands/run_wsbroadcast.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
         return lines
 
     @classmethod
-    def get_connection_status(cls, me, hostnames, data):
+    def get_connection_status(cls, hostnames, data):
         host_stats = [('hostname', 'state', 'start time', 'duration (sec)')]
         for h in hostnames:
             connection_color = '91'  # red
@@ -78,7 +78,7 @@ class Command(BaseCommand):
         return host_stats
 
     @classmethod
-    def get_connection_stats(cls, me, hostnames, data):
+    def get_connection_stats(cls, hostnames, data):
         host_stats = [('hostname', 'total', 'per minute')]
         for h in hostnames:
             h_safe = safe_name(h)
@@ -119,8 +119,8 @@ class Command(BaseCommand):
             return
 
         try:
-            me = Instance.objects.me()
-            logger.info('Active instance with hostname {} is registered.'.format(me.hostname))
+            my_hostname = Instance.objects.my_hostname()
+            logger.info('Active instance with hostname {} is registered.'.format(my_hostname))
         except RuntimeError as e:
             # the CLUSTER_HOST_ID in the task, and web instance must match and
             # ensure network connectivity between the task and web instance
@@ -145,19 +145,19 @@ class Command(BaseCommand):
                 else:
                     data[family.name] = family.samples[0].value
 
-            me = Instance.objects.me()
-            hostnames = [i.hostname for i in Instance.objects.exclude(hostname=me.hostname)]
+            my_hostname = Instance.objects.my_hostname()
+            hostnames = [i.hostname for i in Instance.objects.exclude(hostname=my_hostname)]
 
-            host_stats = Command.get_connection_status(me, hostnames, data)
+            host_stats = Command.get_connection_status(hostnames, data)
             lines = Command._format_lines(host_stats)
 
-            print(f'Broadcast websocket connection status from "{me.hostname}" to:')
+            print(f'Broadcast websocket connection status from "{my_hostname}" to:')
             print('\n'.join(lines))
 
-            host_stats = Command.get_connection_stats(me, hostnames, data)
+            host_stats = Command.get_connection_stats(hostnames, data)
             lines = Command._format_lines(host_stats)
 
-            print(f'\nBroadcast websocket connection stats from "{me.hostname}" to:')
+            print(f'\nBroadcast websocket connection stats from "{my_hostname}" to:')
             print('\n'.join(lines))
 
             return

--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -99,9 +99,12 @@ class InstanceManager(models.Manager):
     instance or role.
     """
 
+    def my_hostname(self):
+        return settings.CLUSTER_HOST_ID
+
     def me(self):
         """Return the currently active instance."""
-        node = self.filter(hostname=settings.CLUSTER_HOST_ID)
+        node = self.filter(hostname=self.my_hostname())
         if node.exists():
             return node[0]
         raise RuntimeError("No instance found with the current cluster host id")

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -700,7 +700,7 @@ class SourceControlMixin(BaseTask):
 
     def spawn_project_sync(self, project, sync_needs, scm_branch=None):
         pu_ig = self.instance.instance_group
-        pu_en = Instance.objects.me().hostname
+        pu_en = Instance.objects.my_hostname()
 
         sync_metafields = dict(
             launch_type="sync",

--- a/awx/main/wsbroadcast.py
+++ b/awx/main/wsbroadcast.py
@@ -35,7 +35,7 @@ def unwrap_broadcast_msg(payload: dict):
 def get_broadcast_hosts():
     Instance = apps.get_model('main', 'Instance')
     instances = (
-        Instance.objects.exclude(hostname=Instance.objects.me().hostname)
+        Instance.objects.exclude(hostname=Instance.objects.my_hostname())
         .exclude(node_type='execution')
         .exclude(node_type='hop')
         .order_by('hostname')
@@ -47,7 +47,7 @@ def get_broadcast_hosts():
 
 def get_local_host():
     Instance = apps.get_model('main', 'Instance')
-    return Instance.objects.me().hostname
+    return Instance.objects.my_hostname()
 
 
 class WebsocketTask:


### PR DESCRIPTION
##### SUMMARY
The only time we actually need to get the instance record for the local node is when we're doing something with capacity. Otherwise, generally, services shouldn't require any information from that to function correctly. The only thing required is that the installer sets up the CLUSTER_HOST_ID setting, which happens much earlier and is much more static and reliable.

Cases of `Instance.objects.me().hostname` don't make any sense to me at all. So I want to look into whether there are any ill-effects from this, and if not, I don't see what is keeping us from using the simpler and less error-prone approach.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

