### PR TITLE
Avoid cache warning for dispatching control type tasks

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -609,8 +609,6 @@ class TaskManager(TaskBase):
 
             found_acceptable_queue = False
 
-            preferred_instance_groups = self.instance_groups.get_instance_groups_from_task_cache(task)
-
             # Determine if there is control capacity for the task
             if task.capacity_type == 'control':
                 control_impact = task.task_impact + settings.AWX_CONTROL_NODE_TASK_IMPACT
@@ -636,7 +634,7 @@ class TaskManager(TaskBase):
                 found_acceptable_queue = True
                 continue
 
-            for instance_group in preferred_instance_groups:
+            for instance_group in self.instance_groups.get_instance_groups_from_task_cache(task):
                 if instance_group.is_container_group:
                     self.start_task(task, instance_group, task.get_jobs_fail_chain(), None)
                     found_acceptable_queue = True


### PR DESCRIPTION
##### SUMMARY
I saw that we have significant log noise from this particular error log.

```python
logger.warn(f"No instance groups in cache exist, defaulting to global instance groups for task {task}")
```

It seems like that root problem is that `preferred_instance_groups` just _shouldn't be a construct_ for project updates. So I hope this is the logical change to avoid this log. We will `continue` before we try to obtain this list for looping, and avoid all those errors in logs.

I could file an issue for this, but since it was only introduced in `devel` and is mostly concerned with logs, I thought I'd just go straight to the fix.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
