### PR TITLE
Extend black excludes instead of overriding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ build-backend = "setuptools.build_meta"
 line-length = 160
 fast = true
 skip-string-normalization = true
-exclude = "awx_collection"
+extend-exclude = "awx_collection"


### PR DESCRIPTION
##### SUMMARY

By default it will ignore things in .gitignore, which we want.

Before this is was basically impossible to run `$ black .` - it takes _forever_.

```
black .  249.20s user 3.09s system 553% cpu 45.589 total
```

With this change:

```
black .  0.90s user 0.08s system 97% cpu 1.001 total
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other