### PR TITLE
Fix automation analytics link in license page

### DIFF
--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionEdit/AnalyticsStep.js
@@ -41,7 +41,7 @@ function AnalyticsStep() {
             component="a"
             href={`${getDocsBaseUrl(
               config
-            )}/html/installandreference/user-data.html#index-0`}
+            )}/html/administration/usability_data_collection.html#automation-analytics`}
             variant="link"
             isInline
             ouiaId="tower-documentation-link"


### PR DESCRIPTION
##### SUMMARY
Fix broken link to automation analytics docs on the licensing page. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

