### PR TITLE
Add "cryptography" kind to CredentialType

### DIFF
--- a/awx/main/migrations/0167_project_signature_validation_credential.py
+++ b/awx/main/migrations/0167_project_signature_validation_credential.py
@@ -2,7 +2,6 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
-from django.utils.translation import gettext_lazy as _
 
 from awx.main.models import CredentialType
 from awx.main.utils.common import set_current_apps
@@ -30,7 +29,28 @@ class Migration(migrations.Migration):
                 on_delete=django.db.models.deletion.SET_NULL,
                 related_name='projects_signature_validation',
                 to='main.credential',
-                help_text=_('An optional credential used for validating files in the project against unexpected changes.'),
+                help_text='An optional credential used for validating files in the project against unexpected changes.',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='credentialtype',
+            name='kind',
+            field=models.CharField(
+                choices=[
+                    ('ssh', 'Machine'),
+                    ('vault', 'Vault'),
+                    ('net', 'Network'),
+                    ('scm', 'Source Control'),
+                    ('cloud', 'Cloud'),
+                    ('registry', 'Container Registry'),
+                    ('token', 'Personal Access Token'),
+                    ('insights', 'Insights'),
+                    ('external', 'External'),
+                    ('kubernetes', 'Kubernetes'),
+                    ('galaxy', 'Galaxy/Automation Hub'),
+                    ('cryptography', 'Cryptography'),
+                ],
+                max_length=32,
             ),
         ),
         migrations.RunPython(setup_tower_managed_defaults),

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -336,6 +336,7 @@ class CredentialType(CommonModelNameNotUnique):
         ('external', _('External')),
         ('kubernetes', _('Kubernetes')),
         ('galaxy', _('Galaxy/Automation Hub')),
+        ('cryptography', _('Cryptography')),
     )
 
     kind = models.CharField(max_length=32, choices=KIND_CHOICES)


### PR DESCRIPTION
##### SUMMARY

This was missed when we landed #12813. Adds `cryptography` kind to the `CredentialType` allowed kinds list, which now produces the proper error message when attempting to `PUT` to modify the managed credential type.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API