### PR TITLE
Fix typo in controller_api lookup plugin

### DIFF
--- a/awx_collection/plugins/lookup/controller_api.py
+++ b/awx_collection/plugins/lookup/controller_api.py
@@ -74,7 +74,7 @@ EXAMPLES = """
 
 - name: Load the UI settings specifying the connection info
   set_fact:
-    controller_settings: "{{ lookup('awx.awx.controller_api', 'settings/ui' host='controller.example.com',
+    controller_settings: "{{ lookup('awx.awx.controller_api', 'settings/ui', host='controller.example.com',
                              username='admin', password=my_pass_var, verify_ssl=False) }}"
 
 - name: Report the usernames of all users with admin privs


### PR DESCRIPTION
##### SUMMARY
Fix typo in controller_api lookup plugin. One of the example have typo in it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs


##### AWX VERSION
```
None
```
