### PR TITLE
Fix job error traceback in job output

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/JobEvent.js
+++ b/awx/ui/src/screens/Job/JobOutput/JobEvent.js
@@ -41,7 +41,7 @@ function JobEvent({
         if (lineNumber < 0) {
           return null;
         }
-        const canToggle = index === toggleLineIndex;
+        const canToggle = index === toggleLineIndex && !event.isTracebackOnly;
         return (
           <JobEventLine
             onClick={isClickable ? onJobEventClick : undefined}
@@ -55,7 +55,7 @@ function JobEvent({
               onToggle={onToggleCollapsed}
             />
             <JobEventLineNumber>
-              {lineNumber}
+              {!event.isTracebackOnly ? lineNumber : ''}
               <JobEventEllipsis isCollapsed={isCollapsed && canToggle} />
             </JobEventLineNumber>
             <JobEventLineText

--- a/awx/ui/src/screens/Job/JobOutput/loadJobEvents.js
+++ b/awx/ui/src/screens/Job/JobOutput/loadJobEvents.js
@@ -29,8 +29,11 @@ export function prependTraceback(job, events) {
     start_line: 0,
   };
   const firstIndex = events.findIndex((jobEvent) => jobEvent.counter === 1);
-  if (firstIndex && events[firstIndex]?.stdout) {
-    const stdoutLines = events[firstIndex].stdout.split('\r\n');
+  if (firstIndex > -1) {
+    if (!events[firstIndex].stdout) {
+      events[firstIndex].isTracebackOnly = true;
+    }
+    const stdoutLines = events[firstIndex].stdout?.split('\r\n') || [];
     stdoutLines[0] = tracebackEvent.stdout;
     events[firstIndex].stdout = stdoutLines.join('\r\n');
   } else {


### PR DESCRIPTION
##### SUMMARY
Fixes the way tracebacks are displayed in job output so it doesn't break tree lookup for events in the event tree.

Addresses #13189 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
