### PR TITLE
[WIP] bugfix - allow edit hostname when org.max_hosts == active_count

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -993,9 +993,6 @@ class HostAccess(BaseAccess):
         if data and 'name' in data:
             self.check_license(add_host_name=data['name'])
 
-            # Check the per-org limit
-            self.check_org_host_limit({'inventory': obj.inventory}, add_host_name=data['name'])
-
         # Checks for admin or change permission on inventory, controls whether
         # the user can edit variable data.
         return obj and self.user in obj.inventory.admin_role


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

removed check that was disabling user from editing hostname of a host attached to an inventory when the max_hosts limit was reached for a particular organization.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.6.1.dev183+g5e4590a2ed
```

##### TO-DO

- [x] functional tests for this functionality