### PR TITLE
Fix CSS overflow for legend and tooltip in Topology view.

### DIFF
--- a/awx/ui/src/screens/TopologyView/Legend.js
+++ b/awx/ui/src/screens/TopologyView/Legend.js
@@ -26,9 +26,9 @@ const Wrapper = styled.div`
   position: absolute;
   left: 0;
   padding: 0 10px;
-  width: 150px;
+  min-width: 150px;
   background-color: rgba(255, 255, 255, 0.85);
-  overflow: scroll;
+  overflow: auto;
   height: 100%;
 `;
 const Button = styled(PFButton)`

--- a/awx/ui/src/screens/TopologyView/Tooltip.js
+++ b/awx/ui/src/screens/TopologyView/Tooltip.js
@@ -37,7 +37,7 @@ const Wrapper = styled.div`
   padding: 0 10px;
   width: 25%;
   background-color: rgba(255, 255, 255, 0.85);
-  overflow: scroll;
+  overflow: auto;
   height: 100%;
 `;
 const Button = styled(PFButton)`


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Only show scrollbars when document height is shorter than the length of either the legend or tooltip.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 