### PR TITLE
[performance] Reduce unnecessary queries for job launch and start process

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -224,8 +224,11 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
         encrypted = encrypt_field(self, field, ask=ask)
         if encrypted:
             self.inputs[field] = encrypted
+            return True
         elif field in self.inputs:
             del self.inputs[field]
+            return True
+        return False
 
     def display_inputs(self):
         field_val = self.inputs.copy()

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -446,16 +446,19 @@ class BaseTask(object):
         collections_info = os.path.join(artifact_dir, 'collections.json')
         ansible_version_file = os.path.join(artifact_dir, 'ansible_version.txt')
 
+        update_fields = []
         if os.path.exists(collections_info):
             with open(collections_info) as ee_json_info:
                 ee_collections_info = json.loads(ee_json_info.read())
                 instance.installed_collections = ee_collections_info
-                instance.save(update_fields=['installed_collections'])
+                update_fields.append('installed_collections')
         if os.path.exists(ansible_version_file):
             with open(ansible_version_file) as ee_ansible_info:
                 ansible_version_info = ee_ansible_info.readline()
                 instance.ansible_version = ansible_version_info
-                instance.save(update_fields=['ansible_version'])
+                update_fields.append('ansible_version')
+        if update_fields:
+            instance.save(update_fields=update_fields)
 
     def should_use_fact_cache(self):
         return False

--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -37,6 +37,7 @@ class TestComputedFields:
         """
         original_sch_modified = schedule.modified
         original_sch_modified_by = schedule.modified_by
+        schedule.unified_job_template.refresh_from_db()
         original_ujt_modified = schedule.unified_job_template.modified
         original_ujt_modified_by = schedule.unified_job_template.modified_by
         original_AS_entries = ActivityStream.objects.count()


### PR DESCRIPTION
##### SUMMARY
This focuses on inefficiencies seen in the process of:

```python
job = jt.launch()
job.signal_start()
```

This is done in the task manager for spawning dependencies, and separately in the workflow manager for workflow jobs. So this is, in some significant part, a task manager performance enhancement as well.

For some of this, I've tried to make similar performance improvements in the past. Here, I've tried to keep it fairly conservative.

I would like to be able to get this in to enable us to move more responsibilities into the launch request-response cycle as in https://github.com/ansible/awx/pull/13061

I measured 93 queries before and 55 queries afterwards for a particular scenario, for about a 40% improvement.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
This is all really low-hanging fruit. Like, if you do `job.save(update_fields=["status"])`, then you should need to update the RBAC structure, or obtain the related inventory from the database. Or, when apply credentials/labels to a job just created, there's not a need to fetch every related object in support of that...
