### PR TITLE
Fix make messages target by specify lang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -598,7 +598,7 @@ messages:
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	$(PYTHON) manage.py makemessages -l $(LANG) --keep-pot
+	$(PYTHON) manage.py makemessages -l en_us --keep-pot
 
 print-%:
 	@echo $($*)


### PR DESCRIPTION
##### SUMMARY

This PR removed the `LANG` variable from the Makefile:
* https://github.com/ansible/awx/pull/13266

`make messages` now fails with:

```
bash-5.1$ make messages
UnicodeDecodeError: skipped file ThirdPartyNoticeText.txt in ./awx/ui/node_modules/typescript (reason: 'utf-8' codec can't decode byte 0xa0 in position 6038: invalid start byte)
invalid locale en_US.UTF-8, did you mean en_US.UTF_8?
```

I don't know why builds all the sudden started failing on this, it's been in the Makefile for quite some time.  But we can fix it by just hardcoding `-l en_us` in the `makemessages` command there.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Localization
