### PR TITLE
Make nginx conf consistent with settings.STATIC_ROOT

### DIFF
--- a/tools/docker-compose/nginx.vh.default.conf
+++ b/tools/docker-compose/nginx.vh.default.conf
@@ -85,8 +85,7 @@ server {
     add_header X-Content-Type-Options nosniff;
 
     location /static/ {
-        root /awx_devel;
-        try_files /awx/ui/$uri /awx/$uri /awx/public/$uri =404;
+        alias /var/lib/awx/public/static/;
         access_log off;
         sendfile off;
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
default django settings expects to place static files here
`STATIC_ROOT = '/var/lib/awx/public/static'`

but nginx conf expects to serve them from
`/awx_devel/static/awx/ui/`

we can fix this by being consistent with the 8013 server nginx conf
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
