### PR TITLE
Fixes bug re-launching adhoc command with passwords required

### DIFF
--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -107,6 +107,17 @@ function LaunchButton({ resource, children }) {
         jobPromise = JobsAPI.relaunch(resource.id, params || {});
       } else if (resource.type === 'workflow_job') {
         jobPromise = WorkflowJobsAPI.relaunch(resource.id, params || {});
+      } else if (resource.type === 'ad_hoc_command') {
+        if (params?.credential_passwords) {
+          // The api expects the passwords at the top level of the object instead of nested
+          // in credential_passwords like the other relaunch endpoints
+          Object.keys(params.credential_passwords).forEach((key) => {
+            params[key] = params.credential_passwords[key];
+          });
+
+          delete params.credential_passwords;
+        }
+        jobPromise = AdHocCommandsAPI.relaunch(resource.id, params || {});
       }
 
       const { data: job } = await jobPromise;

--- a/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
+++ b/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
@@ -129,7 +129,7 @@ function PromptModalForm({
       }}
       title={t`Launch | ${resource.name}`}
       description={
-        resource.description.length > 512 ? (
+        resource.description?.length > 512 ? (
           <ExpandableSection
             toggleText={
               showDescription ? t`Hide description` : t`Show description`


### PR DESCRIPTION
##### SUMMARY
Link https://github.com/ansible/awx/issues/13033

Adhoc commands don't have a description field so we need to protect against attempting to access the length.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
