### PR TITLE
Pass --force when installing ui deps to get around dependency resolution warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,7 +379,7 @@ clean-ui:
 	rm -rf $(UI_BUILD_FLAG_FILE)
 
 awx/ui/node_modules:
-	NODE_OPTIONS=--max-old-space-size=6144 $(NPM_BIN) --prefix awx/ui --loglevel warn ci
+	NODE_OPTIONS=--max-old-space-size=6144 $(NPM_BIN) --prefix awx/ui --loglevel warn --force ci
 
 $(UI_BUILD_FLAG_FILE):
 	$(MAKE) awx/ui/node_modules


### PR DESCRIPTION
##### SUMMARY
See https://github.com/npm/cli/issues/5113

There are certain app dependencies that depend on an older version of ReactJS.  npm v8+ will start checking dependency resolution and will fail to install based on our current configuration.  This _should_ be a short term fix while we evaluate those dependencies and test out whether they'll run without issue on our preferred version of ReactJS.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
