### PR TITLE
No InventoryUpdates when source Project is failed

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2221,6 +2221,15 @@ class InventorySourceUpdateSerializer(InventorySourceSerializer):
     class Meta:
         fields = ('can_update',)
 
+    def validate(self, attrs):
+        project = self.instance.source_project
+        if project:
+            failed_reason = project.get_reason_if_failed()
+            if failed_reason:
+                raise serializers.ValidationError(failed_reason)
+
+        return super(InventorySourceUpdateSerializer, self).validate(attrs)
+
 
 class InventoryUpdateSerializer(UnifiedJobSerializer, InventorySourceOptionsSerializer):
 
@@ -4272,17 +4281,10 @@ class JobLaunchSerializer(BaseSerializer):
         # Basic validation - cannot run a playbook without a playbook
         if not template.project:
             errors['project'] = _("A project is required to run a job.")
-        elif template.project.status in ('error', 'failed'):
-            errors['playbook'] = _("Missing a revision to run due to failed project update.")
-
-            latest_update = template.project.project_updates.last()
-            if latest_update is not None and latest_update.failed:
-                failed_validation_tasks = latest_update.project_update_events.filter(
-                    event='runner_on_failed',
-                    play="Perform project signature/checksum verification",
-                )
-                if failed_validation_tasks:
-                    errors['playbook'] = _("Last project update failed due to signature validation failure.")
+        else:
+            failure_reason = template.project.get_reason_if_failed()
+            if failure_reason:
+                errors['playbook'] = failure_reason
 
         # cannot run a playbook without an inventory
         if template.inventory and template.inventory.pending_deletion is True:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -2222,8 +2222,7 @@ class InventorySourceUpdateView(RetrieveAPIView):
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
         serializer = self.get_serializer(instance=obj, data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        serializer.is_valid(raise_exception=True)
         if obj.can_update:
             update = obj.update()
             if not update:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -2221,6 +2221,9 @@ class InventorySourceUpdateView(RetrieveAPIView):
 
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
+        serializer = self.get_serializer(instance=obj, data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
         if obj.can_update:
             update = obj.update()
             if not update:

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -471,6 +471,29 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
     def get_absolute_url(self, request=None):
         return reverse('api:project_detail', kwargs={'pk': self.pk}, request=request)
 
+    def get_reason_if_failed(self):
+        """
+        If the project is in a failed or errored state, return a human-readable
+        error message explaining why. Otherwise return None.
+
+        This is used during validation in the serializer and also by
+        RunProjectUpdate/RunInventoryUpdate.
+        """
+
+        if self.status not in ('error', 'failed'):
+            return None
+
+        latest_update = self.project_updates.last()
+        if latest_update is not None and latest_update.failed:
+            failed_validation_tasks = latest_update.project_update_events.filter(
+                event='runner_on_failed',
+                play="Perform project signature/checksum verification",
+            )
+            if failed_validation_tasks:
+                return _("Last project update failed due to signature validation failure.")
+
+        return _("Missing a revision to run due to failed project update.")
+
     '''
     RelatedJobsMixin
     '''

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -769,6 +769,7 @@ class SourceControlMixin(BaseTask):
             original_branch = None
             failed_reason = project.get_reason_if_failed()
             if failed_reason:
+                self.update_model(self.instance.pk, status='failed', job_explanation=failed_reason)
                 raise RuntimeError(failed_reason)
             project_path = project.get_project_path(check_if_exists=False)
             if project.scm_type == 'git' and (scm_branch and scm_branch != project.scm_branch):
@@ -1066,11 +1067,7 @@ class RunJob(SourceControlMixin, BaseTask):
             update_smart_memberships_for_inventory(job.inventory)
 
     def build_project_dir(self, job, private_data_dir):
-        try:
-            self.sync_and_copy(job.project, private_data_dir, scm_branch=job.scm_branch)
-        except RuntimeError as e:
-            self.update_model(job.pk, status='failed', job_explanation=str(e))
-            raise
+        self.sync_and_copy(job.project, private_data_dir, scm_branch=job.scm_branch)
 
     def final_run_hook(self, job, status, private_data_dir, fact_modification_times):
         super(RunJob, self).final_run_hook(job, status, private_data_dir, fact_modification_times)


### PR DESCRIPTION
##### SUMMARY

Previously, in some cases, an InventoryUpdate sourced by an SCM project would still run and be successful even after the project it is sourced from failed to update. This would happen because the InventoryUpdate would revert the project back to its last working revision. This behavior is confusing and inconsistent with how we handle jobs (which just refuse to launch when the project is failed).

This change pulls out the logic that the job launch serializer and RunJob#pre_run_hook had implemented (independently) to check if the project is in a failed state, and puts it into a method on the Project model. This is then checked in the project launch serializer as well as the inventory update serializer, along with
SourceControlMixin#sync_and_copy as a fallback for things that don't run the serializer validation (such as scheduled jobs and WFJT jobs).

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API