### PR TITLE
Fixed bug where inventory field was erroneously disabled on WFJT form

### DIFF
--- a/awx/ui/src/components/Lookup/InventoryLookup.js
+++ b/awx/ui/src/components/Lookup/InventoryLookup.js
@@ -26,7 +26,6 @@ function InventoryLookup({
   hideSmartInventories,
   history,
   isDisabled,
-  isOverrideDisabled,
   isPromptableField,
   onBlur,
   onChange,
@@ -120,7 +119,7 @@ function InventoryLookup({
       label={t`Inventory`}
       promptId={promptId}
       promptName={promptName}
-      isDisabled={isOverrideDisabled || isDisabled}
+      isDisabled={isDisabled}
       tooltip={t`Select the inventory containing the hosts
             you want this job to manage.`}
     >
@@ -136,7 +135,7 @@ function InventoryLookup({
         fieldName={fieldName}
         validate={validate}
         isLoading={isLoading}
-        isDisabled={isOverrideDisabled || isDisabled}
+        isDisabled={isDisabled}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList
@@ -191,7 +190,7 @@ function InventoryLookup({
         onBlur={onBlur}
         required={required}
         isLoading={isLoading}
-        isDisabled={isOverrideDisabled || isDisabled}
+        isDisabled={isDisabled}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList
@@ -242,7 +241,6 @@ InventoryLookup.propTypes = {
   fieldName: string,
   hideSmartInventories: bool,
   isDisabled: bool,
-  isOverrideDisabled: bool,
   onChange: func.isRequired,
   required: bool,
   validate: func,
@@ -255,7 +253,6 @@ InventoryLookup.defaultProps = {
   fieldName: 'inventory',
   hideSmartInventories: false,
   isDisabled: false,
-  isOverrideDisabled: false,
   required: false,
   validate: () => {},
   value: null,

--- a/awx/ui/src/components/Lookup/InventoryLookup.js
+++ b/awx/ui/src/components/Lookup/InventoryLookup.js
@@ -39,13 +39,7 @@ function InventoryLookup({
   const autoPopulateLookup = useAutoPopulateLookup(onChange);
 
   const {
-    result: {
-      inventories,
-      count,
-      relatedSearchableKeys,
-      searchableKeys,
-      canEdit,
-    },
+    result: { inventories, count, relatedSearchableKeys, searchableKeys },
     request: fetchInventories,
     error,
     isLoading,
@@ -85,8 +79,6 @@ function InventoryLookup({
             key,
             type: actionsResponse.data.actions?.GET[key].type,
           })),
-        canEdit:
-          Boolean(actionsResponse.data.actions.POST) || isOverrideDisabled,
       };
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [autoPopulate, autoPopulateLookup, history.location]),
@@ -95,7 +87,6 @@ function InventoryLookup({
       count: 0,
       relatedSearchableKeys: [],
       searchableKeys: [],
-      canEdit: false,
     }
   );
 
@@ -129,7 +120,7 @@ function InventoryLookup({
       label={t`Inventory`}
       promptId={promptId}
       promptName={promptName}
-      isDisabled={!canEdit || isDisabled}
+      isDisabled={isOverrideDisabled || isDisabled}
       tooltip={t`Select the inventory containing the hosts
             you want this job to manage.`}
     >
@@ -145,7 +136,7 @@ function InventoryLookup({
         fieldName={fieldName}
         validate={validate}
         isLoading={isLoading}
-        isDisabled={!canEdit || isDisabled}
+        isDisabled={isOverrideDisabled || isDisabled}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList
@@ -200,7 +191,7 @@ function InventoryLookup({
         onBlur={onBlur}
         required={required}
         isLoading={isLoading}
-        isDisabled={!canEdit || isDisabled}
+        isDisabled={isOverrideDisabled || isDisabled}
         qsConfig={QS_CONFIG}
         renderOptionsList={({ state, dispatch, canDelete }) => (
           <OptionsList

--- a/awx/ui/src/components/Lookup/InventoryLookup.test.js
+++ b/awx/ui/src/components/Lookup/InventoryLookup.test.js
@@ -99,7 +99,7 @@ describe('InventoryLookup', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <Formik>
-          <InventoryLookup isOverrideDisabled onChange={() => {}} />
+          <InventoryLookup onChange={() => {}} />
         </Formik>
       );
     });
@@ -121,7 +121,7 @@ describe('InventoryLookup', () => {
     await act(async () => {
       wrapper = mountWithContexts(
         <Formik>
-          <InventoryLookup onChange={() => {}} />
+          <InventoryLookup isDisabled onChange={() => {}} />
         </Formik>
       );
     });

--- a/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.js
+++ b/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.js
@@ -151,7 +151,7 @@ function WorkflowJobTemplateForm({
             onChange={handleInventoryUpdate}
             touched={inventoryMeta.touched}
             error={inventoryMeta.error}
-            isOverrideDisabled={isInventoryDisabled}
+            isDisabled={isInventoryDisabled}
           />
         </FormGroup>
         <FieldWithPrompt

--- a/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.js
+++ b/awx/ui/src/screens/Template/shared/WorkflowJobTemplateForm.js
@@ -39,6 +39,7 @@ function WorkflowJobTemplateForm({
   handleCancel,
   submitError,
   isOrgAdmin,
+  isInventoryDisabled,
 }) {
   const helpText = getHelpText();
   const { setFieldValue, setFieldTouched } = useFormikContext();
@@ -150,6 +151,7 @@ function WorkflowJobTemplateForm({
             onChange={handleInventoryUpdate}
             touched={inventoryMeta.touched}
             error={inventoryMeta.error}
+            isOverrideDisabled={isInventoryDisabled}
           />
         </FormGroup>
         <FieldWithPrompt
@@ -284,6 +286,7 @@ WorkflowJobTemplateForm.propTypes = {
   handleCancel: PropTypes.func.isRequired,
   submitError: shape({}),
   isOrgAdmin: PropTypes.bool,
+  isInventoryDisabled: PropTypes.bool,
 };
 
 WorkflowJobTemplateForm.defaultProps = {
@@ -295,6 +298,7 @@ WorkflowJobTemplateForm.defaultProps = {
     project: undefined,
   },
   isOrgAdmin: false,
+  isInventoryDisabled: false,
 };
 
 const FormikApp = withFormik({


### PR DESCRIPTION
##### SUMMARY
The inventory field on a WFJT should only be disabled if the editing user does not have at least use permissions on the previously selected inventory.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
