### PR TITLE
Draft: add config export

### DIFF
--- a/awx_collection/all.yaml
+++ b/awx_collection/all.yaml
@@ -1,0 +1,1502 @@
+changed: false
+controller_credential_input_sources:
+  - created: '2022-10-22T17:42:56.159989Z'
+    description: Fill the gitlab credential from CyberArk
+    id: 1
+    input_field_name: password
+    metadata:
+      object_query: Safe=MY_SAFE;Object=AWX-user
+      object_query_format: Exact
+    modified: '2022-10-22T17:42:56.160036Z'
+    related:
+      created_by: /api/v2/users/1/
+      modified_by: /api/v2/users/1/
+      source_credential: /api/v2/credentials/13/
+      target_credential: /api/v2/credentials/14/
+    source_credential:
+      credential_type: CyberArk AIM Central Credential Provider Lookup
+      name: cyberark
+      organization: Default
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      source_credential:
+        cloud: false
+        credential_type_id: 19
+        description: CyberArk Lookup Credential
+        id: 13
+        kind: aim
+        name: cyberark
+      target_credential:
+        cloud: false
+        credential_type_id: 2
+        description: ''
+        id: 14
+        kind: scm
+        name: gitlab
+      user_capabilities:
+        delete: true
+    target_credential:
+      credential_type: Source Control
+      name: gitlab
+      organization: Default
+    type: credential_input_source
+    url: /api/v2/credential_input_sources/1/
+controller_credentials:
+  - cloud: true
+    created: '2022-10-22T17:42:51.415643Z'
+    credential_type: Red Hat Virtualization
+    description: infra-rhvm-01 creds for inventory sources.
+    id: 9
+    inputs:
+      host: 'https://example.com/ovirt-engine/api'
+      password: $encrypted$
+      username: user
+    kind: rhv
+    kubernetes: false
+    managed: false
+    modified: '2022-10-22T17:45:30.766532Z'
+    name: admin@internal-RHVM-01
+    organization: Satellite
+    related:
+      access_list: /api/v2/credentials/9/access_list/
+      activity_stream: /api/v2/credentials/9/activity_stream/
+      copy: /api/v2/credentials/9/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/14/
+      input_sources: /api/v2/credentials/9/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/9/object_roles/
+      organization: /api/v2/organizations/2/
+      owner_teams: /api/v2/credentials/9/owner_teams/
+      owner_users: /api/v2/credentials/9/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 14
+        name: Red Hat Virtualization
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 89
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 91
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 90
+          name: Use
+      organization:
+        description: ''
+        id: 2
+        name: Satellite
+      owners:
+        - description: ''
+          id: 2
+          name: Satellite
+          type: organization
+          url: /api/v2/organizations/2/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/9/
+  - cloud: false
+    created: '2022-10-09T06:03:47.215778Z'
+    credential_type: Ansible Galaxy/Automation Hub API Token
+    description: ''
+    id: 2
+    inputs:
+      url: 'https://galaxy.ansible.com/'
+    kind: galaxy_api_token
+    kubernetes: false
+    managed: true
+    modified: '2022-10-09T06:03:47.215828Z'
+    name: Ansible Galaxy
+    organization: null
+    related:
+      access_list: /api/v2/credentials/2/access_list/
+      activity_stream: /api/v2/credentials/2/activity_stream/
+      copy: /api/v2/credentials/2/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/18/
+      input_sources: /api/v2/credentials/2/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/2/object_roles/
+      owner_teams: /api/v2/credentials/2/owner_teams/
+      owner_users: /api/v2/credentials/2/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 18
+        name: Ansible Galaxy/Automation Hub API Token
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 23
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 25
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 24
+          name: Use
+      owners: []
+      user_capabilities:
+        copy: true
+        delete: false
+        edit: false
+        use: true
+    type: credential
+    url: /api/v2/credentials/2/
+  - cloud: false
+    created: '2022-10-09T06:03:58.360165Z'
+    credential_type: Ansible Galaxy/Automation Hub API Token
+    description: ''
+    id: 6
+    inputs:
+      auth_url: ''
+      token: $encrypted$
+      url: 'https://hub.nas/api/galaxy/content/community/'
+    kind: galaxy_api_token
+    kubernetes: false
+    managed: false
+    modified: '2022-10-14T00:06:28.775194Z'
+    name: Automation Hub Community Repository
+    organization: Default
+    related:
+      access_list: /api/v2/credentials/6/access_list/
+      activity_stream: /api/v2/credentials/6/activity_stream/
+      copy: /api/v2/credentials/6/copy/
+      credential_type: /api/v2/credential_types/18/
+      input_sources: /api/v2/credentials/6/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/6/object_roles/
+      organization: /api/v2/organizations/1/
+      owner_teams: /api/v2/credentials/6/owner_teams/
+      owner_users: /api/v2/credentials/6/owner_users/
+    summary_fields:
+      credential_type:
+        description: ''
+        id: 18
+        name: Ansible Galaxy/Automation Hub API Token
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 43
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 45
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 44
+          name: Use
+      organization:
+        description: ''
+        id: 1
+        name: Default
+      owners:
+        - description: ''
+          id: 1
+          name: Default
+          type: organization
+          url: /api/v2/organizations/1/
+        - description: ''
+          id: 3
+          name: differential-1
+          type: team
+          url: /api/v2/teams/3/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    teams:
+      - differential-1
+    type: credential
+    url: /api/v2/credentials/6/
+  - cloud: false
+    created: '2022-10-09T06:03:58.749765Z'
+    credential_type: Container Registry
+    description: ''
+    id: 7
+    inputs:
+      host: hub.nas
+      password: $encrypted$
+      username: admin
+      verify_ssl: true
+    kind: registry
+    kubernetes: false
+    managed: false
+    modified: '2022-10-14T00:06:39.035801Z'
+    name: Automation Hub Container Registry
+    organization: null
+    related:
+      access_list: /api/v2/credentials/7/access_list/
+      activity_stream: /api/v2/credentials/7/activity_stream/
+      copy: /api/v2/credentials/7/copy/
+      credential_type: /api/v2/credential_types/17/
+      input_sources: /api/v2/credentials/7/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/7/object_roles/
+      owner_teams: /api/v2/credentials/7/owner_teams/
+      owner_users: /api/v2/credentials/7/owner_users/
+    summary_fields:
+      credential_type:
+        description: ''
+        id: 17
+        name: Container Registry
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 46
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 48
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 47
+          name: Use
+      owners: []
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/7/
+  - cloud: false
+    created: '2022-10-09T06:03:57.676285Z'
+    credential_type: Ansible Galaxy/Automation Hub API Token
+    description: ''
+    id: 4
+    inputs:
+      auth_url: ''
+      token: $encrypted$
+      url: 'https://hub.nas/api/galaxy/content/published/'
+    kind: galaxy_api_token
+    kubernetes: false
+    managed: false
+    modified: '2022-10-14T00:06:51.239642Z'
+    name: Automation Hub Published Repository
+    organization: Default
+    related:
+      access_list: /api/v2/credentials/4/access_list/
+      activity_stream: /api/v2/credentials/4/activity_stream/
+      copy: /api/v2/credentials/4/copy/
+      credential_type: /api/v2/credential_types/18/
+      input_sources: /api/v2/credentials/4/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/4/object_roles/
+      organization: /api/v2/organizations/1/
+      owner_teams: /api/v2/credentials/4/owner_teams/
+      owner_users: /api/v2/credentials/4/owner_users/
+    summary_fields:
+      credential_type:
+        description: ''
+        id: 18
+        name: Ansible Galaxy/Automation Hub API Token
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 37
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 39
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 38
+          name: Use
+      organization:
+        description: ''
+        id: 1
+        name: Default
+      owners:
+        - description: ''
+          id: 1
+          name: Default
+          type: organization
+          url: /api/v2/organizations/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/4/
+  - cloud: false
+    created: '2022-10-09T06:03:58.115026Z'
+    credential_type: Ansible Galaxy/Automation Hub API Token
+    description: ''
+    id: 5
+    inputs:
+      auth_url: ''
+      token: $encrypted$
+      url: 'https://hub.nas/api/galaxy/content/rh-certified/'
+    kind: galaxy_api_token
+    kubernetes: false
+    managed: false
+    modified: '2022-10-14T00:06:17.265515Z'
+    name: Automation Hub RH Certified Repository
+    organization: Default
+    related:
+      access_list: /api/v2/credentials/5/access_list/
+      activity_stream: /api/v2/credentials/5/activity_stream/
+      copy: /api/v2/credentials/5/copy/
+      credential_type: /api/v2/credential_types/18/
+      input_sources: /api/v2/credentials/5/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/5/object_roles/
+      organization: /api/v2/organizations/1/
+      owner_teams: /api/v2/credentials/5/owner_teams/
+      owner_users: /api/v2/credentials/5/owner_users/
+    summary_fields:
+      credential_type:
+        description: ''
+        id: 18
+        name: Ansible Galaxy/Automation Hub API Token
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 40
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 42
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 41
+          name: Use
+      organization:
+        description: ''
+        id: 1
+        name: Default
+      owners:
+        - description: ''
+          id: 1
+          name: Default
+          type: organization
+          url: /api/v2/organizations/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/5/
+  - cloud: false
+    created: '2022-10-22T17:42:52.441957Z'
+    credential_type: CyberArk AIM Central Credential Provider Lookup
+    description: CyberArk Lookup Credential
+    id: 13
+    inputs:
+      app_id: $encrypted$
+      url: 'https://cyberark.example.com'
+    kind: aim
+    kubernetes: false
+    managed: false
+    modified: '2022-10-22T17:45:31.916044Z'
+    name: cyberark
+    organization: Default
+    related:
+      access_list: /api/v2/credentials/13/access_list/
+      activity_stream: /api/v2/credentials/13/activity_stream/
+      copy: /api/v2/credentials/13/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/19/
+      input_sources: /api/v2/credentials/13/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/13/object_roles/
+      organization: /api/v2/organizations/1/
+      owner_teams: /api/v2/credentials/13/owner_teams/
+      owner_users: /api/v2/credentials/13/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 19
+        name: CyberArk AIM Central Credential Provider Lookup
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 101
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 103
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 102
+          name: Use
+      organization:
+        description: ''
+        id: 1
+        name: Default
+      owners:
+        - description: ''
+          id: 1
+          name: Default
+          type: organization
+          url: /api/v2/organizations/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/13/
+  - cloud: false
+    created: '2022-10-09T06:03:50.740444Z'
+    credential_type: Container Registry
+    description: ''
+    id: 3
+    inputs:
+      host: registry.redhat.io
+      password: $encrypted$
+      username: rhn-gps-ssulliva
+      verify_ssl: true
+    kind: registry
+    kubernetes: false
+    managed: true
+    modified: '2022-10-09T06:03:50.937720Z'
+    name: Default Execution Environment Registry Credential
+    organization: null
+    related:
+      access_list: /api/v2/credentials/3/access_list/
+      activity_stream: /api/v2/credentials/3/activity_stream/
+      copy: /api/v2/credentials/3/copy/
+      credential_type: /api/v2/credential_types/17/
+      input_sources: /api/v2/credentials/3/input_sources/
+      object_roles: /api/v2/credentials/3/object_roles/
+      owner_teams: /api/v2/credentials/3/owner_teams/
+      owner_users: /api/v2/credentials/3/owner_users/
+    summary_fields:
+      credential_type:
+        description: ''
+        id: 17
+        name: Container Registry
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 34
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 36
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 35
+          name: Use
+      owners: []
+      user_capabilities:
+        copy: true
+        delete: false
+        edit: false
+        use: true
+    type: credential
+    url: /api/v2/credentials/3/
+  - cloud: false
+    created: '2022-10-09T06:03:47.032048Z'
+    credential_type: Machine
+    description: ''
+    id: 1
+    inputs:
+      username: admin
+    kind: ssh
+    kubernetes: false
+    managed: false
+    modified: '2022-10-09T06:03:47.032078Z'
+    name: Demo Credential
+    organization: null
+    related:
+      access_list: /api/v2/credentials/1/access_list/
+      activity_stream: /api/v2/credentials/1/activity_stream/
+      copy: /api/v2/credentials/1/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/1/
+      input_sources: /api/v2/credentials/1/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/1/object_roles/
+      owner_teams: /api/v2/credentials/1/owner_teams/
+      owner_users: /api/v2/credentials/1/owner_users/
+      user: /api/v2/users/1/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 1
+        name: Machine
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 20
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 22
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 21
+          name: Use
+      owners:
+        - description: ' '
+          id: 1
+          name: admin
+          type: user
+          url: /api/v2/users/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/1/
+    users:
+      - admin
+  - cloud: true
+    created: '2022-10-14T00:04:28.412079Z'
+    credential_type: Registery Credentials
+    description: ''
+    id: 8
+    inputs:
+      base_registery_password: $encrypted$
+      base_registery_username: rhn-gps-ssulliva
+      ee_ah_host: hub.nas
+      ee_ah_token: $encrypted$
+      ee_registry_password: $encrypted$
+      ee_registry_username: admin
+      ee_validate_certs: false
+    kind: null
+    kubernetes: false
+    managed: false
+    modified: '2022-10-14T00:08:48.789863Z'
+    name: Execution Build Credentials
+    organization: Default
+    related:
+      access_list: /api/v2/credentials/8/access_list/
+      activity_stream: /api/v2/credentials/8/activity_stream/
+      copy: /api/v2/credentials/8/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/27/
+      input_sources: /api/v2/credentials/8/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/8/object_roles/
+      organization: /api/v2/organizations/1/
+      owner_teams: /api/v2/credentials/8/owner_teams/
+      owner_users: /api/v2/credentials/8/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: REST API Credential
+        id: 27
+        name: Registery Credentials
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 49
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 51
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 50
+          name: Use
+      organization:
+        description: ''
+        id: 1
+        name: Default
+      owners:
+        - description: ''
+          id: 1
+          name: Default
+          type: organization
+          url: /api/v2/organizations/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/8/
+  - cloud: false
+    created: '2022-10-23T01:58:05.781361Z'
+    credential_type: GitHub Personal Access Token
+    description: ''
+    id: 17
+    inputs:
+      token: $encrypted$
+    kind: github_token
+    kubernetes: false
+    managed: false
+    modified: '2022-10-23T01:58:05.781415Z'
+    name: git
+    organization: null
+    related:
+      access_list: /api/v2/credentials/17/access_list/
+      activity_stream: /api/v2/credentials/17/activity_stream/
+      copy: /api/v2/credentials/17/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/11/
+      input_sources: /api/v2/credentials/17/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/17/object_roles/
+      owner_teams: /api/v2/credentials/17/owner_teams/
+      owner_users: /api/v2/credentials/17/owner_users/
+      user: /api/v2/users/1/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 11
+        name: GitHub Personal Access Token
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 165
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 167
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 166
+          name: Use
+      owners:
+        - description: ' '
+          id: 1
+          name: admin
+          type: user
+          url: /api/v2/users/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/17/
+    users:
+      - admin
+  - cloud: false
+    created: '2022-10-22T17:42:52.807013Z'
+    credential_type: Source Control
+    description: ''
+    id: 14
+    inputs:
+      username: username
+    kind: scm
+    kubernetes: false
+    managed: false
+    modified: '2022-10-22T17:42:52.807060Z'
+    name: gitlab
+    organization: Default
+    related:
+      access_list: /api/v2/credentials/14/access_list/
+      activity_stream: /api/v2/credentials/14/activity_stream/
+      copy: /api/v2/credentials/14/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/2/
+      input_sources: /api/v2/credentials/14/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/14/object_roles/
+      organization: /api/v2/organizations/1/
+      owner_teams: /api/v2/credentials/14/owner_teams/
+      owner_users: /api/v2/credentials/14/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 2
+        name: Source Control
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 104
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 106
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 105
+          name: Use
+      organization:
+        description: ''
+        id: 1
+        name: Default
+      owners:
+        - description: ''
+          id: 1
+          name: Default
+          type: organization
+          url: /api/v2/organizations/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/14/
+  - cloud: false
+    created: '2022-10-22T17:42:51.800058Z'
+    credential_type: Source Control
+    description: >-
+      General purpose token that can be used by anyone for satlab-admin(or other
+      private) repo clone
+    id: 11
+    inputs:
+      password: $encrypted$
+      username: gitlab
+    kind: scm
+    kubernetes: false
+    managed: false
+    modified: '2022-10-22T17:45:31.324323Z'
+    name: gitlab-personal-access-token for satqe_auto_droid
+    organization: Satellite
+    related:
+      access_list: /api/v2/credentials/11/access_list/
+      activity_stream: /api/v2/credentials/11/activity_stream/
+      copy: /api/v2/credentials/11/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/2/
+      input_sources: /api/v2/credentials/11/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/11/object_roles/
+      organization: /api/v2/organizations/2/
+      owner_teams: /api/v2/credentials/11/owner_teams/
+      owner_users: /api/v2/credentials/11/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 2
+        name: Source Control
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 95
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 97
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 96
+          name: Use
+      organization:
+        description: ''
+        id: 2
+        name: Satellite
+      owners:
+        - description: ''
+          id: 2
+          name: Satellite
+          type: organization
+          url: /api/v2/organizations/2/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/11/
+  - cloud: false
+    created: '2022-10-22T17:42:51.541670Z'
+    credential_type: Machine
+    description: >-
+      This credential can be used with any vm that contains jenkins_public key
+      in authorized keys
+    id: 10
+    inputs:
+      ssh_key_data: $encrypted$
+      username: root
+    kind: ssh
+    kubernetes: false
+    managed: false
+    modified: '2022-10-22T17:45:31.106948Z'
+    name: machine-creds-with-jenkins-pvt-key
+    organization: Satellite
+    related:
+      access_list: /api/v2/credentials/10/access_list/
+      activity_stream: /api/v2/credentials/10/activity_stream/
+      copy: /api/v2/credentials/10/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/1/
+      input_sources: /api/v2/credentials/10/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/10/object_roles/
+      organization: /api/v2/organizations/2/
+      owner_teams: /api/v2/credentials/10/owner_teams/
+      owner_users: /api/v2/credentials/10/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 1
+        name: Machine
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 92
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 94
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 93
+          name: Use
+      organization:
+        description: ''
+        id: 2
+        name: Satellite
+      owners:
+        - description: ''
+          id: 2
+          name: Satellite
+          type: organization
+          url: /api/v2/organizations/2/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/10/
+  - cloud: false
+    created: '2022-10-22T17:42:52.289319Z'
+    credential_type: Vault
+    description: satlab-admin-vault password aka vault_secret
+    id: 12
+    inputs:
+      vault_password: $encrypted$
+    kind: vault
+    kubernetes: false
+    managed: false
+    modified: '2022-10-22T17:45:31.636634Z'
+    name: satlab-admin-vault
+    organization: Satellite
+    related:
+      access_list: /api/v2/credentials/12/access_list/
+      activity_stream: /api/v2/credentials/12/activity_stream/
+      copy: /api/v2/credentials/12/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/3/
+      input_sources: /api/v2/credentials/12/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/12/object_roles/
+      organization: /api/v2/organizations/2/
+      owner_teams: /api/v2/credentials/12/owner_teams/
+      owner_users: /api/v2/credentials/12/owner_users/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 3
+        name: Vault
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 98
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 100
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 99
+          name: Use
+      organization:
+        description: ''
+        id: 2
+        name: Satellite
+      owners:
+        - description: ''
+          id: 2
+          name: Satellite
+          type: organization
+          url: /api/v2/organizations/2/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/12/
+  - cloud: true
+    created: '2022-10-22T23:24:23.151387Z'
+    credential_type: Amazon Web Services
+    description: ''
+    id: 15
+    inputs:
+      password: $encrypted$
+      username: asdf
+    kind: aws
+    kubernetes: false
+    managed: false
+    modified: '2022-10-22T23:24:23.151436Z'
+    name: sean
+    organization: null
+    related:
+      access_list: /api/v2/credentials/15/access_list/
+      activity_stream: /api/v2/credentials/15/activity_stream/
+      copy: /api/v2/credentials/15/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/5/
+      input_sources: /api/v2/credentials/15/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/15/object_roles/
+      owner_teams: /api/v2/credentials/15/owner_teams/
+      owner_users: /api/v2/credentials/15/owner_users/
+      user: /api/v2/users/1/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 5
+        name: Amazon Web Services
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 159
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 161
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 160
+          name: Use
+      owners:
+        - description: ' '
+          id: 1
+          name: admin
+          type: user
+          url: /api/v2/users/1/
+        - description: asdf asdf
+          id: 3
+          name: asdf
+          type: user
+          url: /api/v2/users/3/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/15/
+    users:
+      - admin
+      - asdf
+  - cloud: false
+    created: '2022-10-23T01:30:01.671454Z'
+    credential_type: OpenShift or Kubernetes API Bearer Token
+    description: ''
+    id: 16
+    inputs:
+      bearer_token: $encrypted$
+      host: asdf
+      verify_ssl: true
+    kind: kubernetes_bearer_token
+    kubernetes: true
+    managed: false
+    modified: '2022-10-23T01:30:01.671505Z'
+    name: shift
+    organization: null
+    related:
+      access_list: /api/v2/credentials/16/access_list/
+      activity_stream: /api/v2/credentials/16/activity_stream/
+      copy: /api/v2/credentials/16/copy/
+      created_by: /api/v2/users/1/
+      credential_type: /api/v2/credential_types/16/
+      input_sources: /api/v2/credentials/16/input_sources/
+      modified_by: /api/v2/users/1/
+      object_roles: /api/v2/credentials/16/object_roles/
+      owner_teams: /api/v2/credentials/16/owner_teams/
+      owner_users: /api/v2/credentials/16/owner_users/
+      user: /api/v2/users/1/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      credential_type:
+        description: ''
+        id: 16
+        name: OpenShift or Kubernetes API Bearer Token
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      object_roles:
+        admin_role:
+          description: Can manage all aspects of the credential
+          id: 162
+          name: Admin
+        read_role:
+          description: May view settings for the credential
+          id: 164
+          name: Read
+        use_role:
+          description: Can use the credential in a job template
+          id: 163
+          name: Use
+      owners:
+        - description: ' '
+          id: 1
+          name: admin
+          type: user
+          url: /api/v2/users/1/
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+        use: true
+    type: credential
+    url: /api/v2/credentials/16/
+    users:
+      - admin
+controller_execution_environments:
+  - created: '2022-10-22T22:43:01.081801Z'
+    credential: null
+    description: ''
+    id: 9
+    image: quay.io/ansible/awx-ee
+    managed: false
+    modified: '2022-10-22T22:43:01.081849Z'
+    name: org_ee
+    organization: Satellite
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/9/activity_stream/
+      copy: /api/v2/execution_environments/9/copy/
+      created_by: /api/v2/users/1/
+      modified_by: /api/v2/users/1/
+      organization: /api/v2/organizations/2/
+      unified_job_templates: /api/v2/execution_environments/9/unified_job_templates/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      organization:
+        description: ''
+        id: 2
+        name: Satellite
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/9/
+  - created: '2022-10-22T17:46:30.581632Z'
+    credential: null
+    description: ''
+    id: 8
+    image: quay.io/ansible/awx-ee
+    managed: false
+    modified: '2022-10-22T17:46:30.581679Z'
+    name: My EE
+    organization: null
+    pull: always
+    related:
+      activity_stream: /api/v2/execution_environments/8/activity_stream/
+      copy: /api/v2/execution_environments/8/copy/
+      created_by: /api/v2/users/1/
+      modified_by: /api/v2/users/1/
+      unified_job_templates: /api/v2/execution_environments/8/unified_job_templates/
+    summary_fields:
+      created_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      modified_by:
+        first_name: ''
+        id: 1
+        last_name: ''
+        username: admin
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/8/
+  - created: '2022-10-09T06:03:51.504954Z'
+    credential: Default Execution Environment Registry Credential
+    description: ''
+    id: 7
+    image: >-
+      registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+    managed: true
+    modified: '2022-10-16T01:53:53.637157Z'
+    name: Control Plane Execution Environment
+    organization: null
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/7/activity_stream/
+      copy: /api/v2/execution_environments/7/copy/
+      credential: /api/v2/credentials/3/
+      unified_job_templates: /api/v2/execution_environments/7/unified_job_templates/
+    summary_fields:
+      credential:
+        cloud: false
+        credential_type_id: 17
+        description: ''
+        id: 3
+        kind: registry
+        kubernetes: false
+        name: Default Execution Environment Registry Credential
+      user_capabilities:
+        copy: true
+        delete: false
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/7/
+  - created: '2022-10-09T06:03:51.402081Z'
+    credential: Default Execution Environment Registry Credential
+    description: ''
+    id: 6
+    image: >-
+      registry.redhat.io/ansible-automation-platform-22/ee-supported-rhel8:latest
+    managed: false
+    modified: '2022-10-16T01:53:53.626610Z'
+    name: Default execution environment
+    organization: null
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/6/activity_stream/
+      copy: /api/v2/execution_environments/6/copy/
+      credential: /api/v2/credentials/3/
+      unified_job_templates: /api/v2/execution_environments/6/unified_job_templates/
+    summary_fields:
+      credential:
+        cloud: false
+        credential_type_id: 17
+        description: ''
+        id: 3
+        kind: registry
+        kubernetes: false
+        name: Default Execution Environment Registry Credential
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/6/
+  - created: '2022-10-09T06:03:51.297443Z'
+    credential: Default Execution Environment Registry Credential
+    description: ''
+    id: 5
+    image: 'registry.redhat.io/ansible-automation-platform-22/ee-29-rhel8:latest'
+    managed: false
+    modified: '2022-10-16T01:53:53.616164Z'
+    name: Ansible Engine 2.9 execution environment
+    organization: null
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/5/activity_stream/
+      copy: /api/v2/execution_environments/5/copy/
+      credential: /api/v2/credentials/3/
+      unified_job_templates: /api/v2/execution_environments/5/unified_job_templates/
+    summary_fields:
+      credential:
+        cloud: false
+        credential_type_id: 17
+        description: ''
+        id: 3
+        kind: registry
+        kubernetes: false
+        name: Default Execution Environment Registry Credential
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/5/
+  - created: '2022-10-09T06:03:51.236835Z'
+    credential: Default Execution Environment Registry Credential
+    description: ''
+    id: 4
+    image: 'registry.redhat.io/ansible-automation-platform-22/ee-minimal-rhel8:latest'
+    managed: false
+    modified: '2022-10-16T01:53:53.605748Z'
+    name: Minimal execution environment
+    organization: null
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/4/activity_stream/
+      copy: /api/v2/execution_environments/4/copy/
+      credential: /api/v2/credentials/3/
+      unified_job_templates: /api/v2/execution_environments/4/unified_job_templates/
+    summary_fields:
+      credential:
+        cloud: false
+        credential_type_id: 17
+        description: ''
+        id: 3
+        kind: registry
+        kubernetes: false
+        name: Default Execution Environment Registry Credential
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/4/
+  - created: '2022-10-09T06:03:51.161193Z'
+    credential: Automation Hub Container Registry
+    description: ''
+    id: 3
+    image: 'hub.nas/ee-supported-rhel8:latest'
+    managed: false
+    modified: '2022-10-16T01:53:53.510696Z'
+    name: Automation Hub Default execution environment
+    organization: null
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/3/activity_stream/
+      copy: /api/v2/execution_environments/3/copy/
+      credential: /api/v2/credentials/7/
+      unified_job_templates: /api/v2/execution_environments/3/unified_job_templates/
+    summary_fields:
+      credential:
+        cloud: false
+        credential_type_id: 17
+        description: ''
+        id: 7
+        kind: registry
+        kubernetes: false
+        name: Automation Hub Container Registry
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/3/
+  - created: '2022-10-09T06:03:51.057652Z'
+    credential: Automation Hub Container Registry
+    description: ''
+    id: 2
+    image: 'hub.nas/ee-29-rhel8:latest'
+    managed: false
+    modified: '2022-10-16T01:53:53.423579Z'
+    name: Automation Hub Ansible Engine 2.9 execution environment
+    organization: null
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/2/activity_stream/
+      copy: /api/v2/execution_environments/2/copy/
+      credential: /api/v2/credentials/7/
+      unified_job_templates: /api/v2/execution_environments/2/unified_job_templates/
+    summary_fields:
+      credential:
+        cloud: false
+        credential_type_id: 17
+        description: ''
+        id: 7
+        kind: registry
+        kubernetes: false
+        name: Automation Hub Container Registry
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/2/
+  - created: '2022-10-09T06:03:50.959400Z'
+    credential: Automation Hub Container Registry
+    description: ''
+    id: 1
+    image: 'hub.nas/ee-minimal-rhel8:latest'
+    managed: false
+    modified: '2022-10-16T01:53:53.280899Z'
+    name: Automation Hub Minimal execution environment
+    organization: null
+    pull: ''
+    related:
+      activity_stream: /api/v2/execution_environments/1/activity_stream/
+      copy: /api/v2/execution_environments/1/copy/
+      credential: /api/v2/credentials/7/
+      unified_job_templates: /api/v2/execution_environments/1/unified_job_templates/
+    summary_fields:
+      credential:
+        cloud: false
+        credential_type_id: 17
+        description: ''
+        id: 7
+        kind: registry
+        kubernetes: false
+        name: Automation Hub Container Registry
+      user_capabilities:
+        copy: true
+        delete: true
+        edit: true
+    type: execution_environment
+    url: /api/v2/execution_environments/1/
+failed: false
+lookup_data: {}
+warnings:
+  - >-
+    You are using the awx version of this collection but connecting to Red Hat
+    Ansible Automation Platform

--- a/awx_collection/export.yml
+++ b/awx_collection/export.yml
@@ -1,0 +1,51 @@
+---
+- name: Export Workflow
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  collections:
+    - awx.awx
+  environment:
+     CONTROLLER_HOST: https://controller.nas
+     CONTROLLER_USERNAME: admin
+     CONTROLLER_PASSWORD: secret123
+     CONTROLLER_VERIFY_SSL: False
+
+  tasks:
+    - name: Export workflow job template
+      awx.awx.export_config:
+        endpoints:
+          #- applications
+          #- inventories
+          #- labels
+          #- notification_templates
+          #- teams
+          #- users
+          - credentials
+          - credential_input_sources
+          - execution_environments
+          #- groups
+          #- hosts
+          #- instances
+          #- instance_groups
+          #- inventory_sources
+          #- job_templates
+          #- organizations
+          #- schedules
+          #- workflow_job_templates
+          #- credential_types
+          #- settings
+        raw: False
+#        search_fields:
+#          - organization: Default
+#          - inventory: AAP Hosts
+      register: export_results
+
+    - debug:
+        var: export_results
+
+    - name: Export workflow job template to file
+      copy:
+        content: "{{ export_results | to_nice_yaml(width=50, explicit_start=True, explicit_end=True) }}"
+        dest: all.yaml
+...

--- a/awx_collection/export_working_notes.yml
+++ b/awx_collection/export_working_notes.yml
@@ -1,0 +1,165 @@
+Done:
+  applications: "/api/v2/applications/"
+    organization:
+      name: Default
+  inventories: "/api/v2/inventories/"
+    organization:
+      name: Satellite
+  labels: "/api/v2/labels/"
+    organization:
+      name: Default
+  notification_templates: "/api/v2/notification_templates/"
+    organization:
+      name: Satellite
+  teams: "/api/v2/teams/"
+    organization:
+      name: Satellite
+  users: "/api/v2/users/"
+    organization:
+      name: Satellite
+  credential_types: "/api/v2/credential_types/"
+    none
+  settings: "/api/v2/settings/"
+    none
+
+  credentials: "/api/v2/credentials/"
+    organization:
+      name: Default
+    credential_type:
+      name: Source Control
+    users:
+      username: admin
+    teams:
+      name: name
+  credential_input_sources: "/api/v2/credential_input_sources/"
+      "source_credential": "/api/v2/credentials/13/",
+      "target_credential": "/api/v2/credentials/14/"
+  hosts: "/api/v2/hosts/"
+    inventory:
+      organization: Satellite
+      name: Testing Inventory
+
+Working on:
+  execution_environments: "/api/v2/execution_environments/"
+    organization:
+      name: Default
+      # not required
+    credential:
+      name: Default
+      org: name
+      # not required
+  groups: "/api/v2/groups/"
+    inventory:
+      organization: Satellite
+      name: Testing Inventory
+    hosts: list
+    children: lists
+  instances: "/api/v2/instances/"
+    instance_groups:
+      name: Satellite
+  instance_groups: "/api/v2/instance_groups/"
+    instances:
+      name: Satellite
+    credential:
+      name: Default
+      # not required 
+
+  inventory_sources: "/api/v2/inventory_sources/"
+    organization:
+      name: Default
+    inventory:
+      organization:
+        name: Satellite
+      name: Testing Inventory
+    source_project
+    execution_environment
+    credential
+    related:
+      schedules: []
+      notification_templates_started: []
+      notification_templates_success: []
+      notification_templates_error: []
+  job_templates: "/api/v2/job_templates/"
+    credentials: []
+    execution_environment:
+        name: My EE
+    inventory:
+      organization:
+        name: Satellite
+      name: Testing Inventory
+    project:
+      organization:
+        name: Satellite
+      name: Tower Config
+    webhook_credential:
+      organization:
+        name: Satellite
+      name: Testing Inventory
+    related:
+      labels: []
+      survey_spec
+      credentials: []
+      notification_templates_started: []
+      notification_templates_success: []
+      notification_templates_error: []
+
+
+  organizations: "/api/v2/organizations/"
+    default_environment:
+      name: My EE
+    related:
+      instance_groups: []
+      execution_environments: []
+      galaxy_credentials: []
+      notification_templates: []
+        - name: irc-satqe-chat-notification
+          organization:
+              name: Satellite
+              type: organization
+          type: notification_template
+      notification_templates_started: []
+      notification_templates_success: []
+      notification_templates_error: []
+      notification_templates_approvals: []
+  projects: "/api/v2/projects/"
+    related:
+      credentials: []
+      notification_templates_started: []
+      notification_templates_success: []
+      notification_templates_error: []
+  # roles: "/api/v2/roles/"
+  schedules: "/api/v2/schedules/"
+    unified_job_template:
+    organization: Unified job template org
+    credentials:
+    inventory:
+      organization:
+        name: Satellite
+      name: Testing Inventory
+
+  workflow_job_templates: "/api/v2/workflow_job_templates/"
+    survey_spec
+    organization:
+      name: Satellite
+    related:
+      labels: []
+      survey_spec
+      notification_templates_started: []
+        - name: irc-satqe-chat-notification
+          organization:
+              name: Satellite
+              type: organization
+          type: notification_template
+      notification_templates_success: []
+      notification_templates_error: []
+      notification_templates_approvals: []
+    inventory:
+      organization:
+        name: Satellite
+      name: Testing Inventory
+    webhook_credential:
+      organization:
+        name: Satellite
+      name: Testing Inventory
+
+

--- a/awx_collection/plugins/modules/export_config.py
+++ b/awx_collection/plugins/modules/export_config.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2021, Sean Sullivan
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0', 'status': ['preview'], 'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: export_config
+author: "Sean Sullivan (@sean-m-sullivan)"
+short_description: export cassets with associations from Automation Platform Controller.
+description:
+    - Export assets with associations from Automation Platform Controller.
+options:
+    endpoints:
+      description:
+        - list of endpoints to export
+      type: list
+      elements: str
+    search_fields:
+      description:
+        - The fields to use to narrow down search results.
+        - This is likely organization, however it does accept other fields
+      type: list
+      elements: dict
+    raw:
+      description:
+        - Export raw output without processing.
+      type: bool
+notes:
+  - Specifying a name of "all" for any asset type will export all items of that asset type.
+extends_documentation_fragment: awx.awx.auth
+'''
+
+EXAMPLES = '''
+- name: Export all assets
+  export:
+    all: True
+
+- name: Export all inventories
+  export:
+    inventory: 'all'
+
+- name: Export a job template named "My Template" and all Credentials
+  export:
+    job_templates: "My Template"
+    credential: 'all'
+'''
+
+from ..module_utils.controller_api import ControllerAPIModule
+
+
+def nested_get(module, dic, keys):    
+    for key in keys:
+        dic = dic[key]
+    return dic
+
+
+def resolve_dict_associations(module, data, type):
+    models = {
+      'credential': {
+        'organization': ["summary_fields", "organization", "name"],
+        'credential_type': ["summary_fields", "credential_type", "name"],
+        'name': ['name'],
+      },
+      'inventory': {
+        'organization': ["summary_fields", "organization", "name"],
+        'name': ['name'],
+      }
+    }
+    response = {}
+    for key, value in models[type].items():
+        response[key] = nested_get(module, data, value)
+    return response
+
+
+def resolve_associations(module, response, endpoint):
+    summary_fields = {
+      'credentials': {
+        'credential_type': 'name',
+      },
+      'execution_environments': {
+        'credential': 'name',
+      },
+    }
+    related_fields = {
+      'credential_input_sources': {
+        'dicts': {
+          'source_credential': 'credential',
+          'target_credential': 'credential',
+        },
+      },
+      'groups': {
+        'dicts': {
+          'inventory': 'inventory',
+        }
+      },
+      'hosts': {
+        'dicts': {
+          'inventory': 'inventory',
+        }
+      },
+    }
+
+
+    for index, list_item in enumerate(response):
+      # add organization to summary fields
+      if endpoint not in summary_fields:
+          summary_fields[endpoint] = {'organization': 'name'}
+      else:
+          summary_fields[endpoint].update({'organization': 'name'})
+
+      # Resolve lookups that can be done with summary fields.
+      if endpoint in summary_fields:
+          for key, value in summary_fields[endpoint].items():
+              if key in list_item and list_item[key] is not None:
+                  response[index][key] = list_item['summary_fields'][key][value]
+
+      # Resolve lookups that can be done with summary fields.
+      if endpoint in related_fields:
+          if 'dicts' in related_fields[endpoint]:
+              for key, value in related_fields[endpoint]['dicts'].items():
+                  response[index][key] = resolve_dict_associations(module, module.get_endpoint(list_item['related'][key])['json'], value)
+
+      # Exceptions
+      if endpoint == 'credentials':
+          for owner in list_item['summary_fields']['owners']:
+              if owner['type'] == 'user':
+                  response[index].setdefault('users', []).append(owner['name'])
+              if owner['type'] == 'team':
+                  response[index].setdefault('teams', []).append(owner['name'])
+    return response
+
+
+def main():
+    argument_spec = dict(
+        endpoints=dict(type='list', required=True, elements='str'),
+        raw=dict(type='bool', default=False),
+        search_fields=dict(type='list', elements='dict'),
+    )
+
+    # Create a module for ourselves
+    module = ControllerAPIModule(argument_spec=argument_spec)
+    # The export process will never change the AWX system
+    module.json_output['changed'] = False
+
+    endpoints = module.params.get('endpoints')
+    
+    raw = module.params.get('raw')
+    search_fields = None
+    lookup_data = {}
+    if module.params.get('search_fields'):
+        search_fields = module.params.get('search_fields')
+        for list_field in search_fields:
+            for key, value in list_field.items():
+              lookup_id = module.get_one(module.param_to_endpoint(key), name_or_id=value)['id']
+              lookup_data[key] = lookup_id
+    module.json_output['lookup_data'] = lookup_data
+    for endpoint in endpoints:
+        response = module.get_all_filtered(endpoint, **{'data': lookup_data})
+        output_name = 'controller_' + endpoint
+        if raw:
+            module.json_output[output_name] = response
+        else:
+            module.json_output[output_name] = resolve_associations(module, response, endpoint)
+
+    module.exit_json(**module.json_output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
To improve on the export of objects from the controller, either as a supplement to the awx_export/cli or replacement.
 Idea is to add endpoints that are not there, resolve associations, and to allow for easier exporting of the endpoints to get people into configuration as code.

Included working playbook, with working filter, and a to do list of endpoints done and those with work needed. output file included for review during Draft. 

Mainly wanting some validation that this is a route to keep perusing and flushing out, or if you think this is a Horrible idea and that we should never include it in the collection, and/or feedback.


##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection
