### PR TITLE
Remove LANG declaration in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -593,7 +593,6 @@ pot: $(UI_BUILD_FLAG_FILE)
 po: $(UI_BUILD_FLAG_FILE)
 	$(NPM_BIN) --prefix awx/ui --loglevel warn run extract-strings -- --clean
 
-LANG = "en_us"
 ## generate API django .pot .po
 messages:
 	@if [ "$(VENV_BASE)" ]; then \


### PR DESCRIPTION
##### SUMMARY

Not sure why this was there to begin with....

On a fresh Fedora VM with latest Ansible installed, I was seeing:

```
$ make docker-compose-build
ansible-playbook tools/ansible/dockerfile.yml -e build_dev=True -e receptor_image=quay.io/ansible/receptor:devel
ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
```

This fixes it


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other
