### PR TITLE
Prevent altering certain fields on Instance

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4778,12 +4778,12 @@ class InstanceSerializer(BaseSerializer):
         read_only_fields = ('ip_address', 'uuid', 'version')
         fields = (
             'id',
+            'hostname',
             'type',
             'url',
             'related',
             'summary_fields',
             'uuid',
-            'hostname',
             'created',
             'modified',
             'last_seen',
@@ -4807,6 +4807,7 @@ class InstanceSerializer(BaseSerializer):
             'ip_address',
             'listener_port',
         )
+        extra_kwargs = {'node_type': {'default': 'execution'}, 'node_state': {'default': 'installed'}}
 
     def get_related(self, obj):
         res = super(InstanceSerializer, self).get_related(obj)
@@ -4865,6 +4866,18 @@ class InstanceSerializer(BaseSerializer):
         else:
             if value and value != Instance.States.INSTALLED:
                 raise serializers.ValidationError("Can only create instances in the 'installed' state.")
+
+        return value
+
+    def validate_hostname(self, value):
+        if self.instance and self.instance.hostname != value:
+            raise serializers.ValidationError("Cannot change hostname.")
+
+        return value
+
+    def validate_listener_port(self, value):
+        if self.instance and self.instance.listener_port != value:
+            raise serializers.ValidationError("Cannot change listener port.")
 
         return value
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Prevents changing hostname, listener_port, or node_type for instances
that already exist
- API default node_type is execution
- API default node_state is installed

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

