### PR TITLE
Expand the dependencies of the Schedule page type

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -275,7 +275,13 @@ class ApiV2(base.Base):
                         # When creating a project, we need to wait for its
                         # first project update to finish so that associated
                         # JTs have valid options for playbook names
-                        _page.wait_until_completed()
+                        try:
+                            _page.wait_until_completed(timeout=300)
+                        except AssertionError:
+                            # If the project update times out, try to
+                            # carry on in the hopes that it will
+                            # finish before it is needed.
+                            pass
                 else:
                     # If we are an existing project and our scm_tpye is not changing don't try and import the local_path setting
                     if asset['natural_key']['type'] == 'project' and 'local_path' in post_data and _page['scm_type'] == post_data['scm_type']:

--- a/awxkit/awxkit/api/pages/schedules.py
+++ b/awxkit/awxkit/api/pages/schedules.py
@@ -1,6 +1,7 @@
 from contextlib import suppress
 
-from awxkit.api.pages import SystemJobTemplate
+from awxkit.api.pages import JobTemplate, SystemJobTemplate, Project, InventorySource
+from awxkit.api.pages.workflow_job_templates import WorkflowJobTemplate
 from awxkit.api.mixins import HasCreate
 from awxkit.api.resources import resources
 from awxkit.config import config
@@ -11,7 +12,7 @@ from . import base
 
 
 class Schedule(HasCreate, base.Base):
-    dependencies = [SystemJobTemplate]
+    dependencies = [JobTemplate, SystemJobTemplate, Project, InventorySource, WorkflowJobTemplate]
     NATURAL_KEY = ('unified_job_template', 'name')
 
     def silent_delete(self):


### PR DESCRIPTION
##### SUMMARY
Really these could get any of the unified job template types, not just system job templates, so importing e.g. a project with a schedule was doing them in the wrong order.

Also, bump the timeout of the project update and make sure that we stash it in the page cache even if it doesn't finish in 5 minutes.

related #13084
replaces #13090

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI
