### PR TITLE
Speed up image build when UI is pre-built on host

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
-awx/ui/node_modules
 Dockerfile
 .git

--- a/Makefile
+++ b/Makefile
@@ -381,7 +381,8 @@ clean-ui:
 awx/ui/node_modules:
 	NODE_OPTIONS=--max-old-space-size=6144 $(NPM_BIN) --prefix awx/ui --loglevel warn ci
 
-$(UI_BUILD_FLAG_FILE): awx/ui/node_modules
+$(UI_BUILD_FLAG_FILE):
+	$(MAKE) awx/ui/node_modules
 	$(PYTHON) tools/scripts/compilemessages.py
 	$(NPM_BIN) --prefix awx/ui --loglevel warn run compile-strings
 	$(NPM_BIN) --prefix awx/ui --loglevel warn run build


### PR DESCRIPTION
##### SUMMARY
While this gives someone the chance to shoot themselves in the foot, it's worth it. In CI we'll always have a clean checkout. If you are building images locally, you need to `make clean-ui` to force a rebuild.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change