### PR TITLE
Experimental podman integration for devel environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ clean-schema:
 
 clean-languages:
 	rm -f $(I18N_FLAG_FILE)
-	find ./awx/locale/ -type f -regex ".*\.mo$" -delete
+	find ./awx/locale/ -type f -regex ".*\.mo$$" -delete
 
 ## Remove temporary build files, compiled Python files.
 clean: clean-ui clean-api clean-awxkit clean-dist

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -118,6 +118,12 @@
     dest: "{{ sources_dest }}/{{ compose_name }}"
     mode: "0600"
 
+- name: Render Podman Kube Play
+  template:
+    src: podman_kube.yml.j2
+    dest: "{{ sources_dest }}/podman_kube.yml"
+    mode: "0600"
+
 - name: Render Receptor Config(s) for Control Plane
   template:
     src: "receptor-awx.conf.j2"

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -1,10 +1,9 @@
 ---
-
 - name: Create _sources directories
   file:
     path: "{{ sources_dest }}/{{ item }}"
-    state: 'directory'
-    mode: '0700'
+    state: "directory"
+    mode: "0700"
   loop:
     - secrets
     - receptor
@@ -22,13 +21,13 @@
 
 - name: Generate secrets if needed
   template:
-    src: 'secrets.yml.j2'
-    dest: '{{ sources_dest }}/secrets/{{ item.item }}.yml'
-    mode: '0600'
+    src: "secrets.yml.j2"
+    dest: "{{ sources_dest }}/secrets/{{ item.item }}.yml"
+    mode: "0600"
   when: not lookup('vars', item.item, default='') and not item.stat.exists
   loop: "{{ secrets.results }}"
   loop_control:
-    label: '{{ item.item }}'
+    label: "{{ item.item }}"
 
 - name: Include generated secrets unless they are explicitly passed in
   include_vars: "{{ sources_dest }}/secrets/{{ item.item }}.yml"
@@ -46,7 +45,7 @@
   template:
     src: "{{ item }}.j2"
     dest: "{{ sources_dest }}/{{ item }}"
-    mode: '0600'
+    mode: "0600"
   with_items:
     - "database.py"
     - "websocket_secret.py"
@@ -63,10 +62,25 @@
     dest: "{{ sources_dest }}/local_settings.py"
 
 - name: Get OS info for sdb
-  shell: |
-    docker info | grep 'Operating System'
-  register: os_info
-  changed_when: false
+  block:
+    - name: Get OS info for sdb from docker
+      shell: |
+        docker info | grep 'Operating System'
+      register: os_info
+      changed_when: false
+  rescue:
+    - block:
+        - name: Get OS info for sdb from lsb_release
+          shell: |
+            lsb_release -ds
+          register: os_info
+          changed_when: false
+      rescue:
+        - name: Get OS info for sdb from podman
+          shell: |
+            podman info --format "{% raw %}{{ .Host.Distribution.Distribution|title }} {{ .Host.Distribution.Version }}{% endraw %}"
+          register: os_info
+          changed_when: false
 
 - name: Get user UID
   shell: id -u
@@ -102,34 +116,34 @@
   template:
     src: docker-compose.yml.j2
     dest: "{{ sources_dest }}/{{ compose_name }}"
-    mode: '0600'
+    mode: "0600"
 
 - name: Render Receptor Config(s) for Control Plane
   template:
     src: "receptor-awx.conf.j2"
     dest: "{{ sources_dest }}/receptor/receptor-awx-{{ item }}.conf"
-    mode: '0600'
+    mode: "0600"
   with_sequence: start=1 end={{ control_plane_node_count }}
 
 - name: Create Receptor Config Lock File
   file:
     path: "{{ sources_dest }}/receptor/receptor-awx-{{ item }}.conf.lock"
     state: touch
-    mode: '0600'
+    mode: "0600"
   with_sequence: start=1 end={{ control_plane_node_count }}
 
 - name: Render Receptor Config(s) for Control Plane
   template:
     src: "receptor-awx.conf.j2"
     dest: "{{ sources_dest }}/receptor/receptor-awx-{{ item }}.conf"
-    mode: '0600'
+    mode: "0600"
   with_sequence: start=1 end={{ control_plane_node_count }}
 
 - name: Render Receptor Hop Config
   template:
     src: "receptor-hop.conf.j2"
     dest: "{{ sources_dest }}/receptor/receptor-hop.conf"
-    mode: '0600'
+    mode: "0600"
   when:
     - execution_node_count | int > 0
 
@@ -137,7 +151,7 @@
   template:
     src: "receptor-worker.conf.j2"
     dest: "{{ sources_dest }}/receptor/receptor-worker-{{ item }}.conf"
-    mode: '0600'
+    mode: "0600"
   with_sequence: start=1 end={{ execution_node_count if execution_node_count | int > 0 else 1}}
   when: execution_node_count | int > 0
 

--- a/tools/docker-compose/ansible/roles/sources/templates/podman_kube.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/podman_kube.yml.j2
@@ -1,0 +1,283 @@
+#jinja2: lstrip_blocks: True
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.podman.io/driver: local
+  labels:
+    name: tools_awx_db
+    pod: awx
+  name: awx_db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{% for i in range(control_plane_node_count|int) -%}
+  {% set container_postfix = loop.index %}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.podman.io/driver: local
+  labels:
+    name: tools_redis_socket_{{ container_postfix }}
+    pod: awx
+  name: redis_socket_{{ container_postfix }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{% endfor -%}
+{% if enable_ldap|bool %}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.podman.io/driver: local
+  labels:
+    name: tools_ldap_1
+    pod: awx
+  name: openldap_data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{% endif %}
+{% if enable_prometheus|bool %}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.podman.io/driver: local
+  labels:
+    name: tools_prometheus_storage
+    pod: awx
+  name: prometheus_storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{% endif %}
+{% if enable_grafana|bool %}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    volume.podman.io/driver: local
+  labels:
+    name: tools_grafana_storage
+    pod: awx
+  name: grafana_storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{% endif %}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: awx
+  name: awx
+spec:
+  ports:
+    - name: "https"
+      port: 8043
+      targetPort: 8043
+    - name: "unused/debugging"
+      port: 8080
+      targetPort: 8080
+    - name: "http"
+      port: 8013
+      targetPort: 8013
+    - name: "jupyter"
+      targetPort: 8888
+  selector:
+    app: awx
+  type: NodePort
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: awx
+  name: awx
+spec:
+  securityContext:
+    capabilities:
+      drop:
+        - CAP_MKNOD
+        - CAP_NET_RAW
+        - CAP_AUDIT_WRITE
+  containers:
+    - name: tools_postgres_1
+      image: docker.io/library/postgres:12
+      env:
+        - name: POSTGRES_HOST_AUTH_METHOD
+          value: trust
+        - name: POSTGRES_DB
+          value: {{ pg_database|quote }}
+        - name: POSTGRES_USER
+          value: {{ pg_username|quote }}
+        - name: POSTGRES_PASSWORD
+          value: {{ pg_password|quote }}
+      args: [postgres, -c, log_destination=stderr, -c, log_min_messages=info, -c, log_min_duration_statement=1000, -c, max_connections=1024]
+      ports:
+        - containerPort: 8043
+          hostPort: 8043
+        - containerPort: 8080
+          hostPort: 8080
+        - containerPort: 8888
+          hostPort: 42689
+      volumeMounts:
+        - mountPath: /var/lib/postgresql_data
+          name: awx_db-pvc
+    - name: tools_redis_1
+      image: docker.io/library/redis:latest
+      command:
+        - redis-server
+      args:
+        - /usr/local/etc/redis/redis.conf
+      volumeMounts:
+        - mountPath: /usr/local/etc/redis/redis.conf
+          name: tools-redis-redis.conf-host-0
+        - mountPath: /var/run/redis/
+          name: redis_socket_1-pvc
+          readOnly: false
+    - name: tools_awx_1
+      image: "{{ awx_image }}:{{ awx_image_tag }}"
+      args: [launch_awx.sh]
+      env:
+        - name: OS
+          value: "{{ os_info.stdout }}"
+        - name: SDB_HOST
+          value: "0.0.0.0"
+        - name: SDB_PORT
+          value: 7899
+        - name: AWX_GROUP_QUEUES
+          value: tower
+        - name: MAIN_NODE_TYPE
+          value: {{ lookup('ansible.builtin.env', 'MAIN_NODE_TYPE') | default('hybrid', true) }}
+        - name: RECEPTORCTL_SOCKET
+          value: {{ receptor_socket_file }}
+        - name: CONTROL_PLANE_NODE_COUNT
+          value: {{ control_plane_node_count|int }}
+        - name: EXECUTION_NODE_COUNT
+          value: {{ execution_node_count|int }}
+        - name: AWX_LOGGING_MODE
+          value: stdout
+        - name: DJANGO_SUPERUSER_PASSWORD
+          value: {{ admin_password }}
+        - name: RUN_MIGRATIONS
+          value: 1
+      securityContext:
+        privileged: true
+      workingDir: /awx_devel
+      volumeMounts:
+        - mountPath: /awx_devel
+          name: awx_devel-host-0
+        - mountPath: /etc/supervisord.conf
+          name: tools-docker-compose-supervisor.conf-host-0
+        - mountPath: /etc/tower/conf.d/database.py
+          name: tools-docker-compose-sources-database.py-host-0
+        - mountPath: /etc/tower/conf.d/websocket_secret.py
+          name: tools-docker-compose-sources-websocket-secret.py-host-0
+        - mountPath: /etc/tower/SECRET_KEY
+          name: tools-docker-compose-sources-SECRET-KEY-host-0
+        - mountPath: /etc/tower/conf.d/local_settings.py
+          name: tools-docker-compose-sources-local-settings.py-host-0
+        - mountPath: /etc/receptor/receptor.conf
+          name: tools-docker-compose-sources-receptor-receptor-awx-1.conf-host-0
+        - mountPath: /etc/receptor/receptor.conf.lock
+          name: tools-docker-compose-sources-receptor-receptor-awx-1.conf.lock-host-0
+        - mountPath: /sys/fs/cgroup
+          name: sys-fs-cgroup-host-0
+        - mountPath: /var/lib/awx/.kube/config
+          name: kube-config-host-0
+        - mountPath: /var/run/redis
+          name: redis_socket_1-pvc
+          readOnly: false
+  hostAliases:
+    - ip: 127.0.0.1
+      hostnames:
+        - postgres
+        - redis_1
+        - awx_1
+  restartPolicy: Never
+  volumes:
+    - name: awx_db-pvc
+      persistentVolumeClaim:
+        claimName: awx_db
+    - name: tools-redis-redis.conf-host-0
+      hostPath:
+        path: ./tools/redis/redis.conf
+        type: File
+    - name: redis_socket_1-pvc
+      persistentVolumeClaim:
+        claimName: redis_socket_1
+    - name: awx_devel-host-0
+      hostPath:
+        path: ./
+        type: Directory
+    - name: tools-docker-compose-supervisor.conf-host-0
+      hostPath:
+        path: ./tools/docker-compose/supervisor.conf
+        type: File
+    - name: tools-docker-compose-sources-database.py-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/database.py
+        type: File
+    - name: tools-docker-compose-sources-websocket-secret.py-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/websocket_secret.py
+        type: File
+    - name: tools-docker-compose-sources-local-settings.py-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/local_settings.py
+        type: File
+    - name: tools-docker-compose-sources-SECRET-KEY-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/SECRET_KEY
+        type: File
+    - name: tools-docker-compose-sources-receptor-receptor-awx-1.conf-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/receptor/receptor-awx-1.conf
+        type: File
+    - name: tools-docker-compose-sources-receptor-receptor-awx-1.conf.lock-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/receptor/receptor-awx-1.conf.lock
+        type: File
+{% if sign_work|bool %}
+    - name: tools-docker-compose-sources-receptor-work-public-key.pem-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/receptor/work_public_key.pem
+        type: File
+    - name: tools-docker-compose-sources-receptor-work-private-key.pem-host-0
+      hostPath:
+        path: ./tools/docker-compose/_sources/receptor/work_private_key.pem
+        type: File
+{% endif %}
+    - name: sys-fs-cgroup-host-0
+      hostPath:
+        path: /sys/fs/cgroup
+        type: Directory
+    - name: kube-config-host-0
+      hostPath:
+        path: {{ lookup('ansible.builtin.env', 'HOME') }}/.kube/config
+        type: File


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I've switched to using podman exclusively on my development VM, so I've been unable to use the documented development installation. 

These changes (though messy and in need of much improvement) make it possible for me to follow the documented installation with minor changes to spin up AWX in a podman pod.

<ins>**NOTE:** this is really not intended to be merged, it's just to provide a PoC for determined users.</ins>
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.9.1.dev70+gfdb2d14157.d20221214
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
On my Ubuntu 22.04.1 LTS VM, the following works for me to stand up the development environment:

<!--- Paste verbatim command output below, e.g. before and after your change -->
###### Pre-clean
I had to use sudo for this, as podman changes the uid on the files it generates, so the make clean targets fail for those cases.
```sh
$ PYTHON=python3 sudo -E make clean clean-venv clean-schema clean-languages
```
###### Spin it up
Use the new `IMAGE_BUILDER=podman` variable to switch from docker to podman for the targets that are run in common.
```sh
$ PYTHON=python3 IMAGE_BUILDER=podman make docker-compose-build
# ... renders the Dockerfile and supervisor configs as usual...
# ... runs podman build with lots of output...
$ PYTHON=python3 IMAGE_BUILDER=podman make podman-kube-play
# ... renders _sources files and secrets via docker-compose-sources target
# ... docker-compose-sources target renders an additional file for podman kube play!
podman play kube tools/docker-compose/_sources/podman_kube.yml
Volumes:
redis_socket_1
awx_db
Pod:
c48f62c69f1e2824442f8769df8e760555f1d43d23ee5acd2c0c933e1224bfe0
Containers:
e773908787f3048881e6a1a1f2758b92c3fce7a7ed9d9dbe6f25851ebb631279
758575f91362488b5b429f857740f8bdd5a3d86fdd31b60c17245ba7639d71a0
eeacc331150cbc378de47a5ffc7381abe8940155efffb9959d2d302997983368

# Then we check the logs...
$ podman logs -f awx-tools_awx_1
# and see that the migrations are being applied; so far so good. Once is reaches running state,  we check out https://localhost:8043/, but alas there's no UI! So we build that next:
$ podman exec awx-tools_awx_1 make clean-ui ui-devel
# But we get rm: cannot remove 'awx/ui/build/static': Permission denied 
# I should probably figure out why this happens, but for now, just fix it and try again.
$ sudo chown -R philipsd6:philipsd6 awx/ui/build
$ podman exec awx-tools_awx_1 make clean-ui ui-devel

# And now we have a UI! Time to finish up
$ podman exec awx-tools_awx_1 awx-manage create_preload_data
$ podman exec -ti awx-tools_awx_1 awx-manage changepassword admin
```
And finally we can log in successfully as admin, and run the demo playbook!