### PR TITLE
Change role of scheduler DependencyManager, spawn fixed deps on creation

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -196,8 +196,6 @@ class Metrics:
             SetIntM('task_manager_pending_processed', 'Number of pending tasks processed'),
             SetIntM('task_manager_tasks_blocked', 'Number of tasks blocked from running'),
             SetFloatM('task_manager_commit_seconds', 'Time spent in db transaction, including on_commit calls'),
-            SetFloatM('dependency_manager_get_tasks_seconds', 'Time spent loading pending tasks from db'),
-            SetFloatM('dependency_manager_generate_dependencies_seconds', 'Time spent generating dependencies for pending tasks'),
             SetFloatM('dependency_manager__schedule_seconds', 'Time spent in running the entire _schedule'),
             IntM('dependency_manager__schedule_calls', 'Number of calls to _schedule, after lock is acquired'),
             SetFloatM('dependency_manager_recorded_timestamp', 'Unix timestamp when metrics were last recorded'),

--- a/awx/main/models/__init__.py
+++ b/awx/main/models/__init__.py
@@ -65,10 +65,6 @@ from awx.main.models.mixins import (  # noqa
     ResourceMixin,
     SurveyJobMixin,
     SurveyJobTemplateMixin,
-    TaskManagerInventoryUpdateMixin,
-    TaskManagerJobMixin,
-    TaskManagerProjectUpdateMixin,
-    TaskManagerUnifiedJobMixin,
 )
 from awx.main.models.notifications import Notification, NotificationTemplate, JobNotificationMixin  # noqa
 from awx.main.models.label import Label  # noqa

--- a/awx/main/models/ad_hoc_commands.py
+++ b/awx/main/models/ad_hoc_commands.py
@@ -90,9 +90,6 @@ class AdHocCommand(UnifiedJob, JobNotificationMixin):
 
     extra_vars_dict = VarsDictProperty('extra_vars', True)
 
-    def _set_default_dependencies_processed(self):
-        self.dependencies_processed = True
-
     def clean_inventory(self):
         inv = self.inventory
         if not inv:

--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -35,10 +35,6 @@ __all__ = [
     'ResourceMixin',
     'SurveyJobTemplateMixin',
     'SurveyJobMixin',
-    'TaskManagerUnifiedJobMixin',
-    'TaskManagerJobMixin',
-    'TaskManagerProjectUpdateMixin',
-    'TaskManagerInventoryUpdateMixin',
     'ExecutionEnvironmentMixin',
     'CustomVirtualEnvMixin',
 ]
@@ -425,67 +421,6 @@ class SurveyJobMixin(models.Model):
             return json.dumps(extra_vars)
         else:
             return self.extra_vars
-
-
-class TaskManagerUnifiedJobMixin(models.Model):
-    class Meta:
-        abstract = True
-
-    def get_jobs_fail_chain(self):
-        return []
-
-
-class TaskManagerJobMixin(TaskManagerUnifiedJobMixin):
-    class Meta:
-        abstract = True
-
-    def get_jobs_fail_chain(self):
-        if self.project_update_id:
-            return [self.project_update]
-        return []
-
-
-class TaskManagerUpdateOnLaunchMixin(TaskManagerUnifiedJobMixin):
-    class Meta:
-        abstract = True
-
-
-class TaskManagerProjectUpdateMixin(TaskManagerUpdateOnLaunchMixin):
-    class Meta:
-        abstract = True
-
-    def get_jobs_fail_chain(self):
-        # project update can be a dependency of an inventory update, in which
-        # case we need to fail the job that may have spawned the inventory
-        # update.
-        # The inventory update will fail, but since it is not running it will
-        # not cascade fail to the job from the errback logic in apply_async. As
-        # such we should capture it here.
-        blocked_jobs = list(self.unifiedjob_blocked_jobs.all().prefetch_related("unifiedjob_blocked_jobs"))
-        other_tasks = []
-        for b in blocked_jobs:
-            other_tasks += list(b.unifiedjob_blocked_jobs.all())
-        return blocked_jobs + other_tasks
-
-
-class TaskManagerInventoryUpdateMixin(TaskManagerUpdateOnLaunchMixin):
-    class Meta:
-        abstract = True
-
-    def get_jobs_fail_chain(self):
-        blocked_jobs = list(self.unifiedjob_blocked_jobs.all())
-        other_updates = []
-        if blocked_jobs:
-            # blocked_jobs[0] is just a reference to a job that depends on this
-            # inventory update.
-            # We can look at the dependencies of this blocked job to find other
-            # inventory sources that are safe to fail.
-            # Since the dependencies could also include project updates,
-            # we need to check for type.
-            for dep in blocked_jobs[0].dependent_jobs.all():
-                if type(dep) is type(self) and dep.id != self.id:
-                    other_updates.append(dep)
-        return blocked_jobs + other_updates
 
 
 class ExecutionEnvironmentMixin(models.Model):

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -427,7 +427,7 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
 
         # manually issue the create activity stream entry _after_ M2M relations
         # have been associated to the UJ
-        if unified_job.__class__ in activity_stream_registrar.models:
+        if unified_job.__class__ in activity_stream_registrar.models and unified_job.launch_type != 'dependency':
             activity_stream_create(None, unified_job, True)
         unified_job.log_lifecycle("created")
 

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -653,9 +653,6 @@ class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificatio
     )
     is_sliced_job = models.BooleanField(default=False)
 
-    def _set_default_dependencies_processed(self):
-        self.dependencies_processed = True
-
     @property
     def workflow_nodes(self):
         return self.workflow_job_nodes
@@ -849,9 +846,6 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
         editable=False,
         on_delete=models.SET_NULL,
     )
-
-    def _set_default_dependencies_processed(self):
-        self.dependencies_processed = True
 
     @classmethod
     def _get_unified_job_template_class(cls):

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -67,12 +67,7 @@ from awx.main.exceptions import AwxTaskError, PostRunError, ReceptorNodeNotFound
 from awx.main.utils.ansible import read_ansible_config
 from awx.main.utils.execution_environments import CONTAINER_ROOT, to_container_path
 from awx.main.utils.safe_yaml import safe_dump, sanitize_jinja
-from awx.main.utils.common import (
-    update_scm_url,
-    extract_ansible_vars,
-    get_awx_version,
-    create_partition,
-)
+from awx.main.utils.common import update_scm_url, extract_ansible_vars, get_awx_version, create_partition
 from awx.conf.license import get_license
 from awx.main.utils.handlers import SpecialInventoryHandler
 from awx.main.tasks.system import update_smart_memberships_for_inventory, update_inventory_computed_fields

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -1,11 +1,8 @@
 import pytest
 from unittest import mock
-import json
-from datetime import timedelta
 
 from awx.main.scheduler import TaskManager, DependencyManager, WorkflowManager
-from awx.main.utils import encrypt_field
-from awx.main.models import WorkflowJobTemplate, JobTemplate, Job
+from awx.main.models import WorkflowJobTemplate, JobTemplate
 from awx.main.models.ha import Instance
 from . import create_job
 from django.conf import settings
@@ -18,7 +15,7 @@ def test_single_job_scheduler_launch(hybrid_instance, controlplane_instance_grou
     j = create_job(objects.job_template)
     with mocker.patch("awx.main.scheduler.TaskManager.start_task"):
         TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(j, controlplane_instance_group, [], instance)
+        TaskManager.start_task.assert_called_once_with(j, controlplane_instance_group, instance)
 
 
 @pytest.mark.django_db
@@ -65,7 +62,6 @@ class TestJobLifeCycle:
 
         # Submits jobs
         # intermission - jobs will run and reschedule TM when finished
-        self.run_tm(DependencyManager())  # flip dependencies_processed to True
         self.run_tm(TaskManager())
         # I am the job runner
         for job in jt.jobs.all():
@@ -105,7 +101,6 @@ class TestJobLifeCycle:
         for uj in all_ujs:
             uj.signal_start()
 
-        DependencyManager().schedule()
         tm = TaskManager()
         self.run_tm(tm)
 
@@ -128,7 +123,6 @@ class TestJobLifeCycle:
         for uj in all_ujs:
             uj.signal_start()
 
-        DependencyManager().schedule()
         # There is only enough control capacity to run one of the jobs so one should end up in pending and the other in waiting
         tm = TaskManager()
         self.run_tm(tm)
@@ -151,7 +145,6 @@ class TestJobLifeCycle:
         for uj in all_ujs:
             uj.signal_start()
 
-        DependencyManager().schedule()
         # There is only enough control capacity to run one of the jobs so one should end up in pending and the other in waiting
         tm = TaskManager()
         self.run_tm(tm)
@@ -228,7 +221,7 @@ def test_single_jt_multi_job_launch_allow_simul_allowed(job_template_factory):
 
 
 @pytest.mark.django_db
-def test_multi_jt_capacity_blocking(hybrid_instance, job_template_factory, mocker):
+def test_multi_jt_capacity_blocking(hybrid_instance, job_template_factory):
     instance = hybrid_instance
     controlplane_instance_group = instance.rampart_groups.first()
     objects1 = job_template_factory('jt1', organization='org1', project='proj1', inventory='inv1', credential='cred1')
@@ -240,46 +233,43 @@ def test_multi_jt_capacity_blocking(hybrid_instance, job_template_factory, mocke
         mock_task_impact.return_value = 505
         with mock.patch.object(TaskManager, "start_task", wraps=tm.start_task) as mock_job:
             tm.schedule()
-            mock_job.assert_called_once_with(j1, controlplane_instance_group, [], instance)
+            mock_job.assert_called_once_with(j1, controlplane_instance_group, instance)
             j1.status = "successful"
             j1.save()
     with mock.patch.object(TaskManager, "start_task", wraps=tm.start_task) as mock_job:
         tm.schedule()
-        mock_job.assert_called_once_with(j2, controlplane_instance_group, [], instance)
+        mock_job.assert_called_once_with(j2, controlplane_instance_group, instance)
 
 
 @pytest.mark.django_db
-def test_single_job_dependencies_project_launch(controlplane_instance_group, job_template_factory, mocker):
+def test_single_job_dependencies_project_launch(job_template_factory):
     objects = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred')
-    instance = controlplane_instance_group.instances.all()[0]
-    j = create_job(objects.job_template, dependencies_processed=False)
     p = objects.project
     p.scm_update_on_launch = True
-    p.scm_update_cache_timeout = 0
-    p.scm_type = "git"
-    p.scm_url = "http://github.com/ansible/ansible.git"
     p.save(skip_update=True)
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        dm = DependencyManager()
-        with mock.patch.object(DependencyManager, "create_project_update", wraps=dm.create_project_update) as mock_pu:
-            dm.schedule()
-            mock_pu.assert_called_once_with(j)
-            pu = [x for x in p.project_updates.all()]
-            assert len(pu) == 1
-            TaskManager().schedule()
-            TaskManager.start_task.assert_called_once_with(pu[0], controlplane_instance_group, [j], instance)
-            pu[0].status = "successful"
-            pu[0].save()
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(j, controlplane_instance_group, [], instance)
+
+    j = objects.job_template.create_unified_job()
+    j.signal_start()
+    assert j.dependencies_processed is False
+    assert j.status == 'pending'
+
+    deps = list(j.dependent_jobs.all())
+    assert len(deps) == 1
+    pu = deps[0]
+    assert pu.project == p
+    assert pu.status == 'pending'
+
+    pu.status = 'successful'
+    pu.save(update_fields=['status'])
+    DependencyManager().schedule()
+    j.refresh_from_db()
+    assert j.dependencies_processed is True
 
 
 @pytest.mark.django_db
-def test_single_job_dependencies_inventory_update_launch(controlplane_instance_group, job_template_factory, mocker, inventory_source_factory):
+def test_single_job_dependencies_inventory_update_launch(job_template_factory, inventory_source_factory):
     objects = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred')
-    instance = controlplane_instance_group.instances.all()[0]
-    j = create_job(objects.job_template, dependencies_processed=False)
+
     i = objects.inventory
     ii = inventory_source_factory("ec2")
     ii.source = "ec2"
@@ -287,43 +277,48 @@ def test_single_job_dependencies_inventory_update_launch(controlplane_instance_g
     ii.update_cache_timeout = 0
     ii.save()
     i.inventory_sources.add(ii)
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        dm = DependencyManager()
-        with mock.patch.object(DependencyManager, "create_inventory_update", wraps=dm.create_inventory_update) as mock_iu:
-            dm.schedule()
-            mock_iu.assert_called_once_with(j, ii)
-            iu = [x for x in ii.inventory_updates.all()]
-            assert len(iu) == 1
-            TaskManager().schedule()
-            TaskManager.start_task.assert_called_once_with(iu[0], controlplane_instance_group, [j], instance)
-            iu[0].status = "successful"
-            iu[0].save()
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(j, controlplane_instance_group, [], instance)
+
+    j = objects.job_template.create_unified_job()
+    j.signal_start()
+    assert j.dependencies_processed is False
+    assert j.status == 'pending'
+    deps = list(j.dependent_jobs.all())
+    assert len(deps) == 1
+    inv_update = deps[0]
+
+    inv_update.status = 'successful'
+    inv_update.save()
+    DependencyManager().schedule()
+    j.refresh_from_db()
+    assert j.dependencies_processed is True
 
 
 @pytest.mark.django_db
-def test_inventory_update_launches_project_update(controlplane_instance_group, scm_inventory_source):
+def test_inventory_update_launches_project_update(scm_inventory_source):
     ii = scm_inventory_source
     project = scm_inventory_source.source_project
     project.scm_update_on_launch = True
     project.save()
-    iu = ii.create_inventory_update()
-    iu.status = "pending"
-    iu.save()
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        dm = DependencyManager()
-        with mock.patch.object(DependencyManager, "create_project_update", wraps=dm.create_project_update) as mock_pu:
-            dm.schedule()
-            mock_pu.assert_called_with(iu, project_id=project.id)
+
+    iu = ii.create_unified_job()
+    iu.signal_start()
+    assert iu.dependencies_processed is False
+    assert iu.status == 'pending'
+    deps = list(iu.dependent_jobs.all())
+    assert len(deps) == 1
+    pu = deps[0]
+
+    pu.status = 'successful'
+    pu.save()
+    DependencyManager().schedule()
+    iu.refresh_from_db()
+    assert iu.dependencies_processed is True
 
 
 @pytest.mark.django_db
-def test_job_dependency_with_already_updated(controlplane_instance_group, job_template_factory, mocker, inventory_source_factory):
+def test_job_dependency_with_already_updated(job_template_factory, inventory_source_factory):
     objects = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred')
-    instance = controlplane_instance_group.instances.all()[0]
-    j = create_job(objects.job_template, dependencies_processed=False)
+
     i = objects.inventory
     ii = inventory_source_factory("ec2")
     ii.source = "ec2"
@@ -331,33 +326,24 @@ def test_job_dependency_with_already_updated(controlplane_instance_group, job_te
     ii.update_cache_timeout = 0
     ii.save()
     i.inventory_sources.add(ii)
-    j.start_args = json.dumps(dict(inventory_sources_already_updated=[ii.id]))
-    j.save()
-    j.start_args = encrypt_field(j, field_name="start_args")
-    j.save()
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        dm = DependencyManager()
-        with mock.patch.object(DependencyManager, "create_inventory_update", wraps=dm.create_inventory_update) as mock_iu:
-            dm.schedule()
-            mock_iu.assert_not_called()
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(j, controlplane_instance_group, [], instance)
+
+    iu = ii.create_unified_job(_eager_fields={'status': 'successful'})
+
+    j = objects.job_template.create_unified_job(available_deps=[iu])
+
+    DependencyManager().schedule()
+    assert list(j.dependent_jobs.all()) == [iu]
 
 
 @pytest.mark.django_db
-def test_shared_dependencies_launch(controlplane_instance_group, job_template_factory, mocker, inventory_source_factory):
-    instance = controlplane_instance_group.instances.all()[0]
+def test_shared_dependencies_launch(job_template_factory, inventory_source_factory):
     objects = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred')
     objects.job_template.allow_simultaneous = True
     objects.job_template.save()
-    j1 = create_job(objects.job_template, dependencies_processed=False)
-    j2 = create_job(objects.job_template, dependencies_processed=False)
+
     p = objects.project
     p.scm_update_on_launch = True
     p.scm_update_cache_timeout = 300
-    p.scm_type = "git"
-    p.scm_url = "http://github.com/ansible/ansible.git"
     p.save()
 
     i = objects.inventory
@@ -367,29 +353,34 @@ def test_shared_dependencies_launch(controlplane_instance_group, job_template_fa
     ii.update_cache_timeout = 300
     ii.save()
     i.inventory_sources.add(ii)
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        DependencyManager().schedule()
-        TaskManager().schedule()
-        pu = p.project_updates.first()
-        iu = ii.inventory_updates.first()
-        TaskManager.start_task.assert_has_calls(
-            [mock.call(iu, controlplane_instance_group, [j1, j2], instance), mock.call(pu, controlplane_instance_group, [j1, j2], instance)]
-        )
-        pu.status = "successful"
-        pu.finished = pu.created + timedelta(seconds=1)
-        pu.save()
-        iu.status = "successful"
-        iu.finished = iu.created + timedelta(seconds=1)
-        iu.save()
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        TaskManager().schedule()
-        TaskManager.start_task.assert_has_calls(
-            [mock.call(j1, controlplane_instance_group, [], instance), mock.call(j2, controlplane_instance_group, [], instance)]
-        )
-    pu = [x for x in p.project_updates.all()]
-    iu = [x for x in ii.inventory_updates.all()]
-    assert len(pu) == 1
-    assert len(iu) == 1
+
+    j1 = objects.job_template.create_unified_job()
+    j1.signal_start()
+    j2 = objects.job_template.create_unified_job()
+    j2.signal_start()
+    pu = p.project_updates.first()
+    iu = ii.inventory_updates.first()
+    assert set([iu, pu]) == set(j1.dependent_jobs.all()) == set(j2.dependent_jobs.all())
+    assert list(p.project_updates.all()) == [pu]
+    assert list(ii.inventory_updates.all()) == [iu]
+
+    DependencyManager().schedule()
+    for j in (j1, j2):
+        j.refresh_from_db()
+        assert j.status == 'pending'
+        assert j.dependencies_processed is False
+
+    for uj in (pu, iu):
+        uj.status = 'successful'
+        uj.save()
+
+    DependencyManager().schedule()
+    for j in (j1, j2):
+        j.refresh_from_db()
+        assert j.dependencies_processed
+
+    j3 = objects.job_template.create_unified_job()
+    assert set(j3.dependent_jobs.all()) == set([iu, pu])  # dependencies all inside cache timeout
 
 
 @pytest.mark.django_db
@@ -409,7 +400,7 @@ def test_job_not_blocking_project_update(controlplane_instance_group, job_templa
         project_update.status = "pending"
         project_update.save()
         TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(project_update, controlplane_instance_group, [], instance)
+        TaskManager.start_task.assert_called_once_with(project_update, controlplane_instance_group, instance)
 
 
 @pytest.mark.django_db
@@ -433,30 +424,19 @@ def test_job_not_blocking_inventory_update(controlplane_instance_group, job_temp
 
         DependencyManager().schedule()
         TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(inventory_update, controlplane_instance_group, [], instance)
+        TaskManager.start_task.assert_called_once_with(inventory_update, controlplane_instance_group, instance)
 
 
 @pytest.mark.django_db
-def test_generate_dependencies_only_once(job_template_factory):
+def test_generate_dependencies_with_no_dependencies(job_template_factory):
+    """We should continue to advance a job (to be ran) if it actually has no dependencies"""
     objects = job_template_factory('jt', organization='org1')
 
-    job = objects.job_template.create_job()
-    job.status = "pending"
-    job.name = "job_gen_dep"
+    job = objects.job_template.create_unified_job()
+    job.signal_start()
+    job.dependencies_processed = True
     job.save()
-    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
-        # job starts with dependencies_processed as False
-        assert not job.dependencies_processed
-        # run one cycle of ._schedule() to generate dependencies
-        DependencyManager().schedule()
 
-        # make sure dependencies_processed is now True
-        job = Job.objects.filter(name="job_gen_dep")[0]
-        assert job.dependencies_processed
-
-        # Run ._schedule() again, but make sure .generate_dependencies() is not
-        # called with job in the argument list
-        dm = DependencyManager()
-        dm.generate_dependencies = mock.MagicMock(return_value=[])
-        dm.schedule()
-        dm.generate_dependencies.assert_not_called()
+    DependencyManager().schedule()
+    job.refresh_from_db()
+    assert job.dependencies_processed

--- a/awx/main/tests/unit/models/test_inventory.py
+++ b/awx/main/tests/unit/models/test_inventory.py
@@ -3,21 +3,8 @@ import pytest
 from django.core.exceptions import ValidationError
 
 from awx.main.models import (
-    InventoryUpdate,
     InventorySource,
 )
-
-
-def test__build_job_explanation():
-    iu = InventoryUpdate(id=3, name='I_am_an_Inventory_Update')
-
-    job_explanation = iu._build_job_explanation()
-
-    assert job_explanation == 'Previous Task Canceled: {"job_type": "%s", "job_name": "%s", "job_id": "%s"}' % (
-        'inventory_update',
-        'I_am_an_Inventory_Update',
-        3,
-    )
 
 
 class TestControlledBySCM:

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -147,7 +147,7 @@ def test_work_success_callback_missing_job():
     task_data = {'type': 'project_update', 'id': 9999}
     with mock.patch('django.db.models.query.QuerySet.get') as get_mock:
         get_mock.side_effect = ProjectUpdate.DoesNotExist()
-        assert system.handle_work_success(task_data) is None
+        assert system.handle_work_finish(task_data) is None
 
 
 @mock.patch('awx.main.models.UnifiedJob.objects.get')

--- a/tools/grafana/dashboards/demo_dashboard.json
+++ b/tools/grafana/dashboards/demo_dashboard.json
@@ -188,7 +188,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.6",
+      "pluginVersion": "9.2.1",
       "targets": [
         {
           "datasource": {
@@ -250,7 +250,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.1.6",
+      "pluginVersion": "9.2.1",
       "targets": [
         {
           "datasource": {
@@ -642,30 +642,6 @@
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "awx_prometheus"
-              },
-              "editorMode": "builder",
-              "expr": "dependency_manager_generate_dependencies_seconds",
-              "hide": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "B"
-            },
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "awx_prometheus"
-              },
-              "editorMode": "builder",
-              "expr": "dependency_manager_get_tasks_seconds",
-              "hide": false,
-              "legendFormat": "__auto",
-              "range": true,
-              "refId": "C"
             },
             {
               "datasource": {
@@ -1518,6 +1494,6 @@
   "timezone": "",
   "title": "awx-demo",
   "uid": "GISWZOXnk",
-  "version": 12,
+  "version": 13,
   "weekStart": ""
 }


### PR DESCRIPTION
##### SUMMARY
This moves logic from `DependencyManager` into `create_unified_job`.

Also changes the _meaning_ of the unified job field `dependencies_processed` (but makes no schema change).
 - before: A value of `False` means the dependencies had not been spawned
 - now:  A value of `False` means the dependencies have not _finished_

Since spawning happens on creation, the state of "unspawned dependencies" is no longer a possible state (without errors)

I believe this is much more simple and has a lot of performance benefits, as even the `TaskManager` has to process fewer jobs each time.

Offshoot of tabled enhancements related to https://github.com/ansible/tower/issues/5943

##### Expected performance impacts

There is a drawback that a POST to the launch endpoint will take longer for jobs trigger update-on-launch behaviors. If a problem, I believe we could pay this back with some debugging and optimization, as we have done before.

This is balanced by greater scalability, although it only really matters inasmuch as someone uses `update_on_launch` features. In that case, this should speed up the `TaskManager` significantly. It leaves the `DependencyManager` with a finite set of queries (2) if none of them are erroring.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
Still trying to run more tests as of opening this.
