### PR TITLE
Pin channels-redis to 3.4.1 to fix an async issue

### DIFF
--- a/licenses/aioredis.txt
+++ b/licenses/aioredis.txt
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2014-2017 Alexey Popravka
+Copyright (c) 2021 Sean Stewart
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/hiredis.txt
+++ b/licenses/hiredis.txt
@@ -1,0 +1,29 @@
+Copyright (c) 2009-2011, Salvatore Sanfilippo <antirez at gmail dot com>
+Copyright (c) 2010-2011, Pieter Noordhuis <pcnoordhuis at gmail dot com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Redis nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -148,6 +148,15 @@ in the top-level Makefile.
 
 If modifying this library make sure testing with the offline build is performed to confirm it is functionally working.
 
+### channels-redis
+
+Due to an upstream bug (linked below), we see `RuntimeError: Event loop is closed` errors with newer versions of `channels-redis`.
+Upstream is aware of the bug and it is likely to be fixed in the next release according to the issue linked below.
+For now, we pin to the old version, 3.4.1
+
+* https://github.com/django/channels_redis/issues/332
+* https://github.com/ansible/awx/issues/13313
+
 ## Library Notes
 
 ### pexpect

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -4,7 +4,7 @@ asciichartpy
 asn1
 azure-keyvault==1.1.0  # see UPGRADE BLOCKERs
 channels
-channels-redis
+channels-redis==3.4.1  # see UPGRADE BLOCKERs
 cryptography
 Cython<3 # Since the bump to PyYAML 5.4.1 this is now a mandatory dep
 daphne

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,6 +2,8 @@ adal==1.2.7
     # via msrestazure
 aiohttp==3.8.3
     # via -r /awx_devel/requirements/requirements.in
+aioredis==1.3.1
+    # via channels-redis
 aiosignal==1.3.1
     # via aiohttp
     # via -r /awx_devel/requirements/requirements_git.txt
@@ -20,6 +22,7 @@ asn1==2.6.0
 async-timeout==4.0.2
     # via
     #   aiohttp
+    #   aioredis
     #   redis
 attrs==22.1.0
     # via
@@ -51,11 +54,11 @@ cachetools==5.2.0
     #   requests
 cffi==1.15.1
     # via cryptography
-channels==4.0.0
+channels==3.0.5
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels-redis
-channels-redis==4.0.0
+channels-redis==3.4.1
     # via -r /awx_devel/requirements/requirements.in
 charset-normalizer==2.1.1
     # via
@@ -76,8 +79,10 @@ cryptography==38.0.4
     #   social-auth-core
 cython==0.29.32
     # via -r /awx_devel/requirements/requirements.in
-daphne==4.0.0
-    # via -r /awx_devel/requirements/requirements.in
+daphne==3.0.2
+    # via
+    #   -r /awx_devel/requirements/requirements.in
+    #   channels
 dataclasses==0.6
     # via
     #   python-dsv-sdk
@@ -153,6 +158,8 @@ gitpython==3.1.29
     # via -r /awx_devel/requirements/requirements.in
 google-auth==2.14.1
     # via kubernetes
+hiredis==2.1.0
+    # via aioredis
 hyperlink==21.0.0
     # via
     #   autobahn
@@ -334,7 +341,6 @@ receptorctl==1.2.3
 redis==4.3.5
     # via
     #   -r /awx_devel/requirements/requirements.in
-    #   channels-redis
     #   django-redis
 requests==2.28.1
     # via


### PR DESCRIPTION
##### SUMMARY

As a side effect this also downgrades channels back to 3.x.

It does seem to solve the traceback issues, though.

Refs django/channels_redis#332
Refs #13313

Signed-off-by: Rick Elrod <rick@elrod.me>

Many thanks to @shanemcd for hanging out and debugging this with me on a Friday night.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
