### PR TITLE
Configure dbshell to use the 'less' pager

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -273,7 +273,8 @@ RUN for dir in \
       /var/lib/shared/vfs-layers/layers.lock \
       /var/run/nginx.pid \
       /var/lib/awx/venv/awx/lib/python3.9/site-packages/awx.egg-link ; \
-    do touch $file ; chmod g+rw $file ; done
+    do touch $file ; chmod g+rw $file ; done && \
+    echo "\setenv PAGER 'less -S'" > /var/lib/awx/.psqlrc
 {% endif %}
 
 {% if not build_dev|bool %}


### PR DESCRIPTION
##### SUMMARY
Configure dbshell to use the 'less' pager.  The 'more' pager used by default is obnoxious.

This ought to only apply to the dev environment.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
