### PR TITLE
Adding make option to enable sql debugging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ SPLUNK ?= false
 PROMETHEUS ?= false
 # If set to true docker-compose will also start a grafana instance
 GRAFANA ?= false
+# Set to true to enable postgres debugging on startup
+PG_DEBUG ?= false
 
 VENV_BASE ?= /var/lib/awx/venv
 
@@ -475,7 +477,9 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e enable_ldap=$(LDAP) \
 	    -e enable_splunk=$(SPLUNK) \
 	    -e enable_prometheus=$(PROMETHEUS) \
-	    -e enable_grafana=$(GRAFANA) $(EXTRA_SOURCES_ANSIBLE_OPTS)
+	    -e enable_grafana=$(GRAFANA) \
+            -e pg_debug=$(PG_DEBUG) \
+            $(EXTRA_SOURCES_ANSIBLE_OPTS)
 
 
 

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -20,6 +20,9 @@ work_sign_public_keyfile: "{{ work_sign_key_dir }}/work_public_key.pem"
 # SSO variables
 enable_keycloak: false
 
+# LDAP Debugging
+pg_debug: false
+
 enable_ldap: false
 ldap_public_key_file_name: 'ldap.cert'
 ldap_private_key_file_name: 'ldap.key'

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -96,6 +96,10 @@
   include_tasks: ldap.yml
   when: enable_ldap | bool
 
+- name: Enable SQL debugging
+  include_tasks: sql_debug.yml
+  when: pg_debug | bool
+
 - name: Render Docker-Compose
   template:
     src: docker-compose.yml.j2

--- a/tools/docker-compose/ansible/roles/sources/tasks/sql_debug.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/sql_debug.yml
@@ -1,0 +1,16 @@
+---
+- name: Enable SQL Logging in container
+  set_fact:
+    pg_log_statement: -c log_statement=all
+
+# This setting will add two headers to http responses about SQL:
+#   < X-API-Query-Count: 9
+#   < X-API-Query-Time: 0.006s
+# Technically, the way this is setup, if you disbale pg_debug after its enabled
+#  and don't rebuild your container the flag to set the headers will remain in the conf
+#  if I tried to remove it from here and someone had manually set it in the local_overrides files
+#  it would cause confustion as this code would strip it out of their local_overrides
+- name: Add SQL_DEBUG to local_settings.py
+  lineinfile:
+    path: "{{ sources_dest }}/local_settings.py"
+    line: "SQL_DEBUG = True"

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -179,7 +179,7 @@ services:
     image: postgres:12
     container_name: tools_postgres_1
     # additional logging settings for postgres can be found https://www.postgresql.org/docs/current/runtime-config-logging.html
-    command: postgres -c log_destination=stderr -c log_min_messages=info -c log_min_duration_statement={{ pg_log_min_duration_statement|default(1000) }}
+    command: postgres -c log_destination=stderr -c log_min_messages=info -c log_min_duration_statement={{ pg_log_min_duration_statement|default(1000) }} {{ pg_log_statement | default('') }}
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_USER: {{ pg_username }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Turns on SQL query logging and SQL headers if enabled.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.6.1.dev52+g05e3c29fe8
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
