### PR TITLE
Fix list_instances command

### DIFF
--- a/awx/main/management/commands/list_instances.py
+++ b/awx/main/management/commands/list_instances.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
 
                 capacity = f' capacity={x.capacity}' if x.node_type != 'hop' else ''
                 version = f" version={x.version or '?'}" if x.node_type != 'hop' else ''
-                heartbeat = f' heartbeat="{x.modified:%Y-%m-%d %H:%M:%S}"' if x.capacity or x.node_type == 'hop' else ''
+                heartbeat = f' heartbeat="{x.last_seen:%Y-%m-%d %H:%M:%S}"' if x.capacity or x.node_type == 'hop' else ''
                 print(f'\t{color}{x.hostname}{capacity} node_type={x.node_type}{version}{heartbeat}\033[0m')
 
             print()


### PR DESCRIPTION
Hello there,

I was having issues with some jobs not progressing in Ansible Automation Platform. After checking with Red Hat support team, they said

Looking at the shared awx-dbshell_last-seen.txt and also in the sosreport command awx-manage list_instances we can see a huge discrepancy in the nodes timestamp.
It looks like our list_instances.py which is performing the heartbeat check is looking for the modified timestamp and not last_seen.
In order to tackle this Bug we believe that heartbeat in awx list_instances command should look for the last_seen attribute of the node and not the modified. This was a Breaking Change

Please, let me know if this makes sense.

(Git commit command was ran with the --signoff option).

Thank you!