### PR TITLE
Run instance health check in task container

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -459,41 +459,16 @@ class InstanceHealthCheck(GenericAPIView):
 
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
-
         # Note: hop nodes are already excluded by the get_queryset method
         if obj.node_type == 'execution':
             from awx.main.tasks.system import execution_node_health_check
 
-            runner_data = execution_node_health_check(obj.hostname)
-            obj.refresh_from_db()
-            data = self.get_serializer(data=request.data).to_representation(obj)
-            # Add in some extra unsaved fields
-            for extra_field in ('transmit_timing', 'run_timing'):
-                if extra_field in runner_data:
-                    data[extra_field] = runner_data[extra_field]
+            execution_node_health_check.apply_async([obj.hostname])
         else:
             from awx.main.tasks.system import cluster_node_health_check
 
-            if settings.CLUSTER_HOST_ID == obj.hostname:
-                cluster_node_health_check(obj.hostname)
-            else:
-                cluster_node_health_check.apply_async([obj.hostname], queue=obj.hostname)
-                start_time = time.time()
-                prior_check_time = obj.last_health_check
-                while time.time() - start_time < 50.0:
-                    obj.refresh_from_db(fields=['last_health_check'])
-                    if obj.last_health_check != prior_check_time:
-                        break
-                    if time.time() - start_time < 1.0:
-                        time.sleep(0.1)
-                    else:
-                        time.sleep(1.0)
-                else:
-                    obj.mark_offline(errors=_('Health check initiated by user determined this instance to be unresponsive'))
-            obj.refresh_from_db()
-            data = self.get_serializer(data=request.data).to_representation(obj)
-
-        return Response(data, status=status.HTTP_200_OK)
+            cluster_node_health_check.apply_async([obj.hostname], queue=obj.hostname)
+        return Response(dict(msg=f"Health check is running for {obj.hostname}."), status=status.HTTP_200_OK)
 
 
 class InstanceGroupList(ListCreateAPIView):

--- a/awx/main/tests/functional/api/test_instance.py
+++ b/awx/main/tests/functional/api/test_instance.py
@@ -1,15 +1,8 @@
 import pytest
 
-from unittest import mock
-
 from awx.api.versioning import reverse
 from awx.main.models.activity_stream import ActivityStream
 from awx.main.models.ha import Instance
-
-import redis
-
-# Django
-from django.test.utils import override_settings
 
 
 INSTANCE_KWARGS = dict(hostname='example-host', cpu=6, memory=36000000000, cpu_capacity=6, mem_capacity=42)
@@ -50,33 +43,14 @@ def test_enabled_sets_capacity(patch, admin_user):
 def test_auditor_user_health_check(get, post, system_auditor):
     instance = Instance.objects.create(**INSTANCE_KWARGS)
     url = reverse('api:instance_health_check', kwargs={'pk': instance.pk})
-    r = get(url=url, user=system_auditor, expect=200)
-    assert r.data['cpu_capacity'] == instance.cpu_capacity
+    get(url=url, user=system_auditor, expect=200)
     post(url=url, user=system_auditor, expect=403)
 
 
 @pytest.mark.django_db
-def test_health_check_throws_error(post, admin_user):
-    instance = Instance.objects.create(node_type='execution', **INSTANCE_KWARGS)
-    url = reverse('api:instance_health_check', kwargs={'pk': instance.pk})
-    # we will simulate a receptor error, similar to this one
-    # https://github.com/ansible/receptor/blob/156e6e24a49fbf868734507f9943ac96208ed8f5/receptorctl/receptorctl/socket_interface.py#L204
-    # related to issue https://github.com/ansible/tower/issues/5315
-    with mock.patch('awx.main.tasks.receptor.run_until_complete', side_effect=RuntimeError('Remote error: foobar')):
-        post(url=url, user=admin_user, expect=200)
-    instance.refresh_from_db()
-    assert 'Remote error: foobar' in instance.errors
-    assert instance.capacity == 0
-
-
-@pytest.mark.django_db
-@mock.patch.object(redis.client.Redis, 'ping', lambda self: True)
 def test_health_check_usage(get, post, admin_user):
     instance = Instance.objects.create(**INSTANCE_KWARGS)
     url = reverse('api:instance_health_check', kwargs={'pk': instance.pk})
-    r = get(url=url, user=admin_user, expect=200)
-    assert r.data['cpu_capacity'] == instance.cpu_capacity
-    assert r.data['last_health_check'] is None
-    with override_settings(CLUSTER_HOST_ID=instance.hostname):  # force direct call of cluster_node_health_check
-        r = post(url=url, user=admin_user, expect=200)
-        assert r.data['last_health_check'] is not None
+    get(url=url, user=admin_user, expect=200)
+    r = post(url=url, user=admin_user, expect=200)
+    assert r.data['msg'] == f"Health check is running for {instance.hostname}."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
addresses https://github.com/ansible/awx/issues/12739

awx-web container does not have access to receptor socket, and the
execution node health check requires receptorctl in order to run.

This change runs the health check asynchronously in the task container.

Note -- We no longer spin in a loop waiting for the instance health check to complete. This was not working as intended anyways, as the apply_async inside of a django view does not start the task right away. This is because view are ran in a transaction, and pgnotify will only submit messages after the transaction is complete.

We'll need another method of updating the UI the data that returns from the health check (either websockets or refreshes)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
