### PR TITLE
Configuring Keycloak to also do OIDC

### DIFF
--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -243,7 +243,7 @@ $ make docker-compose
 - [Using Logstash](./docs/logstash.md)
 - [Start a Cluster](#start-a-cluster)
 - [Start with Minikube](#start-with-minikube)
-- [Keycloak Integration](#keycloak-integration)
+- [SAML and OIDC Integration](#saml-and-oidc-integration)
 - [OpenLDAP Integration](#openldap-integration)
 - [Splunk Integration](#splunk-integration)
 
@@ -317,8 +317,8 @@ If you want to clean all things once your are done, you can do:
 (host)$ make docker-compose-container-group-clean
 ```
 
-### Keycloak Integration
-Keycloak is a SAML provider and can be used to test AWX social auth. This section describes how to build a reference Keycloak instance and plumb it with AWX for testing purposes.
+### SAML and OIDC Integration
+Keycloak can be used as both a SAML and OIDC provider and can be used to test AWX social auth. This section describes how to build a reference Keycloak instance and plumb it with AWX for testing purposes.
 
 First, be sure that you have the awx.awx collection installed by running `make install_collection`.
 Next, make sure you have your containers running by running `make docker-compose`.
@@ -357,13 +357,15 @@ Go ahead and stop your existing docker-compose run and restart with Keycloak bef
 Once the containers come up a new port (8443) should be exposed and the Keycloak interface should be running on that port. Connect to this through a url like `https://localhost:8443` to confirm that Keycloak has stared. If you wanted to login and look at Keycloak itself you could select the "Administration console" link and log into the UI the username/password set in the previous `docker run` command. For more information about Keycloak and links to their documentation see their project at https://github.com/keycloak/keycloak.
 
 Now we are ready to configure and plumb Keycloak with AWX. To do this we have provided a playbook which will:
-* Create a certificate for data exchange between Keycloak and AWX.
-* Create a realm in Keycloak with a client for AWX and 3 users.
-* Backup and configure the SMAL adapter in AWX. NOTE: the private key of any existing SAML adapters can not be backed up through the API, you need a DB backup to recover this.
+* Create a certificate for SAML data exchange between Keycloak and AWX.
+* Create a realm in Keycloak with a client for AWX via SAML and OIDC and 3 users.
+* Backup and configure the SMAL and OIDC adapter in AWX. NOTE: the private key of any existing SAML or OIDC adapters can not be backed up through the API, you need a DB backup to recover this.
 
 Before we can run the playbook we need to understand that SAML works by sending redirects between AWX and Keycloak through the browser. Because of this we have to tell both AWX and Keycloak how they will construct the redirect URLs. On the Keycloak side, this is done within the realm configuration and on the AWX side its done through the SAML settings. The playbook requires a variable called `container_reference` to be set. The container_reference variable needs to be how your browser will be able to talk to the running containers.  Here are some examples of how to choose a proper container_reference.
 * If you develop on a mac which runs a Fedora VM which has AWX running within that and the browser you use to access AWX runs on the mac. The the VM with the container has its own IP that is mapped to a name like `tower.home.net`. In this scenario your "container_reference" could be either the IP of the VM or the tower.home.net friendly name.
 * If you are on a Fedora work station running AWX and also using a browser on your workstation you could use localhost, your work stations IP or hostname as the container_reference.
+
+In addition, OIDC works similar but slightly differently. OIDC has browser redirection but OIDC will also communicate from the AWX docker instance to the Keycloak docker instance directly. Any hostnames you might have are likely not propagated down into the AWX container. So we need a method for both the browser and AWX container to talk to Keycloak. For this we will likely use your machines IP address. This can be passed in as a variable called `oidc_reference`. If unset this will default to container_reference which may be viable for some configurations. 
 
 In addition to container_reference, there are some additional variables which you can override if you need/choose to do so. Here are their names and default values:
 ```yaml
@@ -375,23 +377,27 @@ In addition to container_reference, there are some additional variables which yo
 * keycloak_(user|pass) need to change if you modified the user when starting the initial container above.
 * cert_subject will be the subject line of the certificate shared between AWX and keycloak you can change this if you like or just use the defaults.
 
-To override any of the variables above you can add more `-e` arguments to the playbook run below. For example, if you simply need to change the `keycloak_pass` add the argument `-r keycloak_pass=my_secret_pass` to the next command.
+To override any of the variables above you can add more `-e` arguments to the playbook run below. For example, if you simply need to change the `keycloak_pass` add the argument `-e keycloak_pass=my_secret_pass` to the following ansible-playbook command.
 
-In addition, you may need to override the username or password to get into your AWX instance. We log into AWX in order to read and write the SAML settings. This can be done in several ways because we are using the awx.awx collection. The easiest way is to set environment variables such as `CONTROLLER_USERNAME`. See the awx.awx documentation for more information on setting environment variables. In the example provided below we are showing an example of specifying a username/password for authentication.
+In addition, you may need to override the username or password to get into your AWX instance. We log into AWX in order to read and write the SAML and OIDC settings. This can be done in several ways because we are using the awx.awx collection. The easiest way is to set environment variables such as `CONTROLLER_USERNAME`. See the awx.awx documentation for more information on setting environment variables. In the example provided below we are showing an example of specifying a username/password for authentication.
 
 Now that we have all of our variables covered we can run the playbook like:
 ```bash
 export CONTROLLER_USERNAME=<your username>
 export CONTROLLER_PASSWORD=<your password>
-ansible-playbook tools/docker-compose/ansible/plumb_keycloak.yml -e container_reference=<your container_reference here>
+ansible-playbook tools/docker-compose/ansible/plumb_keycloak.yml -e container_reference=<your container_reference here> -e oidc_reference=<your oidc reference>
 ```
 
-Once the playbook is done running SAML should now be setup in your development environment. This realm has three users with the following username/passwords:
+Once the playbook is done running both SAML and OIDC should now be setup in your development environment. This realm has three users with the following username/passwords:
 1. awx_unpriv:unpriv123
 2. awx_admin:admin123
 3. awx_auditor:audit123
 
-The first account is a normal user. The second account has the attribute is_superuser set in Keycloak so will be a super user in AWX. The third account has the is_system_auditor attribute in Keycloak so it will be a system auditor in AWX. To log in with one of these Keycloak users go to the AWX login screen and click the small "Sign In With SAML Keycloak" button at the bottom of the login box.
+The first account is a normal user. The second account has the SMAL attribute is_superuser set in Keycloak so will be a super user in AWX if logged in through SAML. The third account has the SAML is_system_auditor attribute in Keycloak so it will be a system auditor in AWX if logged in through SAML. To log in with one of these Keycloak users go to the AWX login screen and click the small "Sign In With SAML Keycloak" button at the bottom of the login box.
+
+Note: The OIDC adapter performs authentication only, not authorization. So any user created in AWX will not have any permissions on it at all.
+
+If you Keycloak configuration is not working and you need to rerun the playbook to try a different `container_reference` or `oidc_reference` you can log into the Keycloak admin console on port 8443 and select the AWX realm in the upper left drop down. Then make sure you are on "Ream Settings" in the Configure menu option and click the trash can next to AWX in the main page window pane. This will completely remove the AWX ream (which has both SAML and OIDC settings) enabling you to re-run the plumb playbook.
 
 ### OpenLDAP Integration
 

--- a/tools/docker-compose/ansible/plumb_keycloak.yml
+++ b/tools/docker-compose/ansible/plumb_keycloak.yml
@@ -24,6 +24,8 @@
         public_key_trimmed: "{{ public_key_content | regex_replace('-----BEGIN CERTIFICATE-----\\\\n', '') | regex_replace('\\\\n-----END CERTIFICATE-----', '') }}"
         existing_saml: "{{ lookup('awx.awx.controller_api', 'settings/saml', host=awx_host, verify_ssl=false) }}"
         new_saml: "{{ lookup('template', 'saml_settings.json.j2') }}"
+        existing_oidc: "{{ lookup('awx.awx.controller_api', 'settings/oidc', host=awx_host, verify_ssl=false) }}"
+        new_oidc: "{{ lookup('template', 'oidc_settings.json.j2') }}"
       vars:
         # We add the extra \\ in here so that when jinja is templating out the files we end up with \n in the strings.
         public_key_content: "{{ lookup('file', public_key_file) | regex_replace('\n', '\\\\n') }}"
@@ -34,18 +36,31 @@
         msg:
           - "Here is your existing SAML configuration for reference:"
           - "{{ existing_saml }}"
+          - "Here is your existing OIDC configuration for reference:"
+          - "{{ existing_oidc }}"
 
     - pause:
-        prompt: "Continuing to run this will replace your existing saml settings (displayed above). They will all be captured except for your private key. Be sure that is backed up before continuing"
+        prompt: "Continuing to run this will replace your existing saml and OIDC settings (displayed above). They will all be captured except for your private key. Be sure that is backed up before continuing"
 
     - name: Write out the existing content
       copy:
-        dest: "../_sources/existing_saml_adapter_settings.json"
-        content: "{{ existing_saml }}"
+        dest: "../_sources/{{ item.filename }}"
+        content: "{{ item.content }}"
+      loop:
+        - filename: "existing_saml_adapter_settings.json"
+          content: "{{ existing_saml }}"
+        - filename: "existing_oidc_adapter_settings.json"
+          content: "{{ existing_oidc }}"
 
     - name: Configure AWX SAML adapter
       awx.awx.settings:
         settings: "{{ new_saml }}"
+        controller_host: "{{ awx_host }}"
+        validate_certs: False
+
+    - name: Configure AWX OIDC adapter
+      awx.awx.settings:
+        settings: "{{ new_oidc }}"
         controller_host: "{{ awx_host }}"
         validate_certs: False
 

--- a/tools/docker-compose/ansible/templates/keycloak.awx.realm.json.j2
+++ b/tools/docker-compose/ansible/templates/keycloak.awx.realm.json.j2
@@ -2,7 +2,7 @@
 	This template is an export from Keycloak.
 	See https://github.com/keycloak/keycloak-documentation/blob/main/server_admin/topics/export-import.adoc for instructions on how to run the export.
 	Once you have the export you want to variablize the public cert, private cert, and the endpoints.
-	The endpoints should be replaced with the variable {{ container_reference }}
+	The endpoints should be replaced with either the variable {{ container_reference }} or {{ oidc_reference }}
 	Some of the keys have \n's in there and some references do not.
 	The ones with the \n can be variablized by {{ private_key }} and {{ public_key }}.
 	The public key in the setting `saml.signing.certificate` should be replaced with {{ public_key_trimmed }}
@@ -65,7 +65,8 @@
         "composite": true,
         "composites": {
           "realm": [
-            "offline_access"
+            "offline_access",
+            "uma_authorization"
           ],
           "client": {
             "account": [
@@ -75,12 +76,31 @@
           }
         },
         "clientRole": false,
-        "containerId": "Tower Realm",
+        "containerId": "AWX Realm",
+        "attributes": {}
+      },
+      {
+        "id": "ea2c2864-93b0-4022-9ef1-202bc2f9c87a",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "AWX Realm",
+        "attributes": {}
+      },
+      {
+        "id": "3764c3ca-d706-424e-8802-65be0d2e060d",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "AWX Realm",
         "attributes": {}
       }
     ],
     "client": {
-      "{{ container_reference }}:8043": []
+      "{{ container_reference }}:8043": [],
+      "awx_oidc_client": []
     }
   },
   "groups": [],
@@ -90,7 +110,7 @@
     "description": "${role_default-roles}",
     "composite": true,
     "clientRole": false,
-    "containerId": "Tower Realm"
+    "containerId": "AWX Realm"
   },
   "requiredCredentials": [
     "password"
@@ -290,6 +310,85 @@
         "role_list"
       ],
       "optionalClientScopes": []
+    },
+    {
+      "id": "525e0eeb-56ee-429f-a040-c6fc18072dc4",
+      "clientId": "awx_oidc_client",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "7b1c3527-8702-4742-af69-2b74ee5742e8",
+      "redirectUris": [
+        "https://{{ oidc_reference | default(container_reference) }}:8043/sso/complete/oidc/"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "id.token.as.detached.signature": "false",
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "use.refresh.tokens": "true",
+        "exclude.session.state.from.auth.response": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "saml.artifact.binding": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "saml_force_name_id_format": "false",
+        "require.pushed.authorization.requests": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "a8f4a0a8-ece4-4a9d-9e7b-830f23ba0067",
+          "name": "AWX OIDC Group Membership",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "false",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "Group",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "microprofile-jwt"
+      ]
     }
   ],
   "clientScopes": [
@@ -626,6 +725,7 @@
           "consentRequired": false,
           "config": {
             "multivalued": "true",
+            "userinfo.token.claim": "true",
             "user.attribute": "foo",
             "id.token.claim": "true",
             "access.token.claim": "true",
@@ -1686,7 +1786,7 @@
     "clientOfflineSessionIdleTimeout": "0",
     "cibaInterval": "5"
   },
-  "keycloakVersion": "15.0.2.redhat-00001",
+  "keycloakVersion": "15.0.2",
   "userManagedAccessAllowed": false,
   "clientProfiles": {
     "profiles": []

--- a/tools/docker-compose/ansible/templates/keycloak.awx.realm.json.j2
+++ b/tools/docker-compose/ansible/templates/keycloak.awx.realm.json.j2
@@ -321,7 +321,10 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "7b1c3527-8702-4742-af69-2b74ee5742e8",
       "redirectUris": [
-        "https://{{ oidc_reference | default(container_reference) }}:8043/sso/complete/oidc/"
+        {% if oidc_reference is defined %}
+        "https://{{ oidc_reference }}:8043/sso/complete/oidc/",
+        {% endif %}
+        "https://{{ container_reference }}:8043/sso/complete/oidc/"
       ],
       "webOrigins": [],
       "notBefore": 0,

--- a/tools/docker-compose/ansible/templates/oidc_settings.json.j2
+++ b/tools/docker-compose/ansible/templates/oidc_settings.json.j2
@@ -1,0 +1,6 @@
+{
+    "SOCIAL_AUTH_OIDC_KEY": "awx_oidc_client",
+    "SOCIAL_AUTH_OIDC_SECRET": "7b1c3527-8702-4742-af69-2b74ee5742e8",
+    "SOCIAL_AUTH_OIDC_OIDC_ENDPOINT": "https://{{ oidc_reference | default(container_reference) }}:8443/auth/realms/awx",
+    "SOCIAL_AUTH_OIDC_VERIFY_SSL": "False"
+}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This will allow us to startup keycloak next to AWX as an OIDC provider and plumbing the OIDC adapter in AWX.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.4.1.dev104+g1faa53bbf0.d20220819
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
