### PR TITLE
Allow metrics collection for anonymous users via settings

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -101,7 +101,7 @@ register(
     field_class=fields.BooleanField,
     default=False,
     label=_('Allow anonymous users to poll metrics'),
-    help_text=_('If false, only superusers and system auditors are allowed to poll metrics.'),
+    help_text=_('If true, anonymous users are allowed to poll metrics.'),
     category=_('Authentication'),
     category_slug='authentication',
 )

--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -96,6 +96,15 @@ register(
     category=_('Authentication'),
     category_slug='authentication',
 )
+register(
+    'ALLOW_METRICS_FOR_ANONYMOUS_USERS',
+    field_class=fields.BooleanField,
+    default=False,
+    label=_('Allow anonymous users to poll metrics'),
+    help_text=_('If false, only superusers and system auditors are allowed to poll metrics.'),
+    category=_('Authentication'),
+    category_slug='authentication',
+)
 
 
 def authentication_validate(serializer, attrs):

--- a/awx/api/views/metrics.py
+++ b/awx/api/views/metrics.py
@@ -5,9 +5,11 @@
 import logging
 
 # Django
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 # Django REST Framework
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.exceptions import PermissionDenied
 
@@ -31,9 +33,14 @@ class MetricsView(APIView):
 
     renderer_classes = [renderers.PlainTextRenderer, renderers.PrometheusJSONRenderer, renderers.BrowsableAPIRenderer]
 
+    def initialize_request(self, request, *args, **kwargs):
+        if settings.ALLOW_METRICS_FOR_ANONYMOUS_USERS:
+            self.permission_classes = (AllowAny,)
+        return super(APIView, self).initialize_request(request, *args, **kwargs)
+
     def get(self, request):
         '''Show Metrics Details'''
-        if request.user.is_superuser or request.user.is_system_auditor:
+        if settings.ALLOW_METRICS_FOR_ANONYMOUS_USERS or request.user.is_superuser or request.user.is_system_auditor:
             metrics_to_show = ''
             if not request.query_params.get('subsystemonly', "0") == "1":
                 metrics_to_show += metrics().decode('UTF-8')

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -418,6 +418,9 @@ AUTH_BASIC_ENABLED = True
 # when trying to access a UI page that requries authentication.
 LOGIN_REDIRECT_OVERRIDE = ''
 
+# Note: This setting may be overridden by database settings.
+ALLOW_METRICS_FOR_ANONYMOUS_USERS = False
+
 DEVSERVER_DEFAULT_ADDR = '0.0.0.0'
 DEVSERVER_DEFAULT_PORT = '8013'
 


### PR DESCRIPTION
Signed-off-by: Nico Ohnezat <nico@no-12.net>

##### SUMMARY
Some tools that collect metrics are not able to use authentication to poll metrics. related #6753

This PR will allow to disable the authentication of the metrics endpoint by setting ALLOW_METRICS_FOR_ANONYMOUS_USERS to 'true'.
The default value of ALLOW_METRICS_FOR_ANONYMOUS_USERS is 'false'


##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

