### PR TITLE
Validate job_slice_count in API

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4140,9 +4140,9 @@ class JobLaunchSerializer(BaseSerializer):
     verbosity = serializers.ChoiceField(required=False, choices=VERBOSITY_CHOICES, write_only=True)
     execution_environment = serializers.PrimaryKeyRelatedField(queryset=ExecutionEnvironment.objects.all(), required=False, write_only=True)
     labels = serializers.PrimaryKeyRelatedField(many=True, queryset=Label.objects.all(), required=False, write_only=True)
-    forks = serializers.IntegerField(required=False, write_only=True, min_value=0, default=1)
-    job_slice_count = serializers.IntegerField(required=False, write_only=True, min_value=0, default=0)
-    timeout = serializers.IntegerField(required=False, write_only=True, default=0)
+    forks = serializers.IntegerField(required=False, write_only=True, min_value=0)
+    job_slice_count = serializers.IntegerField(required=False, write_only=True, min_value=0)
+    timeout = serializers.IntegerField(required=False, write_only=True)
     instance_groups = serializers.PrimaryKeyRelatedField(many=True, queryset=InstanceGroup.objects.all(), required=False, write_only=True)
 
     class Meta:

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -333,9 +333,6 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
         actual_slice_count = self.job_slice_count
         if self.ask_job_slice_count_on_launch and 'job_slice_count' in kwargs:
             actual_slice_count = kwargs['job_slice_count']
-            # Set the eager fields if its there as well
-            if '_eager_fields' in kwargs and 'job_slice_count' in kwargs['_eager_fields']:
-                kwargs['_eager_fields']['job_slice_count'] = actual_slice_count
         if actual_inventory:
             return min(actual_slice_count, actual_inventory.hosts.count())
         else:
@@ -476,6 +473,10 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
                         rejected_data[field_name] = new_value
                         errors_dict[field_name] = _('Project does not allow override of branch.')
                         continue
+                elif field_name == 'job_slice_count' and (new_value > 1) and (self.get_effective_slice_ct(kwargs) <= 1):
+                    rejected_data[field_name] = new_value
+                    errors_dict[field_name] = _('Job inventory does not have enough hosts for slicing')
+                    continue
                 # accepted prompt
                 prompted_data[field_name] = new_value
             else:

--- a/awx/main/tests/functional/models/test_job.py
+++ b/awx/main/tests/functional/models/test_job.py
@@ -79,3 +79,11 @@ class TestSlicingModels:
         assert job_template.get_effective_slice_ct({'inventory': inventory2}) == 2
         # Now we are going to pass in an override (like the prompt would) and as long as that is < host count we expect that back
         assert job_template.get_effective_slice_ct({'inventory': inventory2, 'job_slice_count': 3}) == 3
+
+    def test_slice_count_prompt_limited_by_inventory(self, job_template, inventory, organization):
+        assert inventory.hosts.count() == 0
+        job_template.inventory = inventory
+        inventory.hosts.create(name='foo')
+
+        unified_job = job_template.create_unified_job(job_slice_count=2)
+        assert isinstance(unified_job, Job)


### PR DESCRIPTION
##### SUMMARY
Followup from a few comments I left on the main feature PR.

I was having a problem with the use of `_eager_fields`, and now I see the problem it was addressing, but I found it better to not allow us to get to that point in the first place. Host counts can change over time, so I get not enforcing this on the JT, but _on launch_ it seems like nonsense to accept these values.

Separately, removing integer defaults.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

