### PR TITLE
Add support of update_on_project_update in inventory_source

### DIFF
--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -97,6 +97,10 @@ options:
       description:
         - Refresh inventory data from its source each time a job is run.
       type: bool
+    update_on_project_update:
+      description:
+        - Automatically update the inventory source on project update.
+      type: bool
     update_cache_timeout:
       description:
         - Time in seconds to consider an inventory sync to be current.
@@ -176,6 +180,7 @@ def main():
         timeout=dict(type='int'),
         verbosity=dict(type='int', choices=[0, 1, 2]),
         update_on_launch=dict(type='bool'),
+        update_on_project_update=dict(type='bool'),
         update_cache_timeout=dict(type='int'),
         source_project=dict(),
         notification_templates_started=dict(type="list", elements='str'),
@@ -268,6 +273,7 @@ def main():
         'timeout',
         'verbosity',
         'update_on_launch',
+        'update_on_project_update',
         'update_cache_timeout',
         'enabled_var',
         'enabled_value',

--- a/awx_collection/tests/integration/targets/inventory_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source/tasks/main.yml
@@ -33,6 +33,7 @@
     credential: "{{ credential_result.id }}"
     overwrite: true
     update_on_launch: true
+    update_on_project_update: true
     source_vars:
       private: false
     source: openstack


### PR DESCRIPTION
##### SUMMARY
The flag `update_on_project_update  `was missing from `inventory_source `module.

Api ref: https://docs.ansible.com/ansible-tower/latest/html/towerapi/api_ref.html#/Inventories/Inventories_inventories_inventory_sources_create

##### ISSUE TYPE
New or Enhanced Feature

##### COMPONENT NAME
 - Collection


