### PR TITLE
[proof of concept -- 2nd round] Bulk Job Launch

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4499,7 +4499,7 @@ class BulkJobLaunchSerializer(serializers.Serializer):
         WorkflowJobNode.objects.bulk_create(nodes)
         wfj.status = 'pending'
         wfj.save()
-        return wfj
+        return WorkflowJobSerializer().to_representation(wfj)
 
 
 class NotificationTemplateSerializer(BaseSerializer):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4488,11 +4488,11 @@ class BulkJobNodeSerializer(serializers.Serializer):
 
 
 class BulkJobLaunchSerializer(serializers.Serializer):
-    name = serializers.CharField(max_length=512)  # limited by max name of jobs
+    name = serializers.CharField(max_length=512, required=False)  # limited by max name of jobs
     jobs = serializers.ListField(child=BulkJobNodeSerializer(), allow_empty=False, max_length=100)
 
     class Meta:
-        fields = ('name', 'workflow_job_nodes')
+        fields = ('name', 'jobs')
         read_only_fields = ()
 
     def validate_jobs(self, jobs):
@@ -4531,9 +4531,16 @@ class BulkJobLaunchSerializer(serializers.Serializer):
 
     def create(self, validated_data):
         job_node_data = validated_data.pop('jobs')
+
+        # TODO: add 'is_bulk_job' to workflow_job
         # validated_data['is_bulk_job'] = True
+
         # FIXME: Need to set organization on the WorkflowJob in order for users to be able to see it --
         # normally their permission is sourced from the underlying WorkflowJobTemplate
+        # maybe we need to add Organization to WorkflowJob
+        if 'name' not in validated_data:
+            validated_data['name'] = 'Bulk Job Launch'
+
         wfj = WorkflowJob.objects.create(**validated_data)
         nodes = []
         node_m2m_objects = {}

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -30,6 +30,7 @@ from awx.api.views import (
     OAuth2TokenList,
     ApplicationOAuth2TokenList,
     OAuth2ApplicationDetail,
+    BulkJobLaunchView,
 )
 from awx.api.views.mesh_visualizer import MeshVisualizer
 
@@ -136,6 +137,7 @@ v2_urls = [
     re_path(r'^activity_stream/', include(activity_stream_urls)),
     re_path(r'^workflow_approval_templates/', include(workflow_approval_template_urls)),
     re_path(r'^workflow_approvals/', include(workflow_approval_urls)),
+    re_path(r'^bulk_jobs/launch/$', BulkJobLaunchView, name='bulk_job_launch'),
 ]
 
 

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -137,7 +137,7 @@ v2_urls = [
     re_path(r'^activity_stream/', include(activity_stream_urls)),
     re_path(r'^workflow_approval_templates/', include(workflow_approval_template_urls)),
     re_path(r'^workflow_approvals/', include(workflow_approval_urls)),
-    re_path(r'^bulk_jobs/launch/$', BulkJobLaunchView, name='bulk_job_launch'),
+    re_path(r'^bulk_jobs/launch/$', BulkJobLaunchView.as_view(), name='bulk_job_launch'),
 ]
 
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4558,6 +4558,18 @@ class WorkflowApprovalDetail(UnifiedJobDeletionMixin, RetrieveDestroyAPIView):
     serializer_class = serializers.WorkflowApprovalSerializer
 
 
+from rest_framework.decorators import api_view
+
+
+@api_view(['GET', 'POST'])
+def BulkJobLaunchView(request, *args, **kwargs):
+    bulkjob_serializer = serializers.BulkJobLaunchSerializer(data=request.data)
+    if bulkjob_serializer.is_valid():
+        result = bulkjob_serializer.create(bulkjob_serializer.validated_data)
+        return Response(serializers.WorkflowJobSerializer().to_representation(result), status=status.HTTP_201_CREATED)
+    return Response(bulkjob_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
 class WorkflowApprovalApprove(RetrieveAPIView):
     model = models.WorkflowApproval
     serializer_class = serializers.WorkflowApprovalViewSerializer

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4565,9 +4565,10 @@ class BulkJobLaunchView(APIView):
     _ignore_model_permissions = True
     permission_classes = [IsAuthenticated]
     serializer_class = serializers.BulkJobLaunchSerializer
-    allowed_methods = ['GET', 'POST']
+    allowed_methods = ['GET', 'POST', 'OPTIONS']
 
     def get(self, request):
+        # TODO Return something sensible here, like the defaults
         bulkjob_serializer = serializers.BulkJobLaunchSerializer(data={})
         bulkjob_serializer.is_valid()
         return Response(bulkjob_serializer.errors, status=status.HTTP_200_OK)

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4561,13 +4561,23 @@ class WorkflowApprovalDetail(UnifiedJobDeletionMixin, RetrieveDestroyAPIView):
 from rest_framework.decorators import api_view
 
 
-@api_view(['GET', 'POST'])
-def BulkJobLaunchView(request, *args, **kwargs):
-    bulkjob_serializer = serializers.BulkJobLaunchSerializer(data=request.data)
-    if bulkjob_serializer.is_valid():
-        result = bulkjob_serializer.create(bulkjob_serializer.validated_data)
-        return Response(serializers.WorkflowJobSerializer().to_representation(result), status=status.HTTP_201_CREATED)
-    return Response(bulkjob_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+class BulkJobLaunchView(APIView):
+    _ignore_model_permissions = True
+    permission_classes = [IsAuthenticated]
+    serializer_class = serializers.BulkJobLaunchSerializer
+    allowed_methods = ['GET', 'POST']
+
+    def get(self, request):
+        bulkjob_serializer = serializers.BulkJobLaunchSerializer(data={})
+        bulkjob_serializer.is_valid()
+        return Response(bulkjob_serializer.errors, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        bulkjob_serializer = serializers.BulkJobLaunchSerializer(data=request.data)
+        if bulkjob_serializer.is_valid():
+            result = bulkjob_serializer.create(bulkjob_serializer.validated_data)
+            return Response(result, status=status.HTTP_201_CREATED)
+        return Response(bulkjob_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 
 class WorkflowApprovalApprove(RetrieveAPIView):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
replaces https://github.com/ansible/awx/pull/13271

The idea behind this is some way to launch a number of jobs with 1 request, the client could then subscribe to websocket channel and get updates on status of the nodes or at least just poll this one workflow until individual job nodes are done and then reach into the jobs.

This is all to provide some interface that allows clients to get information they need without barraging controller with many many requests. With a limit of 100 nodes per Bulk Job, launching 1,000 jobs would take 10 web requests -- which is totally achievable with current uwsgi setup.

First pass does not attempt to implement any workflow structure other than flat, maybe not even necessary if only goal is a bulk job launch endpoint. Even so, we support passing "identifier"s on the workflow nodes to be able to tell the jobs apart in websocket messages or the api.

A significant concern is performing all necessary RBAC checks for all nodes and promptable items like Inventory, Credentials, etc. I have implemented this a good bit of the way, but it needs review/testing for both correctness and performance depending on how many unified job templates, credentials, etc are in system and how many nodes are in workflow/use of prompt-able items for nodes.

POST /api/v2/bulk_jobs/launch
```
{
"jobs": [
{"unified_job_template": 7, "inventory": 1, "credentials": [1]},
{"unified_job_template": 7, "inventory": 1, "credentials": [1]},
{"unified_job_template": 7, "inventory": 1, "credentials": [1]},
{"unified_job_template": 7, "inventory": 1, "credentials": [1]}
]
}
```
results in:
```
HTTP 201 Created
Allow: GET, POST, OPTIONS
Content-Type: application/json
Vary: Accept
X-API-Node: awx_1
X-API-Product-Name: AWX
X-API-Product-Version: 21.6.1.dev146+g1619462fb0
X-API-Query-Count: 29
X-API-Query-Time: 0.008s
X-API-Time: 0.034s

{
    "id": 947,
    "type": "workflow_job",
    "url": "[/api/v2/workflow_jobs/947/](https://localhost:8043/api/v2/workflow_jobs/947/)",
    "related": {
        "created_by": "[/api/v2/users/3/](https://localhost:8043/api/v2/users/3/)",
        "modified_by": "[/api/v2/users/3/](https://localhost:8043/api/v2/users/3/)",
        "workflow_nodes": "[/api/v2/workflow_jobs/947/workflow_nodes/](https://localhost:8043/api/v2/workflow_jobs/947/workflow_nodes/)",
        "labels": "[/api/v2/workflow_jobs/947/labels/](https://localhost:8043/api/v2/workflow_jobs/947/labels/)",
        "activity_stream": "[/api/v2/workflow_jobs/947/activity_stream/](https://localhost:8043/api/v2/workflow_jobs/947/activity_stream/)",
        "relaunch": "[/api/v2/workflow_jobs/947/relaunch/](https://localhost:8043/api/v2/workflow_jobs/947/relaunch/)",
        "cancel": "[/api/v2/workflow_jobs/947/cancel/](https://localhost:8043/api/v2/workflow_jobs/947/cancel/)"
    },
    "summary_fields": {
        "created_by": {
            "id": 3,
            "username": "org_admin",
            "first_name": "org_admin",
            "last_name": ""
        },
        "modified_by": {
            "id": 3,
            "username": "org_admin",
            "first_name": "org_admin",
            "last_name": ""
        },
        "labels": {
            "count": 0,
            "results": []
        }
    },
    "created": "2022-12-13T22:52:09.780122Z",
    "modified": "2022-12-13T22:52:09.789201Z",
    "name": "Bulk Job Launch",
    "description": "",
    "unified_job_template": null,
    "launch_type": "manual",
    "status": "pending",
    "failed": false,
    "started": null,
    "finished": null,
    "canceled_on": null,
    "elapsed": 0.0,
    "job_args": "",
    "job_cwd": "",
    "job_env": {},
    "job_explanation": "",
    "result_traceback": "",
    "launched_by": {
        "id": 3,
        "name": "org_admin",
        "type": "user",
        "url": "[/api/v2/users/3/](https://localhost:8043/api/v2/users/3/)"
    },
    "work_unit_id": null,
    "workflow_job_template": null,
    "extra_vars": "",
    "allow_simultaneous": false,
    "job_template": null,
    "is_sliced_job": false,
    "inventory": null,
    "limit": null,
    "scm_branch": null,
    "webhook_service": "",
    "webhook_credential": null,
    "webhook_guid": "",
    "skip_tags": null,
    "job_tags": null
}
```


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

One currently open question right now is how to determine read access to the resulting WorkflowJob and WorkflowJobNodes. Without changes to current RBAC, only system administrators can see them because these workflow jobs are essentially "orphaned" meaning they have no source WorkflowJobTemplate -- which is how we currently determine if you have permission to see a WorkflowJob or its WorkflowJobNodes
