### PR TITLE
Fix LDAP volume conditional, better metrics interval

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -228,7 +228,7 @@ volumes:
   redis_socket_{{ container_postfix }}:
     name: tools_redis_socket_{{ container_postfix }}
 {% endfor -%}
-{% if enable_ldap %}
+{% if enable_ldap|bool %}
   openldap_data:
     name: tools_ldap_1
     driver: local

--- a/tools/grafana/dashboards/demo_dashboard.json
+++ b/tools/grafana/dashboards/demo_dashboard.json
@@ -90,7 +90,6 @@
         "y": 0
       },
       "id": 8,
-      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -177,7 +176,6 @@
         "y": 8
       },
       "id": 12,
-      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -291,7 +289,6 @@
         "y": 8
       },
       "id": 10,
-      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -430,7 +427,6 @@
         "y": 16
       },
       "id": 16,
-      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -552,7 +548,6 @@
         "y": 16
       },
       "id": 18,
-      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -650,7 +645,6 @@
         "y": 24
       },
       "id": 14,
-      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],
@@ -740,7 +734,6 @@
         "y": 24
       },
       "id": 20,
-      "interval": "5",
       "options": {
         "legend": {
           "calcs": [],

--- a/tools/grafana/datasources/prometheus_source.yml
+++ b/tools/grafana/datasources/prometheus_source.yml
@@ -8,3 +8,5 @@ datasources:
     access: proxy
     url: http://prometheus:9090
     editable: true
+    jsonData:
+      timeInterval: 5s


### PR DESCRIPTION
##### SUMMARY
First thing here - I find locally that `docker-volume ls` will show the ldap container, even when it shouldn't and I never asked for it. This fixes that.

Second thing - this appears to be a better way to set the graph interval. Grafana was deferring to what Prometheus was reporting, which was 15s for whatever reason. This still isn't templated, but it would be more reasonable for us to template later on.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
