### PR TITLE
Add multiple asset export for awx cli

### DIFF
--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -28,51 +28,51 @@ options:
       default: 'False'
     organizations:
       description:
-        - organization name to export
+        - organization names to export
       type: str
     users:
       description:
-        - user name to export
+        - user names to export
       type: str
     teams:
       description:
-        - team name to export
+        - team names to export
       type: str
     credential_types:
       description:
-        - credential type name to export
+        - credential type names to export
       type: str
     credentials:
       description:
-        - credential name to export
+        - credential names to export
       type: str
     execution_environments:
       description:
-        - execution environment name to export
+        - execution environment names to export
       type: str
     notification_templates:
       description:
-        - notification template name to export
+        - notification template names to export
       type: str
     inventory_sources:
       description:
-        - inventory soruce to export
+        - inventory soruces to export
       type: str
     inventory:
       description:
-        - inventory name to export
+        - inventory names to export
       type: str
     projects:
       description:
-        - project name to export
+        - project names to export
       type: str
     job_templates:
       description:
-        - job template name to export
+        - job template names to export
       type: str
     workflow_job_templates:
       description:
-        - workflow name to export
+        - workflow names to export
       type: str
 requirements:
   - "awxkit >= 9.3.0"
@@ -94,6 +94,10 @@ EXAMPLES = '''
   export:
     job_templates: "My Template"
     credential: 'all'
+
+- name: Export two or more inventories with a comma separated list of names
+  export:
+    inventory: "My Inventory1,My Inventory2"
 '''
 
 import logging

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -29,51 +29,51 @@ options:
     organizations:
       description:
         - organization names to export
-      type: str
+      type: list
     users:
       description:
         - user names to export
-      type: str
+      type: list
     teams:
       description:
         - team names to export
-      type: str
+      type: list
     credential_types:
       description:
         - credential type names to export
-      type: str
+      type: list
     credentials:
       description:
         - credential names to export
-      type: str
+      type: list
     execution_environments:
       description:
         - execution environment names to export
-      type: str
+      type: list
     notification_templates:
       description:
         - notification template names to export
-      type: str
+      type: list
     inventory_sources:
       description:
         - inventory soruces to export
-      type: str
+      type: list
     inventory:
       description:
         - inventory names to export
-      type: str
+      type: list
     projects:
       description:
         - project names to export
-      type: str
+      type: list
     job_templates:
       description:
         - job template names to export
-      type: str
+      type: list
     workflow_job_templates:
       description:
         - workflow names to export
-      type: str
+      type: list
 requirements:
   - "awxkit >= 9.3.0"
 notes:
@@ -95,9 +95,9 @@ EXAMPLES = '''
     job_templates: "My Template"
     credential: 'all'
 
-- name: Export two or more inventories with a comma separated list of names
+- name: Export a list of inventories
   export:
-    inventory: "My Inventory1,My Inventory2"
+    inventory: ['My Inventory 1', 'My Inventory 2']
 '''
 
 import logging
@@ -115,24 +115,12 @@ except ImportError:
 def main():
     argument_spec = dict(
         all=dict(type='bool', default=False),
-        credential_types=dict(type='str'),
-        credentials=dict(type='str'),
-        execution_environments=dict(type='str'),
-        inventory=dict(type='str'),
-        inventory_sources=dict(type='str'),
-        job_templates=dict(type='str'),
-        notification_templates=dict(type='str'),
-        organizations=dict(type='str'),
-        projects=dict(type='str'),
-        teams=dict(type='str'),
-        users=dict(type='str'),
-        workflow_job_templates=dict(type='str'),
     )
 
     # We are not going to raise an error here because the __init__ method of ControllerAWXKitModule will do that for us
     if HAS_EXPORTABLE_RESOURCES:
         for resource in EXPORTABLE_RESOURCES:
-            argument_spec[resource] = dict(type='str')
+            argument_spec[resource] = dict(type='list')
 
     module = ControllerAWXKitModule(argument_spec=argument_spec)
 

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -30,50 +30,62 @@ options:
       description:
         - organization names to export
       type: list
+      elements: str
     users:
       description:
         - user names to export
       type: list
+      elements: str
     teams:
       description:
         - team names to export
       type: list
+      elements: str
     credential_types:
       description:
         - credential type names to export
       type: list
+      elements: str
     credentials:
       description:
         - credential names to export
       type: list
+      elements: str
     execution_environments:
       description:
         - execution environment names to export
       type: list
+      elements: str
     notification_templates:
       description:
         - notification template names to export
       type: list
+      elements: str
     inventory_sources:
       description:
         - inventory soruces to export
       type: list
+      elements: str
     inventory:
       description:
         - inventory names to export
       type: list
+      elements: str
     projects:
       description:
         - project names to export
       type: list
+      elements: str
     job_templates:
       description:
         - job template names to export
       type: list
+      elements: str
     workflow_job_templates:
       description:
         - workflow names to export
       type: list
+      elements: str
 requirements:
   - "awxkit >= 9.3.0"
 notes:

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -120,7 +120,7 @@ def main():
     # We are not going to raise an error here because the __init__ method of ControllerAWXKitModule will do that for us
     if HAS_EXPORTABLE_RESOURCES:
         for resource in EXPORTABLE_RESOURCES:
-            argument_spec[resource] = dict(type='list')
+            argument_spec[resource] = dict(type='list', elements='str')
 
     module = ControllerAWXKitModule(argument_spec=argument_spec)
 

--- a/awx_collection/tests/integration/targets/export/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/export/tasks/main.yml
@@ -61,6 +61,40 @@
           - mixed_export['assets']['organizations'] | length() == 1
           - "'workflow_job_templates' not in mixed_export['assets']"
 
+    - name: Export list of organizations
+      export:
+        organizations: "{{[org_name1, org_name2]}}"
+      register: list_asserts
+
+    - assert:
+        that:
+          - list_asserts is not changed
+          - list_asserts is successful
+          - list_asserts['assets']['organizations'] | length() >= 2
+
+    - name: Export list with one organization
+      export:
+        organizations: "{{[org_name1]}}"
+      register: list_asserts
+
+    - assert:
+        that:
+          - list_asserts is not changed
+          - list_asserts is successful
+          - list_asserts['assets']['organizations'] | length() >= 1
+          - "org_name1 in (list_asserts['assets']['organizations'] | map(attribute='name') )"
+
+    - name: Export one organization as string
+      export:
+        organizations: "{{org_name2}}"
+      register: string_asserts
+
+    - assert:
+        that:
+          - string_asserts is not changed
+          - string_asserts is successful
+          - string_asserts['assets']['organizations'] | length() >= 1
+          - "org_name2 in (string_asserts['assets']['organizations'] | map(attribute='name') )"
   always:
     - name: Remove our inventory
       inventory:

--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -213,13 +213,23 @@ class ApiV2(base.Base):
         assets = (self._export(asset, post_fields) for asset in endpoint.results)
         return [asset for asset in assets if asset is not None]
 
+    def _check_for_int(self, value):
+        return isinstance(value, int) or (isinstance(value, str) and value.isdecimal())
+
     def _filtered_list(self, endpoint, value):
-        if isinstance(value, int) or value.isdecimal():
+        if isinstance(value, list) and len(value) == 1:
+            value = value[0]
+        if self._check_for_int(value):
             return endpoint.get(id=int(value))
+
         options = self._cache.get_options(endpoint)
         identifier = next(field for field in options['search_fields'] if field in ('name', 'username', 'hostname'))
-        if len(value.split(',')) > 0:
-            identifier += '__in'
+        if isinstance(value, list):
+            if all(self._check_for_int(item) for item in value):
+                identifier = 'or__id'
+            else:
+                identifier = 'or__' + identifier
+
         return endpoint.get(**{identifier: value}, all_pages=True)
 
     def export_assets(self, **kwargs):

--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -218,6 +218,8 @@ class ApiV2(base.Base):
             return endpoint.get(id=int(value))
         options = self._cache.get_options(endpoint)
         identifier = next(field for field in options['search_fields'] if field in ('name', 'username', 'hostname'))
+        if len(value.split(',')) > 0:
+            identifier += '__in'
         return endpoint.get(**{identifier: value}, all_pages=True)
 
     def export_assets(self, **kwargs):

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -161,7 +161,7 @@ class Export(CustomCommand):
             # 1) the resource flag is not used at all, which will result in the attr being None
             # 2) the resource flag is used with no argument, which will result in the attr being ''
             # 3) the resource flag is used with an argument, and the attr will be that argument's value
-            resources.add_argument('--{}'.format(resource), nargs='?', const='')
+            resources.add_argument('--{}'.format(resource), nargs='*')
 
     def handle(self, client, parser):
         self.extend_parser(parser)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Related #13055.
I'm trying to add a new small feature for ansible collection/awx cli. This is a multiple export of certain assets. 

Why I added that? My scenario is to be able to export some assets at the same time in one run. Before this change, I have to export asset by asset by names. After that combine all asset json files into one common assets file which is used later to import back assets in one run.

This small new feature will reduce some extra work when exporting assets. And also it will sort of sync export and import as you can import all/some assets in one run but you cannot export some assets into one json file.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
