### PR TITLE
Implement instance deprovisioning

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4775,7 +4775,7 @@ class InstanceSerializer(BaseSerializer):
 
     class Meta:
         model = Instance
-        read_only_fields = ('ip_address', 'uuid', 'version', 'node_state')
+        read_only_fields = ('ip_address', 'uuid', 'version')
         fields = (
             'id',
             'type',
@@ -4850,6 +4850,21 @@ class InstanceSerializer(BaseSerializer):
         else:
             if self.instance.node_type != value:
                 raise serializers.ValidationError("Cannot change node type.")
+
+        return value
+
+    def validate_node_state(self, value):
+        if self.instance:
+            if value != self.instance.node_state:
+                if not settings.IS_K8S:
+                    raise serializers.ValidationError("Can only change the state on Kubernetes or OpenShift.")
+                if value != Instance.States.DEPROVISIONING:
+                    raise serializers.ValidationError("Can only change instances to the 'deprovisioning' state.")
+                if self.instance.node_type not in (Instance.Types.EXECUTION,):
+                    raise serializers.ValidationError("Can only deprovision execution nodes.")
+        else:
+            if value and value != Instance.States.INSTALLED:
+                raise serializers.ValidationError("Can only create instances in the 'installed' state.")
 
         return value
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -383,6 +383,9 @@ class InstanceDetail(RetrieveUpdateAPIView):
         r = super(InstanceDetail, self).update(request, *args, **kwargs)
         if status.is_success(r.status_code):
             obj = self.get_object()
+            if obj.node_state == models.Instance.States.DEPROVISIONING:
+                models.InstanceLink.objects.filter(target=obj).update(link_state=models.InstanceLink.States.REMOVING)
+                models.InstanceLink.objects.filter(source=obj).update(link_state=models.InstanceLink.States.REMOVING)
             obj.set_capacity_value()
             obj.save(update_fields=['capacity'])
             r.data = serializers.InstanceSerializer(obj, context=self.get_serializer_context()).to_representation(obj)

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -25,7 +25,7 @@ from awx.main.utils.common import (
     cleanup_new_process,
 )
 from awx.main.constants import MAX_ISOLATED_PATH_COLON_DELIMITER
-from awx.main.models import Instance
+from awx.main.models import Instance, InstanceLink, UnifiedJob
 from awx.main.dispatch.publish import task
 
 # Receptorctl
@@ -641,29 +641,50 @@ RECEPTOR_CONFIG_STARTER = (
 
 @task()
 def write_receptor_config():
-    receptor_config = list(RECEPTOR_CONFIG_STARTER)
-
-    instances = Instance.objects.filter(node_type=Instance.Types.EXECUTION)
-    for instance in instances:
-        peer = {'tcp-peer': {'address': f'{instance.hostname}:{instance.listener_port}', 'tls': 'tlsclient'}}
-        receptor_config.append(peer)
-
     lock = FileLock(__RECEPTOR_CONF_LOCKFILE)
     with lock:
+        receptor_config = list(RECEPTOR_CONFIG_STARTER)
+
+        this_inst = Instance.objects.me()
+        instances = Instance.objects.filter(node_type=Instance.Types.EXECUTION)
+        for instance in instances:
+            peer = {'tcp-peer': {'address': f'{instance.hostname}:{instance.listener_port}', 'tls': 'tlsclient'}}
+            receptor_config.append(peer)
+
         with open(__RECEPTOR_CONF, 'w') as file:
             yaml.dump(receptor_config, file, default_flow_style=False)
 
-    receptor_ctl = get_receptor_ctl()
+        receptor_ctl = get_receptor_ctl()
 
-    attempts = 10
-    backoff = 1
-    for attempt in range(attempts):
-        try:
-            receptor_ctl.simple_command("reload")
-            break
-        except ValueError:
-            logger.warning(f"Unable to reload Receptor configuration. {attempts-attempt} attempts left.")
-            time.sleep(backoff)
-            backoff += 1
-    else:
-        raise RuntimeError("Receptor reload failed")
+        attempts = 10
+        for backoff in range(1, attempts + 1):
+            try:
+                receptor_ctl.simple_command("reload")
+                break
+            except ValueError:
+                logger.warning(f"Unable to reload Receptor configuration. {attempts-backoff} attempts left.")
+                time.sleep(backoff)
+        else:
+            raise RuntimeError("Receptor reload failed")
+
+        links = InstanceLink.objects.filter(source=this_inst, target__in=instances, link_state=InstanceLink.States.ADDING)
+        links.update(link_state=InstanceLink.States.ESTABLISHED)
+
+
+@task()
+def wait_for_jobs(hostname):
+    node_jobs = UnifiedJob.objects.filter(
+        execution_node=hostname,
+        status__in=(
+            'running',
+            'waiting',
+        ),
+    )
+    while node_jobs.exists():
+        time.sleep(60)
+
+    # This will as a side effect also delete the InstanceLinks that are tied to it.
+    Instance.objects.filter(hostname=hostname).delete()
+
+    # Update the receptor configs for all of the control-plane.
+    write_receptor_config.apply_async(queue='tower_broadcast_all')


### PR DESCRIPTION
##### SUMMARY
- allow the node_state to be set to 'deprovisioning'
- set the links that touch the instance to 'removing'
- only allow on K8S
- only allow to be done to execution nodes
- kick off a task that waits for jobs to complete, then delete the node and broadcast the `write_receptor_config` task
- make `write_receptor_config` change any 'adding' links (for newly created nodes) to 'established' when complete

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
