### PR TITLE
Treat instance_groups prompt as template-less

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4139,12 +4139,12 @@ class JobLaunchSerializer(BaseSerializer):
     skip_tags = serializers.CharField(required=False, write_only=True, allow_blank=True)
     limit = serializers.CharField(required=False, write_only=True, allow_blank=True)
     verbosity = serializers.ChoiceField(required=False, choices=VERBOSITY_CHOICES, write_only=True)
-    execution_environment = serializers.PrimaryKeyRelatedField(queryset=ExecutionEnvironment.objects.all(), required=False)
-    labels = serializers.PrimaryKeyRelatedField(many=True, queryset=Label.objects.all(), required=False)
+    execution_environment = serializers.PrimaryKeyRelatedField(queryset=ExecutionEnvironment.objects.all(), required=False, write_only=True)
+    labels = serializers.PrimaryKeyRelatedField(many=True, queryset=Label.objects.all(), required=False, write_only=True)
     forks = serializers.IntegerField(required=False, write_only=True, min_value=0, default=1)
     job_slice_count = serializers.IntegerField(required=False, write_only=True, min_value=0, default=0)
     timeout = serializers.IntegerField(required=False, write_only=True, default=0)
-    instance_groups = serializers.PrimaryKeyRelatedField(many=True, queryset=InstanceGroup.objects.all(), required=False)
+    instance_groups = serializers.PrimaryKeyRelatedField(many=True, queryset=InstanceGroup.objects.all(), required=False, write_only=True)
 
     class Meta:
         model = JobTemplate
@@ -4243,9 +4243,7 @@ class JobLaunchSerializer(BaseSerializer):
                     label_dict = {'id': label.id, 'name': label.name}
                     defaults_dict.setdefault(field_name, []).append(label_dict)
             elif field_name == 'instance_groups':
-                for instance_group in obj.instance_groups.all():
-                    ig_dict = {'id': instance_group.id, 'name': instance_group.name}
-                    defaults_dict.setdefault(field_name, []).append(ig_dict)
+                defaults_dict[field_name] = []
             else:
                 defaults_dict[field_name] = getattr(obj, field_name)
         return defaults_dict

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3068,7 +3068,6 @@ class JobSerializer(UnifiedJobSerializer, JobOptionsSerializer):
                 res['project_update'] = self.reverse('api:project_update_detail', kwargs={'pk': obj.project_update.pk})
         except ObjectDoesNotExist:
             pass
-        res['instance_groups'] = self.reverse('api:job_instance_group_list', kwargs={'pk': obj.pk})
         res['relaunch'] = self.reverse('api:job_relaunch', kwargs={'pk': obj.pk})
         return res
 

--- a/awx/api/urls/job.py
+++ b/awx/api/urls/job.py
@@ -16,7 +16,6 @@ from awx.api.views import (
     JobStdout,
     JobNotificationsList,
     JobLabelList,
-    JobInstanceGroupList,
     JobHostSummaryDetail,
 )
 
@@ -34,7 +33,6 @@ urls = [
     re_path(r'^(?P<pk>[0-9]+)/stdout/$', JobStdout.as_view(), name='job_stdout'),
     re_path(r'^(?P<pk>[0-9]+)/notifications/$', JobNotificationsList.as_view(), name='job_notifications_list'),
     re_path(r'^(?P<pk>[0-9]+)/labels/$', JobLabelList.as_view(), name='job_label_list'),
-    re_path(r'^(?P<pk>[0-9]+)/instance_groups/$', JobInstanceGroupList.as_view(), name='job_instance_group_list'),
     re_path(r'^(?P<pk>[0-9]+)/$', JobHostSummaryDetail.as_view(), name='job_host_summary_detail'),
 ]
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3568,15 +3568,6 @@ class JobLabelList(SubListAPIView):
     parent_key = 'job'
 
 
-class JobInstanceGroupList(SubListAPIView):
-
-    model = models.InstanceGroup
-    serializer_class = serializers.InstanceGroupSerializer
-    parent_model = models.Job
-    relationship = 'instance_groups'
-    parent_key = 'job'
-
-
 class WorkflowJobLabelList(JobLabelList):
     parent_model = models.WorkflowJob
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -2398,6 +2398,9 @@ class JobTemplateLaunch(RetrieveAPIView):
                 elif isinstance(getattr(obj.__class__, field).field, ForeignKey):
                     data[field] = getattrd(obj, "%s.%s" % (field, 'id'), None)
                 elif isinstance(getattr(obj.__class__, field).field, ManyToManyField):
+                    if field == 'instance_groups':
+                        data[field] = []
+                        continue
                     data[field] = [item.id for item in getattr(obj, field).all()]
                 else:
                     data[field] = getattr(obj, field)

--- a/awx/main/migrations/0169_jt_prompt_everything_on_launch.py
+++ b/awx/main/migrations/0169_jt_prompt_everything_on_launch.py
@@ -175,22 +175,6 @@ class Migration(migrations.Migration):
                 ('joblaunchconfig', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.joblaunchconfig')),
             ],
         ),
-        migrations.CreateModel(
-            name='JobInstanceGroupMembership',
-            fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('position', models.PositiveIntegerField(db_index=True, default=None, null=True)),
-                ('instancegroup', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.instancegroup')),
-                ('unifiedjob', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='main.job')),
-            ],
-        ),
-        migrations.AddField(
-            model_name='job',
-            name='instance_groups',
-            field=awx.main.fields.OrderedManyToManyField(
-                blank=True, editable=False, related_name='job_instance_groups', through='main.JobInstanceGroupMembership', to='main.InstanceGroup'
-            ),
-        ),
         migrations.AddField(
             model_name='joblaunchconfig',
             name='instance_groups',

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -436,6 +436,7 @@ class InventoryInstanceGroupMembership(models.Model):
     )
 
 
+# TODO: delete after migration sorted out
 class JobInstanceGroupMembership(models.Model):
 
     unifiedjob = models.ForeignKey('Job', on_delete=models.CASCADE)

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -436,18 +436,6 @@ class InventoryInstanceGroupMembership(models.Model):
     )
 
 
-# TODO: delete after migration sorted out
-class JobInstanceGroupMembership(models.Model):
-
-    unifiedjob = models.ForeignKey('Job', on_delete=models.CASCADE)
-    instancegroup = models.ForeignKey('InstanceGroup', on_delete=models.CASCADE)
-    position = models.PositiveIntegerField(
-        null=True,
-        default=None,
-        db_index=True,
-    )
-
-
 class JobLaunchConfigInstanceGroupMembership(models.Model):
 
     joblaunchconfig = models.ForeignKey('JobLaunchConfig', on_delete=models.CASCADE)

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -604,14 +604,6 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         default=1,
         help_text=_("If ran as part of sliced jobs, the total number of slices. " "If 1, job is not part of a sliced job."),
     )
-    # TODO: delete after migration sorted out
-    instance_groups = OrderedManyToManyField(
-        'InstanceGroup',
-        related_name='job_instance_groups',
-        blank=True,
-        editable=False,
-        through='JobInstanceGroupMembership',
-    )
 
     def _get_parent_field_name(self):
         return 'job_template'

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -292,7 +292,6 @@ class JobTemplate(UnifiedJobTemplate, JobOptions, SurveyJobTemplateMixin, Resour
                 'job_slice_number',
                 'job_slice_count',
                 'execution_environment',
-                'instance_groups',
             ]
         )
 
@@ -605,6 +604,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         default=1,
         help_text=_("If ran as part of sliced jobs, the total number of slices. " "If 1, job is not part of a sliced job."),
     )
+    # TODO: delete after migration sorted out
     instance_groups = OrderedManyToManyField(
         'InstanceGroup',
         related_name='job_instance_groups',

--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -132,6 +132,10 @@ class TaskManagerInstanceGroups:
                 else:
                     logger.warn(f"Unknown instance group with pk {pk} for task {task}")
         if len(igs) == 0:
+            # TODO: change behavior here, options are
+            # (1) fail the job
+            # (2) re-compute the list
+            # if re-computing: [ig.pk for ig in job.launch_config.instance_groups.all()] OR task.preferred_instance_groups
             logger.warn(f"No instance groups in cache exist, defaulting to global instance groups for task {task}")
             return task.global_instance_groups
         return igs

--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -132,10 +132,6 @@ class TaskManagerInstanceGroups:
                 else:
                     logger.warn(f"Unknown instance group with pk {pk} for task {task}")
         if len(igs) == 0:
-            # TODO: change behavior here, options are
-            # (1) fail the job
-            # (2) re-compute the list
-            # if re-computing: [ig.pk for ig in job.launch_config.instance_groups.all()] OR task.preferred_instance_groups
             logger.warn(f"No instance groups in cache exist, defaulting to global instance groups for task {task}")
             return task.global_instance_groups
         return igs

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -154,6 +154,7 @@ class TestLaunchConfig:
         job = Job.objects.create(job_template=job_template)
         ig1 = InstanceGroup.objects.create(name='bar')
         ig2 = InstanceGroup.objects.create(name='foo')
+        job_template.instance_groups.add(ig2)
         label1 = Label.objects.create(name='foo', description='bar', organization=organization)
         label2 = Label.objects.create(name='faz', description='baz', organization=organization)
         # Order should matter here which is why we do 2 and then 1

--- a/awx/main/tests/unit/api/serializers/test_job_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_job_serializers.py
@@ -55,7 +55,6 @@ class TestJobSerializerGetRelated:
             'job_events',
             'relaunch',
             'labels',
-            'instance_groups',
         ],
     )
     def test_get_related(self, test_get_related, job, related_resource_name):

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -531,11 +531,6 @@ def copy_m2m_relationships(obj1, obj2, fields, kwargs=None):
                 src_field_value = getattr(obj1, field_name)
                 if kwargs and field_name in kwargs:
                     override_field_val = kwargs[field_name]
-                    if field_name == 'instance_groups':
-                        # instance_groups are a list but we need to preserve the order
-                        for ig_id in override_field_val:
-                            getattr(obj2, field_name).add(ig_id)
-                        continue
                     if isinstance(override_field_val, (set, list, QuerySet)):
                         # Labels are additive so we are going to add any src labels in addition to the override labels
                         if field_name == 'labels':

--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -42,7 +42,6 @@ function LaunchButton({ resource, children }) {
   const [launchConfig, setLaunchConfig] = useState(null);
   const [surveyConfig, setSurveyConfig] = useState(null);
   const [labels, setLabels] = useState([]);
-  const [instanceGroups, setInstanceGroups] = useState([]);
   const [isLaunching, setIsLaunching] = useState(false);
   const [error, setError] = useState(null);
 
@@ -71,35 +70,17 @@ function LaunchButton({ resource, children }) {
         setSurveyConfig(data);
       }
 
-      const relatedPromises = [];
-
       if (launch.ask_labels_on_launch) {
-        relatedPromises.push(readLabels);
-      } else {
-        relatedPromises.push(null);
-      }
+        const {
+          data: { results },
+        } = await readLabels;
 
-      if (launch.ask_instance_groups_on_launch) {
-        relatedPromises.push(JobTemplatesAPI.readInstanceGroups(resource.id));
-      } else {
-        relatedPromises.push(null);
-      }
-
-      const [labelsResponse, instanceGroupsResponse] = await Promise.all(
-        relatedPromises
-      );
-
-      if (launch.ask_labels_on_launch) {
-        const allLabels = labelsResponse?.data?.results.map((label) => ({
+        const allLabels = results.map((label) => ({
           ...label,
           isReadOnly: true,
         }));
 
         setLabels(allLabels);
-      }
-
-      if (launch.ask_instance_groups_on_launch) {
-        setInstanceGroups(instanceGroupsResponse?.data?.results);
       }
 
       if (canLaunchWithoutPrompt(launch)) {
@@ -216,7 +197,6 @@ function LaunchButton({ resource, children }) {
           labels={labels}
           onLaunch={launchWithParams}
           onCancel={() => setShowLaunchPrompt(false)}
-          instanceGroups={instanceGroups}
         />
       )}
     </>

--- a/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
+++ b/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
@@ -170,7 +170,6 @@ function LaunchPrompt({
   labels = [],
   surveyConfig,
   resourceDefaultCredentials = [],
-  instanceGroups = [],
 }) {
   return (
     <Formik initialValues={{}} onSubmit={(values) => onLaunch(values)}>
@@ -182,7 +181,7 @@ function LaunchPrompt({
         resource={resource}
         labels={labels}
         resourceDefaultCredentials={resourceDefaultCredentials}
-        instanceGroups={instanceGroups}
+        instanceGroups={[]}
       />
     </Formik>
   );

--- a/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
+++ b/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
@@ -31,8 +31,9 @@ function ScheduleEdit({
     values,
     launchConfiguration,
     surveyConfiguration,
-    scheduleCredentials = [],
-    originalLabels = []
+    originalInstanceGroups,
+    originalLabels,
+    scheduleCredentials = []
   ) => {
     const {
       execution_environment,
@@ -160,8 +161,8 @@ function ScheduleEdit({
         ),
         SchedulesAPI.orderInstanceGroups(
           scheduleId,
-          instance_groups,
-          resource?.summary_fields.instance_groups || []
+          instance_groups || [],
+          originalInstanceGroups
         ),
       ]);
 

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeModal.js
@@ -245,13 +245,7 @@ const NodeModalInner = ({ title, ...rest }) => {
   const {
     request: readLaunchConfigs,
     error: launchConfigError,
-    result: {
-      launchConfig,
-      surveyConfig,
-      resourceDefaultCredentials,
-      labels,
-      instanceGroups,
-    },
+    result: { launchConfig, surveyConfig, resourceDefaultCredentials, labels },
     isLoading,
   } = useRequest(
     useCallback(async () => {
@@ -271,7 +265,6 @@ const NodeModalInner = ({ title, ...rest }) => {
           surveyConfig: {},
           resourceDefaultCredentials: [],
           labels: [],
-          instanceGroups: [],
         };
       }
 
@@ -318,27 +311,11 @@ const NodeModalInner = ({ title, ...rest }) => {
         defaultLabels = results;
       }
 
-      let defaultInstanceGroups = [];
-
-      if (launch.ask_instance_groups_on_launch) {
-        const {
-          data: { results },
-        } = await await JobTemplatesAPI.readInstanceGroups(
-          values?.nodeResource?.id,
-          {
-            page_size: 200,
-          }
-        );
-
-        defaultInstanceGroups = results;
-      }
-
       return {
         launchConfig: launch,
         surveyConfig: survey,
         resourceDefaultCredentials: defaultCredentials,
         labels: defaultLabels,
-        instanceGroups: defaultInstanceGroups,
       };
 
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -392,7 +369,7 @@ const NodeModalInner = ({ title, ...rest }) => {
       isLaunchLoading={isLoading}
       title={wizardTitle}
       labels={labels}
-      instanceGroups={instanceGroups}
+      instanceGroups={[]}
     />
   );
 };


### PR DESCRIPTION
##### SUMMARY
Stems from conversations in the main branch. Avoids saving instance_groups to job, which are not meaningful.

Needs UI work, because the UI still presents the JT `instance_groups` related data. We need it to always give an empty list in the pre-fill data in the prompts form. The launch endpoint is now present `[]` in the defaults, but the UI reads from the JT related list, but this has a different meaning.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
