### PR TITLE
[ui] make signature cred. field be project-global

### DIFF
--- a/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
+++ b/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
@@ -22,15 +22,13 @@ function ProjectAdd() {
     } else if (typeof values.credential.id === 'number') {
       values.credential = values.credential.id;
     }
-    if (values.scm_type === 'git') {
-      if (!values.signature_validation_credential) {
-        values.signature_validation_credential = null;
-      } else if (
-        typeof values.signature_validation_credential.id === 'number'
-      ) {
-        values.signature_validation_credential =
-          values.signature_validation_credential.id;
-      }
+    if (!values.signature_validation_credential) {
+      values.signature_validation_credential = null;
+    } else if (
+      typeof values.signature_validation_credential.id === 'number'
+    ) {
+      values.signature_validation_credential =
+        values.signature_validation_credential.id;
     }
     setFormSubmitError(null);
     try {

--- a/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
+++ b/awx/ui/src/screens/Project/ProjectAdd/ProjectAdd.js
@@ -24,9 +24,7 @@ function ProjectAdd() {
     }
     if (!values.signature_validation_credential) {
       values.signature_validation_credential = null;
-    } else if (
-      typeof values.signature_validation_credential.id === 'number'
-    ) {
+    } else if (typeof values.signature_validation_credential.id === 'number') {
       values.signature_validation_credential =
         values.signature_validation_credential.id;
     }

--- a/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
+++ b/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
@@ -24,9 +24,7 @@ function ProjectEdit({ project }) {
     }
     if (!values.signature_validation_credential) {
       values.signature_validation_credential = null;
-    } else if (
-      typeof values.signature_validation_credential.id === 'number'
-    ) {
+    } else if (typeof values.signature_validation_credential.id === 'number') {
       values.signature_validation_credential =
         values.signature_validation_credential.id;
     }

--- a/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
+++ b/awx/ui/src/screens/Project/ProjectEdit/ProjectEdit.js
@@ -22,15 +22,13 @@ function ProjectEdit({ project }) {
     } else if (typeof values.credential.id === 'number') {
       values.credential = values.credential.id;
     }
-    if (values.scm_type === 'git') {
-      if (!values.signature_validation_credential) {
-        values.signature_validation_credential = null;
-      } else if (
-        typeof values.signature_validation_credential.id === 'number'
-      ) {
-        values.signature_validation_credential =
-          values.signature_validation_credential.id;
-      }
+    if (!values.signature_validation_credential) {
+      values.signature_validation_credential = null;
+    } else if (
+      typeof values.signature_validation_credential.id === 'number'
+    ) {
+      values.signature_validation_credential =
+        values.signature_validation_credential.id;
     }
 
     try {

--- a/awx/ui/src/screens/Project/shared/ProjectForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.js
@@ -183,7 +183,11 @@ function ProjectFormFields({
       setFieldValue('signature_validation_credential', value);
       setFieldTouched('signature_validation_credential', true, false);
     },
-    [handleSignatureValidationCredentialSelection, setFieldValue, setFieldTouched]
+    [
+      handleSignatureValidationCredentialSelection,
+      setFieldValue,
+      setFieldTouched,
+    ]
   );
 
   const handleOrganizationUpdate = useCallback(

--- a/awx/ui/src/screens/Project/shared/ProjectForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.js
@@ -9,6 +9,7 @@ import { useConfig } from 'contexts/Config';
 import AnsibleSelect from 'components/AnsibleSelect';
 import ContentError from 'components/ContentError';
 import ContentLoading from 'components/ContentLoading';
+import CredentialLookup from 'components/Lookup/CredentialLookup';
 import FormActionGroup from 'components/FormActionGroup/FormActionGroup';
 import FormField, { FormSubmitError } from 'components/FormField';
 import OrganizationLookup from 'components/Lookup/OrganizationLookup';
@@ -176,6 +177,15 @@ function ProjectFormFields({
     [signatureValidationCredentials, setSignatureValidationCredentials]
   );
 
+  const handleSignatureValidationCredentialChange = useCallback(
+    (value) => {
+      handleSignatureValidationCredentialSelection('cryptography', value);
+      setFieldValue('signature_validation_credential', value);
+      setFieldTouched('signature_validation_credential', true, false);
+    },
+    [handleSignatureValidationCredentialSelection, setFieldValue, setFieldTouched]
+  );
+
   const handleOrganizationUpdate = useCallback(
     (value) => {
       setFieldValue('organization', value);
@@ -270,6 +280,13 @@ function ProjectFormFields({
           }}
         />
       </FormGroup>
+      <CredentialLookup
+        credentialTypeId={signatureValidationCredentials.cryptography.typeId}
+        label={t`Content Signature Validation Credential`}
+        onChange={handleSignatureValidationCredentialChange}
+        value={signatureValidationCredentials.cryptography.value}
+        tooltip={projectHelpText.signatureValidation}
+      />
       {formik.values.scm_type !== '' && (
         <SubFormLayout>
           <Title size="md" headingLevel="h4">
@@ -288,13 +305,7 @@ function ProjectFormFields({
                 git: (
                   <GitSubForm
                     credential={credentials.scm}
-                    signature_validation_credential={
-                      signatureValidationCredentials.cryptography
-                    }
                     onCredentialSelection={handleCredentialSelection}
-                    onSignatureValidationCredentialSelection={
-                      handleSignatureValidationCredentialSelection
-                    }
                     scmUpdateOnLaunch={formik.values.scm_update_on_launch}
                   />
                 ),

--- a/awx/ui/src/screens/Project/shared/ProjectForm.test.js
+++ b/awx/ui/src/screens/Project/shared/ProjectForm.test.js
@@ -276,14 +276,22 @@ describe('<ProjectForm />', () => {
       1
     );
     await act(async () => {
-      wrapper.find('CredentialLookup').invoke('onBlur')();
-      wrapper.find('CredentialLookup').invoke('onChange')({
+      wrapper
+        .find('CredentialLookup[label="Insights Credential"]')
+        .invoke('onBlur')();
+      wrapper
+        .find('CredentialLookup[label="Insights Credential"]')
+        .invoke('onChange')({
         id: 123,
         name: 'credential',
       });
     });
     wrapper.update();
-    expect(wrapper.find('CredentialLookup').prop('value')).toEqual({
+    expect(
+      wrapper
+        .find('CredentialLookup[label="Insights Credential"]')
+        .prop('value')
+    ).toEqual({
       id: 123,
       name: 'credential',
     });

--- a/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
@@ -1,8 +1,6 @@
 import 'styled-components/macro';
-import React, { useCallback } from 'react';
+import React from 'react';
 import { t } from '@lingui/macro';
-import { useFormikContext } from 'formik';
-import CredentialLookup from 'components/Lookup/CredentialLookup';
 import FormField from 'components/FormField';
 import getDocsBaseUrl from 'util/getDocsBaseUrl';
 import { useConfig } from 'contexts/Config';
@@ -18,21 +16,9 @@ import projectHelpStrings from '../Project.helptext';
 
 const GitSubForm = ({
   credential,
-  signature_validation_credential,
   onCredentialSelection,
-  onSignatureValidationCredentialSelection,
   scmUpdateOnLaunch,
 }) => {
-  const { setFieldValue, setFieldTouched } = useFormikContext();
-
-  const onCredentialChange = useCallback(
-    (value) => {
-      onSignatureValidationCredentialSelection('cryptography', value);
-      setFieldValue('signature_validation_credential', value);
-      setFieldTouched('signature_validation_credential', true, false);
-    },
-    [onSignatureValidationCredentialSelection, setFieldValue, setFieldTouched]
-  );
 
   const docsURL = `${getDocsBaseUrl(
     useConfig()
@@ -49,13 +35,6 @@ const GitSubForm = ({
         type="text"
         tooltipMaxWidth="400px"
         tooltip={projectHelpStrings.sourceControlRefspec(docsURL)}
-      />
-      <CredentialLookup
-        credentialTypeId={signature_validation_credential.typeId}
-        label={t`Content Signature Validation Credential`}
-        onChange={onCredentialChange}
-        value={signature_validation_credential.value}
-        tooltip={projectHelpStrings.signatureValidation}
       />
       <ScmCredentialFormField
         credential={credential}

--- a/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
+++ b/awx/ui/src/screens/Project/shared/ProjectSubForms/GitSubForm.js
@@ -19,7 +19,6 @@ const GitSubForm = ({
   onCredentialSelection,
   scmUpdateOnLaunch,
 }) => {
-
   const docsURL = `${getDocsBaseUrl(
     useConfig()
   )}/html/userguide/projects.html#manage-playbooks-using-source-control`;


### PR DESCRIPTION
##### SUMMARY

Rather than only allowing the signature credential to be specified on
project using git, allow it to be specified on any project at all.

This moves the field to always show, and moves it out of the git
subform.

Signed-off-by: Rick Elrod <rick@elrod.me>

Fixes #12691 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

