### PR TITLE
Remove un-editable Instance fields from pre-filled edit data in API browser

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -344,6 +344,13 @@ class InstanceDetail(RetrieveUpdateAPIView):
     model = models.Instance
     serializer_class = serializers.InstanceSerializer
 
+    def update_raw_data(self, data):
+        # these fields are only valid on creation of an instance, so they unwanted on detail view
+        data.pop('listener_port', None)
+        data.pop('node_type', None)
+        data.pop('hostname', None)
+        return super(InstanceDetail, self).update_raw_data(data)
+
     def update(self, request, *args, **kwargs):
         r = super(InstanceDetail, self).update(request, *args, **kwargs)
         if status.is_success(r.status_code):


### PR DESCRIPTION
##### SUMMARY
You can clearly see that these are prohibited from editing in the serializer validators. For example:

```python
    def validate_hostname(self, value):
        """
        - Hostname cannot be "localhost" - but can be something like localhost.domain
        - Cannot change the hostname of an-already instantiated & initialized Instance object
        """
        if self.instance and self.instance.hostname != value:
            raise serializers.ValidationError("Cannot change hostname.")

        return value
```

It says it right there - the field is only editable in that it can be set on creation.

This is the instance _detail_ view, so there's no way you're here unless it has already been created. Including the fields is going to either do nothing or get you an error.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
for the URL

https://localhost:8043/api/v2/instances/1/

updated

![Screenshot from 2022-12-06 15-19-27](https://user-images.githubusercontent.com/1385596/206014732-43c68dde-6f70-4c56-9d83-d58c138919c6.png)

before

![Screenshot from 2022-12-06 15-22-30](https://user-images.githubusercontent.com/1385596/206014817-7cc1131e-9bf2-4546-8797-b765a2a4150b.png)

We have a _very very similar_ type of override for InstanceGroup detail view, so it's logical to add this here.

