### PR TITLE
Avoid adding the 'config' subparser twice

### DIFF
--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -197,8 +197,10 @@ def parse_resource(client, skip_deprecated=False):
 
     if hasattr(client, 'v2'):
         for k in client.v2.json.keys():
-            if k in ('dashboard',):
-                # the Dashboard API is deprecated and not supported
+            if k in ('dashboard', 'config'):
+                # - the Dashboard API is deprecated and not supported
+                # - the Config command is already dealt with by the
+                #    CustomCommand section above
                 continue
 
             # argparse aliases are *only* supported in Python3 (not 2.7)


### PR DESCRIPTION
##### SUMMARY

Once since it is defined as a CustomCommand subclass, and once because it is an endpoint at the /api/v2/ level.  With Python 3.11 argparse has become more strict and will raise an exception when you try to inject duplicate subparsers.

related #13130
related #12938

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI

##### ADDITIONAL INFORMATION
It is sufficient to do e.g.
```bash
awx export --help -v
```
to test it out (assuming that you have the necessary host and creds set as env vars).

Pre-change:
```
DEBUG:awxkit.api.client:"GET https://localhost:8043/api/v2/" elapsed: 0:00:00.026702
Traceback (most recent call last):
  File "/home/jrb/ansible/awx/awxkit/awxkit/cli/__init__.py", line 25, in run
    cli.parse_resource()
  File "/home/jrb/ansible/awx/awxkit/awxkit/cli/client.py", line 152, in parse_resource
    self.resource = parse_resource(self, skip_deprecated=skip_deprecated)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jrb/ansible/awx/awxkit/awxkit/cli/resource.py", line 210, in parse_resource
    client.subparsers[k] = subparsers.add_parser(k, help='', **kwargs)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/argparse.py", line 1185, in add_parser
    raise ArgumentError(self, _('conflicting subparser: %s') % name)
argparse.ArgumentError: argument resource: conflicting subparser: config
```

Post-change:
```
DEBUG:awxkit.api.client:"GET https://localhost:8043/api/v2/" elapsed: 0:00:00.026566
usage: awx export > exportfile

export resources to stdout

options:
  -h, --help            show this help message and exit

resources:
  --users [USERS]
  --organizations [ORGANIZATIONS]
  --teams [TEAMS]
  --credential_types [CREDENTIAL_TYPES]
  --credentials [CREDENTIALS]
  --notification_templates [NOTIFICATION_TEMPLATES]
  --projects [PROJECTS]
  --inventory [INVENTORY]
  --inventory_sources [INVENTORY_SOURCES]
  --job_templates [JOB_TEMPLATES]
  --workflow_job_templates [WORKFLOW_JOB_TEMPLATES]
  --execution_environments [EXECUTION_ENVIRONMENTS]
  --applications [APPLICATIONS]
  --schedules [SCHEDULES]

input/output formatting:
  -f {json,yaml}, --conf.format {json,yaml}
                        specify a format for the input and output
  -v, --verbose         print debug-level logs, including requests made
```