### PR TITLE
[tech debt] Avoid recursive include of DEFAULT_SETTINGS, sanity test

### DIFF
--- a/awx/main/tests/unit/test_settings.py
+++ b/awx/main/tests/unit/test_settings.py
@@ -24,9 +24,8 @@ def test_default_settings():
     from django.conf import settings
 
     for k in dir(settings):
-        default_val = getattr(settings.default_settings, k, None)
         if k not in settings.DEFAULTS_SNAPSHOT or k in LOCAL_SETTINGS:
             continue
+        default_val = getattr(settings.default_settings, k, None)
         snapshot_val = settings.DEFAULTS_SNAPSHOT[k]
-        if default_val != snapshot_val:
-            raise Exception(f'Setting for {k} does not match shapshot:\nsnapshot: {snapshot_val}\ndefault: {default_val}')
+        assert default_val == snapshot_val, f'Setting for {k} does not match shapshot:\nsnapshot: {snapshot_val}\ndefault: {default_val}'

--- a/awx/main/tests/unit/test_settings.py
+++ b/awx/main/tests/unit/test_settings.py
@@ -1,8 +1,32 @@
 from split_settings.tools import include
 
 
+LOCAL_SETTINGS = (
+    'ALLOWED_HOSTS',
+    'BROADCAST_WEBSOCKET_PORT',
+    'BROADCAST_WEBSOCKET_VERIFY_CERT',
+    'BROADCAST_WEBSOCKET_PROTOCOL',
+    'BROADCAST_WEBSOCKET_SECRET',
+    'DATABASES',
+    'DEBUG',
+    'NAMED_URL_GRAPH',
+)
+
+
 def test_postprocess_auth_basic_enabled():
     locals().update({'__file__': __file__})
 
     include('../../../settings/defaults.py', scope=locals())
     assert 'awx.api.authentication.LoggedBasicAuthentication' in locals()['REST_FRAMEWORK']['DEFAULT_AUTHENTICATION_CLASSES']
+
+
+def test_default_settings():
+    from django.conf import settings
+
+    for k in dir(settings):
+        default_val = getattr(settings.default_settings, k, None)
+        if k not in settings.DEFAULTS_SNAPSHOT or k in LOCAL_SETTINGS:
+            continue
+        snapshot_val = settings.DEFAULTS_SNAPSHOT[k]
+        if default_val != snapshot_val:
+            raise Exception(f'Setting for {k} does not match shapshot:\nsnapshot: {snapshot_val}\ndefault: {default_val}')

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -62,19 +62,6 @@ DEBUG_TOOLBAR_CONFIG = {'ENABLE_STACKTRACES': True}
 SYSTEM_UUID = '00000000-0000-0000-0000-000000000000'
 INSTALL_UUID = '00000000-0000-0000-0000-000000000000'
 
-# Store a snapshot of default settings at this point before loading any
-# customizable config files.
-DEFAULTS_SNAPSHOT = {}
-this_module = sys.modules[__name__]
-for setting in dir(this_module):
-    if setting == setting.upper():
-        DEFAULTS_SNAPSHOT[setting] = copy.deepcopy(getattr(this_module, setting))
-
-# If there is an `/etc/tower/settings.py`, include it.
-# If there is a `/etc/tower/conf.d/*.py`, include them.
-include(optional('/etc/tower/settings.py'), scope=locals())
-include(optional('/etc/tower/conf.d/*.py'), scope=locals())
-
 BASE_VENV_PATH = "/var/lib/awx/venv/"
 AWX_VENV_PATH = os.path.join(BASE_VENV_PATH, "awx")
 
@@ -105,11 +92,28 @@ AWX_CALLBACK_PROFILE = True
 AWX_DISABLE_TASK_MANAGERS = False
 # ======================!!!!!!! FOR DEVELOPMENT ONLY !!!!!!!=================================
 
-from .application_name import set_application_name
+# Store a snapshot of default settings at this point before loading any
+# customizable config files.
+#
+###############################################################################################
+#
+#  Any settings defined after this point will be marked as as a read_only database setting
+#
+################################################################################################
+this_module = sys.modules[__name__]
+local_vars = dir(this_module)
+DEFAULTS_SNAPSHOT = {}  # define after we save local_vars so we do not snapshot the snapshot
+for setting in local_vars:
+    if setting == setting.upper():
+        DEFAULTS_SNAPSHOT[setting] = copy.deepcopy(getattr(this_module, setting))
 
-set_application_name(DATABASES, CLUSTER_HOST_ID)
+del local_vars  # avoid temporary variables from showing up in dir(settings)
+del this_module
 
-del set_application_name
+# If there is an `/etc/tower/settings.py`, include it.
+# If there is a `/etc/tower/conf.d/*.py`, include them.
+include(optional('/etc/tower/settings.py'), scope=locals())
+include(optional('/etc/tower/conf.d/*.py'), scope=locals())
 
 # If any local_*.py files are present in awx/settings/, use them to override
 # default settings for development.  If not present, we can still run using
@@ -123,3 +127,9 @@ try:
 except ImportError:
     traceback.print_exc()
     sys.exit(1)
+
+from .application_name import set_application_name
+
+set_application_name(DATABASES, CLUSTER_HOST_ID)
+
+del set_application_name

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -94,21 +94,21 @@ AWX_DISABLE_TASK_MANAGERS = False
 
 # Store a snapshot of default settings at this point before loading any
 # customizable config files.
+this_module = sys.modules[__name__]
+local_vars = dir(this_module)
+DEFAULTS_SNAPSHOT = {}  # define after we save local_vars so we do not snapshot the snapshot
+for setting in local_vars:
+    if setting.isupper():
+        DEFAULTS_SNAPSHOT[setting] = copy.deepcopy(getattr(this_module, setting))
+
+del local_vars  # avoid temporary variables from showing up in dir(settings)
+del this_module
 #
 ###############################################################################################
 #
 #  Any settings defined after this point will be marked as as a read_only database setting
 #
 ################################################################################################
-this_module = sys.modules[__name__]
-local_vars = dir(this_module)
-DEFAULTS_SNAPSHOT = {}  # define after we save local_vars so we do not snapshot the snapshot
-for setting in local_vars:
-    if setting == setting.upper():
-        DEFAULTS_SNAPSHOT[setting] = copy.deepcopy(getattr(this_module, setting))
-
-del local_vars  # avoid temporary variables from showing up in dir(settings)
-del this_module
 
 # If there is an `/etc/tower/settings.py`, include it.
 # If there is a `/etc/tower/conf.d/*.py`, include them.

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -128,6 +128,8 @@ except ImportError:
     traceback.print_exc()
     sys.exit(1)
 
+# The below runs AFTER all of the custom settings are imported
+# because conf.d files will define DATABASES and this should modify that
 from .application_name import set_application_name
 
 set_application_name(DATABASES, CLUSTER_HOST_ID)

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -102,8 +102,8 @@ except IOError:
     else:
         raise
 
-# The below runs AFTER all of the custom settings are imported.
-
+# The below runs AFTER all of the custom settings are imported
+# because conf.d files will define DATABASES and this should modify that
 from .application_name import set_application_name
 
 set_application_name(DATABASES, CLUSTER_HOST_ID)  # NOQA

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -53,11 +53,15 @@ AWX_ISOLATION_SHOW_PATHS = [
 #  Any settings defined after this point will be marked as as a read_only database setting
 #
 ################################################################################################
-DEFAULTS_SNAPSHOT = {}
 this_module = sys.modules[__name__]
-for setting in dir(this_module):
+local_vars = dir(this_module)
+DEFAULTS_SNAPSHOT = {}  # define after we save local_vars so we do not snapshot the snapshot
+for setting in local_vars:
     if setting == setting.upper():
         DEFAULTS_SNAPSHOT[setting] = copy.deepcopy(getattr(this_module, setting))
+
+del local_vars  # avoid temporary variables from showing up in dir(settings)
+del this_module
 
 # Load settings from any .py files in the global conf.d directory specified in
 # the environment, defaulting to /etc/tower/conf.d/.

--- a/awx/settings/production.py
+++ b/awx/settings/production.py
@@ -47,21 +47,21 @@ AWX_ISOLATION_SHOW_PATHS = [
 
 # Store a snapshot of default settings at this point before loading any
 # customizable config files.
+this_module = sys.modules[__name__]
+local_vars = dir(this_module)
+DEFAULTS_SNAPSHOT = {}  # define after we save local_vars so we do not snapshot the snapshot
+for setting in local_vars:
+    if setting.isupper():
+        DEFAULTS_SNAPSHOT[setting] = copy.deepcopy(getattr(this_module, setting))
+
+del local_vars  # avoid temporary variables from showing up in dir(settings)
+del this_module
 #
 ###############################################################################################
 #
 #  Any settings defined after this point will be marked as as a read_only database setting
 #
 ################################################################################################
-this_module = sys.modules[__name__]
-local_vars = dir(this_module)
-DEFAULTS_SNAPSHOT = {}  # define after we save local_vars so we do not snapshot the snapshot
-for setting in local_vars:
-    if setting == setting.upper():
-        DEFAULTS_SNAPSHOT[setting] = copy.deepcopy(getattr(this_module, setting))
-
-del local_vars  # avoid temporary variables from showing up in dir(settings)
-del this_module
 
 # Load settings from any .py files in the global conf.d directory specified in
 # the environment, defaulting to /etc/tower/conf.d/.


### PR DESCRIPTION
##### SUMMARY
I told @john-westcott-iv this was going to bother me, but I wasn't going to make a PR to change it until I saw this failure.

```
Traceback (most recent call last):
  File "/awx_devel/awx/main/tests/unit/test_settings.py", line 22, in test_default_settings
    raise Exception(f'Default setting for {k} does not match:\nsnapshot: {snapshot_val}\ndefault: {default_val}')
Exception: Default setting for DEFAULTS_SNAPSHOT does not match:
...
```

Wait, what? The snapshot value for `DEFAULTS_SNAPSHOT` doesn't match? That doesn't make any sense. We got that snapshot value _from_ the snapshot dictionary! Did this dict _save a copy of itself... inside itself_?

Yes.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

