### PR TITLE
Add additional schedule fields for new prompts

### DIFF
--- a/awxkit/awxkit/api/pages/unified_job_templates.py
+++ b/awxkit/awxkit/api/pages/unified_job_templates.py
@@ -19,6 +19,10 @@ class UnifiedJobTemplate(HasStatus, base.Base):
         'job_type',
         'verbosity',
         'inventory',
+        'forks',
+        'timeout',
+        'job_slice_count',
+        'execution_environment',
     )
 
     def __str__(self):


### PR DESCRIPTION
Add new prompts fields to the Schedules model, so we can set those when creating schedules from the job templates. 