### PR TITLE
Precise migrate.yml path in development docs

### DIFF
--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -28,7 +28,7 @@ Here are the main `make` targets:
 Notable files:
 
 - `tools/docker-compose/inventory` file - used to configure the AWX development environment.
-- `migrate.yml` - playbook for migrating data from Local Docker to the Development Environment
+- `tools/docker-compose/ansible/migrate.yml` - playbook for migrating data from Local Docker to the Development Environment
 
 ### Prerequisites
 


### PR DESCRIPTION
##### SUMMARY

Precise the path of `migrate.yml` playbook in Docker Compose for Development documentation.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs
