### PR TITLE
Fix expor/import for schedules

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -123,6 +123,9 @@ class ApiV2(base.Base):
             if rel_endpoint.__item_class__.__name__ == 'WorkflowApprovalTemplate':
                 continue
 
+            if rel_endpoint.__item_class__.__name__ == 'Inventory' and _page.__item_class__.__name__ == 'Schedule':
+                continue
+
             rel_natural_key = rel_endpoint.get_natural_key(self._cache)
             if rel_natural_key is None:
                 log.error("Unable to construct a natural key for foreign key %r of object %s.", key, _page.endpoint)

--- a/awxkit/awxkit/api/pages/schedules.py
+++ b/awxkit/awxkit/api/pages/schedules.py
@@ -1,6 +1,6 @@
 from contextlib import suppress
 
-from awxkit.api.pages import SystemJobTemplate
+from awxkit.api.pages import SystemJobTemplate, Projects, JobTemplates, InventorySources
 from awxkit.api.mixins import HasCreate
 from awxkit.api.resources import resources
 from awxkit.config import config
@@ -12,6 +12,7 @@ from . import base
 
 class Schedule(HasCreate, base.Base):
     dependencies = [SystemJobTemplate]
+    optional_dependencies = [Projects, JobTemplates, InventorySources]
     NATURAL_KEY = ('unified_job_template', 'name')
 
     def silent_delete(self):


### PR DESCRIPTION
Signed-off-by: Artsiom Musin <artyom.musin@gmail.com>

##### SUMMARY
related #13084 

Since I'm new to this code, please don't judge much :smile: 

Tried to fix the issue related to this error for importing schedules:
> /api/v2/schedules/ "myschedule": Bad Request (400) received - {'unified_job_template': ['This field may not be null.']}.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### AWX VERSION
Ansible Tower 3.8.3
AAP 4.2.1


##### ADDITIONAL INFORMATION
 
**First issue**
Basically the initial error was related to the incorrect order of dependencies in
https://github.com/ansible/awx/blob/devel/awxkit/awxkit/api/pages/api.py#L386

`schedules` resource came before `inventory_sources`,`projects`,`job_templates` and that's why unified_job_template could not be found in the list of natural keys.

Added optional dependencies in `awxkit/awxkit/api/pages/schedules.py` to make the order correct

**Second issue**
After the first issue was fixed, I saw this error:
> /api/v2/schedules/ "myschedule": Bad Request (400) received - {'inventory': ['Field is not allowed on launch.']}.

This was related to the fact that inventory sources and job templates are setting inventory id. However, it's not possible to set that via API. I tried simple POST and PATCH and provided inventory id and always saw
![image](https://user-images.githubusercontent.com/6213508/197197665-c507eab7-08ac-4f18-861d-727ed04460c8.png)

I'm not sure if the inventory field in schedules is obsolete or something. Anyway I wasn't able to figure out where it's used and how to set it via POST/PATCH. Due to this strange behaviour, import failed as well.

To resolve that, I change the schedule export in `awxkit/awxkit/api/pages/api.py` to skip inventory id when searching in nattural keu. The same way as was done for `WorkflowApprovalTemplate`. After that import starts working fine.

