### PR TITLE
Gracefully handle receptor and redis errors

### DIFF
--- a/awx/main/exceptions.py
+++ b/awx/main/exceptions.py
@@ -38,5 +38,21 @@ class PostRunError(Exception):
         super(PostRunError, self).__init__(msg)
 
 
-class ReceptorNodeNotFound(RuntimeError):
+class ReceptorServiceError(RuntimeError):
+    pass
+
+
+class ReceptorNodeNotFound(ReceptorServiceError):
+    pass
+
+
+class ReceptorNotConfigured(ReceptorServiceError):
+    pass
+
+
+class ReceptorConnectionRefusedError(ReceptorServiceError):
+    pass
+
+
+class ReceptorSocketMissing(ReceptorServiceError):
     pass

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -18,7 +18,7 @@ import ansible_runner
 
 # AWX
 from awx.main.utils.execution_environments import get_default_pod_spec
-from awx.main.exceptions import ReceptorNodeNotFound
+from awx.main.exceptions import ReceptorNodeNotFound, ReceptorNotConfigured, ReceptorConnectionRefusedError, ReceptorSocketMissing
 from awx.main.utils.common import (
     deepmerge,
     parse_yaml_or_json,
@@ -41,8 +41,12 @@ class ReceptorConnectionType(Enum):
 
 
 def get_receptor_sockfile():
-    with open(__RECEPTOR_CONF, 'r') as f:
-        data = yaml.safe_load(f)
+    try:
+        with open(__RECEPTOR_CONF, 'r') as f:
+            data = yaml.safe_load(f)
+    except FileNotFoundError:
+        raise ReceptorNotConfigured(f'Receptor has not been configured, did not find config at {__RECEPTOR_CONF}')
+
     for section in data:
         for entry_name, entry_data in section.items():
             if entry_name == 'control-service':
@@ -82,6 +86,20 @@ def get_conn_type(node_name, receptor_ctl):
         if node.get('NodeID') == node_name:
             return ReceptorConnectionType(node.get('ConnType'))
     raise ReceptorNodeNotFound(f'Instance {node_name} is not in the receptor mesh')
+
+
+def wrapped_receptor_command(receptor_ctl, command):
+    """
+    Run receptor command and raise any known service exceptions that happen as a result
+    """
+    try:
+        return receptor_ctl.simple_command(command)
+    except ValueError as exc:
+        if 'Socket path does not exist' in str(exc):
+            raise ReceptorSocketMissing(f'Receptor error: {str(exc)}')
+        raise
+    except ConnectionRefusedError as exc:
+        raise ReceptorConnectionRefusedError(f'Could not connect to the receptor service: {str(exc)}')
 
 
 def administrative_workunit_reaper(work_list=None):


### PR DESCRIPTION
##### SUMMARY
This is intended to address two painful logging issues that occur in normal or semi-normal operation.

 - When following the _regular install path_ the dispatcher begins life in a restart loop due to missing the receptor config file
 - If the user restarts the redis service (again, not crazy), we get tracebacks that are 0.01 seconds apart. Having this run for just 17 seconds will consume a large fraction of log files.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
We set a new series of expectations with this.

![Screenshot from 2022-08-19 11-41-04](https://user-images.githubusercontent.com/1385596/185660124-11549b5c-3d1c-478a-9712-e991edaa73f3.png)

I hope this is pretty self-obvious, and if this is how a cluster starts off life, then that's cool with me. Respond to requests, run system tasks, but let me know you're not all the way set up.
