### PR TITLE
Set AWS_SESSION_TOKEN in addition to AWS_SECURITY_TOKEN

### DIFF
--- a/awx/main/models/credential/injectors.py
+++ b/awx/main/models/credential/injectors.py
@@ -15,6 +15,7 @@ def aws(cred, env, private_data_dir):
 
     if cred.has_input('security_token'):
         env['AWS_SECURITY_TOKEN'] = cred.get_input('security_token', default='')
+        env['AWS_SESSION_TOKEN'] = env['AWS_SECURITY_TOKEN']
 
 
 def gce(cred, env, private_data_dir):

--- a/awx/main/tests/data/inventory/plugins/ec2/env.json
+++ b/awx/main/tests/data/inventory/plugins/ec2/env.json
@@ -3,5 +3,6 @@
     "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "AWS_ACCESS_KEY_ID": "fooo",
     "AWS_SECRET_ACCESS_KEY": "fooo",
-    "AWS_SECURITY_TOKEN": "fooo"
+    "AWS_SECURITY_TOKEN": "fooo",
+    "AWS_SESSION_TOKEN": "fooo"
 }


### PR DESCRIPTION
##### SUMMARY
AWS started using `AWS_SESSION_TOKEN` instead of `AWS_SECURITY_TOKEN` since 2014. A lot of libraries check for both, but I ended up in a case where a collection `community.aws.aws_ssm` did not check both, and ended up with errors like:

```
caught exception(An error occurred (UnrecognizedClientException) when calling the StartSession operation: The security token included in the request is invalid.)
```

In this case, it was invalid because `AWS_SESSION_TOKEN` was not set.

https://aws.amazon.com/blogs/security/a-new-and-standardized-way-to-manage-credentials-in-the-aws-sdks/

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other (Model/Injectors)

##### AWX VERSION
21.10.0

##### ADDITIONAL INFORMATION

After setting `AWS_SESSION_TOKEN` I no longer got the error and could successfully connect to the EC2 machines.

