### PR TITLE
add podman config role in instance install bundle

### DIFF
--- a/awx/api/templates/instance_install_bundle/group_vars/all.yml
+++ b/awx/api/templates/instance_install_bundle/group_vars/all.yml
@@ -1,3 +1,5 @@
+receptor_user: awx
+receptor_group: awx
 receptor_verify: true
 receptor_tls: true
 receptor_work_commands:
@@ -10,12 +12,12 @@ custom_worksign_public_keyfile: receptor/work-public-key.pem
 custom_tls_certfile: receptor/tls/receptor.crt
 custom_tls_keyfile: receptor/tls/receptor.key
 custom_ca_certfile: receptor/tls/ca/receptor-ca.crt
-receptor_user: awx
-receptor_group: awx
 receptor_protocol: 'tcp'
 receptor_listener: true
 receptor_port: {{ instance.listener_port }}
 receptor_dependencies:
-  - podman
-  - crun
   - python39-pip
+{% verbatim %}
+podman_user: "{{ receptor_user }}"
+podman_group: "{{ receptor_group }}"
+{% endverbatim %}

--- a/awx/api/templates/instance_install_bundle/install_receptor.yml
+++ b/awx/api/templates/instance_install_bundle/install_receptor.yml
@@ -10,6 +10,8 @@
     - name: Enable Copr repo for Receptor
       command: dnf copr enable ansible-awx/receptor -y
     - import_role:
+        name: ansible.receptor.podman
+    - import_role:
         name: ansible.receptor.setup
     - name: Install ansible-runner
       pip:

--- a/awx/api/templates/instance_install_bundle/requirements.yml
+++ b/awx/api/templates/instance_install_bundle/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: ansible.receptor
-    version: 1.0.0
+    version: 1.1.0


### PR DESCRIPTION
##### SUMMARY
related to https://github.com/ansible/receptor-collection/issues/19
related to https://github.com/ansible/receptor-collection/pull/20

configure podman to
- use crun
- use cgroupfs
- force fully qualified image name

DO NOT MERGE until https://github.com/ansible/receptor-collection/pull/20 is merged and v1.0.1 is released

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 21.7.1.dev45+gd9cdf8a3b2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
