### PR TITLE
Fixing updater.sh script to run on OS X

### DIFF
--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -1,15 +1,10 @@
 #!/bin/sh
 set -ue
 
-if [[ $OSTYPE == 'darwin'* ]]; then
-	requirements_in="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements.in)"
-	requirements="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements.txt)"
-	requirements_git="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements_git.txt)"
-else
-	requirements_in="$(readlink -f ./requirements.in)"
-	requirements="$(readlink -f ./requirements.txt)"
-	requirements_git="$(readlink -f ./requirements_git.txt)"
-fi
+requirements_in="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements.in)"
+requirements="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements.txt)"
+requirements_git="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements_git.txt)"
+
 pip_compile="pip-compile --no-header --quiet -r --allow-unsafe"
 
 _cleanup() {

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 set -ue
 
-requirements_in="$(readlink -f ./requirements.in)"
-requirements="$(readlink -f ./requirements.txt)"
-requirements_git="$(readlink -f ./requirements_git.txt)"
+if [[ $OSTYPE == 'darwin'* ]]; then
+	requirements_in="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements.in)"
+	requirements="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements.txt)"
+	requirements_git="$(python -c 'import os,sys;print(os.path.realpath(sys.argv[1]))' ./requirements_git.txt)"
+else
+	requirements_in="$(readlink -f ./requirements.in)"
+	requirements="$(readlink -f ./requirements.txt)"
+	requirements_git="$(readlink -f ./requirements_git.txt)"
+fi
 pip_compile="pip-compile --no-header --quiet -r --allow-unsafe"
 
 _cleanup() {
@@ -26,14 +32,22 @@ generate_requirements() {
   # Then remove any git+ lines from requirements.txt
   while IFS= read -r line; do
     if [[ $line != \#* ]]; then  # ignore comments
-      sed -i "\!${line%#*}!d" requirements.txt
+      if [[ $OSTYPE == 'darwin'* ]]; then
+        sed -i '' -e "\!${line%#*}!d" requirements.txt
+      else
+        sed -i "\!${line%#*}!d" requirements.txt
+      fi
     fi
   done < "${requirements_git}"
 }
 
 main() {
   base_dir=$(pwd)
-  _tmp="$(mktemp -d --suffix .awx-requirements XXXX -p /tmp)"
+  if [[ $OSTYPE == 'darwin'* ]]; then
+    _tmp="$(mktemp -d -t awx-requirements)"
+  else
+    _tmp="$(mktemp -d --suffix .awx-requirements XXXX -p /tmp)"
+  fi
   trap _cleanup INT TERM EXIT
 
   if [ "$1" = "upgrade" ]; then


### PR DESCRIPTION
##### SUMMARY
Modifying the update.sh script, which manages requirements.txt, to be run on OS X in addition to Linux.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.6.1.dev176+ge4135818f1.d20221006
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
