### PR TITLE
Fix compiler warnings.

### DIFF
--- a/awx/ui/src/screens/TopologyView/Legend.js
+++ b/awx/ui/src/screens/TopologyView/Legend.js
@@ -1,3 +1,4 @@
+/* eslint i18next/no-literal-string: "off" */
 import React from 'react';
 import { t } from '@lingui/macro';
 import styled from 'styled-components';
@@ -70,14 +71,14 @@ function Legend() {
       <DescriptionList isHorizontal isFluid>
         <DescriptionListGroup>
           <DescriptionListTerm>
-            <Button isSmall>{t`C`}</Button>
+            <Button isSmall>C</Button>
           </DescriptionListTerm>
           <DescriptionListDescription>{t`Control node`}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>
             <Button variant="primary" isSmall>
-              {t`Ex`}
+              Ex
             </Button>
           </DescriptionListTerm>
           <DescriptionListDescription>
@@ -87,7 +88,7 @@ function Legend() {
         <DescriptionListGroup>
           <DescriptionListTerm>
             <Button variant="primary" isSmall>
-              {t`Hy`}
+              Hy
             </Button>
           </DescriptionListTerm>
           <DescriptionListDescription>{t`Hybrid node`}</DescriptionListDescription>
@@ -95,7 +96,7 @@ function Legend() {
         <DescriptionListGroup>
           <DescriptionListTerm>
             <Button variant="primary" isSmall>
-              {t`h`}
+              h
             </Button>
           </DescriptionListTerm>
           <DescriptionListDescription>{t`Hop node`}</DescriptionListDescription>
@@ -185,7 +186,7 @@ function Legend() {
                 fill="transparent"
                 strokeWidth="1px"
                 stroke="#ccc"
-              ></circle>
+              />
               <text
                 x="10"
                 y="10"
@@ -213,7 +214,7 @@ function Legend() {
                 strokeDasharray="5"
                 strokeWidth="1px"
                 stroke="#ccc"
-              ></circle>
+              />
               <text
                 x="10"
                 y="10"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix compiler warnings introduced when #12860 was merged. The front end may not build correctly without this fix. I also decided to unmark node symbols for translation `H, hy, C, Ex`.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 