### PR TITLE
Fixes #12846 - Secret version not working for Conjur Credential Plugin

### DIFF
--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -81,7 +81,8 @@ def conjur_backend(**kwargs):
     # https://www.conjur.org/api.html#secrets-retrieve-a-secret-get
     path = urljoin(url, '/'.join(['secrets', account, 'variable', secret_path]))
     if version:
-        path = '?'.join([path, version])
+        ver = "version={}".format(version)
+        path = '?'.join([path, ver])
 
     with CertFiles(cacert) as cert:
         lookup_kwargs['verify'] = cert


### PR DESCRIPTION
##### SUMMARY
In it's current form, the declaration of a version when using the CyberArk Conjur Secret Lookup Credential Plugin is improperly formatted and always pulls the latest version of the secret value.  This PR fixes the issue to include `?version={version}` instead of `?{version}` as the URL Query parameter of the REST API request.

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- Other

##### AWX VERSION
21.7.0


##### ADDITIONAL INFORMATION
n/a