### PR TITLE
Make the metrics default sampling interval 5s

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -17,6 +17,7 @@ work_sign_key_dir: '../_sources/receptor'
 work_sign_private_keyfile: "{{ work_sign_key_dir }}/work_private_key.pem"
 work_sign_public_keyfile: "{{ work_sign_key_dir }}/work_public_key.pem"
 
+# SSO variables
 enable_keycloak: false
 
 enable_ldap: false
@@ -28,6 +29,8 @@ ldap_public_key_file: '{{ ldap_cert_dir }}/{{ ldap_public_key_file_name }}'
 ldap_private_key_file: '{{ ldap_cert_dir }}/{{ ldap_private_key_file_name }}'
 ldap_cert_subject: "/C=US/ST=NC/L=Durham/O=awx/CN="
 
+# Metrics
 enable_splunk: false
 enable_grafana: false
 enable_prometheus: false
+scrape_interval: '5s'

--- a/tools/docker-compose/ansible/roles/sources/templates/prometheus.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/prometheus.yml.j2
@@ -1,7 +1,7 @@
 #jinja2: lstrip_blocks: True
 ---
 global:
-  scrape_interval: 15s  # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  scrape_interval: {{ scrape_interval }}  # Set the scrape interval to something faster. Default is every 1 minute.
 
 scrape_configs:
   - job_name: 'awx'
@@ -11,7 +11,7 @@ scrape_configs:
       # so no need to track nodes individually.
       - awx1:8013
     metrics_path: /api/v2/metrics
-    scrape_interval: 5s
+    scrape_interval: {{ scrape_interval }}
     scheme: http
     params:
       format: ['txt']

--- a/tools/grafana/dashboards/demo_dashboard.json
+++ b/tools/grafana/dashboards/demo_dashboard.json
@@ -90,6 +90,7 @@
         "y": 0
       },
       "id": 8,
+      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -176,6 +177,7 @@
         "y": 8
       },
       "id": 12,
+      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -289,6 +291,7 @@
         "y": 8
       },
       "id": 10,
+      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -427,6 +430,7 @@
         "y": 16
       },
       "id": 16,
+      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -548,6 +552,7 @@
         "y": 16
       },
       "id": 18,
+      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -645,6 +650,7 @@
         "y": 24
       },
       "id": 14,
+      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -734,6 +740,7 @@
         "y": 24
       },
       "id": 20,
+      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -777,6 +784,6 @@
   "timezone": "",
   "title": "awx-demo",
   "uid": "GISWZOXnk",
-  "version": 4,
+  "version": 3,
   "weekStart": ""
 }


### PR DESCRIPTION
##### SUMMARY
I had been banging my head against this because it kept staying at 15s no matter what buttons I pushed. Then I figured it out, there's a graph-specific setting that was undermining it.

We could make `tools/grafana/dashboards/demo_dashboard.json` a template so that it shares the variable's value, but it seems like that might over-complicate things as people continue to add to the dashboard.

Here's the fidelity you get from running job templates that sleep for 60 seconds.

![Screenshot from 2022-09-02 13-32-11](https://user-images.githubusercontent.com/1385596/188208548-03d21da3-fd5f-49cd-8d75-ec7d209d3d01.png)

I'm much happier with this, as I thought my stuff wasn't working, but it turned out to be a sampling interval problem.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

