### PR TITLE
Fix error when applying taggit app tags to objects

### DIFF
--- a/awx/main/registrar.py
+++ b/awx/main/registrar.py
@@ -3,6 +3,8 @@
 
 from django.db.models.signals import pre_save, post_save, pre_delete, m2m_changed
 
+from taggit.managers import TaggableManager
+
 
 class ActivityStreamRegistrar(object):
     def __init__(self):
@@ -19,6 +21,8 @@ class ActivityStreamRegistrar(object):
             pre_delete.connect(activity_stream_delete, sender=model, dispatch_uid=str(self.__class__) + str(model) + "_delete")
 
             for m2mfield in model._meta.many_to_many:
+                if isinstance(m2mfield, TaggableManager):
+                    continue  # Special case for taggit app
                 try:
                     m2m_attr = getattr(model, m2mfield.name)
                     m2m_changed.connect(


### PR DESCRIPTION
##### SUMMARY
Fixes error we get with

```python
jt = JobTemplate.objects.first()
jt.tags.add('alan')
```

This will error with an activity stream failure, because a related `tags` relationship was never added to the `ActivityStream` model. I have no appetite to record tag changes to activity stream (you'd have to have shell access anyway), so I thought I'd prefer to just not have this signal connected when it will never work anyway.

With this change, the tag is applied by that snippet.

```python
In [4]: jt.tags.all()
Out[4]: <QuerySet [<Tag: alan>]>
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

