### PR TITLE
[sig validation] better error for job template run

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4201,7 +4201,7 @@ class JobLaunchSerializer(BaseSerializer):
             if latest_update is not None and latest_update.failed:
                 failed_validation_tasks = latest_update.project_update_events.filter(
                     event='runner_on_failed',
-                    play="Validate project content integrity",
+                    play="Perform project signature/checksum verification",
                 )
                 if failed_validation_tasks:
                     errors['playbook'] = _("Last project update failed due to signature validation failure.")

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4197,6 +4197,15 @@ class JobLaunchSerializer(BaseSerializer):
         elif template.project.status in ('error', 'failed'):
             errors['playbook'] = _("Missing a revision to run due to failed project update.")
 
+            latest_update = template.project.project_updates.last()
+            if latest_update is not None and latest_update.failed:
+                failed_validation_tasks = latest_update.project_update_events.filter(
+                    event='runner_on_failed',
+                    play="Validate project content integrity",
+                )
+                if failed_validation_tasks:
+                    errors['playbook'] = _("Last project update failed due to signature validation failure.")
+
         # cannot run a playbook without an inventory
         if template.inventory and template.inventory.pending_deletion is True:
             errors['inventory'] = _("The inventory associated with this Job Template is being deleted.")


### PR DESCRIPTION
##### SUMMARY
When launching a job template, if the last project update failed due to
signature validation, show an error that actually says that.

**NOTE**
I have *no* idea if this is the right way to do this, but if nothing else it acts as a proof of concept and shows that it's possible.
I am tagging @AlanCoding as a reviewer for feedback.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Potentially fixes #12690

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
