### PR TITLE
update instance install bundle requirement

### DIFF
--- a/awx/api/templates/instance_install_bundle/requirements.yml
+++ b/awx/api/templates/instance_install_bundle/requirements.yml
@@ -1,6 +1,4 @@
 ---
 collections:
   - name: ansible.receptor
-    source: https://github.com/ansible/receptor-collection/
-    type: git
-    version: 0.1.1
+    version: 1.0.0


### PR DESCRIPTION
##### SUMMARY
bump receptor collection to published v1.0.0

thanks @thedoubl3j and @jbradberry the receptor collection is now published on ansible-galaxy 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
```
21.7.1.dev6+g8472e3a26d
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
