### PR TITLE
Customize application_name for different connections in dispatcher service

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -85,7 +85,7 @@ def pg_bus_conn(new_connection=False):
     '''
 
     if new_connection:
-        conf = settings.DATABASES['default']
+        conf = settings.DATABASES['default'].copy()
         conf['OPTIONS'] = conf.get('OPTIONS', {}).copy()
         # Modify the application name to distinguish from other connections the process might use
         conf['OPTIONS']['application_name'] = get_application_name(settings.CLUSTER_HOST_ID, function='listener')

--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -4,6 +4,8 @@ import select
 
 from contextlib import contextmanager
 
+from awx.settings.application_name import get_application_name
+
 from django.conf import settings
 from django.db import connection as pg_connection
 
@@ -84,9 +86,10 @@ def pg_bus_conn(new_connection=False):
 
     if new_connection:
         conf = settings.DATABASES['default']
-        conn = psycopg2.connect(
-            dbname=conf['NAME'], host=conf['HOST'], user=conf['USER'], password=conf['PASSWORD'], port=conf['PORT'], **conf.get("OPTIONS", {})
-        )
+        conf['OPTIONS'] = conf.get('OPTIONS', {}).copy()
+        # Modify the application name to distinguish from other connections the process might use
+        conf['OPTIONS']['application_name'] = get_application_name(settings.CLUSTER_HOST_ID, function='listener')
+        conn = psycopg2.connect(dbname=conf['NAME'], host=conf['HOST'], user=conf['USER'], password=conf['PASSWORD'], port=conf['PORT'], **conf['OPTIONS'])
         # Django connection.cursor().connection doesn't have autocommit=True on by default
         conn.set_session(autocommit=True)
     else:

--- a/awx/main/dispatch/periodic.py
+++ b/awx/main/dispatch/periodic.py
@@ -10,6 +10,7 @@ from django_guid import set_guid
 from django_guid.utils import generate_guid
 
 from awx.main.dispatch.worker import TaskWorker
+from awx.main.utils.db import set_connection_name
 
 logger = logging.getLogger('awx.main.dispatch.periodic')
 
@@ -21,6 +22,9 @@ class Scheduler(Scheduler):
         def run():
             ppid = os.getppid()
             logger.warning('periodic beat started')
+
+            set_connection_name(proc_function='periodic')  # set application_name to distinguish from other dispatcher processes
+
             while True:
                 if os.getppid() != ppid:
                     # if the parent PID changes, this process has been orphaned

--- a/awx/main/dispatch/periodic.py
+++ b/awx/main/dispatch/periodic.py
@@ -23,7 +23,7 @@ class Scheduler(Scheduler):
             ppid = os.getppid()
             logger.warning('periodic beat started')
 
-            set_connection_name(proc_function='periodic')  # set application_name to distinguish from other dispatcher processes
+            set_connection_name('periodic')  # set application_name to distinguish from other dispatcher processes
 
             while True:
                 if os.getppid() != ppid:

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -174,9 +174,7 @@ class AWXConsumerPG(AWXConsumerBase):
 
         while True:
             try:
-                set_connection_name(proc_function='listen')  # identify listener connection as separate from other
                 with pg_bus_conn(new_connection=True) as conn:
-                    set_connection_name(proc_function='')  # reset name
                     for queue in self.queues:
                         conn.listen(queue)
                     if init is False:
@@ -222,7 +220,7 @@ class BaseWorker(object):
     def work_loop(self, queue, finished, idx, *args):
         ppid = os.getppid()
         signal_handler = WorkerSignalHandler()
-        set_connection_name(proc_function='worker')  # set application_name to distinguish from other dispatcher processes
+        set_connection_name('worker')  # set application_name to distinguish from other dispatcher processes
         while not signal_handler.kill_now:
             # if the parent PID changes, this process has been orphaned
             # via e.g., segfault or sigkill, we should exit too

--- a/awx/main/utils/db.py
+++ b/awx/main/utils/db.py
@@ -23,5 +23,5 @@ def get_all_field_names(model):
     )
 
 
-def set_connection_name(proc_function=None):
-    set_application_name(settings.DATABASES, settings.CLUSTER_HOST_ID, proc_function=proc_function)
+def set_connection_name(function):
+    set_application_name(settings.DATABASES, settings.CLUSTER_HOST_ID, function=function)

--- a/awx/main/utils/db.py
+++ b/awx/main/utils/db.py
@@ -3,6 +3,9 @@
 
 from itertools import chain
 
+from awx.settings.application_name import set_application_name
+from django.conf import settings
+
 
 def get_all_field_names(model):
     # Implements compatibility with _meta.get_all_field_names
@@ -18,3 +21,7 @@ def get_all_field_names(model):
             )
         )
     )
+
+
+def set_connection_name(proc_function=None):
+    set_application_name(settings.DATABASES, settings.CLUSTER_HOST_ID, proc_function=proc_function)

--- a/awx/settings/application_name.py
+++ b/awx/settings/application_name.py
@@ -2,11 +2,27 @@ import os
 import sys
 
 
+def get_service_name(argv):
+    '''
+    Return best-effort guess as to the name of this service
+    '''
+    for arg in argv:
+        if arg == '-m':
+            continue
+        if 'python' in arg:
+            continue
+        if 'manage' in arg:
+            continue
+        if arg.startswith('run_'):
+            return arg[len('run_') :]
+        return arg
+
+
 def set_application_name(DATABASES, CLUSTER_HOST_ID, proc_function=''):
     if 'sqlite3' in DATABASES['default']['ENGINE']:
         return
     options_dict = DATABASES['default'].setdefault('OPTIONS', dict())
     if proc_function:
-        proc_function = f'-{proc_function}'
-    connection_name = f'{os.getpid()}{proc_function}-{CLUSTER_HOST_ID}-{" ".join(sys.argv)}'[:63]
+        proc_function = f'_{proc_function}'
+    connection_name = f'awx-{os.getpid()}-{get_service_name(sys.argv)}{proc_function}-{CLUSTER_HOST_ID}'[:63]
     options_dict['application_name'] = connection_name

--- a/awx/settings/application_name.py
+++ b/awx/settings/application_name.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+
+def set_application_name(DATABASES, CLUSTER_HOST_ID, proc_function=''):
+    if 'sqlite3' in DATABASES['default']['ENGINE']:
+        return
+    options_dict = DATABASES['default'].setdefault('OPTIONS', dict())
+    if proc_function:
+        proc_function = f'-{proc_function}'
+    connection_name = f'{os.getpid()}{proc_function}-{CLUSTER_HOST_ID}-{" ".join(sys.argv)}'[:63]
+    options_dict['application_name'] = connection_name

--- a/awx/settings/application_name.py
+++ b/awx/settings/application_name.py
@@ -18,11 +18,14 @@ def get_service_name(argv):
         return arg
 
 
-def set_application_name(DATABASES, CLUSTER_HOST_ID, proc_function=''):
+def get_application_name(CLUSTER_HOST_ID, function=''):
+    if function:
+        function = f'_{function}'
+    return f'awx-{os.getpid()}-{get_service_name(sys.argv)}{function}-{CLUSTER_HOST_ID}'[:63]
+
+
+def set_application_name(DATABASES, CLUSTER_HOST_ID, function=''):
     if 'sqlite3' in DATABASES['default']['ENGINE']:
         return
     options_dict = DATABASES['default'].setdefault('OPTIONS', dict())
-    if proc_function:
-        proc_function = f'_{proc_function}'
-    connection_name = f'awx-{os.getpid()}-{get_service_name(sys.argv)}{proc_function}-{CLUSTER_HOST_ID}'[:63]
-    options_dict['application_name'] = connection_name
+    options_dict['application_name'] = get_application_name(CLUSTER_HOST_ID, function)

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -105,8 +105,11 @@ AWX_CALLBACK_PROFILE = True
 AWX_DISABLE_TASK_MANAGERS = False
 # ======================!!!!!!! FOR DEVELOPMENT ONLY !!!!!!!=================================
 
-if 'sqlite3' not in DATABASES['default']['ENGINE']:  # noqa
-    DATABASES['default'].setdefault('OPTIONS', dict()).setdefault('application_name', f'{CLUSTER_HOST_ID}-{os.getpid()}-{" ".join(sys.argv)}'[:63])  # noqa
+from .application_name import set_application_name
+
+set_application_name(DATABASES, CLUSTER_HOST_ID)
+
+del set_application_name
 
 # If any local_*.py files are present in awx/settings/, use them to override
 # default settings for development.  If not present, we can still run using

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -102,6 +102,6 @@ except IOError:
 
 from .application_name import set_application_name
 
-set_application_name(DATABASES, CLUSTER_HOST_ID)
+set_application_name(DATABASES, CLUSTER_HOST_ID)  # NOQA
 
 del set_application_name

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -100,6 +100,8 @@ except IOError:
 
 # The below runs AFTER all of the custom settings are imported.
 
-DATABASES.setdefault('default', dict()).setdefault('OPTIONS', dict()).setdefault(
-    'application_name', f'{CLUSTER_HOST_ID}-{os.getpid()}-{" ".join(sys.argv)}'[:63]  # NOQA
-)  # noqa
+from .application_name import set_application_name
+
+set_application_name(DATABASES, CLUSTER_HOST_ID)
+
+del set_application_name


### PR DESCRIPTION
##### SUMMARY
I legitimately needed this to debug another issue I was working. I could not have gotten to the root of it without identifying which was the listener connection and which was another process.

With this change:

```
(env) [alancoding@alan-red-hat awx]$ docker exec -t tools_postgres_1 psql -d awx -U awx -c "select pid,application_name, state from pg_stat_activity;"
  pid  |                  application_name                  | state  
-------+----------------------------------------------------+--------
    30 |                                                    | 
    32 |                                                    | 
 10827 | 20204-awx_1-manage.py run_wsbroadcast              | idle
 10828 | 20204-awx_1-manage.py run_wsbroadcast              | idle
 10829 | 20206-listen-awx_1-manage.py run_dispatcher        | idle
 10830 | 20206-awx_1-manage.py run_dispatcher               | idle
 10879 | 20246-worker-awx_1-manage.py run_callback_receiver | idle
 10837 | 20238-periodic-awx_1-manage.py run_dispatcher      | idle
 10880 | 20248-worker-awx_1-manage.py run_callback_receiver | idle
 10839 | 20240-worker-awx_1-manage.py run_dispatcher        | idle
 10842 | 20242-worker-awx_1-manage.py run_dispatcher        | idle
 10882 | 20247-worker-awx_1-manage.py run_callback_receiver | idle
 10881 | 20249-worker-awx_1-manage.py run_callback_receiver | idle
 10896 | psql                                               | active
    28 |                                                    | 
    27 |                                                    | 
    29 |                                                    | 
(17 rows)
```

I'm putting this up as a draft because this does need more aesthetic and formatting input.

Problems I'm trying to address here:
 - Sometimes in prod the `CLUSTER_HOST_ID` is too long, and makes the other items (like pid) impossible to read
 - All the `run_dispatcher` names are totally indistinguishable from each other
 - There's no indicator of function - sometimes a single process will hold multiple connections, and debugging this is impossible

This makes it possible to debug a lot of things we couldn't before. It just needs some help to get it to the finish line.

Would still like to have:
 - short name as opposed to `sys.argv`, like dispatcher / callback / websocket
 - fixed width columns... at least for the first few?
 - insert a placeholder function when one is not given, like "main" as opposed to "listener"
 - a shorted version of the hostname. How? No idea, help @jbradberry 

##### ISSUE TYPE
 - Breaking Change 

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
Example of the host name swamping out the others:

```
[awx@ip-10-0-40-32 ~]$ echo "select pid,application_name, state from pg_stat_activity;" | awx-manage dbshell
  pid   |                        application_name                         |        state        
--------+-----------------------------------------------------------------+---------------------
  23186 |                                                                 | 
  23188 |                                                                 | 
  59762 | ec2-3-85-163-248.compute-1.amazonaws.com-59742-/usr/bin/awx-man | idle
  61893 | ec2-3-85-163-248.compute-1.amazonaws.com-61785-/usr/bin/awx-man | idle
  59765 | ec2-3-85-163-248.compute-1.amazonaws.com-59742-/usr/bin/awx-man | idle
 138280 | ec2-3-85-163-248.compute-1.amazonaws.com-61785-/usr/bin/awx-man | idle
 138194 | ec2-3-85-163-248.compute-1.amazonaws.com-61785-/usr/bin/awx-man | idle
 138221 | ec2-3-85-163-248.compute-1.amazonaws.com-61785-/usr/bin/awx-man | idle
 138005 | ec2-3-85-163-248.compute-1.amazonaws.com-61785-/usr/bin/awx-man | idle
 138219 | ec2-3-85-163-248.compute-1.amazonaws.com-61785-/usr/bin/awx-man | idle
  70185 | ec2-3-85-163-248.compute-1.amazonaws.com-59739-/usr/bin/awx-man | idle
 138226 | ec2-3-85-163-248.compute-1.amazonaws.com-61785-/usr/bin/awx-man | idle
 138308 | ec2-3-85-163-248.compute-1.amazonaws.com-59740-uwsgi            | idle
 138312 | ec2-3-85-163-248.compute-1.amazonaws.com-59740-uwsgi            | idle
 138307 | ec2-3-85-163-248.compute-1.amazonaws.com-59740-uwsgi            | idle in transaction
 138311 | ec2-3-85-163-248.compute-1.amazonaws.com-59741-/var/lib/awx/ven | idle
 138314 | psql                                                            | active
  23184 |                                                                 | 
  23183 |                                                                 | 
  23185 |                                                                 | 
(20 rows)
```

There, we get the process id here, but only barely. In many deployments we won't get this.

Now, some reference data in docker-compose environment

```
 pid  |           application_name           | state  
------+--------------------------------------+--------
   29 |                                      | 
   31 |                                      | 
 3597 | awx_1-3104-manage.py run_wsbroadcast | idle
 3598 | awx_1-3104-manage.py run_wsbroadcast | idle
 3600 | awx_1-3108-manage.py run_dispatcher  | idle
 3647 | awx_1-3108-manage.py run_dispatcher  | idle
 3648 | awx_1-3108-manage.py run_dispatcher  | idle
 3651 | awx_1-3108-manage.py run_dispatcher  | idle
 3650 | awx_1-3108-manage.py run_dispatcher  | idle
 3652 | awx_1-3108-manage.py run_dispatcher  | idle
 3645 | awx_1-3108-manage.py run_dispatcher  | idle
 3654 | psql                                 | active
   27 |                                      | 
   26 |                                      | 
   28 |                                      | 
(15 rows)
```

This tells me... very little. The dispatcher has a parent process, an associated pg_notify listener, and multiple workers. I would really like to make it so that I can see that.
