### PR TITLE
Add back in the uniqueness validation on Instance.hostname

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4931,7 +4931,8 @@ class InstanceSerializer(BaseSerializer):
             'node_state': {'initial': Instance.States.INSTALLED, 'default': Instance.States.INSTALLED},
             'hostname': {
                 'validators': [
-                    MaxLengthValidator(limit_value=255),
+                    MaxLengthValidator(limit_value=250),
+                    validators.UniqueValidator(queryset=Instance.objects.all()),
                     RegexValidator(
                         regex='^localhost$|^127(?:\.[0-9]+){0,2}\.[0-9]+$|^(?:0*\:)*?:?0*1$',
                         flags=re.IGNORECASE,


### PR DESCRIPTION
##### SUMMARY
Our new explicitly defined validators on Instance.hostname missed the implied uniqueness validator that comes from the model field.  Add it back in.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
