### PR TITLE
initial commit for (hashcorp) vault machinery in docker stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ SPLUNK ?= false
 PROMETHEUS ?= false
 # If set to true docker-compose will also start a grafana instance
 GRAFANA ?= false
+# If set to true docker-compose will also start a hashicorp vault instance
+VAULT ?= false
 
 VENV_BASE ?= /var/lib/awx/venv
 
@@ -477,7 +479,8 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e enable_ldap=$(LDAP) \
 	    -e enable_splunk=$(SPLUNK) \
 	    -e enable_prometheus=$(PROMETHEUS) \
-	    -e enable_grafana=$(GRAFANA) $(EXTRA_SOURCES_ANSIBLE_OPTS)
+	    -e enable_grafana=$(GRAFANA) $(EXTRA_SOURCES_ANSIBLE_OPTS) \
+	    -e enable_vault=$(VAULT)
 
 
 

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -96,6 +96,10 @@
   include_tasks: ldap.yml
   when: enable_ldap | bool
 
+- name: Include Vault tasks if enabled
+  include_tasks: vault.yaml
+  when: enable_vault | bool
+
 - name: Render Docker-Compose
   template:
     src: docker-compose.yml.j2

--- a/tools/docker-compose/ansible/roles/sources/tasks/vault.yaml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/vault.yaml
@@ -1,0 +1,18 @@
+---
+- name: create vault secret file and scope into ansible-runtime
+  block:
+  - ansible.builtin.stat:
+      path: "{{ sources_dest }}/secrets/{{ item }}.yml"
+    register: vault_secret
+    loop:
+      - vault_password
+  - ansible.builtin.template:
+      src: "secrets.yml.j2"
+      dest: "{{ sources_dest }}/secrets/{{ item.item }}.yml"
+      mode: "0600"
+    loop: "{{ vault_secret.results }}"
+    loop_control:
+      label: "{{ item.item }}"
+  - include_vars: "{{ sources_dest }}/secrets/{{ item.item }}.yml"
+    loop: "{{ vault_secret.results }}"
+    no_log: true

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -220,6 +220,19 @@ services:
     privileged: true
   {% endfor %}
 {% endif %}
+{% if enable_vault|bool %}
+  vault:
+    image: vault:latest
+    container_name: tools_vault_1
+    hostname: vault
+    ports:
+      - "1234:1234"
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: "{{ vault_password }}"
+      VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:1234"
+    cap_add:
+      - IPC_LOCK
+{% endif %}
 
 volumes:
   awx_db:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Adding a Hashicorp Vault container to the docker-compose stack. Aiming to help other developers quickly debug Hashicorp Vault credential types.

Bring up a vault instance by issuing the following command from the root of the repository:
```bash
VAULT=true COMPOSE_TAG=<something> make docker-compose
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.6.1.dev305+g02b7147803
```
