### PR TITLE
Make sure to include field defaults for Instance node_type and node_state

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4913,7 +4913,10 @@ class InstanceSerializer(BaseSerializer):
             'ip_address',
             'listener_port',
         )
-        extra_kwargs = {'node_type': {'initial': 'execution'}, 'node_state': {'initial': 'installed'}}
+        extra_kwargs = {
+            'node_type': {'initial': Instance.Types.EXECUTION, 'default': Instance.Types.EXECUTION},
+            'node_state': {'initial': Instance.States.INSTALLED, 'default': Instance.States.INSTALLED},
+        }
 
     def get_related(self, obj):
         res = super(InstanceSerializer, self).get_related(obj)


### PR DESCRIPTION
##### SUMMARY
Make sure to include field defaults for Instance node_type and node_state.

We want to make sure that if the user leaves off those fields from the payload that the expected defaults (type: execution, state: installed) get applied, instead of triggering the validation error.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
