### PR TITLE
instance install bundle group vars

### DIFF
--- a/awx/api/templates/instance_install_bundle/group_vars/all.yml
+++ b/awx/api/templates/instance_install_bundle/group_vars/all.yml
@@ -1,0 +1,21 @@
+receptor_verify: true
+receptor_tls: true
+receptor_work_commands:
+  ansible-runner:
+    command: ansible-runner
+    params: worker
+    allowruntimeparams: true
+    verifysignature: true
+custom_worksign_public_keyfile: receptor/work-public-key.pem
+custom_tls_certfile: receptor/tls/receptor.crt
+custom_tls_keyfile: receptor/tls/receptor.key
+custom_ca_certfile: receptor/tls/ca/receptor-ca.crt
+receptor_user: awx
+receptor_group: awx
+receptor_protocol: 'tcp'
+receptor_listener: true
+receptor_port: {{ instance.listener_port }}
+receptor_dependencies:
+  - podman
+  - crun
+  - python39-pip

--- a/awx/api/templates/instance_install_bundle/inventory.yml
+++ b/awx/api/templates/instance_install_bundle/inventory.yml
@@ -5,24 +5,3 @@ all:
       ansible_host: {{ instance.hostname }}
       ansible_user: <username> # user provided
       ansible_ssh_private_key_file: ~/.ssh/id_rsa
-      receptor_verify: true
-      receptor_tls: true
-      receptor_work_commands:
-        ansible-runner:
-          command: ansible-runner
-          params: worker
-          allowruntimeparams: true
-          verifysignature: true
-      custom_worksign_public_keyfile: receptor/work-public-key.pem
-      custom_tls_certfile: receptor/tls/receptor.crt
-      custom_tls_keyfile: receptor/tls/receptor.key
-      custom_ca_certfile: receptor/tls/ca/receptor-ca.crt
-      receptor_user: awx
-      receptor_group: awx
-      receptor_protocol: 'tcp'
-      receptor_listener: true
-      receptor_port: {{ instance.listener_port }}
-      receptor_dependencies:
-        - podman
-        - crun
-        - python39-pip

--- a/awx/api/views/instance_install_bundle.py
+++ b/awx/api/views/instance_install_bundle.py
@@ -29,6 +29,8 @@ RECEPTOR_OID = "1.3.6.1.4.1.2312.19.1"
 # install bundle directory structure
 # ├── install_receptor.yml (playbook)
 # ├── inventory.yml
+# ├── group_vars
+# │   └── all.yml
 # ├── receptor
 # │   ├── tls
 # │   │   ├── ca
@@ -86,6 +88,12 @@ class InstanceInstallBundle(GenericAPIView):
                 inventory_yml_tarinfo.size = len(inventory_yml)
                 tar.addfile(inventory_yml_tarinfo, io.BytesIO(inventory_yml))
 
+                # generate and write group_vars/all.yml to the tar file
+                group_vars = generate_group_vars_all_yml(instance_obj).encode('utf-8')
+                group_vars_tarinfo = tarfile.TarInfo(f"{instance_obj.hostname}_install_bundle/group_vars/all.yml")
+                group_vars_tarinfo.size = len(group_vars)
+                tar.addfile(group_vars_tarinfo, io.BytesIO(group_vars))
+
                 # generate and write requirements.yml to the tar file
                 requirements_yml = generate_requirements_yml().encode('utf-8')
                 requirements_yml_tarinfo = tarfile.TarInfo(f"{instance_obj.hostname}_install_bundle/requirements.yml")
@@ -109,6 +117,10 @@ def generate_requirements_yml():
 
 def generate_inventory_yml(instance_obj):
     return render_to_string("instance_install_bundle/inventory.yml", context=dict(instance=instance_obj))
+
+
+def generate_group_vars_all_yml(instance_obj):
+    return render_to_string("instance_install_bundle/group_vars/all.yml", context=dict(instance=instance_obj))
 
 
 def generate_receptor_tls(instance_obj):


### PR DESCRIPTION
##### SUMMARY
separate constant configuration in instance install bundle  out of inventory.yml to group vars

```
install bundle directory structure
├── install_receptor.yml (playbook)
├── inventory.yml
├── group_vars
│   └── all.yml
├── receptor
│   ├── tls
│   │   ├── ca
│   │   │   └── receptor-ca.crt
│   │   ├── receptor.crt
│   │   └── receptor.key
│   └── work-public-key.pem
└── requirements.yml
```
related to https://github.com/ansible/awx/issues/12928

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API


##### AWX VERSION
```
awx: 21.6.1.dev154+gd48e31b928
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
