### PR TITLE
Change workflow create/edit to null scm_branch when not provided.

### DIFF
--- a/awx/ui/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.js
@@ -24,6 +24,7 @@ function WorkflowJobTemplateAdd() {
       limit,
       job_tags,
       skip_tags,
+      scm_branch,
       ...templatePayload
     } = values;
     templatePayload.inventory = inventory?.id;
@@ -32,6 +33,7 @@ function WorkflowJobTemplateAdd() {
     templatePayload.limit = limit === '' ? null : limit;
     templatePayload.job_tags = job_tags === '' ? null : job_tags;
     templatePayload.skip_tags = skip_tags === '' ? null : skip_tags;
+    templatePayload.scm_branch = scm_branch === '' ? null : scm_branch;
     const organizationId =
       organization?.id || inventory?.summary_fields?.organization.id;
     try {

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.test.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateAdd/WorkflowJobTemplateAdd.test.js
@@ -119,7 +119,7 @@ describe('<WorkflowJobTemplateAdd/>', () => {
       job_tags: null,
       limit: null,
       organization: undefined,
-      scm_branch: '',
+      scm_branch: null,
       skip_tags: null,
       webhook_credential: undefined,
       webhook_service: '',

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateEdit/WorkflowJobTemplateEdit.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateEdit/WorkflowJobTemplateEdit.js
@@ -30,6 +30,7 @@ function WorkflowJobTemplateEdit({ template }) {
       limit,
       job_tags,
       skip_tags,
+      scm_branch,
       ...templatePayload
     } = values;
     templatePayload.inventory = inventory?.id || null;
@@ -38,6 +39,7 @@ function WorkflowJobTemplateEdit({ template }) {
     templatePayload.limit = limit === '' ? null : limit;
     templatePayload.job_tags = job_tags === '' ? null : job_tags;
     templatePayload.skip_tags = skip_tags === '' ? null : skip_tags;
+    templatePayload.scm_branch = scm_branch === '' ? null : scm_branch;
 
     const formOrgId =
       organization?.id || inventory?.summary_fields?.organization.id || null;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The current behavior of workflow job templates is to pass in an empty string as scm_branch on all saves and edits. This becomes problematic when using job templates/workflows which allow prompt on launch for scm_branch as it may override the scm_branch set for the individual workflow nodes to an empty string. That behavior limits the usefulness of prompting scm branch as it can no longer be selected while creating workflows as they'll be overwritten.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 
 - UI
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.10.1.dev35+ga4b950f79b

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
