### PR TITLE
Allow entering playbook filename manually in Job Template

### DIFF
--- a/awx/ui/src/screens/Template/shared/PlaybookSelect.js
+++ b/awx/ui/src/screens/Template/shared/PlaybookSelect.js
@@ -59,13 +59,14 @@ function PlaybookSelect({
       onToggle={setIsOpen}
       placeholderText={t`Select a playbook`}
       typeAheadAriaLabel={t`Select a playbook`}
-      isCreatable={false}
+      isCreatable
+      createText=""
       onSelect={(event, value) => {
         setIsOpen(false);
         onChange(value);
       }}
       id="template-playbook"
-      isValid={isValid}
+      validated={isValid ? 'default' : 'error'}
       onBlur={onBlur}
       isDisabled={isLoading || isDisabled}
       maxHeight="1000%"


### PR DESCRIPTION
Signed-off-by: Vidya Nambiar <vnambiar@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related https://github.com/ansible/tower/issues/6095

1. Sets `isCreatable` on the PF Select component in PlaybookSelect to allow users to manually type in playbook filenames even if those filenames are not present in the select list.
2. Converts PlaybookSelect.test.js file to use React Testing Library and adds additional tests.
3. Fixes an issue with the `isValid` prop in PlaybookSelect.js (Not directly related to https://github.com/ansible/tower/issues/6095). The prop `isValid` was being passed to the PF Select component. But `isValid` does not exist as a prop in Select. I noticed this while I was adding a test that clicked on the SelectToggle. So I've changed the prop to `validated` which is what the PF component expects. 

Test:
1. Setup/create a job template
2. Try to enter a playbook name manually
- This should be accepted by the UI. When you save, however, you may get the error `Playbook not found for project.` if the playbook is not found in the project.
- To test this all the way to a successful save, you can use a project that has "Allow Branch overrides" enabled on it and has a playbook in a different branch from the one specified as the base for the project's GitHub repo. Then in the Job template, you could try manually entering the name of the playbook (the one that's on a separate branch).  https://github.com/vidyanambiar/ansible-tower-samples/branches has branches that can be used for this.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

