### PR TITLE
CI workflows security hardening

### DIFF
--- a/.github/workflows/label_issue.yml
+++ b/.github/workflows/label_issue.yml
@@ -6,6 +6,10 @@ on:
       - opened
       - reopened
 
+    permissions:
+      contents: read # to fetch code
+      issues: write # to label issues
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -7,6 +7,10 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read # to determine modified files (actions/labeler)
+  pull-requests: write # to add labels to PRs (actions/labeler)
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   promote:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.

New or Enhanced Feature
