### PR TITLE
Fix fallout from turning off work signing in docker-compose

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/receptor-worker.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/receptor-worker.conf.j2
@@ -8,8 +8,10 @@
     address: tools_receptor_hop:5555
     redial: true
 
+{% if sign_work|bool %}
 - work-verification:
     publickey: /etc/receptor/work_public_key.pem
+{% endif %}
 
 - work-command:
     worktype: ansible-runner


### PR DESCRIPTION
##### SUMMARY
Specifically, this is fixing fallout from https://github.com/ansible/awx/pull/13200, which merged 2 days ago so it's not surprising to just be hitting problems with it now.

For a short summary of the issue - If you deploy with a control node & hybrid node, nothing works. Health checks don't work, so the task manager doesn't find any capacity available. If you get a job running, the job doesn't work. In all these cases that's because we pass `signwork=True`. I expect this affects the default hybrid deployment to a major extent (even if lesser) as well.

You hit this by doing:

```
MAIN_NODE_TYPE=control EXECUTION_NODE_COUNT=1 COMPOSE_TAG=devel make docker-compose
```

Right off the bat in the logs, the health check will fail due to work signing.

This PR tries to get us to a point where the health checks work and jobs will run again.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
This would also make it possible to run in production with work signing turned off... but only by editing the receptor config, which we won't say that we support anyway, so I'm sure that's fine.
