### PR TITLE
Fix bug, sign work based signing, not verification

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -63,7 +63,7 @@ def read_receptor_config():
 
 def work_signing_enabled(config_data):
     for section in config_data:
-        if 'work-verification' in section:
+        if 'work-signing' in section:
             return True
     return False
 


### PR DESCRIPTION
##### SUMMARY
This is intended to be a direct bug fix from the bug I introduced in https://github.com/ansible/awx/pull/13213

This is an alternative to https://github.com/ansible/awx/pull/13281, with no new performance implications.

There is a major consequence to this about what will be allowed in the future.

 - as in the development environment now, we will ALLOW an installer to turn off work signing, this is done by excluding the work-signing sections in control plane and the work-verification sections in the execution plane
 - this will categorically _not_ allow using work signing in _some_ execution nodes, but turning off work signing in _other_ execution nodes
 - this will not allow selectively enabling work signing _based on work types_. Whatever templating is being done should turn work signing on for all work types in the config, or none
 - it is the responsibility of the installer / operator to have consistency in receptor config files throughout the cluster


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

