### PR TITLE
docs: fix incorrect file extension in execution_nodes.md

### DIFF
--- a/docs/execution_nodes.md
+++ b/docs/execution_nodes.md
@@ -63,7 +63,7 @@ The playbook requires the Receptor collection which can be obtained via
 
 Modify `inventory.yml`. Set the `ansible_user` and any other ansible variables that may be needed to run playbooks against the remote machine.
 
-`ansible-playbook -i inventory.yml install_receptor.py` to start installing Receptor on the remote machine.
+`ansible-playbook -i inventory.yml install_receptor.yml` to start installing Receptor on the remote machine.
 
 Note, the playbook will enable the [Copr ansible-awx/receptor repository](https://copr.fedorainfracloud.org/coprs/ansible-awx/receptor/) so that Receptor can be installed.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fix incorrect file extension for a playbook in `execution_nodes.md`; 

> `ansible-playbook -i inventory.yml install_receptor.py` to start installing Receptor on the remote machine.

`install_receptor.py` should be `install_receptor.yml` as included in the install bundle.

```bash
$ ls -l
total 12
drwxrwxr-x. 2 kuro kuro  21 Oct  4 08:58 group_vars
-rw-r--r--. 1 kuro kuro 406 Jan  1  1970 install_receptor.yml     👈👈👈
-rw-r--r--. 1 kuro kuro 171 Oct  4 09:01 inventory.yml
drwxrwxr-x. 3 kuro kuro  44 Oct  4 08:58 receptor
-rw-r--r--. 1 kuro kuro 137 Jan  1  1970 requirements.yml
```

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.7.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
