### PR TITLE
Fix make target for compiling api strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -576,7 +576,7 @@ pot: $(UI_BUILD_FLAG_FILE)
 po: $(UI_BUILD_FLAG_FILE)
 	$(NPM_BIN) --prefix awx/ui --loglevel warn run extract-strings -- --clean
 
-LANG = "en-us"
+LANG = "en_us"
 ## generate API django .pot .po
 messages:
 	@if [ "$(VENV_BASE)" ]; then \


### PR DESCRIPTION
##### SUMMARY
Up until recently, our translation automation had been overriding this `--lang` flag with `en_us`, which is why this issue got overlooked previously.  This lang ref should be updated to fix the Makefile.  Addresses https://github.com/ansible/awx/issues/12675

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Other
