### PR TITLE
Re-enable work signing in development environment

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -13,7 +13,7 @@ receptor_image: quay.io/ansible/receptor:devel
 # Keys for signing work
 receptor_rsa_bits: 4096
 receptor_work_sign_reconfigure: false
-sign_work: no  # currently defaults to no because openssl version mismatch causes "unknown block type PRIVATE KEY"
+sign_work: yes
 work_sign_key_dir: '../_sources/receptor'
 work_sign_private_keyfile: "{{ work_sign_key_dir }}/work_private_key.pem"
 work_sign_public_keyfile: "{{ work_sign_key_dir }}/work_public_key.pem"

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -83,7 +83,7 @@
   when: awx_image_tag is not defined
 
 - name: Generate Private RSA key for signing work
-  command: openssl genrsa -out {{ work_sign_private_keyfile }} {{ receptor_rsa_bits }}
+  command: openssl genrsa -traditional -out {{ work_sign_private_keyfile }} {{ receptor_rsa_bits }}
   args:
     creates: "{{ work_sign_private_keyfile }}"
   when: sign_work | bool


### PR DESCRIPTION
##### SUMMARY
Effectively reverses what I did here: https://github.com/ansible/awx/pull/13200.

Using the approach described in https://github.com/ansible/awx/issues/12266#issuecomment-1171605519

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
