### PR TITLE
Sending field_name in AttributeError

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -282,7 +282,7 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
                         return field['default']
                 if 'default' in kwargs:
                     return kwargs['default']
-                raise AttributeError
+                raise AttributeError(field_name)
         if field_name in self.inputs:
             return self.inputs[field_name]
         if 'default' in kwargs:


### PR DESCRIPTION
Signed-off-by: Cesar Francisco San Nicolas [csannico@redhat.com](mailto:csannico@redhat.com)

##### SUMMARY
Including field_name in the AttributeError field, to have more information about the attribute that is missing

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### AWX VERSION
21.7.0

##### ADDITIONAL INFORMATION
We do provide the attribute in line 293, so replicating this in line 285