### PR TITLE
Improves visibility of workflow approval notification bell

### DIFF
--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
@@ -9,12 +9,12 @@ import {
   DropdownItem,
   DropdownToggle,
   DropdownPosition,
+  NotificationBadge,
+  NotificationBadgeVariant,
   PageHeaderTools,
   PageHeaderToolsGroup,
   PageHeaderToolsItem,
   Tooltip,
-  NotificationBadge,
-  NotificationBadgeVariant,
 } from '@patternfly/react-core';
 import { QuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
 import { WorkflowApprovalsAPI } from 'api';

--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
@@ -5,7 +5,6 @@ import { t } from '@lingui/macro';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import {
-  Badge,
   Dropdown,
   DropdownItem,
   DropdownToggle,
@@ -14,12 +13,10 @@ import {
   PageHeaderToolsGroup,
   PageHeaderToolsItem,
   Tooltip,
+  NotificationBadge,
+  NotificationBadgeVariant,
 } from '@patternfly/react-core';
-import {
-  BellIcon,
-  QuestionCircleIcon,
-  UserIcon,
-} from '@patternfly/react-icons';
+import { QuestionCircleIcon, UserIcon } from '@patternfly/react-icons';
 import { WorkflowApprovalsAPI } from 'api';
 import useRequest from 'hooks/useRequest';
 import getDocsBaseUrl from 'util/getDocsBaseUrl';
@@ -31,10 +28,6 @@ const PendingWorkflowApprovals = styled.div`
   align-items: center;
   padding: 10px;
   margin-right: 10px;
-`;
-
-const PendingWorkflowApprovalBadge = styled(Badge)`
-  margin-left: 10px;
 `;
 
 function PageHeaderToolbar({
@@ -84,13 +77,15 @@ function PageHeaderToolbar({
           <PageHeaderToolsItem>
             <Link to="/workflow_approvals?workflow_approvals.status=pending">
               <PendingWorkflowApprovals>
-                <BellIcon color="white" />
-                <PendingWorkflowApprovalBadge
+                <NotificationBadge
                   id="toolbar-workflow-approval-badge"
-                  isRead={pendingApprovalsCount === 0}
-                >
-                  {pendingApprovalsCount}
-                </PendingWorkflowApprovalBadge>
+                  count={pendingApprovalsCount}
+                  variant={
+                    pendingApprovalsCount === 0
+                      ? NotificationBadgeVariant.read
+                      : NotificationBadgeVariant.unread
+                  }
+                />
               </PendingWorkflowApprovals>
             </Link>
           </PageHeaderToolsItem>

--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.js
@@ -87,7 +87,7 @@ function PageHeaderToolbar({
                 <BellIcon color="white" />
                 <PendingWorkflowApprovalBadge
                   id="toolbar-workflow-approval-badge"
-                  isRead
+                  isRead={pendingApprovalsCount === 0}
                 >
                   {pendingApprovalsCount}
                 </PendingWorkflowApprovalBadge>

--- a/awx/ui/src/components/AppContainer/PageHeaderToolbar.test.js
+++ b/awx/ui/src/components/AppContainer/PageHeaderToolbar.test.js
@@ -80,7 +80,7 @@ describe('PageHeaderToolbar', () => {
     });
 
     expect(
-      wrapper.find('Badge#toolbar-workflow-approval-badge').text()
+      wrapper.find('NotificationBadge#toolbar-workflow-approval-badge').text()
     ).toEqual('20');
   });
 });


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Previously, unapproved workflows  on header looked the same even if they existed or not. It was difficult to distinguish between them.
<img width="418" alt="image" src="https://user-images.githubusercontent.com/16851744/186439268-feaca9e4-1fa1-4070-8638-123763f036c3.png">

<img width="393" alt="image" src="https://user-images.githubusercontent.com/16851744/186439318-c97fc1b0-ed1f-46df-a941-dedbb59b5ea8.png">


So, if there are unapproved workflows, I made it easier to notice them by changing the color.

<img width="1332" alt="image" src="https://user-images.githubusercontent.com/16851744/186438892-5782d5da-2030-4891-ad1f-c91f31c06537.png">

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/16851744/186438950-80c6cb7b-672a-47d6-8a3f-28055e8f0992.png">

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.4.1.dev23+g8ea3c9c43e
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
