### PR TITLE
UI static files are now directly copied to the proper static dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,7 @@ clean: clean-ui clean-api clean-awxkit clean-dist
 
 clean-api:
 	rm -rf build $(NAME)-$(VERSION) *.egg-info
+	rm -rf .tox
 	find . -type f -regex ".*\.py[co]$$" -delete
 	find . -type d -name "__pycache__" -delete
 	rm -f awx/awx_test.sqlite3*
@@ -181,7 +182,7 @@ collectstatic:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	mkdir -p awx/public/static && $(PYTHON) manage.py collectstatic --clear --noinput > /dev/null 2>&1
+	$(PYTHON) manage.py collectstatic --clear --noinput > /dev/null 2>&1
 
 DEV_RELOAD_COMMAND ?= supervisorctl restart tower-processes:*
 
@@ -377,6 +378,8 @@ clean-ui:
 	rm -rf awx/ui/build
 	rm -rf awx/ui/src/locales/_build
 	rm -rf $(UI_BUILD_FLAG_FILE)
+        # the collectstatic command doesn't like it if this dir doesn't exist.
+	mkdir -p awx/ui/build/static
 
 awx/ui/node_modules:
 	NODE_OPTIONS=--max-old-space-size=6144 $(NPM_BIN) --prefix awx/ui --loglevel warn --force ci
@@ -386,15 +389,13 @@ $(UI_BUILD_FLAG_FILE):
 	$(PYTHON) tools/scripts/compilemessages.py
 	$(NPM_BIN) --prefix awx/ui --loglevel warn run compile-strings
 	$(NPM_BIN) --prefix awx/ui --loglevel warn run build
-	mkdir -p awx/public/static/css
-	mkdir -p awx/public/static/js
-	mkdir -p awx/public/static/media
-	cp -r awx/ui/build/static/css/* awx/public/static/css
-	cp -r awx/ui/build/static/js/* awx/public/static/js
-	cp -r awx/ui/build/static/media/* awx/public/static/media
+	mkdir -p /var/lib/awx/public/static/css
+	mkdir -p /var/lib/awx/public/static/js
+	mkdir -p /var/lib/awx/public/static/media
+	cp -r awx/ui/build/static/css/* /var/lib/awx/public/static/css
+	cp -r awx/ui/build/static/js/* /var/lib/awx/public/static/js
+	cp -r awx/ui/build/static/media/* /var/lib/awx/public/static/media
 	touch $@
-
-
 
 ui-release: $(UI_BUILD_FLAG_FILE)
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -101,7 +101,7 @@ USE_L10N = True
 
 USE_TZ = True
 
-STATICFILES_DIRS = (os.path.join(BASE_DIR, 'ui', 'build', 'static'), os.path.join(BASE_DIR, 'static'))
+STATICFILES_DIRS = [os.path.join(BASE_DIR, 'ui', 'build', 'static'), os.path.join(BASE_DIR, 'static')]
 
 # Absolute filesystem path to the directory where static file are collected via
 # the collectstatic command.

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -19,6 +19,9 @@ else
     wait-for-migrations
 fi
 
+# Make sure that the UI static file directory exists, Django complains otherwise.
+mkdir -p /awx_devel/awx/ui/build/static
+
 if output=$(awx-manage createsuperuser --noinput --username=admin --email=admin@localhost 2> /dev/null); then
     echo $output
 fi
@@ -26,10 +29,6 @@ echo "Admin password: ${DJANGO_SUPERUSER_PASSWORD}"
 
 awx-manage create_preload_data
 awx-manage register_default_execution_environments
-
-mkdir -p /awx_devel/awx/public/static
-mkdir -p /awx_devel/awx/ui/static
-mkdir -p /awx_devel/awx/ui/build/static
 
 awx-manage provision_instance --hostname="$(hostname)" --node_type="$MAIN_NODE_TYPE"
 awx-manage register_queue --queuename=controlplane --instance_percent=100


### PR DESCRIPTION
##### SUMMARY
UI static files are now directly copied to the proper static dir when running `make ui-devel`.  Previously they were going to /awx_devel/awx/public/static, but that directory is no longer being served up by nginx, which forced us to have to run `make collectstatic` (or equivalent) to get the files to the right place.

The (prior) flow of static files due to various commands:
![static-files](https://user-images.githubusercontent.com/685957/198146849-5e41136d-5b2b-495c-ae86-f3f4a054a7bc.png)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
