### PR TITLE
Make installing minikube optional in dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -454,6 +454,7 @@ COMPOSE_OPTS ?=
 CONTROL_PLANE_NODE_COUNT ?= 1
 EXECUTION_NODE_COUNT ?= 2
 MINIKUBE_CONTAINER_GROUP ?= false
+MINIKUBE_SETUP ?= false # if false, run minikube separately
 EXTRA_SOURCES_ANSIBLE_OPTS ?=
 
 ifneq ($(ADMIN_PASSWORD),)
@@ -462,7 +463,7 @@ endif
 
 docker-compose-sources: .git/hooks/pre-commit
 	@if [ $(MINIKUBE_CONTAINER_GROUP) = true ]; then\
-	    ansible-playbook -i tools/docker-compose/inventory tools/docker-compose-minikube/deploy.yml; \
+	    ansible-playbook -i tools/docker-compose/inventory -e minikube_setup=$(MINIKUBE_SETUP) tools/docker-compose-minikube/deploy.yml; \
 	fi;
 
 	ansible-playbook -i tools/docker-compose/inventory tools/docker-compose/ansible/sources.yml \

--- a/tools/docker-compose-minikube/minikube/defaults/main.yml
+++ b/tools/docker-compose-minikube/minikube/defaults/main.yml
@@ -9,8 +9,8 @@ addons:
 minikube_url_linux: 'https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64'
 minikube_url_macos: 'https://storage.googleapis.com/minikube/releases/latest/minikube-darwin-amd64'
 
-kubectl_url_linux: 'https://dl.k8s.io/release/v1.21.0/bin/linux/amd64/kubectl'
-kubectl_url_macos: 'https://dl.k8s.io/release/v1.21.0/bin/darwin/amd64/kubectl'
+kubectl_url_linux: 'https://dl.k8s.io/release/v1.25.0/bin/linux/amd64/kubectl'
+kubectl_url_macos: 'https://dl.k8s.io/release/v1.25.0/bin/darwin/amd64/kubectl'
 
 # Service Account Name
 minikube_service_account_name: 'awx-devel'

--- a/tools/docker-compose-minikube/minikube/tasks/main.yml
+++ b/tools/docker-compose-minikube/minikube/tasks/main.yml
@@ -8,6 +8,10 @@
     state: 'directory'
     mode: '0700'
 
+- name: debug minikube_setup
+  debug:
+    var: minikube_setup
+
 # Linux block
 - block:
     - name: Download Minikube
@@ -24,6 +28,7 @@
   when:
     - ansible_architecture == "x86_64"
     - ansible_system == "Linux"
+    - minikube_setup | default(False) | bool
 
 # MacOS block
 - block:
@@ -41,25 +46,29 @@
   when:
     - ansible_architecture == "x86_64"
     - ansible_system == "Darwin"
+    - minikube_setup | default(False) | bool
 
-- name: Starting Minikube
-  shell: "{{ sources_dest }}/minikube start --driver={{ driver }} --install-addons=true --addons={{ addons | join(',') }}"
-  register: minikube_stdout
+- block:
+    - name: Starting Minikube
+      shell: "{{ sources_dest }}/minikube start --driver={{ driver }} --install-addons=true --addons={{ addons | join(',') }}"
+      register: minikube_stdout
 
-- name: Enable Ingress Controller on Minikube
-  shell: "{{ sources_dest }}/minikube addons enable ingress"
+    - name: Enable Ingress Controller on Minikube
+      shell: "{{ sources_dest }}/minikube addons enable ingress"
+      when:
+        - minikube_stdout.rc == 0
+      register: _minikube_ingress
+      ignore_errors: true
+
+    - name: Show Minikube Ingress known-issue 7332 warning
+      pause:
+        seconds: 5
+        prompt: "The Minikube Ingress addon has been disabled since it looks like you are hitting https://github.com/kubernetes/minikube/issues/7332"
+      when:
+        - '"minikube/issues/7332" in _minikube_ingress.stderr'
+        - ansible_system == "Darwin"
   when:
-    - minikube_stdout.rc == 0
-  register: _minikube_ingress
-  ignore_errors: true
-
-- name: Show Minikube Ingress known-issue 7332 warning
-  pause:
-    seconds: 5
-    prompt: "The Minikube Ingress addon has been disabled since it looks like you are hitting https://github.com/kubernetes/minikube/issues/7332"
-  when:
-    - '"minikube/issues/7332" in _minikube_ingress.stderr'
-    - ansible_system == "Darwin"
+    - minikube_setup | default(False) | bool
 
 - name: Create ServiceAccount and clusterRoleBinding
   k8s:

--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -301,11 +301,19 @@ Note that you may see multiple messages of the form `2021-03-04 20:11:47,666 WAR
 
 To bring up a 1 node AWX + minikube that is accessible from AWX run the following.
 
+Start minikube
+
+```bash
+(host)$minikube start --cpus=4  --memory=8g --addons=ingress`
+```
+
+Start AWX
+
 ```bash
 (host)$ make docker-compose-container-group
 ```
 
-Alternatively, you can set the env var `MINIKUBE_CONTAINER_GROUP=true` to use the default dev env bring up. his way you can use other env flags like the cluster node count.
+Alternatively, you can set the env var `MINIKUBE_CONTAINER_GROUP=true` to use the default dev env bring up. his way you can use other env flags like the cluster node count. Set `MINIKUBE_SETUP=true` to make the roles download, install and run minikube for you, but if you run into issues with this just start minikube yourself.
 
 ```bash
 (host)$ MINIKUBE_CONTAINER_GROUP=true make docker-compose


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In development environment we can bootstrap minikube to use as a container group cluster

`MINIKUBE_CONTAINER_GROUP=true make docker-compose`

this attempts to install and run minikube, but I found this to be problematic (stuck when trying to start minikube). I think we can skip minikube startup, and instead it should just use whatever connected k8s cluster is running.

With this change, it is assumed the user will run minikube separately before running docker-compose. To get the old behavior

`MINIKUBE_CONTAINER_GROUP=true MINIKUBE_SETUP=true make docker-compose` which does the installation bootstrap.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

