### PR TITLE
Fix the `is_successful` assertion corner case

### DIFF
--- a/awxkit/awxkit/api/mixins/has_status.py
+++ b/awxkit/awxkit/api/mixins/has_status.py
@@ -63,7 +63,7 @@ class HasStatus(object):
             status_list = [status_list]
         if self.status in status_list:
             # include corner cases in is_successful logic
-            if 'successful' not in status_list or self.is_successful:
+            if self.status != 'successful' or self.is_successful:
                 return
         if msg is None:
             msg = ''


### PR DESCRIPTION
##### SUMMARY
This was breaking my attempts to write tests that did `job.assert_status(['successful', 'canceled'])`. Because "successful" is in the allowed status list, it won't pass on the "canceled" status because `is_successful` isn't true.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

