### PR TITLE
[ui] Don't double-entity encode on event stdout

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
@@ -79,7 +79,7 @@ function HostEventModal({ onClose, hostEvent = {}, isOpen = false }) {
 
   const jsonObj = processCodeEditorValue(hostEvent?.event_data?.res);
   const stdErr = hostEvent?.event_data?.res?.stderr;
-  const stdOut = processCodeEditorValue(getStdOutValue(hostEvent));
+  const stdOut = getStdOutValue(hostEvent);
 
   return (
     <Modal


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

- stdout output on events was being double HTML entity encoded meaning that all output with < and > was shown as literal `&lt;` and `&gt;`

**NOTE** This needs some review, I'm not confident if there are any XSS implications here or cases where we *do* need to run the escaping logic.

refs #9062

and #12064 which fixed this for stderr but not stdout

**Before:**
![image](https://user-images.githubusercontent.com/43930/192079321-94f9b44e-6de4-4217-bbf3-2b93f911f37d.png)


**After:**
![image](https://user-images.githubusercontent.com/43930/192079179-a7cb1517-1133-4641-9a54-e44fed3ff543.png)


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.6.1.dev52+g93f50b5211
```
