### PR TITLE
Allow for setting custom admin password in dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,7 +469,8 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e enable_ldap=$(LDAP) \
 	    -e enable_splunk=$(SPLUNK) \
 	    -e enable_prometheus=$(PROMETHEUS) \
-	    -e enable_grafana=$(GRAFANA)
+	    -e enable_grafana=$(GRAFANA) \
+	    -e admin_password=$(ADMIN_PASSWORD)
 
 
 docker-compose: awx/projects docker-compose-sources

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -18,6 +18,7 @@
     - pg_password
     - secret_key
     - broadcast_websocket_secret
+    - admin_password
 
 - name: Generate secrets if needed
   template:

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -22,6 +22,7 @@ services:
       CONTROL_PLANE_NODE_COUNT: {{ control_plane_node_count|int }}
       EXECUTION_NODE_COUNT: {{ execution_node_count|int }}
       AWX_LOGGING_MODE: stdout
+      DJANGO_SUPERUSER_PASSWORD: {{ admin_password }}
 {% if loop.index == 1 %}
       RUN_MIGRATIONS: 1
 {% endif %}

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -21,10 +21,9 @@ fi
 
 if output=$(awx-manage createsuperuser --noinput --username=admin --email=admin@localhost 2> /dev/null); then
     echo $output
-    admin_password=$(openssl rand -base64 12)
-    echo "Admin password: ${admin_password}"
-    awx-manage update_password --username=admin --password=${admin_password}
 fi
+echo "Admin password: ${DJANGO_SUPERUSER_PASSWORD}"
+
 awx-manage create_preload_data
 awx-manage register_default_execution_environments
 


### PR DESCRIPTION
##### SUMMARY
This will allow a follow-up PR I'm working on that renders out `prometheus.yml` when booting the development environment. It currently requires manually editing and copying a file.

Implements feedback left on https://github.com/ansible/awx/pull/12660

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other
