### PR TITLE
Fix dispatcher connection deadlock w scheduler and cleanup

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -387,6 +387,8 @@ class AutoscalePool(WorkerPool):
                                 reaper.reap_job(j, 'failed')
                         except Exception:
                             logger.exception('failed to reap job UUID {}'.format(w.current_task['uuid']))
+                    else:
+                        logger.warning(f'Worker was told to quit but has not, pid={w.pid}')
                 orphaned.extend(w.orphaned_tasks)
                 self.workers.remove(w)
             elif w.idle and len(self.workers) > self.min_workers:
@@ -450,9 +452,6 @@ class AutoscalePool(WorkerPool):
         try:
             if isinstance(body, dict) and body.get('bind_kwargs'):
                 self.add_bind_kwargs(body)
-            # when the cluster heartbeat occurs, clean up internally
-            if isinstance(body, dict) and 'cluster_node_heartbeat' in body['task']:
-                self.cleanup()
             if self.should_grow:
                 self.up()
             # we don't care about "preferred queue" round robin distribution, just


### PR DESCRIPTION
##### SUMMARY
This is a fairly critical fix that address a complete system deadlock. Telling the story of what happens:
 - Deploy a system with too few max_connections in postgres, like 100
 - Launch a burst of jobs which will run out the max connections
 - [consequence] Due to some questionable reasons, the dispatcher periodic scheduler loses its connection and tries to create a new one
   - this fails because postgres has already exceeded max connections
   - the periodic scheduler remains in an error loop
   - obviously, no scheduled tasks are submitted anymore
  - [consequence] The dispatcher main process stops running the `.cleanup` method because _no new tasks are submitted_
    - the cleanup method is only ran as a side-effect of submitting the `cluster_node_heartbeat` task
    - because `.cleanup` isn't getting ran, workers are not getting scaled down
    - all those workers not getting scaled down are still keeping their database connections open
  - DEADLOCK - the dispatcher won't scale down workers, which won't release their connections, which prevent the periodic scheduler from submitting tasks, which prevents the dispatcher from scaling down workers

I believe this is a fairly conservative fix that uses an already-existing functionality of `yield_timeouts`. This makes it so that the dispatcher main process main loop - `for e in conn.events(yield_timeouts=True):` will always be active. In the deadlocked situation, we never got another `e` until infinity. This gives us one every 5 seconds. It was already going through the loop every 5 seconds deeper in the `PubSub`, the only thing this does is break us back out to the `AWXConsumerPG.run` loop in those events.

Then, while we have control back, we just do a minor re-org of the cleanup trigger. I've tested this, and with the reproducer we had, this allows us to saturate connections but then still scale down workers so we do not remain permanently deadlocked.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
Added some more logging, you might see how these are the places I _thought_ were causing the problem, but they were not. It will still be good to have these logs IMO, even though I've never seen them happen. I want to have the logs so that we rule out those scenarios in any future debugging.
