### PR TITLE
CyberArk Central Credential Provider Lookup custom Web Service ID & update branding

### DIFF
--- a/awx/main/credential_plugins/aim.py
+++ b/awx/main/credential_plugins/aim.py
@@ -14,6 +14,12 @@ aim_inputs = {
             'format': 'url',
         },
         {
+            'id': 'webservice_id',
+            'label': _('Web Service ID'),
+            'type': 'string',
+            'help_text': _('The AIM Web Service ID. Default: AIMWebService'),
+        },
+        {
             'id': 'app_id',
             'label': _('Application ID'),
             'type': 'string',
@@ -64,6 +70,7 @@ def aim_backend(**kwargs):
     client_cert = kwargs.get('client_cert', None)
     client_key = kwargs.get('client_key', None)
     verify = kwargs['verify']
+    webservice_id = kwargs.get('webservice_id', 'AIMWebService')
     app_id = kwargs['app_id']
     object_query = kwargs['object_query']
     object_query_format = kwargs['object_query_format']
@@ -78,7 +85,7 @@ def aim_backend(**kwargs):
         query_params['reason'] = reason
 
     request_qs = '?' + urlencode(query_params, quote_via=quote)
-    request_url = urljoin(url, '/'.join(['AIMWebService', 'api', 'Accounts']))
+    request_url = urljoin(url, '/'.join([webservice_id, 'api', 'Accounts']))
 
     with CertFiles(client_cert, client_key) as cert:
         res = requests.get(
@@ -92,4 +99,4 @@ def aim_backend(**kwargs):
     return res.json()['Content']
 
 
-aim_plugin = CredentialPlugin('CyberArk AIM Central Credential Provider Lookup', inputs=aim_inputs, backend=aim_backend)
+aim_plugin = CredentialPlugin('CyberArk Central Credential Provider Lookup', inputs=aim_inputs, backend=aim_backend)

--- a/awx/main/credential_plugins/aim.py
+++ b/awx/main/credential_plugins/aim.py
@@ -70,12 +70,12 @@ def aim_backend(**kwargs):
     client_cert = kwargs.get('client_cert', None)
     client_key = kwargs.get('client_key', None)
     verify = kwargs['verify']
-    webservice_id = kwargs.get('webservice_id', None)
+    webservice_id = kwargs['webservice_id']
     app_id = kwargs['app_id']
     object_query = kwargs['object_query']
     object_query_format = kwargs['object_query_format']
     reason = kwargs.get('reason', None)
-    if webservice_id is None:
+    if webservice_id == '':
         webservice_id = 'AIMWebService'
 
     query_params = {

--- a/awx/main/credential_plugins/aim.py
+++ b/awx/main/credential_plugins/aim.py
@@ -9,7 +9,7 @@ aim_inputs = {
     'fields': [
         {
             'id': 'url',
-            'label': _('CyberArk AIM URL'),
+            'label': _('CyberArk CCP URL'),
             'type': 'string',
             'format': 'url',
         },
@@ -17,7 +17,7 @@ aim_inputs = {
             'id': 'webservice_id',
             'label': _('Web Service ID'),
             'type': 'string',
-            'help_text': _('The AIM Web Service ID. Default: AIMWebService'),
+            'help_text': _('The CCP Web Service ID. Leave blank to default to AIMWebService.'),
         },
         {
             'id': 'app_id',

--- a/awx/main/credential_plugins/aim.py
+++ b/awx/main/credential_plugins/aim.py
@@ -70,11 +70,13 @@ def aim_backend(**kwargs):
     client_cert = kwargs.get('client_cert', None)
     client_key = kwargs.get('client_key', None)
     verify = kwargs['verify']
-    webservice_id = kwargs.get('webservice_id', 'AIMWebService')
+    webservice_id = kwargs.get('webservice_id', None)
     app_id = kwargs['app_id']
     object_query = kwargs['object_query']
     object_query_format = kwargs['object_query_format']
     reason = kwargs.get('reason', None)
+    if webservice_id is None:
+        webservice_id = 'AIMWebService'
 
     query_params = {
         'AppId': app_id,

--- a/awx/ui/src/screens/Credential/shared/data.credentialTypes.json
+++ b/awx/ui/src/screens/Credential/shared/data.credentialTypes.json
@@ -465,7 +465,7 @@
     },
     "created": "2020-05-18T21:53:35.370730Z",
     "modified": "2020-05-18T21:54:05.436400Z",
-    "name": "CyberArk AIM Central Credential Provider Lookup",
+    "name": "CyberArk Central Credential Provider Lookup",
     "description": "",
     "kind": "external",
     "namespace": "aim",

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -52,7 +52,7 @@ options:
         - The credential type being created.
         - Can be a built-in credential type such as "Machine", or a custom credential type such as "My Credential Type"
         - Choices include Amazon Web Services, Ansible Galaxy/Automation Hub API Token, Centrify Vault Credential Provider Lookup,
-          Container Registry, CyberArk AIM Central Credential Provider Lookup, CyberArk Conjur Secret Lookup, Google Compute Engine,
+          Container Registry, CyberArk Central Credential Provider Lookup, CyberArk Conjur Secret Lookup, Google Compute Engine,
           GitHub Personal Access Token, GitLab Personal Access Token, GPG Public Key, HashiCorp Vault Secret Lookup, HashiCorp Vault Signed SSH,
           Insights, Machine, Microsoft Azure Key Vault, Microsoft Azure Resource Manager, Network, OpenShift or Kubernetes API
           Bearer Token, OpenStack, Red Hat Ansible Automation Platform, Red Hat Satellite 6, Red Hat Virtualization, Source Control,

--- a/awx_collection/tests/integration/targets/credential_input_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential_input_source/tasks/main.yml
@@ -14,7 +14,7 @@
       credential:
         description: Credential for Testing Source
         name: "{{ src_cred_name }}"
-        credential_type: CyberArk AIM Central Credential Provider Lookup
+        credential_type: CyberArk Central Credential Provider Lookup
         inputs:
           url: "https://cyberark.example.com"
           app_id: "My-App-ID"
@@ -58,7 +58,7 @@
       credential:
         description: Credential for Testing Source Change
         name: "{{ src_cred_name }}-2"
-        credential_type: CyberArk AIM Central Credential Provider Lookup
+        credential_type: CyberArk Central Credential Provider Lookup
         inputs:
           url: "https://cyberark-prod.example.com"
           app_id: "My-App-ID"
@@ -92,7 +92,7 @@
       credential:
         name: "{{ src_cred_name }}"
         organization: Default
-        credential_type: CyberArk AIM Central Credential Provider Lookup
+        credential_type: CyberArk Central Credential Provider Lookup
         state: absent
       register: result
 
@@ -100,7 +100,7 @@
       credential:
         name: "{{ src_cred_name }}-2"
         organization: Default
-        credential_type: CyberArk AIM Central Credential Provider Lookup
+        credential_type: CyberArk Central Credential Provider Lookup
         state: absent
       register: result
 


### PR DESCRIPTION
##### SUMMARY
Fixes #13122 & fixes #10545. Updates name from `CyberArk AIM Central Credential Provider Lookup` to `CyberArk Central Credential Provider Lookup`.  Removes references to `AIM`.  Adds the ability to set a different CCP Web Service ID than the default `AIMWebService`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
```
awx: 0.1.dev32524+g2cc971a.d20221026
```


##### ADDITIONAL INFORMATION
n/a
