### PR TITLE
Correctly summarize label prompts, and add missing EE

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3222,9 +3222,9 @@ class JobCreateScheduleSerializer(LabelsListMixin, BaseSerializer):
                     ret[field_name] = self._summarize(field_name, ret[field_name])
             for field_name, singular in (('credentials', 'credential'), ('instance_groups', 'instance_group')):
                 if field_name in ret:
-                    ret[field_name] = [self._summarize(singular, cred) for cred in ret[field_name]]
+                    ret[field_name] = [self._summarize(singular, obj) for obj in ret[field_name]]
             if 'labels' in ret:
-                ret['labels'] = self._summary_field_labels(obj)
+                ret['labels'] = self._summary_field_labels(config)
             return ret
         except JobLaunchConfig.DoesNotExist:
             return {'all': _('Unknown, job may have been ran before launch configurations were saved.')}

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3726,6 +3726,7 @@ class JobCreateSchedule(RetrieveAPIView):
             extra_data=config.extra_data,
             survey_passwords=config.survey_passwords,
             inventory=config.inventory,
+            execution_environment=config.execution_environment,
             char_prompts=config.char_prompts,
             credentials=set(config.credentials.all()),
             labels=set(config.labels.all()),

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1007,7 +1007,7 @@ class UnifiedJob(
                 # Here we are doing a loop to make sure we preserve order in case this is a Ordered field
                 job_item = kwargs.get(field_name, [])
                 if job_item:
-                    parent_items = getattr(parent, field_name, []).all()
+                    parent_items = list(getattr(parent, field_name, []).all())
                     for item in job_item:
                         # Do not include this item in the config if its in the parent
                         if item not in parent_items:


### PR DESCRIPTION
##### SUMMARY
a GET to the create_schedule endpoint was showing the job labels, not the prompted labels.

Also, the create_schedule POST wasn't making a copy of the EE

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

