### PR TITLE
fix(sec): upgrade lxml to 4.9.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -196,7 +196,7 @@ kubernetes==23.3.0
     #   openshift
 lockfile==0.12.2
     # via python-daemon
-lxml==4.7.0
+lxml==4.9.1
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   python3-saml


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in lxml 4.7.0
- [CVE-2022-2309](https://www.oscs1024.com/hd/CVE-2022-2309)


### What did I do？
Upgrade lxml from 4.7.0 to 4.9.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS