### PR TITLE
Enable support for injecting complex extra vars

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -790,7 +790,7 @@ class CredentialTypeInjectorField(JSONSchemaField):
                 'extra_vars': {
                     'type': 'object',
                     'patternProperties': {
-                        r'^(?:(?:{{[^{}]*?}})|(?:[a-zA-Z_]+[a-zA-Z0-9_]*)+)+$': {"anyOf": [{'type': 'string'}, {'$ref': '#/properties/extra_vars'}]}
+                        r'^(?:(?:{(?:{|%)[^{}]*?(?:%|})})|(?:[a-zA-Z_]+[a-zA-Z0-9_]*)+)+$': {"anyOf": [{'type': 'string'}, {'$ref': '#/properties/extra_vars'}]}
                     },
                     'additionalProperties': False,
                 },

--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -790,7 +790,9 @@ class CredentialTypeInjectorField(JSONSchemaField):
                 'extra_vars': {
                     'type': 'object',
                     'patternProperties': {
-                        r'^(?:(?:{(?:{|%)[^{}]*?(?:%|})})|(?:[a-zA-Z_]+[a-zA-Z0-9_]*)+)+$': {"anyOf": [{'type': 'string'}, {'$ref': '#/properties/extra_vars'}]}
+                        r'^(?:(?:{(?:{|%)[^{}]*?(?:%|})})|(?:[a-zA-Z_]+[a-zA-Z0-9_]*)+)+$': {
+                            "anyOf": [{'type': 'string'}, {'type': 'array'}, {'$ref': '#/properties/extra_vars'}]
+                        }
                     },
                     'additionalProperties': False,
                 },
@@ -876,9 +878,9 @@ class CredentialTypeInjectorField(JSONSchemaField):
 
         def validate_extra_vars(key, node):
             if isinstance(node, dict):
-                return {validate_extra_vars(key, k): validate_extra_vars(k, v) for k, v in node.items()}
+                return {validate_extra_vars(key, k): validate_extra_vars("{key}.{k}".format(key=key, k=k), v) for k, v in node.items()}
             elif isinstance(node, list):
-                return [validate_extra_vars(key, x) for x in node]
+                return [validate_extra_vars("{key}[{i}]".format(key=key, i=i), x) for i, x in enumerate(node)]
             else:
                 validate_template_string("extra_vars", key, node)
 

--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -790,13 +790,11 @@ class CredentialTypeInjectorField(JSONSchemaField):
                 'extra_vars': {
                     'type': 'object',
                     'patternProperties': {
-                        # http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name
-                        '^[a-zA-Z_]+[a-zA-Z0-9_]*$': {'type': 'string'},
+                        r'^(?:(?:{{[^{}]*?}})|(?:[a-zA-Z_]+[a-zA-Z0-9_]*)+)+$': {"anyOf": [{'type': 'string'}, {'$ref': '#/properties/extra_vars'}]}
                     },
                     'additionalProperties': False,
                 },
             },
-            'additionalProperties': False,
         }
 
     def validate_env_var_allowed(self, env_var):

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -530,7 +530,7 @@ class CredentialType(CommonModelNameNotUnique):
             # awx-manage inventory_update does not support extra_vars via -e
             def build_extra_vars(node):
                 if isinstance(node, dict):
-                    return {k: build_extra_vars(v) for k, v in node.items()}
+                    return {build_extra_vars(k): build_extra_vars(v) for k, v in node.items()}
                 elif isinstance(node, list):
                     return [build_extra_vars(x) for x in node]
                 else:

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -528,9 +528,13 @@ class CredentialType(CommonModelNameNotUnique):
 
         if 'INVENTORY_UPDATE_ID' not in env:
             # awx-manage inventory_update does not support extra_vars via -e
-            extra_vars = {}
-            for var_name, tmpl in self.injectors.get('extra_vars', {}).items():
-                extra_vars[var_name] = sandbox_env.from_string(tmpl).render(**namespace)
+            def build_extra_vars(node):
+                if isinstance(node, dict):
+                    return {k: build_extra_vars(v) for k, v in node.items()}
+                elif isinstance(node, list):
+                    return [build_extra_vars(x) for x in node]
+                else:
+                    return sandbox_env.from_string(node).render(**namespace)
 
             def build_extra_vars_file(vars, private_dir):
                 handle, path = tempfile.mkstemp(dir=os.path.join(private_dir, 'env'))
@@ -540,6 +544,7 @@ class CredentialType(CommonModelNameNotUnique):
                 os.chmod(path, stat.S_IRUSR)
                 return path
 
+            extra_vars = build_extra_vars(self.injectors.get('extra_vars', {}))
             if extra_vars:
                 path = build_extra_vars_file(extra_vars, private_data_dir)
                 container_path = to_container_path(path, private_data_dir)

--- a/docs/credentials/custom_credential_types.md
+++ b/docs/credentials/custom_credential_types.md
@@ -172,7 +172,11 @@ of the [Jinja templating language](https://jinja.palletsprojects.com/en/2.10.x/)
             "THIRD_PARTY_CLOUD_API_TOKEN": "{{api_token}}"
         },
         "extra_vars": {
-            "some_extra_var": "{{username}}:{{password}"
+            "some_extra_var": "{{username}}:{{password}}",
+            "auth": {
+                "username": "{{username}}",
+                "password": "{{password}}"
+            }
         }
     }
 


### PR DESCRIPTION
##### SUMMARY
Until now, it's only been possible to inject flat strings with Jinja templating into extra vars from Custom Credential Types. However, it's quite desirable to be able to pass a data structure containing authentication information for certain collections/modules. For example, the [Infoblox collection](https://docs.ansible.com/ansible/latest/scenario_guides/guide_infoblox.html#credentials-and-authenticating) accepts authentication under the `nios_provider` key.

This PR enables that data structure to be created by an injector config.

related #1965 #13070

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
PYTHON=python3 make VERSION
awx: 21.9.1.dev32+g4af80777dd
```


##### ADDITIONAL INFORMATION
This PR also makes it possible to template the keys of an injector configuration, as requested in #13070.

For example, given an input configuration providing values for `environment`, `host`, `apikey`, `username`, it's possible to use an extra_vars injector configuration of:
```yaml
"{{ environment }}_auth":
  host: "{{ host }}"
  apikey: "{{ apikey }}"
  username: "{{ username }}"
  verify_ssl: "{{ verify_ssl }}"
```
resulting in the following extra var available to the playbooks:
```yaml
prod_auth:
  host: http://production.server
  apikey: 5hfthisj4hisj5hgnotj6hrealgj6
  username: philipsd6
  verify_ssl: True
```
This would lay the groundwork for allowing multiple credentials of the _same_ credential type, as another credential might supply values for a different environment.
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
