### PR TITLE
Disable work signing by default in dev env

### DIFF
--- a/awx/api/templates/instance_install_bundle/group_vars/all.yml
+++ b/awx/api/templates/instance_install_bundle/group_vars/all.yml
@@ -7,7 +7,7 @@ receptor_work_commands:
     command: ansible-runner
     params: worker
     allowruntimeparams: true
-    verifysignature: true
+    verifysignature: {{ sign_work }}
 custom_worksign_public_keyfile: receptor/work-public-key.pem
 custom_tls_certfile: receptor/tls/receptor.crt
 custom_tls_keyfile: receptor/tls/receptor.key

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -13,6 +13,7 @@ receptor_image: quay.io/ansible/receptor:devel
 # Keys for signing work
 receptor_rsa_bits: 4096
 receptor_work_sign_reconfigure: false
+sign_work: no  # currently defaults to no because openssl version mismatch causes "unknown block type PRIVATE KEY"
 work_sign_key_dir: '../_sources/receptor'
 work_sign_private_keyfile: "{{ work_sign_key_dir }}/work_private_key.pem"
 work_sign_public_keyfile: "{{ work_sign_key_dir }}/work_public_key.pem"

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -86,11 +86,13 @@
   command: openssl genrsa -out {{ work_sign_private_keyfile }} {{ receptor_rsa_bits }}
   args:
     creates: "{{ work_sign_private_keyfile }}"
+  when: sign_work | bool
 
 - name: Generate public RSA key for signing work
   command: openssl rsa -in {{ work_sign_private_keyfile }} -out {{ work_sign_public_keyfile }} -outform PEM -pubout
   args:
     creates: "{{ work_sign_public_keyfile }}"
+  when: sign_work | bool
 
 - name: Include LDAP tasks if enabled
   include_tasks: ldap.yml

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -43,8 +43,10 @@ services:
       - "../../docker-compose/_sources/SECRET_KEY:/etc/tower/SECRET_KEY"
       - "../../docker-compose/_sources/receptor/receptor-awx-{{ loop.index }}.conf:/etc/receptor/receptor.conf"
       - "../../docker-compose/_sources/receptor/receptor-awx-{{ loop.index }}.conf.lock:/etc/receptor/receptor.conf.lock"
+{% if sign_work|bool %}
       - "../../docker-compose/_sources/receptor/work_public_key.pem:/etc/receptor/work_public_key.pem"
       - "../../docker-compose/_sources/receptor/work_private_key.pem:/etc/receptor/work_private_key.pem"
+{% endif %}
       # - "../../docker-compose/_sources/certs:/etc/receptor/certs"  # TODO: optionally generate certs
       - "/sys/fs/cgroup:/sys/fs/cgroup"
       - "~/.kube/config:/var/lib/awx/.kube/config"

--- a/tools/docker-compose/ansible/roles/sources/templates/receptor-awx.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/receptor-awx.conf.j2
@@ -11,12 +11,16 @@
 - tcp-listener:
     port: 2222
 
+{% if sign_work|bool %}
 - work-signing:
     privatekey: /etc/receptor/work_private_key.pem
     tokenexpiration: 1m
+{% endif %}
 
+{% if sign_work|bool %}
 - work-verification:
     publickey: /etc/receptor/work_public_key.pem
+{% endif %}
 
 {% for i in range(item | int + 1, control_plane_node_count | int + 1) %}
 - tcp-peer:
@@ -40,7 +44,7 @@
     command: ansible-runner
     params: worker
     allowruntimeparams: true
-    verifysignature: true
+    verifysignature: {{ sign_work }}
 
 - work-kubernetes:
     worktype: kubernetes-runtime-auth
@@ -48,7 +52,7 @@
     allowruntimeauth: true
     allowruntimepod: true
     allowruntimeparams: true
-    verifysignature: true
+    verifysignature: {{ sign_work }}
 
 - work-kubernetes:
     worktype: kubernetes-incluster-auth
@@ -56,4 +60,4 @@
     allowruntimeauth: true
     allowruntimepod: true
     allowruntimeparams: true
-    verifysignature: true
+    verifysignature: {{ sign_work }}

--- a/tools/docker-compose/ansible/roles/sources/templates/receptor-worker.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/receptor-worker.conf.j2
@@ -16,7 +16,7 @@
     command: ansible-runner
     params: worker
     allowruntimeparams: true
-    verifysignature: true
+    verifysignature: {{ sign_work }}
 
 - control-service:
     service: control


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Certs are generated on the host and there is currently an issue due to openssl version mispatch between Fedora 36 and CentOS Stream 8 which causes:

```
tools_awx_1     | ERROR 2022/11/15 17:09:17 could not load signing key file: unknown block type PRIVATE KEY
tools_awx_1     | ERROR 2022/11/15 17:09:17 could not load signing key file: unknown block type PRIVATE KEY
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other