### PR TITLE
Revert "Fix errors in websocket code due to missing template"

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1289,8 +1289,7 @@ class UnifiedJob(
 
             if self.spawned_by_workflow:
                 status_data['group_name'] = "workflow_events"
-                if self.workflow_job:
-                    status_data['workflow_job_template_id'] = self.workflow_job.workflow_job_template_id
+                status_data['workflow_job_template_id'] = self.unified_job_template.id
                 emit_channel_notification('workflow_events-' + str(self.workflow_job_id), status_data)
         except IOError:  # includes socket errors
             logger.exception('%s failed to emit channel msg about status change', self.log_format)


### PR DESCRIPTION
Reverts ansible/awx#12692

I mistook `workflow_job_id` to imply that `workflow_job` is accessible. It is not.

Bug, Docs Fix or other nominal change