### PR TITLE
Additional resiliency patches and logging improvements

### DIFF
--- a/awx/main/dispatch/control.py
+++ b/awx/main/dispatch/control.py
@@ -9,7 +9,7 @@ from awx.main.dispatch import get_local_queuename
 
 from . import pg_bus_conn
 
-logger = logging.getLogger('awx.main.dispatch')
+logger = logging.getLogger('awx.main.dispatch.control')
 
 
 class Control(object):
@@ -45,7 +45,7 @@ class Control(object):
         return f"reply_to_{str(uuid.uuid4()).replace('-','_')}"
 
     def control_with_reply(self, command, timeout=5, extra_data=None):
-        logger.warning('checking {} {} for {}'.format(self.service, command, self.queuename))
+        logger.debug('checking control command {} {} for {}, waiting for reply'.format(self.service, command, self.queuename))
         reply_queue = Control.generate_reply_queue_name()
         self.result = None
 

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -61,7 +61,7 @@ class AWXConsumerBase(object):
         return f'listening on {self.queues}'
 
     def control(self, body):
-        logger.warning(f'Received control signal:\n{body}')
+        logger.debug(f'Received control signal:\n{body}')
         control = body.get('control')
         if control in ('status', 'running', 'cancel'):
             reply_queue = body['reply_to']
@@ -87,6 +87,7 @@ class AWXConsumerBase(object):
             with pg_bus_conn() as conn:
                 conn.notify(reply_queue, json.dumps(msg))
         elif control == 'reload':
+            logger.warning(f'Reloading {len(self.pool.workers)} workers due to control signal')
             for worker in self.pool.workers:
                 worker.quit()
         else:

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -686,7 +686,7 @@ class TaskManager(TaskBase):
         logger.debug("{} couldn't be scheduled on graph, waiting for next cycle".format(task.log_format))
 
     def reap_jobs_from_orphaned_instances(self):
-        # discover jobs that are in running state but have an unregistered controller node or execution node
+        # discover jobs that are in running state but have an unregistered controller node
         # that we know about; it can occur if a running OCP node misses heartbeat and gets deleted,
         # or, SQL backup an awx install with running jobs and restore it elsewhere
         for task in self.all_tasks:
@@ -696,11 +696,7 @@ class TaskManager(TaskBase):
                     reap_job(task, 'failed', job_explanation=f'The controller node for this task, {task.controller_node}, has been deleted.')
                     continue
 
-            if task.execution_node:
-                if (task.execution_node not in self.instances) and (task.controller_node not in self.instances.all_hostnames):
-                    self.all_tasks.remove(task)
-                    reap_job(task, 'failed', job_explanation=f'The execution node for this task, {task.execution_node}, has been deleted.')
-                    continue
+            # If the node execution_node is deleted, then that needs to be handled as action local to the node, and properly cancel
 
     def process_tasks(self):
         running_tasks = [t for t in self.all_tasks if t.status in ['waiting', 'running']]

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -689,17 +689,15 @@ class TaskManager(TaskBase):
         # discover jobs that are in running state but have an unregistered controller node or execution node
         # that we know about; it can occur if a running OCP node misses heartbeat and gets deleted,
         # or, SQL backup an awx install with running jobs and restore it elsewhere
-
-        # TODO: after merging other resillency changes, add job_explanation to all these cases
         for task in self.all_tasks:
             if task.controller_node:
-                if task.controller_node not in self.instances:
+                if (task.controller_node not in self.instances) and (task.controller_node not in self.instances.all_hostnames):
                     self.all_tasks.remove(task)
                     reap_job(task, 'failed', job_explanation=f'The controller node for this task, {task.controller_node}, has been deleted.')
                     continue
 
             if task.execution_node:
-                if task.execution_node not in self.instances:
+                if (task.execution_node not in self.instances) and (task.controller_node not in self.instances.all_hostnames):
                     self.all_tasks.remove(task)
                     reap_job(task, 'failed', job_explanation=f'The execution node for this task, {task.execution_node}, has been deleted.')
                     continue

--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -3,6 +3,7 @@
 import logging
 
 from django.conf import settings
+from django.utils.functional import cached_property
 
 from awx.main.models import (
     Instance,
@@ -61,6 +62,14 @@ class TaskManagerInstances:
 
     def __contains__(self, hostname):
         return hostname in self.instances_by_hostname
+
+    @cached_property
+    def all_hostnames(self):
+        """
+        This is a somewhat-cheap way to access the full list of hostnames, including the dead or disabled instances
+        the main instance list does not include these, because they will not accept new jobs
+        """
+        return list(Instance.objects.values_list('hostname', flat=True))
 
 
 class TaskManagerInstanceGroups:

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -615,8 +615,10 @@ def awx_receptor_workunit_reaper():
     jobs_with_unreleased_receptor_units = UnifiedJob.objects.filter(work_unit_id__in=unit_ids).exclude(status__in=ACTIVE_STATES)
     for job in jobs_with_unreleased_receptor_units:
         logger.debug(f"{job.log_format} is not active, reaping receptor work unit {job.work_unit_id}")
-        receptor_ctl.simple_command(f"work cancel {job.work_unit_id}")
-        receptor_ctl.simple_command(f"work release {job.work_unit_id}")
+        try:
+            receptor_ctl.simple_command(f"work release {job.work_unit_id}")
+        except Exception as exc:
+            logger.error(f'Failed to reap {job.log_format} unit_id={job.work_unit_id}, error: {exc}')
 
     administrative_workunit_reaper(receptor_work_list)
 


### PR DESCRIPTION
##### SUMMARY
Description of changes here:
 - mop up 2 locations where `reap_job` did not attach a custom message. It's tempting to remove the _default_ message now.
 - as a sub-part of that last point, this revives https://github.com/ansible/awx/pull/12592
 - Canceling a job gave way too much logs, this silences two warning messages that were not helpful
 - Do not break out of workunit reaper loop if we get an error, just move onto next, and just log error text

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API



##### ADDITIONAL INFORMATION

some testing, after a sigkill of a worker process running a job:

![Screenshot from 2022-10-05 13-50-39](https://user-images.githubusercontent.com/1385596/194127829-7a9b0e71-6093-4ac3-bfc3-0b7f045d1bbb.png)

old canceling logs

```
tools_awx_1     | 2022-10-05 16:40:28,379 WARNING  [c039cf0d] awx.main.dispatch checking dispatcher cancel for awx_1
tools_awx_1     | 2022-10-05 16:40:28,384 WARNING  [5d57ee20] awx.main.dispatch Received control signal:
tools_awx_1     | {'control': 'cancel', 'reply_to': 'reply_to_a6933321_3be4_452b_be43_2a279d4b91ba', 'task_ids': ['126af4e2-070b-437f-a887-0b501fec2801'], 'time_ack': 1664988028.3845623}
tools_awx_1     | 2022-10-05 16:40:28,386 WARNING  [5d57ee20] awx.main.dispatch Sending SIGTERM to task id=126af4e2-070b-437f-a887-0b501fec2801, task=awx.main.tasks.jobs.RunJob, args=[518]
```

updated, more like just this one

```
tools_awx_1     | 2022-10-05 17:51:31,198 WARNING  [030bf74d] awx.main.dispatch Sending SIGTERM to task id=bd02481b-b015-4016-ab20-84c9b98c11d6, task=awx.main.tasks.jobs.RunJob, args=[519]
```


