### PR TITLE
Fix file name extension for install_receptor

### DIFF
--- a/docs/execution_nodes.md
+++ b/docs/execution_nodes.md
@@ -63,7 +63,7 @@ The playbook requires the Receptor collection which can be obtained via
 
 Modify `inventory.yml`. Set the `ansible_user` and any other ansible variables that may be needed to run playbooks against the remote machine.
 
-`ansible-playbook -i inventory.yml install_receptor.py` to start installing Receptor on the remote machine.
+`ansible-playbook -i inventory.yml install_receptor.yml` to start installing Receptor on the remote machine.
 
 Note, the playbook will enable the [Copr ansible-awx/receptor repository](https://copr.fedorainfracloud.org/coprs/ansible-awx/receptor/) so that Receptor can be installed.
 


### PR DESCRIPTION
##### SUMMARY
Fix install_receptor extension running in execution_nodes.md.

##### ISSUE TYPE
 -  Docs Fix

##### COMPONENT NAME
 - Docs

##### AWX VERSION
21.7
