### PR TITLE
Only get receptor.conf lock in k8s environment

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -46,11 +46,22 @@ class ReceptorConnectionType(Enum):
     STREAMTLS = 2
 
 
-def get_receptor_sockfile():
-    lock = FileLock(__RECEPTOR_CONF_LOCKFILE)
-    with lock:
+def read_receptor_config():
+    # for K8S deployments, getting a lock is necessary as another process
+    # may be re-writing the config at this time
+    if settings.IS_K8S:
+        lock = FileLock(__RECEPTOR_CONF_LOCKFILE)
+        with lock:
+            with open(__RECEPTOR_CONF, 'r') as f:
+                return yaml.safe_load(f)
+    else:
         with open(__RECEPTOR_CONF, 'r') as f:
-            data = yaml.safe_load(f)
+            return yaml.safe_load(f)
+
+
+def get_receptor_sockfile():
+    data = read_receptor_config()
+
     for section in data:
         for entry_name, entry_data in section.items():
             if entry_name == 'control-service':
@@ -66,10 +77,7 @@ def get_tls_client(use_stream_tls=None):
     if not use_stream_tls:
         return None
 
-    lock = FileLock(__RECEPTOR_CONF_LOCKFILE)
-    with lock:
-        with open(__RECEPTOR_CONF, 'r') as f:
-            data = yaml.safe_load(f)
+    data = read_receptor_config()
     for section in data:
         for entry_name, entry_data in section.items():
             if entry_name == 'tls-client':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
a few places we attempt to acquire the lock with `lock = FileLock(__RECEPTOR_CONF_LOCKFILE)`

For non-K8S environments /etc/receptor does not have write permissions for user awx, so attempting to grab a lock fails with permissions errors

```
# ls -la /etc/receptor
total 28
drwxr-x---.  3 receptor awx       122 Sep 15 10:47 .
```
the error:

`PermissionError: [Errno 13] Permission denied: '/etc/receptor/receptor.conf.lock'`

This change only attempts to grab the lock if we are in a k8s environment, otherwise we skip the lock and just read. This is safe because we don't write to receptor.conf in non-k8s deployments (yet).
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
