### PR TITLE
Include listener_port in the defaults for Instance.objects.register

### DIFF
--- a/awx/main/managers.py
+++ b/awx/main/managers.py
@@ -158,7 +158,11 @@ class InstanceManager(models.Manager):
                     return (False, instance)
 
             # Create new instance, and fill in default values
-            create_defaults = {'node_state': Instance.States.INSTALLED, 'capacity': 0}
+            create_defaults = {
+                'node_state': Instance.States.INSTALLED,
+                'capacity': 0,
+                'listener_port': 27199,
+            }
             if defaults is not None:
                 create_defaults.update(defaults)
             uuid_option = {}


### PR DESCRIPTION
##### SUMMARY
Calls to `Instance.objects.register()` during boot-up are (sometimes?) violating the non-null constraint on the `Instance.listener_port` field.  Make sure that the default value is included as a fallback.

related #13285 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
