### PR TITLE
Fix another bug applying extra_vars to incompatible job types

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -965,10 +965,14 @@ class LaunchTimeConfigBase(BaseModel):
         'execution_environment',  # already a unified job and unified JT field
     )
 
-    def prompts_dict(self, display=False):
+    def prompts_dict(self, display=False, for_cls=None):
         data = {}
+        if for_cls:
+            cls = for_cls
+        else:
+            cls = JobTemplate
         # Some types may have different prompts, but always subset of JT prompts
-        for prompt_name in JobTemplate.get_ask_mapping().keys():
+        for prompt_name in cls.get_ask_mapping().keys():
             try:
                 field = self._meta.get_field(prompt_name)
             except FieldDoesNotExist:

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -304,8 +304,8 @@ class WorkflowJobNode(WorkflowNodeBase):
         wj_special_passwords = {}
         ujt_obj = self.unified_job_template
         if ujt_obj is not None:
-            node_prompts_data = self.prompts_dict()
-            wj_prompts_data = self.workflow_job.prompts_dict()
+            node_prompts_data = self.prompts_dict(for_cls=ujt_obj.__class__)
+            wj_prompts_data = self.workflow_job.prompts_dict(for_cls=ujt_obj.__class__)
             # Explanation - special historical case
             # WFJT extra_vars ignored JobTemplate.ask_variables_on_launch, bypassing _accept_or_ignore_job_kwargs
             # inventory and others are only accepted if JT prompts for it with related ask_ field


### PR DESCRIPTION
##### SUMMARY
The _last_ fix which was fixing fallout from _another_ fix seems to have introduced even _more_ fallout, as we end up passing `extra_vars` to an inventory update, and it errors and nothing can ever run again.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

