### PR TITLE
Fix gap between API-loaded job events and WS-streamed events

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/JobOutput.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobOutput.js
@@ -187,7 +187,9 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
   useEffect(() => {
     const pendingRequests = Object.values(eventByUuidRequests.current || {});
     setHasContentLoading(true); // prevents "no content found" screen from flashing
-    setIsFollowModeEnabled(false);
+    if (location.search) {
+      setIsFollowModeEnabled(false);
+    }
     Promise.allSettled(pendingRequests).then(() => {
       setRemoteRowCount(0);
       clearLoadedEvents();
@@ -635,10 +637,14 @@ function JobOutput({ job, eventRelatedSearchableKeys, eventSearchableKeys }) {
     setIsFollowModeEnabled(false);
   };
 
-  const scrollToEnd = () => {
+  const scrollToEnd = useCallback(() => {
     scrollToRow(-1);
-    setTimeout(() => scrollToRow(-1), 100);
-  };
+    let timeout;
+    if (isFollowModeEnabled) {
+      setTimeout(() => scrollToRow(-1), 100);
+    }
+    return () => clearTimeout(timeout);
+  }, [isFollowModeEnabled]);
 
   const handleScrollLast = () => {
     scrollToEnd();


### PR DESCRIPTION
##### SUMMARY
Fixes occasional bug where a gray loading bar appears between job events loaded via API and those streamed over websockets. When the first events stream over websockets, the page will now re-load the prior events from the API, updating them and the `remoteRowCount` to ensure accuracy.

I also fixed an off-by-one error that sometimes made the last API-fetched event not render even if it is already available in memory.

Addresses #13059

This bug generally only presents itself when the initial load of the job or its events via API takes too long to resolve, and already-completed events are missing from the fetched results. I was able to reproduce it with ~50% frequency by manually delaying the response when fetching the job object.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
