### PR TITLE
Add missing auth methods to local auth disable validator

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -101,10 +101,14 @@ register(
 def authentication_validate(serializer, attrs):
     remote_auth_settings = [
         'AUTH_LDAP_SERVER_URI',
+        'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY',
         'SOCIAL_AUTH_GOOGLE_OAUTH2_KEY',
         'SOCIAL_AUTH_GITHUB_KEY',
         'SOCIAL_AUTH_GITHUB_ORG_KEY',
         'SOCIAL_AUTH_GITHUB_TEAM_KEY',
+        'SOCIAL_AUTH_GITHUB_ENTERPRISE_KEY',
+        'SOCIAL_AUTH_GITHUB_ENTERPRISE_ORG_KEY',
+        'SOCIAL_AUTH_GITHUB_ENTERPRISE_TEAM_KEY',
         'SOCIAL_AUTH_SAML_ENABLED_IDPS',
         'RADIUS_SERVER',
         'TACACSPLUS_HOST',


### PR DESCRIPTION
Signed-off-by: Juan Font <juan.font@esa.int>

##### SUMMARY

Currently it is not possible to disable the local authentication mechanism when using Azure AD and GitHub Enterprise, as these social auth mechanisms are not included the `authentication_validate` validator in `awx/api/conf.py.

```python
def authentication_validate(serializer, attrs):
    remote_auth_settings = [
        'AUTH_LDAP_SERVER_URI',
        'SOCIAL_AUTH_GOOGLE_OAUTH2_KEY',
        'SOCIAL_AUTH_GITHUB_KEY',
        'SOCIAL_AUTH_GITHUB_ORG_KEY',
        'SOCIAL_AUTH_GITHUB_TEAM_KEY',
        'SOCIAL_AUTH_SAML_ENABLED_IDPS',
        'RADIUS_SERVER',
        'TACACSPLUS_HOST',
    ]
    if attrs.get('DISABLE_LOCAL_AUTH', False):
        if not any(getattr(settings, s, None) for s in remote_auth_settings):
            raise serializers.ValidationError(_("There are no remote authentication systems configured."))
    return attrs
```

Consecuently error is shown:

![image](https://user-images.githubusercontent.com/181059/194911642-8f3320f6-53db-4095-b4e6-40c912a72952.png)


This small PR fixes that.




##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


