### PR TITLE
add logging to situation in which project lock file is locked

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -390,6 +390,7 @@ class BaseTask(object):
             logger.error("I/O error({0}) while trying to open lock file [{1}]: {2}".format(e.errno, lock_path, e.strerror))
             raise
 
+        emitted_lockfile_log = False
         start_time = time.time()
         while True:
             try:
@@ -401,6 +402,9 @@ class BaseTask(object):
                     logger.error("I/O error({0}) while trying to aquire lock on file [{1}]: {2}".format(e.errno, lock_path, e.strerror))
                     raise
                 else:
+                    if not emitted_lockfile_log:
+                        logger.info(f"exception acquiring lock {lock_path}: {e}")
+                        emitted_lockfile_log = True
                     time.sleep(1.0)
             self.instance.refresh_from_db(fields=['cancel_flag'])
             if self.instance.cancel_flag or signal_callback():


### PR DESCRIPTION
Currently, if lock file of project is locked, there is no trace in logs https://github.com/ansible/awx/blob/devel/awx/main/tasks/jobs.py#L404

How to replicate the issue:
Run on a controller instance following python3 commands:

```
import os
import fcntl
lock_fd = os.open('/var/lib/awx/projects/_8__example_project.lock', os.O_RDWR | os.O_CREAT)
fcntl.lockf(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
```
Then, when running project update, the job will get stuck.

With this change I can see following log entry:
`/var/log/tower/task_system.log:2022-12-19 16:17:15,586 INFO     [dcfe5b893c2b48429d8131ff1ce4dce5] awx.main.tasks.jobs exception acquiring lock /var/lib/awx/projects/_8__example_project.lock: [Errno 11] Resource temporarily unavailable, sleeping`

When running `quit()` command project update should resume.

New or Enhanced Feature