### PR TITLE
[tech debt] Cleanup cruft from job slicing made possible by prompts model changes

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3174,7 +3174,7 @@ class JobTemplateCallback(GenericAPIView):
             kv['extra_vars'] = extra_vars_redacted
         kv['_prevent_slicing'] = True  # will only run against 1 host, so no point
         with transaction.atomic():
-            job = job_template.create_job(**kv)
+            job = job_template.create_unified_job(**kv)
 
         # Send a signal to signify that the job should be started.
         result = job.signal_start(inventory_sources_already_updated=inventory_sources_already_updated)
@@ -3598,7 +3598,7 @@ class WorkflowJobRelaunch(GenericAPIView):
             jt = obj.job_template
             if not jt:
                 raise ParseError(_('Cannot relaunch slice workflow job orphaned from job template.'))
-            elif not obj.inventory or min(obj.inventory.hosts.count(), jt.job_slice_count) != obj.workflow_nodes.count():
+            elif jt and jt.get_effective_slice_ct(obj.launch_prompts()) != obj.workflow_nodes.count():
                 raise ParseError(_('Cannot relaunch sliced workflow job after slice count has changed.'))
         new_workflow_job = obj.create_relaunch_workflow_job()
         new_workflow_job.signal_start()

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2149,13 +2149,16 @@ class WorkflowJobAccess(BaseAccess):
             return False
 
         # Obtain prompts used to start original job
-        JobLaunchConfig = obj._meta.get_field('launch_config').related_model
-        try:
-            config = JobLaunchConfig.objects.get(job=obj)
-        except JobLaunchConfig.DoesNotExist:
-            if self.save_messages:
-                self.messages['detail'] = _('Workflow Job was launched with unknown prompts.')
-            return False
+        if obj.is_sliced_job:
+            config = obj
+        else:
+            JobLaunchConfig = obj._meta.get_field('launch_config').related_model
+            try:
+                config = JobLaunchConfig.objects.get(job=obj)
+            except JobLaunchConfig.DoesNotExist:
+                if self.save_messages:
+                    self.messages['detail'] = _('Workflow Job was launched with unknown prompts.')
+                return False
 
         # execute permission to WFJT is mandatory for any relaunch
         if self.user not in template.execute_role:

--- a/awx/main/models/ad_hoc_commands.py
+++ b/awx/main/models/ad_hoc_commands.py
@@ -144,9 +144,6 @@ class AdHocCommand(UnifiedJob, JobNotificationMixin):
         else:
             return []
 
-    def _get_parent_field_name(self):
-        return ''
-
     @classmethod
     def _get_task_class(cls):
         from awx.main.tasks.jobs import RunAdHocCommand

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1113,10 +1113,6 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, CustomVirtualE
     )
 
     @classmethod
-    def _get_unified_job_class(cls):
-        return InventoryUpdate
-
-    @classmethod
     def _get_unified_job_field_names(cls):
         return set(f.name for f in InventorySourceOptions._meta.fields) | set(['name', 'description', 'organization', 'credentials', 'inventory'])
 
@@ -1262,6 +1258,8 @@ class InventoryUpdate(UnifiedJob, InventorySourceOptions, JobNotificationMixin, 
     Internal job for tracking inventory updates from external sources.
     """
 
+    PARENT_FIELD_NAME = 'inventory_source'
+
     class Meta:
         app_label = 'main'
         ordering = ('inventory', 'name')
@@ -1308,9 +1306,6 @@ class InventoryUpdate(UnifiedJob, InventorySourceOptions, JobNotificationMixin, 
     @property
     def is_container_group_task(self):
         return bool(self.instance_group and self.instance_group.is_container_group)
-
-    def _get_parent_field_name(self):
-        return 'inventory_source'
 
     @classmethod
     def _get_task_class(cls):

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -284,10 +284,6 @@ class JobTemplate(
     )
 
     @classmethod
-    def _get_unified_job_class(cls):
-        return Job
-
-    @classmethod
     def _get_unified_job_field_names(cls):
         return set(f.name for f in JobOptions._meta.fields) | set(
             [
@@ -328,12 +324,6 @@ class JobTemplate(
             raise ValidationError(_(f'Maximum number of forks ({settings.MAX_FORKS}) exceeded.'))
         return self.forks
 
-    def create_job(self, **kwargs):
-        """
-        Create a new job based on this template.
-        """
-        return self.create_unified_job(**kwargs)
-
     def get_effective_slice_ct(self, kwargs):
         actual_inventory = self.inventory
         if self.ask_inventory_on_launch and 'inventory' in kwargs:
@@ -356,31 +346,43 @@ class JobTemplate(
                 update_fields.append('organization_id')
         return super(JobTemplate, self).save(*args, **kwargs)
 
-    def create_unified_job(self, **kwargs):
-        prevent_slicing = kwargs.pop('_prevent_slicing', False)
-        slice_ct = self.get_effective_slice_ct(kwargs)
-        slice_event = bool(slice_ct > 1 and (not prevent_slicing))
-        if slice_event:
-            # A Slice Job Template will generate a WorkflowJob rather than a Job
-            from awx.main.models.workflow import WorkflowJobTemplate, WorkflowJobNode
+    def create_sliced_workflow_job(self, slice_ct, _eager_fields=None, survey_passwords=None, **prompts):
+        """
+        A Slice Job Template will generate a WorkflowJob rather than a Job
+        Implementation is different from create_unified_job because we care to copy
+        prompts but not the JT fields themselves.
+        """
+        from awx.main.models.workflow import WorkflowJob
 
-            kwargs['_unified_job_class'] = WorkflowJobTemplate._get_unified_job_class()
-            kwargs['_parent_field_name'] = "job_template"
-            kwargs.setdefault('_eager_fields', {})
-            kwargs['_eager_fields']['is_sliced_job'] = True
-        elif self.job_slice_count > 1 and (not prevent_slicing):
-            # Unique case where JT was set to slice but hosts not available
-            kwargs.setdefault('_eager_fields', {})
-            kwargs['_eager_fields']['job_slice_count'] = 1
-        elif prevent_slicing:
-            kwargs.setdefault('_eager_fields', {})
-            kwargs['_eager_fields'].setdefault('job_slice_count', 1)
-        job = super(JobTemplate, self).create_unified_job(**kwargs)
+        workflow_job = WorkflowJob(name=self.name, description=self.description)
+        if _eager_fields:
+            for fd, val in _eager_fields.items():
+                setattr(workflow_job, fd, val)
+        workflow_job.job_template = self
+        workflow_job.unified_job_template = self
+        workflow_job.is_sliced_job = True
+        workflow_job.survey_passwords = self.handle_launch_passwords(prompts.get('extra_vars', {}), survey_passwords)
+        # independent slices run in parallel by design, so simultaneity is enforced by workflow
+        workflow_job.allow_simultaneous = self.allow_simultaneous
+        workflow_job.save_prompts_data(self, onto_self=True, **prompts)  # also saves
+        for idx in range(slice_ct):
+            workflow_job.workflow_job_nodes.create(unified_job_template=self, identifier=str(idx + 1))
+        return workflow_job
+
+    def create_unified_job(self, _prevent_slicing=False, **prompts):
+        slice_ct = self.get_effective_slice_ct(prompts)
+        slice_event = bool(slice_ct > 1 and (not _prevent_slicing))
         if slice_event:
-            for idx in range(slice_ct):
-                create_kwargs = dict(workflow_job=job, unified_job_template=self, ancestor_artifacts=dict(job_slice=idx + 1))
-                WorkflowJobNode.objects.create(**create_kwargs)
-        return job
+            return self.create_sliced_workflow_job(slice_ct=slice_ct, **prompts)
+        elif self.job_slice_count > 1 and (not _prevent_slicing):
+            # Unique case where JT was set to slice but hosts not available
+            prompts.setdefault('_eager_fields', {})
+            prompts['_eager_fields']['job_slice_count'] = 1
+        elif _prevent_slicing:
+            # This job is, itself, a sub-job of a sliced workflow job
+            prompts.setdefault('_eager_fields', {})
+            prompts['_eager_fields'].setdefault('job_slice_count', 1)
+        return super(JobTemplate, self).create_unified_job(**prompts)
 
     def validate_unique(self, exclude=None):
         """Custom over-ride for JT specifically
@@ -450,17 +452,17 @@ class JobTemplate(
             new_value = kwargs[field_name]
             old_value = getattr(self, field_name)
 
-            field = self._meta.get_field(field_name)
-            if isinstance(field, models.ManyToManyField):
-                if field_name == 'instance_groups':
-                    # Instance groups are ordered so we can't make a set out of them
-                    old_value = old_value.all()
-                elif field_name == 'credentials':
-                    # Credentials have a weird pattern because of how they are layered
-                    old_value = set(old_value.all())
-                    new_value = set(kwargs[field_name]) - old_value
-                    if not new_value:
-                        continue
+            if field_name == 'instance_groups':
+                # Instance groups do not have a corresponding field on the parent, only skip not-provided
+                old_value = []
+                if not new_value:
+                    continue
+            elif field_name in ('credentials', 'labels'):
+                # Credentials have a weird pattern because of how they are layered
+                old_value = set(old_value.all())
+                new_value = set(kwargs[field_name]) - old_value
+                if not new_value:
+                    continue
 
             if new_value == old_value:
                 # no-op case: Fields the same as template's value
@@ -564,6 +566,8 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
     given parameters.
     """
 
+    PARENT_FIELD_NAME = 'job_template'
+
     class Meta:
         app_label = 'main'
         ordering = ('id',)
@@ -612,9 +616,6 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         default=True,
         help_text=_("Events of this job have been queried for indirect host information, or do not need processing."),
     )
-
-    def _get_parent_field_name(self):
-        return 'job_template'
 
     @classmethod
     def _get_task_class(cls):
@@ -1181,10 +1182,6 @@ class SystemJobTemplate(UnifiedJobTemplate, SystemJobOptions):
         app_label = 'main'
 
     @classmethod
-    def _get_unified_job_class(cls):
-        return SystemJob
-
-    @classmethod
     def _get_unified_job_field_names(cls):
         return ['name', 'description', 'organization', 'job_type', 'extra_vars']
 
@@ -1250,6 +1247,8 @@ class SystemJobTemplate(UnifiedJobTemplate, SystemJobOptions):
 
 
 class SystemJob(UnifiedJob, SystemJobOptions, JobNotificationMixin):
+    PARENT_FIELD_NAME = 'system_job_template'
+
     class Meta:
         app_label = 'main'
         ordering = ('id',)
@@ -1274,10 +1273,6 @@ class SystemJob(UnifiedJob, SystemJobOptions, JobNotificationMixin):
 
     def _set_default_dependencies_processed(self):
         self.dependencies_processed = True
-
-    @classmethod
-    def _get_parent_field_name(cls):
-        return 'system_job_template'
 
     @classmethod
     def _get_task_class(cls):

--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -21,9 +21,10 @@ from ansible_base.lib.utils.models import prevent_search
 # AWX
 
 from awx.main.models.rbac import Role, RoleAncestorEntry, to_permissions
+from awx.main.redact import REPLACE_STR
 from awx.main.utils import parse_yaml_or_json, get_custom_venv_choices, get_licenser, polymorphic
 from awx.main.utils.execution_environments import get_default_execution_environment
-from awx.main.utils.encryption import decrypt_value, get_encryption_key, is_encrypted
+from awx.main.utils.encryption import decrypt_value, get_encryption_key, is_encrypted, encrypt_dict
 from awx.main.utils.polymorphic import build_polymorphic_ctypes_map
 from awx.main.fields import AskForField
 from awx.main.constants import ACTIVE_STATES, org_role_to_permission
@@ -141,6 +142,23 @@ class SurveyJobTemplateMixin(models.Model):
                 if survey_element['type'] == 'password':
                     vars.append(survey_element['variable'])
         return vars
+
+    def handle_launch_passwords(self, prompted_extra_vars, extra_passwords):
+        """
+        Intended to be called as a part of create_unified_job for any template allowing surveys
+        encrypts any incoming prompted extra_vars that are answers to password survey questions
+        If this is ran inside a WFJT, takes extra_passwords which may have come from workflow survey, or artifacts
+        """
+        survey_passwords = {}
+        if self.survey_enabled:
+            password_list = self.survey_password_variables()
+            if password_list:
+                encrypt_dict(prompted_extra_vars, password_list)  # automatically encrypt survey fields
+                for password in password_list:
+                    survey_passwords[password] = REPLACE_STR
+        if extra_passwords:
+            survey_passwords.update(extra_passwords)
+        return survey_passwords
 
     @property
     def variables_needed_to_start(self):

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -348,10 +348,6 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
     )
 
     @classmethod
-    def _get_unified_job_class(cls):
-        return ProjectUpdate
-
-    @classmethod
     def _get_unified_job_field_names(cls):
         return set(f.name for f in ProjectOptions._meta.fields) | set(['name', 'description', 'organization'])
 
@@ -538,6 +534,8 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
     Internal job for tracking project updates from SCM.
     """
 
+    PARENT_FIELD_NAME = 'project'
+
     class Meta:
         app_label = 'main'
 
@@ -570,9 +568,6 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
 
     def _set_default_dependencies_processed(self):
         self.dependencies_processed = True
-
-    def _get_parent_field_name(self):
-        return 'project'
 
     def _update_parent_instance(self):
         if not self.project:

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -56,10 +56,10 @@ from awx.main.utils.common import (
     get_event_partition_epoch,
     get_capacity_type,
 )
-from awx.main.utils.encryption import encrypt_dict, decrypt_field
+from awx.main.utils.encryption import decrypt_field
 from awx.main.utils import polymorphic
 from awx.main.constants import ACTIVE_STATES, CAN_CANCEL, JOB_VARIABLE_PREFIXES
-from awx.main.redact import UriCleaner, REPLACE_STR
+from awx.main.redact import UriCleaner
 from awx.main.consumers import emit_channel_notification
 from awx.main.fields import AskForField, OrderedManyToManyField
 
@@ -354,7 +354,7 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
         """
         Return subclass of UnifiedJob that is created from this template.
         """
-        raise NotImplementedError  # Implement in subclass.
+        return unified_cls_mapping()[cls]
 
     @property
     def notification_templates(self):
@@ -366,56 +366,30 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
 
         return NotificationTemplate.objects.none()
 
-    def create_unified_job(self, instance_groups=None, **kwargs):
+    def create_unified_job(self, _eager_fields=None, instance_groups=None, survey_passwords=None, **prompts):
         """
         Create a new unified job based on this unified job template.
         """
-        # TODO: rename kwargs to prompts, to set expectation that these are runtime values
-        new_job_passwords = kwargs.pop('survey_passwords', {})
-        eager_fields = kwargs.pop('_eager_fields', None)
-
-        # automatically encrypt survey fields
-        if hasattr(self, 'survey_spec') and getattr(self, 'survey_enabled', False):
-            password_list = self.survey_password_variables()
-            encrypt_dict(kwargs.get('extra_vars', {}), password_list)
-
-        unified_job_class = self._get_unified_job_class()
         fields = self._get_unified_job_field_names()
-        parent_field_name = None
-        if "_unified_job_class" in kwargs:
-            # Special case where spawned job is different type than usual
-            # Only used for slice jobs
-            unified_job_class = kwargs.pop("_unified_job_class")
-            fields = unified_job_class._get_unified_job_field_names() & fields
-            parent_field_name = kwargs.pop('_parent_field_name')
 
-        unallowed_fields = set(kwargs.keys()) - set(fields)
-        validated_kwargs = kwargs.copy()
+        unallowed_fields = set(prompts.keys()) - set(fields)
+        unified_job_data = prompts.copy()
         if unallowed_fields:
-            if parent_field_name is None:
-                logger.warning('Fields {} are not allowed as overrides to spawn from {}.'.format(', '.join(unallowed_fields), self))
+            logger.warning('Fields {} are not allowed as overrides to spawn from {}.'.format(', '.join(unallowed_fields), self))
             for f in unallowed_fields:
-                validated_kwargs.pop(f)
+                unified_job_data.pop(f)
 
-        unified_job = copy_model_by_class(self, unified_job_class, fields, validated_kwargs)
+        unified_job = copy_model_by_class(self, self._get_unified_job_class(), fields, unified_job_data)
 
-        if eager_fields:
-            for fd, val in eager_fields.items():
+        # automatically encrypt survey fields, TODO: we should not need survey_passwords field anymore
+        if hasattr(self, 'handle_launch_passwords'):
+            unified_job.survey_passwords = self.handle_launch_passwords(prompts.get('extra_vars', {}), survey_passwords)
+
+        if _eager_fields:
+            for fd, val in _eager_fields.items():
                 setattr(unified_job, fd, val)
 
-        # NOTE: slice workflow jobs _get_parent_field_name method
-        # is not correct until this is set
-        if not parent_field_name:
-            parent_field_name = unified_job._get_parent_field_name()
-        setattr(unified_job, parent_field_name, self)
-
-        # For JobTemplate-based jobs with surveys, add passwords to list for perma-redaction
-        if hasattr(self, 'survey_spec') and getattr(self, 'survey_enabled', False):
-            for password in self.survey_password_variables():
-                new_job_passwords[password] = REPLACE_STR
-        if new_job_passwords:
-            unified_job.survey_passwords = new_job_passwords
-            kwargs['survey_passwords'] = new_job_passwords  # saved in config object for relaunch
+        setattr(unified_job, unified_job.PARENT_FIELD_NAME, self)
 
         if instance_groups:
             unified_job.preferred_instance_groups_cache = [ig.id for ig in instance_groups]
@@ -433,27 +407,36 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
             # credentials and labels
             unified_job.save()
 
-        # Labels and credentials copied here
-        if validated_kwargs.get('credentials'):
+        # TODO: Combine this with prompts combination logic in workflow model
+        # prep for Labels and credentials to be copied
+        if unified_job_data.get('credentials'):
             Credential = UnifiedJob._meta.get_field('credentials').related_model
             cred_dict = Credential.unique_dict(self.credentials.all())
-            prompted_dict = Credential.unique_dict(validated_kwargs['credentials'])
-            # combine prompted credentials with JT
+            prompted_dict = Credential.unique_dict(unified_job_data['credentials'])
+            # combine prompted credentials with JT, but overwriting creds of same type
             cred_dict.update(prompted_dict)
-            validated_kwargs['credentials'] = [cred for cred in cred_dict.values()]
-            kwargs['credentials'] = validated_kwargs['credentials']
+            unified_job_data['credentials'] = [cred for cred in cred_dict.values()]
+        elif 'credentials' in unified_job_data:
+            unified_job_data.pop('credentials')
 
+        if unified_job_data.get('labels'):
+            # Labels are additive so we are going to add any src labels in addition to the override labels
+            template_labels = set(self.labels.all())
+            prompted_labels = set(unified_job_data['labels'])
+            # combine prompted labels with JT
+            unified_job_data['labels'] = template_labels | prompted_labels
+        elif 'labels' in unified_job_data:
+            unified_job_data.pop('labels')
+
+        # Labels and credentials copied here
         with disable_activity_stream():
-            copy_m2m_relationships(self, unified_job, fields, kwargs=validated_kwargs)
+            copy_m2m_relationships(self, unified_job, fields, kwargs=unified_job_data)
 
-        if 'extra_vars' in validated_kwargs:
-            unified_job.handle_extra_data(validated_kwargs['extra_vars'])
+        if 'extra_vars' in unified_job_data:
+            unified_job.handle_extra_data(unified_job_data['extra_vars'])
 
         # Create record of provided prompts for relaunch and rescheduling
-        config = unified_job.create_config_from_prompts(kwargs, parent=self)
-        if instance_groups:
-            for ig in instance_groups:
-                config.instance_groups.add(ig)
+        unified_job.save_prompts_data(self, instance_groups=instance_groups, **prompts)
 
         # manually issue the create activity stream entry _after_ M2M relations
         # have been associated to the UJ
@@ -569,6 +552,8 @@ class UnifiedJob(
     """
     Concrete base class for unified job run by the task engine.
     """
+
+    PARENT_FIELD_NAME = ''  # some job types have no associated template
 
     STATUS_CHOICES = UnifiedJobTemplate.JOB_STATUS_CHOICES
 
@@ -807,9 +792,6 @@ class UnifiedJob(
     def capacity_type(self):
         return get_capacity_type(self)
 
-    def _get_parent_field_name(self):
-        return 'unified_job_template'  # Override in subclasses.
-
     def _get_preferred_instance_group_cache(self):
         return [ig.pk for ig in self.preferred_instance_groups]
 
@@ -835,7 +817,7 @@ class UnifiedJob(
         return '{} {} ({})'.format(get_type_for_model(type(self)), self.id, self.status)
 
     def _get_parent_instance(self):
-        return getattr(self, self._get_parent_field_name(), None)
+        return getattr(self, self.PARENT_FIELD_NAME, None)
 
     def _update_parent_instance_no_save(self, parent_instance, update_fields=None):
         if update_fields is None:
@@ -961,8 +943,10 @@ class UnifiedJob(
         """
         unified_job_class = self.__class__
         unified_jt_class = self._get_unified_job_template_class()
-        parent_field_name = self._get_parent_field_name()
-        fields = unified_jt_class._get_unified_job_field_names() | set([parent_field_name])
+        parent_field_name = self.PARENT_FIELD_NAME
+        fields = unified_jt_class._get_unified_job_field_names()
+        if parent_field_name:
+            fields |= set([parent_field_name])
 
         create_data = {}
         if _eager_fields:
@@ -1000,38 +984,52 @@ class UnifiedJob(
         except JobLaunchConfig.DoesNotExist:
             return None
 
-    def create_config_from_prompts(self, kwargs, parent=None):
+    def save_prompts_data(self, parent, onto_self=False, **kwargs):
         """
         Create a launch configuration entry for this job, given prompts
         returns None if it can not be created
         """
-        JobLaunchConfig = self._meta.get_field('launch_config').related_model
-        config = JobLaunchConfig(job=self)
-        if parent is None:
-            parent = getattr(self, self._get_parent_field_name())
-        if parent is None:
-            return
-        valid_fields = list(parent.get_ask_mapping().keys())
-        # Special cases allowed for workflows
-        if hasattr(self, 'extra_vars'):
-            valid_fields.extend(['survey_passwords', 'extra_vars'])
+        if onto_self:
+            config = self
         else:
-            kwargs.pop('survey_passwords', None)
+            JobLaunchConfig = self._meta.get_field('launch_config').related_model
+            config = JobLaunchConfig(job=self)
+
+        # conservatively save survey_passwords if the job has them
+        if getattr(self, 'survey_passwords', None) and (not onto_self):
+            config.survey_passwords = self.survey_passwords
+
+        from awx.main.models.jobs import JobTemplate
+
+        valid_fields = list(JobTemplate.get_ask_mapping().keys())
+
         many_to_many_fields = []
         for field_name, value in kwargs.items():
-            if field_name not in valid_fields:
-                raise Exception('Unrecognized launch config field {}.'.format(field_name))
             field = None
             # may use extra_data as a proxy for extra_vars
             if field_name in config.SUBCLASS_FIELDS and field_name != 'extra_vars':
                 field = config._meta.get_field(field_name)
+
             if isinstance(field, models.ManyToManyField):
                 many_to_many_fields.append(field_name)
                 continue
-            if isinstance(field, (models.ForeignKey)) and (value is None):
+            elif isinstance(field, (models.ForeignKey)) and (value is None):
                 continue  # the null value indicates not-provided for ForeignKey case
+            elif value is None:
+                continue  # in standard cases None indicates not-provided
+            elif field_name not in valid_fields:
+                raise Exception('Unrecognized launch config field {}.'.format(field_name))
+
             setattr(config, field_name, value)
-        config.save()
+
+        # Actual job models have extra_vars as a text-like field, not a dict
+        if onto_self:
+            config.extra_vars = json.dumps(config.extra_vars)
+
+        from awx.main.signals import disable_activity_stream
+
+        with disable_activity_stream():
+            config.save()
 
         for field_name in many_to_many_fields:
             prompted_items = kwargs.get(field_name, [])
@@ -1044,8 +1042,7 @@ class UnifiedJob(
                     getattr(config, field_name).add(item)
             else:
                 # Assuming this field merges prompts with parent, save just the diff
-                if field_name in [field.name for field in parent._meta.get_fields()]:
-                    prompted_items = set(prompted_items) - set(getattr(parent, field_name).all())
+                prompted_items = set(prompted_items) - set(getattr(parent, field_name).all())
                 if prompted_items:
                     getattr(config, field_name).add(*prompted_items)
 
@@ -1663,3 +1660,13 @@ class UnifiedJob(
     @property
     def ancestor_job(self):
         return self.get_workflow_job().ancestor_job if self.spawned_by_workflow else self
+
+
+def unified_cls_mapping():
+    ret = {}
+    for unified_job_cls in UnifiedJob.__subclasses__():
+        parent_field_name = unified_job_cls.PARENT_FIELD_NAME
+        if parent_field_name:
+            parent_cls = getattr(unified_job_cls, parent_field_name).field.related_model
+            ret[parent_cls] = unified_job_cls
+    return ret

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -350,13 +350,11 @@ class WorkflowJobNode(WorkflowNodeBase):
         # from the parent workflow); exclude job_slice which is internal
         # metadata handled separately below
         aa_dict = {k: v for k, v in self.ancestor_artifacts.items() if k != 'job_slice'} if self.ancestor_artifacts else {}
-        is_root_node = True
         for parent_node in self.get_parent_nodes():
-            is_root_node = False
             aa_dict.update(parent_node.ancestor_artifacts)
             if parent_node.job:
                 aa_dict.update(parent_node.job.get_effective_artifacts(parents_set=set([self.workflow_job_id])))
-        if aa_dict and not is_root_node:
+        if aa_dict:
             self.ancestor_artifacts = aa_dict
             self.save(update_fields=['ancestor_artifacts'])
         # process password list
@@ -388,9 +386,10 @@ class WorkflowJobNode(WorkflowNodeBase):
         if self.workflow_job and self.workflow_job.created_by:
             data['_eager_fields']['created_by'] = self.workflow_job.created_by
         # Extra processing in the case that this is a slice job
-        if 'job_slice' in self.ancestor_artifacts and is_root_node:
+        if self.workflow_job.is_sliced_job:
+            # _eager_fields used to establish that these are not user prompts
             data['_eager_fields']['allow_simultaneous'] = True
-            data['_eager_fields']['job_slice_number'] = self.ancestor_artifacts['job_slice']
+            data['_eager_fields']['job_slice_number'] = int(self.identifier)
             data['_eager_fields']['job_slice_count'] = self.workflow_job.workflow_job_nodes.count()
             data['_prevent_slicing'] = True
         return data
@@ -455,7 +454,7 @@ class WorkflowJobOptions(LaunchTimeConfigBase):
 
     def create_relaunch_workflow_job(self):
         new_workflow_job = self.copy_unified_job()
-        if self.unified_job_template_id is None:
+        if self.workflow_nodes.exists() and (not new_workflow_job.workflow_nodes.exists()):
             new_workflow_job.copy_nodes_from_original(original=self)
         return new_workflow_job
 
@@ -514,10 +513,6 @@ class WorkflowJobTemplate(UnifiedJobTemplate, WorkflowJobOptions, SurveyJobTempl
     @property
     def workflow_nodes(self):
         return self.workflow_job_template_nodes
-
-    @classmethod
-    def _get_unified_job_class(cls):
-        return WorkflowJob
 
     @classmethod
     def _get_unified_jt_copy_names(cls):
@@ -643,6 +638,8 @@ class WorkflowJobTemplate(UnifiedJobTemplate, WorkflowJobOptions, SurveyJobTempl
 
 
 class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificationMixin, WebhookMixin):
+    PARENT_FIELD_NAME = 'workflow_job_template'  # only used for create_unified_job, bypassed for sliced jobs
+
     class Meta:
         app_label = 'main'
         ordering = ('id',)
@@ -681,12 +678,6 @@ class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificatio
     @property
     def has_unpartitioned_events(self):
         return False  # workflow jobs do not have events
-
-    def _get_parent_field_name(self):
-        if self.job_template_id:
-            # This is a workflow job which is a container for slice jobs
-            return 'job_template'
-        return 'workflow_job_template'
 
     @classmethod
     def _get_unified_job_template_class(cls):
@@ -774,22 +765,11 @@ class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificatio
         return artifacts
 
     def prompts_dict(self, *args, **kwargs):
-        if self.job_template_id:
-            # HACK: Exception for sliced jobs here, this is bad
-            # when sliced jobs were introduced, workflows did not have all the prompted JT fields
-            # so to support prompting with slicing, we abused the workflow job launch config
-            # these would be more properly saved on the workflow job, but it gets the wrong fields now
-            try:
-                wj_config = self.launch_config
-                r = wj_config.prompts_dict(*args, **kwargs)
-            except ObjectDoesNotExist:
-                r = {}
-        else:
-            r = super().prompts_dict(*args, **kwargs)
+        r = super().prompts_dict(*args, **kwargs)
+        if not self.is_sliced_job:
             # Workflow labels and job labels are treated separately
             # that means that they do not propogate from WFJT / workflow job to jobs in workflow
             r.pop('labels', None)
-
         return r
 
     def get_notification_templates(self):
@@ -797,6 +777,17 @@ class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificatio
 
     def get_notification_friendly_name(self):
         return "Workflow Job"
+
+    def launch_prompts(self):
+        prompts = super().launch_prompts()
+        if self.is_sliced_job and (prompts is None):
+            prompts = self.prompts_dict()
+        return prompts
+
+    def _get_parent_instance(self):
+        if self.is_sliced_job:
+            return self.job_template
+        return super()._get_parent_instance()
 
     @property
     def preferred_instance_groups(self):
@@ -824,10 +815,6 @@ class WorkflowApprovalTemplate(UnifiedJobTemplate, RelatedJobsMixin):
     )
 
     @classmethod
-    def _get_unified_job_class(cls):
-        return WorkflowApproval
-
-    @classmethod
     def _get_unified_job_field_names(cls):
         return ['name', 'description', 'timeout']
 
@@ -847,6 +834,8 @@ class WorkflowApprovalTemplate(UnifiedJobTemplate, RelatedJobsMixin):
 
 
 class WorkflowApproval(UnifiedJob, JobNotificationMixin):
+    PARENT_FIELD_NAME = 'workflow_approval_template'
+
     class Meta:
         app_label = 'main'
 
@@ -895,9 +884,6 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
 
     def get_ui_url(self):
         return urljoin(settings.TOWER_URL_BASE, WORKFLOW_BASE_URL.format(settings.OPTIONAL_UI_URL_PREFIX, self.workflow_job.id))
-
-    def _get_parent_field_name(self):
-        return 'workflow_approval_template'
 
     def save(self, *args, **kwargs):
         update_fields = list(kwargs.get('update_fields', []))

--- a/awx/main/tests/functional/analytics/test_collectors.py
+++ b/awx/main/tests/functional/analytics/test_collectors.py
@@ -135,7 +135,7 @@ def workflow_job(states=["new", "new", "new", "new", "new"]):
     nodes = [WorkflowJobNode.objects.create(workflow_job=wfj, unified_job_template=jt) for i in range(0, 6)]
     for node, state in zip(nodes, states):
         if state:
-            node.job = jt.create_job()
+            node.job = jt.create_unified_job()
             node.job.status = state
             node.job.save()
             node.save()

--- a/awx/main/tests/functional/api/test_job_runtime_params.py
+++ b/awx/main/tests/functional/api/test_job_runtime_params.py
@@ -6,6 +6,7 @@ import json
 from awx.api.serializers import JobLaunchSerializer
 from awx.main.models import Credential, Inventory, Host, ExecutionEnvironment, Label, InstanceGroup
 from awx.main.models.jobs import Job, JobTemplate, UnifiedJobTemplate
+from awx.main.models.workflow import WorkflowJob
 
 from awx.api.versioning import reverse
 
@@ -112,7 +113,7 @@ def data_to_internal(data):
     if 'execution_environment' in data:
         internal['execution_environment'] = ExecutionEnvironment.objects.get(pk=data['execution_environment'])
     if 'labels' in data:
-        internal['labels'] = [Label.objects.get(pk=_id) for _id in data['labels']]
+        internal['labels'] = set([Label.objects.get(pk=_id) for _id in data['labels']])
     if 'instance_groups' in data:
         internal['instance_groups'] = [InstanceGroup.objects.get(pk=_id) for _id in data['instance_groups']]
     return internal
@@ -217,6 +218,60 @@ def test_slice_count_not_supported(job_template_prompts, post, admin_user):
 
     response = post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), {'job_slice_count': 8}, admin_user, expect=400)
     assert response.data['job_slice_count'][0] == 'Job inventory does not have enough hosts for slicing'
+
+
+@pytest.mark.django_db
+@pytest.mark.job_runtime_vars
+def test_slice_with_survey(job_template_prompts, post, admin_user):
+    job_template = job_template_prompts(True)
+    my_spec = {
+        'name': 'foo',
+        'description': 'bar',
+        'spec': [
+            {'default': 'my_default_ans', 'type': 'password', 'variable': 'my_default', 'required': False, 'question_name': 'foo'},
+            {'default': 'wrong_jt_val', 'type': 'password', 'variable': 'my_answer', 'required': False, 'question_name': 'bar'},
+        ],
+    }
+    # add survey through API so we get normal encryption
+    post(reverse('api:job_template_survey_spec', kwargs={'pk': job_template.pk}), my_spec, admin_user, expect=200)
+    job_template.survey_enabled = True
+    job_template.save(update_fields=['survey_enabled'])
+    for i in range(2):
+        job_template.inventory.hosts.create(name=f'foo{i}')
+
+    response = post(
+        url=reverse('api:job_template_launch', kwargs={'pk': job_template.pk}),
+        data={'job_slice_count': 2, 'extra_vars': {'my_answer': 'my_answer_ans'}},
+        user=admin_user,
+        expect=201,
+    )
+    assert 'id' in response.data
+    assert response.data['type'] == 'workflow_job'
+    workflow_job = WorkflowJob.objects.get(pk=response.data['id'])
+    assert 'my_default' not in workflow_job.extra_vars_dict
+    assert workflow_job.extra_vars_dict['my_answer'].startswith('$encrypted$')
+    assert 'my_default_ans' not in str(workflow_job.extra_vars)
+    assert 'my_answer_ans' not in str(workflow_job.extra_vars)
+
+    node = workflow_job.workflow_nodes.first()
+    kwargs = node.get_job_kwargs()
+    assert 'survey_passwords' in kwargs
+    job = job_template.create_unified_job(**kwargs)
+    assert job.survey_passwords
+    ev = json.loads(job.extra_vars)
+    actual_ev = json.loads(job.decrypted_extra_vars())
+
+    # the survey default should have populated the extra_vars
+    assert 'my_default' in job.extra_vars
+    assert ev['my_default'].startswith('$encrypted$')
+    assert len(ev['my_default']) > 11
+    assert actual_ev['my_default'] == 'my_default_ans'
+
+    # the survey answer should be populated
+    assert 'my_answer' in job.extra_vars
+    assert ev['my_answer'].startswith('$encrypted$')
+    assert len(ev['my_answer']) > 11
+    assert actual_ev['my_answer'] == 'my_answer_ans'
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/models/test_job.py
+++ b/awx/main/tests/functional/models/test_job.py
@@ -1,6 +1,6 @@
 import pytest
 
-from awx.main.models import JobTemplate, Job, JobHostSummary, WorkflowJob, Inventory, Host, Project, Organization
+from awx.main.models import JobTemplate, Job, JobHostSummary, WorkflowJob, Inventory, Project, Organization, JobLaunchConfig
 
 
 @pytest.mark.django_db
@@ -47,9 +47,21 @@ class TestSlicingModels:
         assert job.unified_job_template == slice_jt
         assert job.workflow_nodes.count() == 3
 
+    def test_slices_with_JT_values_no_prompts(self, slice_job_factory):
+        job = slice_job_factory(3, jt_kwargs={'limit': 'foobar'}, spawn=True)
+        assert job.prompts_dict() == {}
+        with pytest.raises(JobLaunchConfig.DoesNotExist):
+            assert job.launch_config
+        for node in job.workflow_nodes.all():
+            assert node.limit is None  # data not saved in node prompts
+            job = node.job
+            assert job.limit == 'foobar'
+
     def test_slices_with_JT_and_prompts(self, slice_job_factory):
         job = slice_job_factory(3, jt_kwargs={'ask_limit_on_launch': True}, prompts={'limit': 'foobar'}, spawn=True)
-        assert job.launch_config.prompts_dict() == {'limit': 'foobar'}
+        assert job.prompts_dict() == {'limit': 'foobar'}
+        with pytest.raises(JobLaunchConfig.DoesNotExist):
+            assert job.launch_config
         for node in job.workflow_nodes.all():
             assert node.limit is None  # data not saved in node prompts
             job = node.job

--- a/awx/main/tests/functional/models/test_job.py
+++ b/awx/main/tests/functional/models/test_job.py
@@ -1,6 +1,6 @@
 import pytest
 
-from awx.main.models import JobTemplate, Job, JobHostSummary, WorkflowJob, Inventory, Project, Organization, JobLaunchConfig
+from awx.main.models import JobTemplate, Job, Host, JobHostSummary, WorkflowJob, Inventory, Project, Organization, JobLaunchConfig
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/models/test_workflow.py
+++ b/awx/main/tests/functional/models/test_workflow.py
@@ -44,7 +44,7 @@ class TestWorkflowDAGFunctional(TransactionTestCase):
         nodes = [WorkflowJobNode.objects.create(workflow_job=wfj, unified_job_template=jt) for i in range(0, 5)]
         for node, state in zip(nodes, states):
             if state:
-                node.job = jt.create_job()
+                node.job = jt.create_unified_job()
                 node.job.status = state
                 node.job.save()
                 node.save()
@@ -142,7 +142,7 @@ class TestWorkflowDNR:
             nodes = [WorkflowJobNode.objects.create(workflow_job=wfj, unified_job_template=jt) for i in range(0, 6)]
             for node, state in zip(nodes, states):
                 if state:
-                    node.job = jt.create_job()
+                    node.job = jt.create_unified_job()
                     node.job.status = state
                     node.job.save()
                     node.save()

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -546,7 +546,7 @@ def test_job_not_blocking_inventory_update(controlplane_instance_group, job_temp
 def test_generate_dependencies_only_once(job_template_factory):
     objects = job_template_factory('jt', organization='org1')
 
-    job = objects.job_template.create_job()
+    job = objects.job_template.create_unified_job()
     job.status = "pending"
     job.name = "job_gen_dep"
     job.save()

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -222,23 +222,6 @@ def test_update_hosts_resolved_deadlock(inventory, mocker):
 
 @pytest.mark.django_db
 class TestLaunchConfig:
-    def test_null_creation_from_prompts(self):
-        job = Job.objects.create()
-        data = {
-            "credentials": [],
-            "extra_vars": {},
-            "limit": None,
-            "job_type": None,
-            "execution_environment": None,
-            "instance_groups": None,
-            "labels": None,
-            "forks": None,
-            "timeout": None,
-            "job_slice_count": None,
-        }
-        config = job.create_config_from_prompts(data)
-        assert config is None
-
     def test_only_limit_defined(self, job_template):
         job = Job.objects.create(job_template=job_template)
         data = {
@@ -253,7 +236,7 @@ class TestLaunchConfig:
             "timeout": None,
             "job_slice_count": None,
         }
-        config = job.create_config_from_prompts(data)
+        config = job.save_prompts_data(parent=job_template, **data)
         assert config.char_prompts == {"limit": ""}
         assert not config.credentials.exists()
         assert config.prompts_dict() == {"limit": ""}
@@ -278,7 +261,7 @@ class TestLaunchConfig:
             "timeout": None,
             "job_slice_count": None,
         }
-        config = job.create_config_from_prompts(data)
+        config = job.save_prompts_data(parent=job_template, **data)
 
         assert config.instance_groups.exists()
         config_instance_group_ids = [item.id for item in config.instance_groups.all()]
@@ -304,7 +287,7 @@ class TestLaunchConfig:
             "timeout": None,
             "job_slice_count": None,
         }
-        config = job.create_config_from_prompts(data)
+        config = job.save_prompts_data(parent=job_template, **data)
 
         assert config.execution_environment
         # We just write the PK instead of trying to assign an item, that happens on the save

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -553,10 +553,6 @@ def copy_m2m_relationships(obj1, obj2, fields, kwargs=None):
                 if kwargs and field_name in kwargs:
                     override_field_val = kwargs[field_name]
                     if isinstance(override_field_val, (set, list, QuerySet)):
-                        # Labels are additive so we are going to add any src labels in addition to the override labels
-                        if field_name == 'labels':
-                            for jt_label in src_field_value.all():
-                                getattr(obj2, field_name).add(jt_label.id)
                         getattr(obj2, field_name).add(*override_field_val)
                         continue
                     if override_field_val.__class__.__name__ == 'ManyRelatedManager':


### PR DESCRIPTION
##### SUMMARY
This is a technical debt patch that hinges on a workaround that is no longer needed:

When sliced jobs were introduced, there was an in-congruence between what prompts could be provided on launch, and the WFJT / WJ models. Because sliced jobs go (JT)->(workflow job)->(job), anything that the job needs to inherit from the original JT prompts needs to pass through the workflow job (not the JT properties itself, only prompts, because prompts are re-combined with the JT properties at the time of job spawn). But at the time, the workflow models didn't have all the fields it needed for this purpose. The workaround was that we saved prompts to the related launch config model, relative to the workflow job. Those were re-applied to the jobs that the workflow spawned.

This workaround wasn't good, because that's not otherwise the purpose or interpretation of the launch config. It should only come into play if the job is relaunched or something like that. The workaround also left the system over-determined, because the role of the properties on the workflow job, itself, for sliced jobs, was left _completely unclear_.

This change here moves the _sliced job prompts_ from the launch config onto the _workflow job_. This is re-affirming the identity of WFJT / WJ models _as a container of prompts_, even though those are more often not-provided than cases like nodes or schedules. This makes the sliced job workflow jobs a lot more like ordinary workflow jobs, mechanically. The remaining custom logic is more feature-specific to slicing.

When ready, this is intended to address https://github.com/ansible/awx/issues/12932

For now, this will be tabled as higher priority work gets in.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
