### PR TITLE
Prevent openldap from getting downgraded during build

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -101,6 +101,7 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     glibc-langpack-en \
     krb5-workstation \
     nginx \
+    "openldap >= 2.6.2-3" \
     postgresql \
     python3-devel \
     python3-libselinux \


### PR DESCRIPTION
##### SUMMARY
We noticed [here](https://github.com/ansible/awx/runs/8118323342?check_suite_focus=true) that openldap was getting downgraded and caused our test suite to blow up.

<img width="736" alt="image" src="https://user-images.githubusercontent.com/773186/187738321-33cdd3d0-b468-413d-bcc4-82261c6a10e2.png">


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other
