### PR TITLE
Fixes #13119 #13120 Conjur Cloud support & update brand

### DIFF
--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -1,6 +1,5 @@
 from .plugin import CredentialPlugin, CertFiles, raise_for_status
 
-import base64
 from urllib.parse import urljoin, quote
 
 from django.utils.translation import gettext_lazy as _

--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -61,7 +61,7 @@ def conjur_backend(**kwargs):
     cacert = kwargs.get('cacert', None)
 
     auth_kwargs = {
-        'headers': {'Content-Type': 'text/plain'},
+        'headers': {'Content-Type': 'text/plain', 'Accept-Encoding': 'base64'},
         'data': api_key,
         'allow_redirects': False,
     }
@@ -69,9 +69,9 @@ def conjur_backend(**kwargs):
     with CertFiles(cacert) as cert:
         # https://www.conjur.org/api.html#authentication-authenticate-post
         auth_kwargs['verify'] = cert
-        resp = requests.post(urljoin(url, '/'.join(['authn', account, username, 'authenticate'])), **auth_kwargs)
+        resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
     raise_for_status(resp)
-    token = base64.b64encode(resp.content).decode('utf-8')
+    token = resp.content.decode('utf-8')
 
     lookup_kwargs = {
         'headers': {'Authorization': 'Token token="{}"'.format(token)},
@@ -79,7 +79,7 @@ def conjur_backend(**kwargs):
     }
 
     # https://www.conjur.org/api.html#secrets-retrieve-a-secret-get
-    path = urljoin(url, '/'.join(['secrets', account, 'variable', secret_path]))
+    path = urljoin(url, '/'.join(['api', 'secrets', account, 'variable', secret_path]))
     if version:
         path = '?'.join([path, version])
 
@@ -90,4 +90,4 @@ def conjur_backend(**kwargs):
     return resp.text
 
 
-conjur_plugin = CredentialPlugin('CyberArk Conjur Secret Lookup', inputs=conjur_inputs, backend=conjur_backend)
+conjur_plugin = CredentialPlugin('CyberArk Conjur Secrets Manager Lookup', inputs=conjur_inputs, backend=conjur_backend)

--- a/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.test.js
+++ b/awx/ui/src/screens/Credential/CredentialEdit/CredentialEdit.test.js
@@ -282,7 +282,7 @@ const mockInputSources = {
         summary_fields: {
           source_credential: {
             id: 20,
-            name: 'CyberArk Conjur Secret Lookup',
+            name: 'CyberArk Conjur Secrets Manager Lookup',
             description: '',
             kind: 'conjur',
             cloud: false,
@@ -301,7 +301,7 @@ const mockInputSources = {
         summary_fields: {
           source_credential: {
             id: 20,
-            name: 'CyberArk Conjur Secret Lookup',
+            name: 'CyberArk Conjur Secrets Manager Lookup',
             description: '',
             kind: 'conjur',
             cloud: false,

--- a/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.test.js
+++ b/awx/ui/src/screens/Credential/shared/CredentialPlugins/CredentialPluginPrompt/CredentialPluginPrompt.test.js
@@ -36,14 +36,14 @@ const mockCredentialTypeDetail = {
     url: '/api/v2/credential_types/20/',
     related: {
       named_url:
-        '/api/v2/credential_types/CyberArk Conjur Secret Lookup+external/',
+        '/api/v2/credential_types/CyberArk Conjur Secrets Manager Lookup+external/',
       credentials: '/api/v2/credential_types/20/credentials/',
       activity_stream: '/api/v2/credential_types/20/activity_stream/',
     },
     summary_fields: { user_capabilities: { edit: false, delete: false } },
     created: '2020-05-18T21:53:35.398260Z',
     modified: '2020-05-18T21:54:05.451444Z',
-    name: 'CyberArk Conjur Secret Lookup',
+    name: 'CyberArk Conjur Secrets Manager Lookup',
     description: '',
     kind: 'external',
     namespace: 'conjur',

--- a/awx/ui/src/screens/Credential/shared/data.credentialTypes.json
+++ b/awx/ui/src/screens/Credential/shared/data.credentialTypes.json
@@ -546,7 +546,7 @@
     },
     "created": "2020-05-18T21:53:35.398260Z",
     "modified": "2020-05-18T21:54:05.451444Z",
-    "name": "CyberArk Conjur Secret Lookup",
+    "name": "CyberArk Conjur Secrets Manager Lookup",
     "description": "",
     "kind": "external",
     "namespace": "conjur",

--- a/awx/ui/src/screens/Credential/shared/data.cyberArkCredential.json
+++ b/awx/ui/src/screens/Credential/shared/data.cyberArkCredential.json
@@ -3,7 +3,7 @@
   "type": "credential",
   "url": "/api/v2/credentials/1/",
   "related": {
-    "named_url": "/api/v2/credentials/CyberArk Conjur Secrets Manager Lookup++CyberArk Conjur Secret Lookup+external++/",
+    "named_url": "/api/v2/credentials/CyberArk Conjur Secrets Manager Lookup+external++/",
     "created_by": "/api/v2/users/1/",
     "modified_by": "/api/v2/users/1/",
     "activity_stream": "/api/v2/credentials/1/activity_stream/",

--- a/awx/ui/src/screens/Credential/shared/data.cyberArkCredential.json
+++ b/awx/ui/src/screens/Credential/shared/data.cyberArkCredential.json
@@ -3,7 +3,7 @@
   "type": "credential",
   "url": "/api/v2/credentials/1/",
   "related": {
-    "named_url": "/api/v2/credentials/CyberArk Conjur Secret Lookup++CyberArk Conjur Secret Lookup+external++/",
+    "named_url": "/api/v2/credentials/CyberArk Conjur Secrets Manager Lookup++CyberArk Conjur Secret Lookup+external++/",
     "created_by": "/api/v2/users/1/",
     "modified_by": "/api/v2/users/1/",
     "activity_stream": "/api/v2/credentials/1/activity_stream/",
@@ -19,7 +19,7 @@
   "summary_fields": {
     "credential_type": {
       "id": 20,
-      "name": "CyberArk Conjur Secret Lookup",
+      "name": "CyberArk Conjur Secrets Manager Lookup",
       "description": ""
     },
     "created_by": {
@@ -69,7 +69,7 @@
   },
   "created": "2020-05-19T12:51:36.956029Z",
   "modified": "2020-05-19T12:51:36.956086Z",
-  "name": "CyberArk Conjur Secret Lookup",
+  "name": "CyberArk Conjur Secrets Manager Lookup",
   "description": "",
   "organization": null,
   "credential_type": 20,

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -52,7 +52,7 @@ options:
         - The credential type being created.
         - Can be a built-in credential type such as "Machine", or a custom credential type such as "My Credential Type"
         - Choices include Amazon Web Services, Ansible Galaxy/Automation Hub API Token, Centrify Vault Credential Provider Lookup,
-          Container Registry, CyberArk AIM Central Credential Provider Lookup, CyberArk Conjur Secret Lookup, Google Compute Engine,
+          Container Registry, CyberArk AIM Central Credential Provider Lookup, CyberArk Conjur Secrets Manager Lookup, Google Compute Engine,
           GitHub Personal Access Token, GitLab Personal Access Token, GPG Public Key, HashiCorp Vault Secret Lookup, HashiCorp Vault Signed SSH,
           Insights, Machine, Microsoft Azure Key Vault, Microsoft Azure Resource Manager, Network, OpenShift or Kubernetes API
           Bearer Token, OpenStack, Red Hat Ansible Automation Platform, Red Hat Satellite 6, Red Hat Virtualization, Source Control,


### PR DESCRIPTION
##### SUMMARY
Fixes #13119 & fixes #13120. Adds Conjur Cloud support and updates credential plugin name to `CyberArk Conjur Secrets Manager Lookup`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
```
awx: 0.1.dev32506+g4a73356.d20221026
```


##### ADDITIONAL INFORMATION
![image](https://user-images.githubusercontent.com/1924063/198053984-d93584de-079f-429c-aa62-447a00018ed6.png)

