### PR TITLE
Fixes 'Not Found' error on looking up credentials

### DIFF
--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -74,7 +74,7 @@
     "prestart-instrumented": "lingui compile",
     "pretest": "lingui compile",
     "pretest-watch": "lingui compile",
-    "start": "GENERATE_SOURCEMAP=false ESLINT_NO_DEV_ERRORS=true PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts start",
+    "start": "GENERATE_SOURCEMAP=false ESLINT_NO_DEV_ERRORS=true PORT=3003 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts start",
     "start-instrumented": "ESLINT_NO_DEV_ERRORS=true DEBUG=instrument-cra PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts -r @cypress/instrument-cra start",
     "build": "INLINE_RUNTIME_CHUNK=false react-scripts build",
     "test": "TZ='UTC' react-scripts test --watchAll=false",

--- a/awx/ui/package.json
+++ b/awx/ui/package.json
@@ -74,7 +74,7 @@
     "prestart-instrumented": "lingui compile",
     "pretest": "lingui compile",
     "pretest-watch": "lingui compile",
-    "start": "GENERATE_SOURCEMAP=false ESLINT_NO_DEV_ERRORS=true PORT=3003 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts start",
+    "start": "GENERATE_SOURCEMAP=false ESLINT_NO_DEV_ERRORS=true PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts start",
     "start-instrumented": "ESLINT_NO_DEV_ERRORS=true DEBUG=instrument-cra PORT=3001 HTTPS=true DANGEROUSLY_DISABLE_HOST_CHECK=true react-scripts -r @cypress/instrument-cra start",
     "build": "INLINE_RUNTIME_CHUNK=false react-scripts build",
     "test": "TZ='UTC' react-scripts test --watchAll=false",

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.js
@@ -153,6 +153,10 @@ function CredentialsStep({
             }))}
             value={selectedType && selectedType.id}
             onChange={(e, id) => {
+              // Reset query params when the category of credentials is changed
+              history.replace({
+                search: '',
+              });
               setSelectedType(types.find((o) => o.id === parseInt(id, 10)));
             }}
           />

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
@@ -4,6 +4,7 @@ import { Formik } from 'formik';
 import { CredentialsAPI, CredentialTypesAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import CredentialsStep from './CredentialsStep';
+import { createMemoryHistory } from 'history';
 
 jest.mock('../../../api/models/CredentialTypes');
 jest.mock('../../../api/models/Credentials');
@@ -150,6 +151,41 @@ describe('CredentialsStep', () => {
       credential_type: 1,
       order_by: 'name',
       page: 1,
+      page_size: 5,
+    });
+
+    await act(async () => {
+      wrapper.find('AnsibleSelect').invoke('onChange')({}, 3);
+    });
+    expect(CredentialsAPI.read).toHaveBeenCalledWith({
+      credential_type: 3,
+      order_by: 'name',
+      page: 1,
+      page_size: 5,
+    });
+  });
+
+  test('should reset query params (credential.page) when selected credential type is changed', async () => {
+    let wrapper;
+    const history = createMemoryHistory({
+      initialEntries: ['?credential.page=2'],
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Formik>
+          <CredentialsStep allowCredentialsWithPasswords />
+        </Formik>,
+        {
+          context: { router: { history } },
+        }
+      );
+    });
+    wrapper.update();
+
+    expect(CredentialsAPI.read).toHaveBeenCalledWith({
+      credential_type: 1,
+      order_by: 'name',
+      page: 2,
       page_size: 5,
     });
 

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
@@ -3,8 +3,8 @@ import { act } from 'react-dom/test-utils';
 import { Formik } from 'formik';
 import { CredentialsAPI, CredentialTypesAPI } from 'api';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
-import CredentialsStep from './CredentialsStep';
 import { createMemoryHistory } from 'history';
+import CredentialsStep from './CredentialsStep';
 
 jest.mock('../../../api/models/CredentialTypes');
 jest.mock('../../../api/models/Credentials');

--- a/awx/ui/src/components/Lookup/MultiCredentialsLookup.js
+++ b/awx/ui/src/components/Lookup/MultiCredentialsLookup.js
@@ -173,6 +173,10 @@ function MultiCredentialsLookup({
                 }))}
                 value={selectedType && selectedType.id}
                 onChange={(e, id) => {
+                  // Reset query params when the category of credentials is changed
+                  history.replace({
+                    search: '',
+                  });
                   setSelectedType(
                     credentialTypes.find((o) => o.id === parseInt(id, 10))
                   );

--- a/awx/ui/src/components/Lookup/MultiCredentialsLookup.test.js
+++ b/awx/ui/src/components/Lookup/MultiCredentialsLookup.test.js
@@ -7,6 +7,7 @@ import {
   waitForElement,
 } from '../../../testUtils/enzymeHelpers';
 import MultiCredentialsLookup from './MultiCredentialsLookup';
+import { createMemoryHistory } from 'history';
 
 jest.mock('../../api');
 
@@ -226,6 +227,53 @@ describe('<Formik><MultiCredentialsLookup /></Formik>', () => {
         label: 'New Cred',
       },
     ]);
+  });
+
+  test('should reset query params (credentials.page) when selected credential type is changed', async () => {
+    const history = createMemoryHistory({
+      initialEntries: ['?credentials.page=2'],
+    });
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Formik>
+          <MultiCredentialsLookup
+            value={credentials}
+            tooltip="This is credentials look up"
+            onChange={() => {}}
+            onError={() => {}}
+          />
+        </Formik>,
+        {
+          context: { router: { history } },
+        }
+      );
+    });
+    const searchButton = await waitForElement(
+      wrapper,
+      'Button[aria-label="Search"]'
+    );
+    await act(async () => {
+      searchButton.invoke('onClick')();
+    });
+    expect(CredentialsAPI.read).toHaveBeenCalledWith({
+      credential_type: 400,
+      order_by: 'name',
+      page: 2,
+      page_size: 5,
+    });
+
+    const select = await waitForElement(wrapper, 'AnsibleSelect');
+    await act(async () => {
+      select.invoke('onChange')({}, 500);
+    });
+    wrapper.update();
+
+    expect(CredentialsAPI.read).toHaveBeenCalledWith({
+      credential_type: 500,
+      order_by: 'name',
+      page: 1,
+      page_size: 5,
+    });
   });
 
   test('should only add 1 credential per credential type except vault(see below)', async () => {

--- a/awx/ui/src/components/Lookup/MultiCredentialsLookup.test.js
+++ b/awx/ui/src/components/Lookup/MultiCredentialsLookup.test.js
@@ -6,8 +6,8 @@ import {
   mountWithContexts,
   waitForElement,
 } from '../../../testUtils/enzymeHelpers';
-import MultiCredentialsLookup from './MultiCredentialsLookup';
 import { createMemoryHistory } from 'history';
+import MultiCredentialsLookup from './MultiCredentialsLookup';
 
 jest.mock('../../api');
 


### PR DESCRIPTION
##### SUMMARY
This addresses #13305 

The issue appears to be that we were retaining the query params (credential.page) even when the credential category was changed and in turn making requests for pages that didn't exist on some categories.

Within the credentials lookup (either in the `Job Template launch prompt` or in the `Add Job Template` form):
1. Select a credential type that has more than one page worth of credentials data. (In the dev env I saw that the "Machine" type had more than one page of data).
2. Switch to page 2 of the credentials (or any page other than the first page)
3. Change the credential category using the dropdown to a category that doesn't have credentials or doesn't have a second page of data.
4. If there are no credentials for that type, the appropriate message should be displayed, but the UI should not show a 404 Not Found error.



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
