### PR TITLE
Make error handling less aggressive when checking status of dispatcher task

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1406,9 +1406,10 @@ class UnifiedJob(
             timeout = 5
             try:
                 running = self.celery_task_id in ControlDispatcher('dispatcher', self.controller_node or self.execution_node).running(timeout=timeout)
-            except (socket.timeout, RuntimeError):
+            except socket.timeout:
                 logger.error('could not reach dispatcher on {} within {}s'.format(self.execution_node, timeout))
-                running = False
+            except Exception:
+                logger.exception("error encountered when checking task status")
         return running
 
     @property


### PR DESCRIPTION
##### SUMMARY
This is something I found when debugging https://github.com/ansible/awx/issues/12740


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API