### PR TITLE
Fix duped stats name and Redis for wsbroadcast

### DIFF
--- a/awx/main/wsbroadcast.py
+++ b/awx/main/wsbroadcast.py
@@ -118,7 +118,7 @@ class WebsocketTask:
             logger.warning(f"Connection from {self.name} to {self.remote_host} timed out.")
         except Exception as e:
             # Early on, this is our canary. I'm not sure what exceptions we can really encounter.
-            logger.warning(f"Connection from {self.name} to {self.remote_host} failed for unknown reason: '{e}'.")
+            logger.exception(f"Connection from {self.name} to {self.remote_host} failed for unknown reason: '{e}'.")
         else:
             logger.warning(f"Connection from {self.name} to {self.remote_host} list.")
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -853,6 +853,7 @@ LOGGING = {
         'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
+        'awx.analytics.broadcast_websocket': {'handlers': ['console', 'file', 'wsbroadcast', 'external_logger'], 'level': 'INFO', 'propagate': False},
         'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
         'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'level': 'DEBUG', 'propagate': False},
         'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},


### PR DESCRIPTION
##### SUMMARY

This fixes several things related to our wsbroadcast stats handling. This was found during the ongoing wsrelay work.

There are really three fixes here:

- Logging was not actually enabled for the analytics.broadcast_websocket module, so that has been added to our loggers config.

- analytics.broadcast_websocket was not actually able to connect to Redis due to 68614b83c00982259be18b0e6e22550f8dd0449a as part of the work in #13187. But there was no easy way to know this because the logging issue meant no exceptions showed up anywhere reasonable.

- Relatedly, and also as part of #13187, we jumped from `prometheus-client` 0.7.1 up to 0.15.0. This included a breaking change where a `Counter` ending with `_total` will clash with a `Gauge` of the same name but without `_total`. I am not 100% sure of the reasoning here, other than "OpenMetrics compatibility".

Refs #13301
Refs #13187

Signed-off-by: Rick Elrod <rick@elrod.me>

---------

With these changes, `awx-manage run_wsbroadcast --status` still works:

![image](https://user-images.githubusercontent.com/43930/206446649-27738bf4-f382-45c9-958b-4034603ba787.png)

------

An easy reproducer for the third bullet point above is this, for anyone who wishes to play around with it some more:

```python
In [1]: from prometheus_client import (
   ...:     Gauge,
   ...:     Counter,
   ...:     CollectorRegistry,
   ...: )

In [2]: %xmode minimal
Exception reporting mode: Minimal

In [3]: registry = CollectorRegistry()

In [4]: foo = Counter('foo_bar_total', 'some description', registry=registry)

In [5]: bar = Gauge('foo_bar', 'another description', registry=registry)
ValueError: Duplicated timeseries in CollectorRegistry: {'foo_bar'}
```

----

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API