### PR TITLE
Add scroll overflow for legend and tooltip in Topology View.

### DIFF
--- a/awx/ui/src/screens/TopologyView/Legend.js
+++ b/awx/ui/src/screens/TopologyView/Legend.js
@@ -24,11 +24,12 @@ import {
 
 const Wrapper = styled.div`
   position: absolute;
-  top: -20px;
   left: 0;
-  padding: 10px;
+  padding: 0 10px;
   width: 150px;
   background-color: rgba(255, 255, 255, 0.85);
+  overflow: scroll;
+  height: 100%;
 `;
 const Button = styled(PFButton)`
   &&& {
@@ -61,7 +62,7 @@ function Legend() {
       <TextContent>
         <Text
           component={TextVariants.small}
-          style={{ fontWeight: 'bold', color: 'black' }}
+          style={{ fontWeight: 'bold', color: 'black', marginTop: 0 }}
         >
           {t`Legend`}
         </Text>

--- a/awx/ui/src/screens/TopologyView/Tooltip.js
+++ b/awx/ui/src/screens/TopologyView/Tooltip.js
@@ -33,11 +33,12 @@ import { formatDateString } from 'util/dates';
 
 const Wrapper = styled.div`
   position: absolute;
-  top: -20px;
   right: 0;
-  padding: 10px;
+  padding: 0 10px;
   width: 25%;
   background-color: rgba(255, 255, 255, 0.85);
+  overflow: scroll;
+  height: 100%;
 `;
 const Button = styled(PFButton)`
   &&& {
@@ -181,7 +182,7 @@ function Tooltip({
         <TextContent>
           <Text
             component={TextVariants.small}
-            style={{ fontWeight: 'bold', color: 'black' }}
+            style={{ fontWeight: 'bold', color: 'black', marginTop: 0 }}
           >
             {t`Details`}
           </Text>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add overflow scroll to legend and tooltip components in Topology View.

<img width="2160" alt="Screen Shot 2022-09-19 at 2 08 56 PM" src="https://user-images.githubusercontent.com/2293210/191117307-c24a94b2-eb73-483b-ae1a-f7667fc56af7.png">

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 