### PR TITLE
Set initial value node_type and node_state

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4819,7 +4819,7 @@ class InstanceSerializer(BaseSerializer):
             'ip_address',
             'listener_port',
         )
-        extra_kwargs = {'node_type': {'default': 'execution'}, 'node_state': {'default': 'installed'}}
+        extra_kwargs = {'node_type': {'initial': 'execution'}, 'node_state': {'initial': 'installed'}}
 
     def get_related(self, obj):
         res = super(InstanceSerializer, self).get_related(obj)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
default doesn't do anything, probably because we supply a default on the model itself. 

instead we should use `initial` to give it the values we want.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
