### PR TITLE
tag awx-ee latest on awx release

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -74,4 +74,6 @@ jobs:
           docker tag ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} quay.io/${{ github.repository }}:latest
           docker push quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
           docker push quay.io/${{ github.repository }}:latest
-
+          docker pull ghcr.io/${{ github.repository_owner }}/awx-ee:${{ github.event.release.tag_name }}
+          docker tag ghcr.io/${{ github.repository_owner }}/awx-ee:${{ github.event.release.tag_name }} quay.io/${{ github.repository_owner }}/awx-ee:${{ github.event.release.tag_name }}
+          docker push quay.io/${{ github.repository_owner }}/awx-ee:${{ github.event.release.tag_name }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -84,6 +84,20 @@ jobs:
             -e push=yes \
             -e awx_official=yes
 
+      - name: Log in to GHCR
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Log in to Quay
+        run: |
+          echo ${{ secrets.QUAY_TOKEN }} | docker login quay.io -u ${{ secrets.QUAY_USER }} --password-stdin
+
+      - name: tag awx-ee:latest with version input
+        run: |
+          docker pull quay.io/ansible/awx-ee:latest
+          docker tag quay.io/ansible/awx-ee:latest ghcr.io/${{ github.repository_owner }}/awx-ee:${{ github.event.inputs.version }}
+          docker push ghcr.io/${{ github.repository_owner }}/awx-ee:${{ github.event.inputs.version }}
+
       - name: Build and stage awx-operator
         working-directory: awx-operator
         run: |
@@ -103,6 +117,7 @@ jobs:
         env:
           AWX_TEST_IMAGE: ${{ github.repository }}
           AWX_TEST_VERSION: ${{ github.event.inputs.version }}
+          AWX_EE_TEST_IMAGE: ghcr.io/${{ github.repository_owner }}/awx-ee:${{ github.event.inputs.version }}
 
       - name: Create draft release for AWX
         working-directory: awx


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

pairs with https://github.com/ansible/awx-operator/pull/1158

each time AWX is released, tag quay.io/ansible/awx-ee:latest with the same AWX tag

this allows users to have an image to fallback to in case the lastest breaks their custom EEs

Tagging it with AWX release tags provides a regular cadence, and the tag itself allows users to roughly align awx-ee to awx images.

see https://github.com/ansible/awx-ee/issues/117
and https://github.com/ansible/awx-ee/issues/125


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
