### PR TITLE
Revert verifysignature variablization in bundle

### DIFF
--- a/awx/api/templates/instance_install_bundle/group_vars/all.yml
+++ b/awx/api/templates/instance_install_bundle/group_vars/all.yml
@@ -7,7 +7,7 @@ receptor_work_commands:
     command: ansible-runner
     params: worker
     allowruntimeparams: true
-    verifysignature: {{ sign_work }}
+    verifysignature: true
 custom_worksign_public_keyfile: receptor/work-public-key.pem
 custom_tls_certfile: receptor/tls/receptor.crt
 custom_tls_keyfile: receptor/tls/receptor.key


### PR DESCRIPTION
##### SUMMARY

In #13200 the dev env was changed to make `verifysignature` optional, dependent on a variable set before ansible gets run to set up the `docker-compose` environment.

However along with that change, a change to the execution node install bundle slipped in, which is seemingly unrelated to the dev env change and is breaking some installs: #13234, ansible/awx-operator#1132.

I think this change was unintentional as it would at least require another change in ansible/receptor-collection and maybe a change in ansible/awx-operator as well.

Signed-off-by: Rick Elrod <rick@elrod.me>

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API