### PR TITLE
Add back pkgconfig for offline build

### DIFF
--- a/licenses/pkgconfig.txt
+++ b/licenses/pkgconfig.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -59,6 +59,7 @@ pip==21.2.4  # see UPGRADE BLOCKERs
 setuptools  # see UPGRADE BLOCKERs
 setuptools_scm[toml]  # see UPGRADE BLOCKERs, xmlsec build dep
 setuptools-rust >= 0.11.4 # cryptography build dep
+pkgconfig>=1.5.1  # xmlsec build dep - needed for offline build
 
 # Temporarily added to use ansible-runner from git branch, to be removed
 # when ansible-runner moves from requirements_git.txt to here

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -250,6 +250,8 @@ pexpect==4.7.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   ansible-runner
+pkgconfig==1.5.5
+    # via -r /awx_devel/requirements/requirements.in
 prometheus-client==0.15.0
     # via -r /awx_devel/requirements/requirements.in
 psutil==5.9.4


### PR DESCRIPTION
##### SUMMARY
Follow-up for #13263. Offline build requires build dependencies to be listed in requirements.txt. `pkgconfig` is xmlsec's build dependency.

```
16:56:25      Processing ./requirements/vendor/xmlsec-1.3.13.tar.gz
16:56:25        Installing build dependencies: started
16:56:25        Installing build dependencies: finished with status 'error'
...
16:56:25        Processing ./requirements/vendor/setuptools_scm-7.0.5-py3-none-any.whl
16:56:25        ERROR: Could not find a version that satisfies the requirement pkgconfig>=1.5.1 (from versions: none)
16:56:25        ERROR: No matching distribution found for pkgconfig>=1.5.1
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

