### PR TITLE
Fix sanity check to use the relevant active connection

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -31,7 +31,7 @@ class PubSub(object):
             cur.execute('SELECT pg_notify(%s, %s);', (channel, payload))
 
     def events(self, select_timeout=5, yield_timeouts=False):
-        if not pg_connection.get_autocommit():
+        if not self.conn.autocommit:
             raise RuntimeError('Listening for events can only be done in autocommit mode')
 
         while True:

--- a/awx/main/dispatch/control.py
+++ b/awx/main/dispatch/control.py
@@ -46,7 +46,7 @@ class Control(object):
         reply_queue = Control.generate_reply_queue_name()
         self.result = None
 
-        with pg_bus_conn() as conn:
+        with pg_bus_conn(new_connection=True) as conn:
             conn.listen(reply_queue)
             conn.notify(self.queuename, json.dumps({'control': command, 'reply_to': reply_queue}))
 


### PR DESCRIPTION
##### SUMMARY
This was a bug I introduced and is tracked in https://github.com/ansible/awx/issues/12740

When doing a control-with-reply to determine the status of a job, we should unambiguously use a new connection. There is no question about that, and it was an oversight that I missed this particular import of `pg_bus_conn`. If we run out of connections, the exception will be caught and `cancel_flag` should still get flipped, which is what we want.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
This hopefully replaces https://github.com/ansible/awx/pull/12741, I still need to run tests quickly.
