### PR TITLE
Add arm64 architecture mapping to image_architecture for m1mac

### DIFF
--- a/tools/ansible/roles/dockerfile/defaults/main.yml
+++ b/tools/ansible/roles/dockerfile/defaults/main.yml
@@ -9,4 +9,4 @@ template_dest: '_build'
 receptor_image: quay.io/ansible/receptor:devel
 
 # Helper vars to construct the proper download URL for the current architecture
-image_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}'
+image_architecture: '{{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "arm64": "arm64", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}'


### PR DESCRIPTION
##### SUMMARY

Add arm64 to the architecture mapping to address the following issue when building devel on m1mac.

##### REPRODUCE STEPS

```shell
$ uname -a
Darwin lagunaseca 21.6.0 Darwin Kernel Version 21.6.0: Mon Aug 22 20:19:52 PDT 2022; root:xnu-8020.140.49~2/RELEASE_ARM64_T6000 arm64
$ make docker-clean
$ make ui-devel
$ GIT_BRANCH=devel make docker-compose-build 
ansible-playbook tools/ansible/dockerfile.yml -e build_dev=True -e receptor_image=quay.io/ansible/receptor:devel
[WARNING]: You are running the development version of Ansible. You should only run Ansible from "devel" if you are
modifying the Ansible engine, or trying out features under development. This is a rapidly changing source of code
and can become unstable at any point.
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not
match 'all'

PLAY [Render AWX Dockerfile and sources] ***************************************************************************

TASK [Gathering Facts] *********************************************************************************************
ok: [localhost]

TASK [dockerfile : Create _build directory] ************************************************************************
ok: [localhost]

TASK [dockerfile : Render supervisor configs] **********************************************************************
ok: [localhost] => (item=supervisor.conf)
ok: [localhost] => (item=supervisor_task.conf)

TASK [dockerfile : Render Dockerfile] ******************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ansible.errors.AnsibleUndefinedVariable: {{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}: 'dict object' has no attribute 'arm64'. 'dict object' has no attribute 'arm64'. {{ { "x86_64": "amd64", "aarch64": "arm64", "armv7": "arm", "ppc64le": "ppc64le" }[ansible_facts.architecture] }}: 'dict object' has no attribute 'arm64'. 'dict object' has no attribute 'arm64'
fatal: [localhost]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: {{ { \"x86_64\": \"amd64\", \"aarch64\": \"arm64\", \"armv7\": \"arm\", \"ppc64le\": \"ppc64le\" }[ansible_facts.architecture] }}: 'dict object' has no attribute 'arm64'. 'dict object' has no attribute 'arm64'. {{ { \"x86_64\": \"amd64\", \"aarch64\": \"arm64\", \"armv7\": \"arm\", \"ppc64le\": \"ppc64le\" }[ansible_facts.architecture] }}: 'dict object' has no attribute 'arm64'. 'dict object' has no attribute 'arm64'"}

PLAY RECAP *********************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```


##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other

##### ENVIRONMENT
- OS: macos 12.6
- CPU: Apple M1 Max

##### AWX VERSION
```
devel
```


##### ADDITIONAL INFORMATION
