### PR TITLE
Register pages for the Instance peers and install bundle endpoints

### DIFF
--- a/awx/api/views/instance_install_bundle.py
+++ b/awx/api/views/instance_install_bundle.py
@@ -48,9 +48,9 @@ class InstanceInstallBundle(GenericAPIView):
         instance_obj = self.get_object()
 
         # if the instance is not a hop or execution node than return 400
-        if instance_obj.node_type not in ('execution', 'hop'):
+        if instance_obj.node_type not in ('execution',):
             return Response(
-                data=dict(msg=_('Install bundle can only be generated for execution or hop nodes.')),
+                data=dict(msg=_('Install bundle can only be generated for execution nodes.')),
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/awxkit/awxkit/api/pages/instances.py
+++ b/awxkit/awxkit/api/pages/instances.py
@@ -16,4 +16,15 @@ class Instances(page.PageList, Instance):
     pass
 
 
-page.register_page([resources.instances, resources.related_instances], Instances)
+page.register_page([resources.instances, resources.related_instances, resources.instance_peers], Instances)
+
+
+class InstanceInstallBundle(page.Page):
+    def extract_data(self, response):
+        # The actual content of this response will be in the full set
+        # of bytes from response.content, which will be exposed via
+        # the Page.bytes interface.
+        return {}
+
+
+page.register_page(resources.instance_install_bundle, InstanceInstallBundle)

--- a/awxkit/awxkit/api/pages/page.py
+++ b/awxkit/awxkit/api/pages/page.py
@@ -154,6 +154,26 @@ class Page(object):
         resp.status_code = 200
         return cls(r=resp, connection=connection)
 
+    @property
+    def bytes(self):
+        if self.r is None:
+            return b''
+        return self.r.content
+
+    def extract_data(self, response):
+        """Takes a `requests.Response` and returns a data dict."""
+        try:
+            data = response.json()
+        except ValueError as e:  # If there was no json to parse
+            data = {}
+            if response.text or response.status_code not in (200, 202, 204):
+                text = response.text
+                if len(text) > 1024:
+                    text = text[:1024] + '... <<< Truncated >>> ...'
+                log.debug("Unable to parse JSON response ({0.status_code}): {1} - '{2}'".format(response, e, text))
+
+        return data
+
     def page_identity(self, response, request_json=None):
         """Takes a `requests.Response` and
         returns a new __item_class__ instance if the request method is not a get, or returns
@@ -171,16 +191,7 @@ class Page(object):
         else:
             ds = None
 
-        try:
-            data = response.json()
-        except ValueError as e:  # If there was no json to parse
-            data = dict()
-            if response.text or response.status_code not in (200, 202, 204):
-                text = response.text
-                if len(text) > 1024:
-                    text = text[:1024] + '... <<< Truncated >>> ...'
-                log.debug("Unable to parse JSON response ({0.status_code}): {1} - '{2}'".format(response, e, text))
-
+        data = self.extract_data(response)
         exc_str = "%s (%s) received" % (http.responses[response.status_code], response.status_code)
 
         exception = exception_from_status_code(response.status_code)

--- a/awxkit/awxkit/api/resources.py
+++ b/awxkit/awxkit/api/resources.py
@@ -53,6 +53,8 @@ class Resources(object):
     _instance_group = r'instance_groups/\d+/'
     _instance_group_related_jobs = r'instance_groups/\d+/jobs/'
     _instance_groups = 'instance_groups/'
+    _instance_install_bundle = r'instances/\d+/install_bundle/'
+    _instance_peers = r'instances/\d+/peers/'
     _instance_related_jobs = r'instances/\d+/jobs/'
     _instances = 'instances/'
     _inventories = 'inventories/'


### PR DESCRIPTION
##### SUMMARY
Register pages for the Instance peers and install bundle endpoints

This includes exposing a new interface for Page objects, Page.bytes,
to return the full bytestring contents of the response.

I have also cleaned up a part of the API where we were still allowing hop nodes for the new bundle endpoint.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - CLI
