### PR TITLE
[collection] Remove instance defaults from docs

### DIFF
--- a/awx_collection/plugins/modules/instance.py
+++ b/awx_collection/plugins/modules/instance.py
@@ -37,12 +37,10 @@ options:
         - If true, the instance will be enabled and used.
       required: False
       type: bool
-      default: True
     managed_by_policy:
       description:
         - Managed by policy
       required: False
-      default: True
       type: bool
     node_type:
       description:
@@ -51,7 +49,6 @@ options:
         - execution
       required: False
       type: str
-      default: execution
     node_state:
       description:
         - Indicates the current life cycle stage of this instance.
@@ -59,13 +56,11 @@ options:
         - deprovisioning
         - installed
       required: False
-      default: installed
       type: str
     listener_port:
       description:
         - Port that Receptor will listen for incoming connections on.
       required: False
-      default: 27199
       type: int
 extends_documentation_fragment: awx.awx.auth
 '''

--- a/awx_collection/tests/integration/targets/instance/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/instance/tasks/main.yml
@@ -14,6 +14,8 @@
     - name: Create an instance
       awx.awx.instance:
         hostname: "{{ item }}"
+        node_type: execution
+        node_state: installed
       with_items:
         - "{{ hostname1 }}"
         - "{{ hostname2 }}"
@@ -26,6 +28,8 @@
     - name: Create an instance with non-default config
       awx.awx.instance:
         hostname: "{{ hostname3 }}"
+        node_type: execution
+        node_state: installed
         capacity_adjustment: 0.4
         listener_port: 31337
       register: result

--- a/docs/development/kind.md
+++ b/docs/development/kind.md
@@ -1,7 +1,7 @@
 # Running Development Environment in Kubernetes using Kind Cluster
 
 ## Start Kind Cluster
-Note: This environment has been tested on MacOS and Fedora with Docker. 
+Note: This environment has been tested on MacOS and Fedora with Docker.
 
 If you do not already have Kind, install it from:
 https://kind.sigs.k8s.io/docs/user/quick-start/
@@ -62,7 +62,7 @@ awx-operator-controller-manager   1/1     1            1           16h
 
 ## Deploy AWX into Kind Cluster using the AWX Operator
 
-If have have not made any changes to the AWX Dockerfile, run the following
+If you have not made any changes to the AWX Dockerfile, run the following
 command. If you need to test out changes to the Dockerfile, see the
 "Custom AWX Development Image for Kubernetes" section below.
 
@@ -103,7 +103,7 @@ export COMPOSE_TAG=<IMAGE_TAG>
 In the root of the AWX repo:
 
 ```bash
-make awx-kube-dev-build 
+make awx-kube-dev-build
 docker push $DEV_DOCKER_TAG_BASE/awx_kube_devel:$COMPOSE_TAG
 ```
 


### PR DESCRIPTION
##### SUMMARY

We don't specify defaults in the module (because it messes up Instance updates because AWX things we are trying to change things to be the default).

- Update the docs to remove the defaults that no longer exist
- Update tests to make them pass (oops)
- Fix tangentially related typo in Kind development docs

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
