### PR TITLE
[feature-project-integrity] Cleanup, mostly around the action plugin and its use in the project update playbook

### DIFF
--- a/awx/main/migrations/0167_project_signature_validation_credential.py
+++ b/awx/main/migrations/0167_project_signature_validation_credential.py
@@ -2,6 +2,7 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
+from django.utils.translation import gettext_lazy as _
 
 from awx.main.models import CredentialType
 from awx.main.utils.common import set_current_apps
@@ -29,6 +30,7 @@ class Migration(migrations.Migration):
                 on_delete=django.db.models.deletion.SET_NULL,
                 related_name='projects_signature_validation',
                 to='main.credential',
+                help_text=_('An optional credential used for validating files in the project against unexpected changes.'),
             ),
         ),
         migrations.RunPython(setup_tower_managed_defaults),

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -292,6 +292,7 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
         null=True,
         default=None,
         on_delete=models.SET_NULL,
+        help_text=_('An optional credential used for validating files in the project against unexpected changes.'),
     )
 
     scm_revision = models.CharField(

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1270,7 +1270,6 @@ class RunProjectUpdate(BaseTask):
             # for raw archive, prevent error moving files between volumes
             extra_vars['ansible_remote_tmp'] = os.path.join(project_update.get_project_path(check_if_exists=False), '.ansible_awx', 'tmp')
 
-        # TODO: Is this the right way to do this? -relrod
         if project_update.project.signature_validation_credential is not None:
             pubkey = project_update.project.signature_validation_credential.get_input('gpg_public_key')
             extra_vars['gpg_pubkey'] = pubkey

--- a/awx/playbooks/library/playbook_integrity.py
+++ b/awx/playbooks/library/playbook_integrity.py
@@ -1,0 +1,65 @@
+ANSIBLE_METADATA = {"metadata_version": "1.0", "status": ["stableinterface"], "supported_by": "community"}
+
+
+DOCUMENTATION = """
+---
+module: playbook_integrity
+short_description: verify that files within a project have not been tampered with.
+description:
+  - Makes use of the 'ansible-sign' project as a library for ensuring that an
+    Ansible project has not been tampered with.
+  - There are multiple types of validation that this action plugin supports,
+    currently: GPG public/private key signing of a checksum manifest file, and
+    checking the checksum manifest file itself against the checksum of each file
+    that is being verified.
+  - In the future, other types of validation may be supported.
+options:
+  project_path:
+    description:
+      - Directory of the project being verified. Expected to contain a
+        C(.ansible-sign) directory with a generated checksum manifest file and a
+        detached signature for it. These files are produced by the
+        C(ansible-sign) command-line utility.
+    required: true
+  validation_type:
+    description:
+      - Describes the kind of validation to perform on the project.
+      - I(validation_type=gpg) means that a GPG Public Key credential is being
+        used to verify the integrity of the checksum manifest (and therefore the
+        project).
+      - 'checksum_manifest' means that the signed checksum manifest is validated
+        against all files in the project listed by its MANIFEST.in file. Just
+        running this plugin with I(validation_type=checksum_manifest) is
+        typically B(NOT) enough. It should also be run with a I(validation_type)
+        that ensures that the manifest file itself has not changed, such as
+        I(validation_type=gpg).
+    required: true
+    choices:
+      - gpg
+      - checksum_manifest
+  gpg_pubkey:
+    description:
+      - The public key to validate a checksum manifest against. Must match the
+        detached signature in the project's C(.ansible-sign) directory.
+      - Required when I(validation_type=gpg).
+author:
+    - Ansible AWX Team
+"""
+
+EXAMPLES = """
+    - name: Verify project content using GPG signature
+      playbook_integrity:
+        project_path: /srv/projects/example
+        validation_type: gpg
+        gpg_pubkey: |
+          -----BEING PGP PUBLIC KEY BLOCK-----
+
+          mWINAFXMtjsACADIf/zJS0V3UO3c+KAUcpVAcChpliM31ICDWydfIfF3dzMzLcCd
+          Cj2kk1mPWtP/JHfk1V5czcWWWWGC2Tw4g4IS+LokAAuwk7VKTlI34eeMl8SiZCAI
+          [...]
+
+    - name: Verify project content against checksum manifest
+      playbook_integrity:
+        project_path: /srv/projects/example
+        validation_type: checksum_manifest
+"""

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -18,6 +18,7 @@
 # galaxy_task_env: environment variables to use specifically for ansible-galaxy commands
 # awx_version: Current running version of the awx or tower as a string
 # awx_license_type: "open" for AWX; else presume Tower
+# gpg_pubkey: the GPG public key to use for validation, when enabled
 
 - hosts: localhost
   gather_facts: false
@@ -156,33 +157,22 @@
 - hosts: localhost
   gather_facts: false
   connection: local
-  name: Validate project content integrity
+  name: Perform project signature/checksum verification
   tasks:
-    - block:
-        - name: verify project integrity using GPG signature
-          playbook_integrity:
-            project_path: "{{ project_path | quote }}"
-            validation_type: gpg
-            gpg_pubkey: "{{ gpg_pubkey }}"
-          register: gpg_result
-
-        - name: GPG result
-          debug:
-            var: gpg_result
+    - name: Verify project content using GPG signature
+      playbook_integrity:
+        project_path: "{{ project_path | quote }}"
+        validation_type: gpg
+        gpg_pubkey: "{{ gpg_pubkey }}"
+      register: gpg_result
       tags:
         - validation_gpg_public_key
 
-    - block:
-        - name: verify project integrity using checksum manifest
-          playbook_integrity:
-            project_path: "{{ project_path | quote }}"
-            validation_type: checksum_manifest
-          register: checksum_result
-
-        - name: Checksum manifest result
-          debug:
-            var: checksum_result
-
+    - name: Verify project content against checksum manifest
+      playbook_integrity:
+        project_path: "{{ project_path | quote }}"
+        validation_type: checksum_manifest
+      register: checksum_result
       tags:
         - validation_checksum_manifest
 


### PR DESCRIPTION
##### SUMMARY

This implements most of the feedback from @AlanCoding's comments in #12745.

Note that this is a PR to merge this feature into `feature-project-integrity`, not `devel`.

- Nuke TODO, no longer needed
- Add `help_text` to new model field
- documentation for action plugin
- remove debug tasks and blocks from update playbook

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API