### PR TITLE
Make schedule teardown more reliable

### DIFF
--- a/awxkit/awxkit/api/pages/schedules.py
+++ b/awxkit/awxkit/api/pages/schedules.py
@@ -15,13 +15,15 @@ class Schedule(HasCreate, base.Base):
     NATURAL_KEY = ('unified_job_template', 'name')
 
     def silent_delete(self):
-        """If we are told to prevent_teardown of schedules, then keep them
-        but do not leave them activated, or system will be swamped quickly"""
+        """
+        In every case, we start by disabling the schedule
+        to avoid cascading errors from a cleanup failure.
+        Then, if we are told to prevent_teardown of schedules, we keep them
+        """
         try:
+            self.patch(enabled=False)
             if not config.prevent_teardown:
                 return self.delete()
-            else:
-                self.patch(enabled=False)
         except (exc.NoContent, exc.NotFound, exc.Forbidden):
             pass
 

--- a/awxkit/awxkit/api/pages/unified_job_templates.py
+++ b/awxkit/awxkit/api/pages/unified_job_templates.py
@@ -1,7 +1,6 @@
 from awxkit.api.resources import resources
 from awxkit.utils import random_title, update_payload
 from awxkit.api.mixins import HasStatus
-from awxkit.config import config
 from . import base
 from . import page
 
@@ -53,9 +52,7 @@ class UnifiedJobTemplate(HasStatus, base.Base):
         return schedule
 
     def silent_delete(self):
-        if hasattr(self, '_schedules_store') and config.prevent_teardown:
-            # when prevent_teardown is off, we rely on cascade deletes
-            # in this case, looping is needed to turn them off
+        if hasattr(self, '_schedules_store'):
             for schedule in self._schedules_store:
                 schedule.silent_delete()
         return super(UnifiedJobTemplate, self).silent_delete()


### PR DESCRIPTION
##### SUMMARY
I hit a bug where we would run an integration test, and schedules would be left over.

Schedules are more risky than other resources, because they don't just keep hanging around, they actively cause havoc, adding new jobs to the system. We need to be extra sure to clean up what we did.

Right now, it appears that we rely on _deletion of the template_ in order to delete a schedule. That's a bit problematic when you notice that we have code that gives a 403 error if that template has jobs running. That might not normally be a problem, since we put it in a retry loop that tries like... 5 times or something. But in this case we have 3 schedules that launch a new sleep job every minute or something - virtually guaranteeing that we'll have a new job queued up constantly.

I don't know why this just started breaking, but my favorite theory is that @fosterseth made the task manager so fast that the retry loop can no longer find a gap in which it can delete the job template.

So the solution here is that, before deleting the job template, we also kill the schedules with :fire: 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
