### PR TITLE
Fix enable/disable node state on browser resize.

### DIFF
--- a/awx/ui/src/screens/TopologyView/TopologyView.js
+++ b/awx/ui/src/screens/TopologyView/TopologyView.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from 'react';
+import React, { useEffect, useCallback, useState, useRef } from 'react';
 import { t } from '@lingui/macro';
 import { PageSection, Card, CardBody } from '@patternfly/react-core';
 import ContentError from 'components/ContentError';
@@ -10,6 +10,7 @@ import useZoom from './utils/useZoom';
 import { CHILDSELECTOR, PARENTSELECTOR } from './constants';
 
 function TopologyView() {
+  const storedNodes = useRef(null);
   const [showLegend, setShowLegend] = useState(true);
   const [showZoomControls, setShowZoomControls] = useState(false);
   const {
@@ -20,6 +21,7 @@ function TopologyView() {
   } = useRequest(
     useCallback(async () => {
       const { data } = await MeshAPI.read();
+      storedNodes.current = data.nodes;
       return {
         meshData: data,
       };
@@ -64,6 +66,7 @@ function TopologyView() {
                   showLegend={showLegend}
                   zoom={zoom}
                   setShowZoomControls={setShowZoomControls}
+                  storedNodes={storedNodes}
                 />
               )}
             </CardBody>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #13038 

Pass `storedNodes` as a prop to MeshGraph. Update `storedNodes.current` within MeshGraph when a user toggles an instance. Update Topology View D3 graph by passing it the updated nodes to the web worker.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI