### PR TITLE
make job lifecycle Cyan again

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -110,7 +110,7 @@ if settings.COLOR_LOGS is True:
                 # logs rendered with cyan text
                 previous_level_map = self.level_map.copy()
                 if record.name == "awx.analytics.job_lifecycle":
-                    self.level_map[logging.DEBUG] = (None, 'cyan', True)
+                    self.level_map[logging.INFO] = (None, 'cyan', True)
                 msg = super(ColorHandler, self).colorize(line, record)
                 self.level_map = previous_level_map
                 return msg


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
we moved job lifecycle logging to info level, which made our cyan logs become white
this restores them to cyan again!
![image](https://user-images.githubusercontent.com/8745776/197594705-a5341fed-b889-4ffa-baeb-6483055bdad2.png)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
