### PR TITLE
Fix Schedules Form date validation same day different time scenario

### DIFF
--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.js
@@ -416,8 +416,14 @@ function ScheduleForm({
 
       if (options.end === 'onDate') {
         if (
-          DateTime.fromISO(values.startDate) >=
-          DateTime.fromISO(options.endDate)
+          DateTime.fromFormat(
+            `${values.startDate} ${values.startTime}`,
+            'yyyy-LL-dd h:mm a'
+          ).toMillis() >=
+          DateTime.fromFormat(
+            `${options.endDate} ${options.endTime}`,
+            'yyyy-LL-dd h:mm a'
+          ).toMillis()
         ) {
           freqErrors.endDate = t`Please select an end date/time that comes after the start date/time.`;
         }

--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.test.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.test.js
@@ -900,6 +900,36 @@ describe('<ScheduleForm />', () => {
       );
     });
 
+    test('should create schedule with the same start and end date provided that the end date is at a later time', async () => {
+      const today = DateTime.now().toFormat('yyyy-LL-dd');
+      const laterTime = DateTime.now().plus({ hours: 1 }).toFormat('h:mm a');
+      await act(async () => {
+        wrapper.find('DatePicker[aria-label="End date"]').prop('onChange')(
+          today,
+          new Date(today)
+        );
+      });
+      wrapper.update();
+      expect(
+        wrapper
+          .find('FormGroup[data-cy="schedule-End date/time"]')
+          .prop('helperTextInvalid')
+      ).toBe(
+        'Please select an end date/time that comes after the start date/time.'
+      );
+      await act(async () => {
+        wrapper.find('TimePicker[aria-label="End time"]').prop('onChange')(
+          laterTime
+        );
+      });
+      wrapper.update();
+      expect(
+        wrapper
+          .find('FormGroup[data-cy="schedule-End date/time"]')
+          .prop('helperTextInvalid')
+      ).toBe(undefined);
+    });
+
     test('error shown when on day number is not between 1 and 31', async () => {
       await act(async () => {
         wrapper.find('FrequencySelect#schedule-frequency').invoke('onChange')([


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes a bug where a user can select a start and end date with the same date, but a different time that is the end time, and they hit a validation error. The form should accept the date time as a valid entry.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 