### PR TITLE
Throw a warning if custom secret key was specified but not given

### DIFF
--- a/awx/main/management/commands/regenerate_secret_key.py
+++ b/awx/main/management/commands/regenerate_secret_key.py
@@ -32,8 +32,14 @@ class Command(BaseCommand):
     def handle(self, **options):
         self.old_key = settings.SECRET_KEY
         custom_key = os.environ.get("TOWER_SECRET_KEY")
-        if options.get("use_custom_key") and custom_key:
-            self.new_key = custom_key
+        if options.get("use_custom_key"):
+            if custom_key:
+                self.new_key = custom_key
+            else:
+                print("Use custom key was specified but the env var TOWER_SECRET_KEY was not available")
+                import sys
+
+                sys.exit(1)
         else:
             self.new_key = base64.encodebytes(os.urandom(33)).decode().rstrip()
         self._notification_templates()

--- a/awx/main/tests/functional/commands/test_secret_key_regeneration.py
+++ b/awx/main/tests/functional/commands/test_secret_key_regeneration.py
@@ -171,13 +171,17 @@ class TestKeyRegeneration:
 
     def test_use_custom_key_with_empty_tower_secret_key_env_var(self):
         os.environ['TOWER_SECRET_KEY'] = ''
-        new_key = call_command('regenerate_secret_key', '--use-custom-key')
-        assert settings.SECRET_KEY != new_key
+        with pytest.raises(SystemExit) as e:
+            call_command('regenerate_secret_key', '--use-custom-key')
+        assert e.type == SystemExit
+        assert e.value.code == 1
 
     def test_use_custom_key_with_no_tower_secret_key_env_var(self):
         os.environ.pop('TOWER_SECRET_KEY', None)
-        new_key = call_command('regenerate_secret_key', '--use-custom-key')
-        assert settings.SECRET_KEY != new_key
+        with pytest.raises(SystemExit) as e:
+            call_command('regenerate_secret_key', '--use-custom-key')
+        assert e.type == SystemExit
+        assert e.value.code == 1
 
     def test_with_tower_secret_key_env_var(self):
         custom_key = 'MXSq9uqcwezBOChl/UfmbW1k4op+bC+FQtwPqgJ1u9XV'


### PR DESCRIPTION
##### SUMMARY
If you ran `awx-manage regerneate_secret_key` and added `--use-custom-key` to specify a key but didn't have the proper env var available it would generate a new key and do the encryption with that. This will now throw the following error and exit:
```
Use custom key was specified but the env var TOWER_SECRET_KEY was not available
```

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.7.1.dev89+gbbeb1a3530
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
