### PR TITLE
fix: UI host event modal when stdout is an array

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
@@ -40,6 +40,8 @@ const processCodeEditorValue = (value) => {
     codeEditorValue = '';
   } else if (typeof value === 'string') {
     codeEditorValue = encode(value);
+  } else if (Array.isArray(value)) {
+    codeEditorValue = encode(value.join(' '));
   } else {
     codeEditorValue = value;
   }

--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
@@ -52,6 +52,10 @@ const hostEvent = {
   },
 };
 
+/*
+Some libraries return a list of string in stdout
+Example: https://github.com/ansible-collections/cisco.ios/blob/main/plugins/modules/ios_command.py#L124-L128
+*/
 const hostEventWithArray = {
   changed: true,
   event: 'runner_on_ok',

--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
@@ -97,6 +97,13 @@ const hostEventWithArray = {
   task: 'command',
   type: 'job_event',
   url: '/api/v2/job_events/123/',
+  summary_fields: {
+    host: {
+      id: 1,
+      name: 'foo',
+      description: 'Bar',
+    },
+  },
 };
 
 /* eslint-disable no-useless-escape */

--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
@@ -52,6 +52,49 @@ const hostEvent = {
   },
 };
 
+const hostEventWithArray = {
+  changed: true,
+  event: 'runner_on_ok',
+  event_data: {
+    host: 'foo',
+    play: 'all',
+    playbook: 'run_command.yml',
+    res: {
+      ansible_loop_var: 'item',
+      changed: true,
+      item: '1',
+      msg: 'This is a debug message: 1',
+      stdout: [
+        '              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023',
+      ],
+      stderr: 'problems',
+      cmd: ['free', '-m'],
+      stderr_lines: [],
+      stdout_lines: [
+        '              total        used        free      shared  buff/cache   available',
+        'Mem:           7973        3005         960          30        4007        4582',
+        'Swap:          1023           0        1023',
+      ],
+    },
+    task: 'command',
+    task_action: 'command',
+  },
+  event_display: 'Host OK',
+  event_level: 3,
+  failed: false,
+  host: 1,
+  host_name: 'foo',
+  id: 123,
+  job: 4,
+  play: 'all',
+  playbook: 'run_command.yml',
+  stdout: `stdout: "[0;33mchanged: [localhost] => {"changed": true, "cmd": ["free", "-m"], "delta": "0:00:01.479609", "end": "2019-09-10 14:21:45.469533", "rc": 0, "start": "2019-09-10 14:21:43.989924", "stderr": "", "stderr_lines": [], "stdout": "              total        used        free      shared  buff/cache   available\nMem:           7973        3005         960          30        4007        4582\nSwap:          1023           0        1023", "stdout_lines": ["              total        used        free      shared  buff/cache   available", "Mem:           7973        3005         960          30        4007        4582", "Swap:          1023           0        1023"]}[0m"
+  `,
+  task: 'command',
+  type: 'job_event',
+  url: '/api/v2/job_events/123/',
+};
+
 /* eslint-disable no-useless-escape */
 const jsonValue = `{
   \"ansible_loop_var\": \"item\",
@@ -280,5 +323,26 @@ describe('HostEventModal', () => {
     expect(codeEditor.prop('mode')).toBe('javascript');
     expect(codeEditor.prop('readOnly')).toBe(true);
     expect(codeEditor.prop('value')).toEqual('baz\nbar');
+  });
+
+  test('should display Standard Out array stdout content', () => {
+    const wrapper = shallow(
+      <HostEventModal
+        hostEvent={hostEventWithArray}
+        onClose={() => {}}
+        isOpen
+      />
+    );
+
+    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
+    handleTabClick(null, 2);
+    wrapper.update();
+
+    const codeEditor = wrapper.find('Tab[eventKey=2] CodeEditor');
+    expect(codeEditor.prop('mode')).toBe('javascript');
+    expect(codeEditor.prop('readOnly')).toBe(true);
+    expect(codeEditor.prop('value')).toEqual(
+      hostEventWithArray.event_data.res.stdout.join(' ')
+    );
   });
 });


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related to https://github.com/ansible/awx/issues/12793

We are currently working with the `arubanetworks.aos_switch` and `cisco.ios` collections and we are experiencing a UI crash when we try to display the result of an ok or error task

After parsing the code of these libraries, the stdout returned is a list.  AWX does not handle this case. The objective of this PR is to fix this problem. 
Example about list in stdout: https://github.com/ansible-collections/cisco.ios/blob/main/plugins/modules/ios_command.py#L124-L128

I'm available to discuss this problem and make the necessary changes to this PR

FYI, thanks to @milc for the help 👍 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.6.1.dev7+g8e2003a36b
```
