### PR TITLE
Fix: preserve_existing_hosts flag in awx.awx.group module, while adding a new host to inventory group, retains only 25 existing hosts related #11605

### DIFF
--- a/awx_collection/plugins/modules/group.py
+++ b/awx_collection/plugins/modules/group.py
@@ -170,7 +170,7 @@ def main():
             id_list.append(sub_obj['id'])
         # Preserve existing objects
         if (preserve_existing_hosts and relationship == 'hosts') or (preserve_existing_children and relationship == 'children'):
-            preserve_existing_check = module.get_endpoint(group['related'][relationship])
+            preserve_existing_check = module.get_all_endpoint(group['related'][relationship])
             for sub_obj in preserve_existing_check['json']['results']:
                 id_list.append(sub_obj['id'])
         if id_list:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
Ansible core 2.12.6, AWX 21.2.0, awx.awx collection 21.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
related #11605
https://github.com/ansible/awx/issues/11605 shows the problem.  After the change, the problem is no longer present i.e. preserve_existing_hosts flag in awx.awx.group module, while adding a new host to inventory group continues to work correctly when a group has more then 25 members

```
