### PR TITLE
fix: extend expiration date for receptor certificate for execution node

### DIFF
--- a/awx/api/views/instance_install_bundle.py
+++ b/awx/api/views/instance_install_bundle.py
@@ -178,7 +178,7 @@ def generate_receptor_tls(instance_obj):
         .public_key(csr.public_key())
         .serial_number(x509.random_serial_number())
         .not_valid_before(datetime.datetime.utcnow())
-        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=10))
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=3650))
         .add_extension(
             csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value,
             critical=csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).critical,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #13020 

Extend the expiration date for the receptor certificate for the execution node from 10 _days_ to 10 _years_.

Please feel free to reject this (or edit my branch directly), if I'm on the wrong way or this fix should be made by _member_ of ansible (or redhat) org to merge rapidly.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.7.1.dev21+gfd38c926b2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Tested as follows;

```bash
# 1, Build and push AWX image including this PR:
$ ansible-playbook -v tools/ansible/build.yml \
  -e registry=registry.example.com \
  -e registry_username=${REGISTRY_USER} \
  -e registry_password=${REGISTRY_PASSWORD} \
  -e awx_image=registry.example.com/ansible/awx \
  -e awx_version=21.7.1 \
  -e ansible_python_interpreter=$(which python3) \
  -e push=yes \
  -e awx_official=yes

# 2, Deploy AWX including following spec using AWX Operator
$ cat awx.yml
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx
spec:
  ingress_type: ingress
  hostname: awx.example.com
  image: registry.example.com/ansible/awx
  image_version: 21.7.1
  ...

# 3, Add new execution node as instance on AWX
$ curl -ku admin:******** -H "Content-Type: application/json" \
-X POST -d '{"hostname": "exec01.example.com", "node_type": "execution", "node_state": "installed", "listener_port": 27199}' \
https://awx.example.com/api/v2/instances/

# 4. Download install bundle
$ curl -ku admin:******** -X GET -o exec01.example.com_install_bundle.tar.gz https://awx.example.com/api/v2/instances/4/install_bundle/

# 5. Extract it and ensure `Not After` has been extended
$ tar zxvf exec01.example.com_install_bundle.tar.gz
$ cd exec01.example.com_install_bundle
$ openssl x509 -text -in receptor/tls/ca/receptor-ca.crt -noout | grep -A 2 Validity
        Validity
            Not Before: Oct  8 21:27:01 2022 GMT
            Not After : Oct  5 21:27:01 2032 GMT     👈👈👈
```

I've confirmed that new install bundle also works good, cert on execution node has been updated, and node become `Ready` once receptor service has been restarted.