### PR TITLE
[bulk_jobs_feature] fix rbac checking and optimize # of queries

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4495,7 +4495,7 @@ class BulkJobLaunchSerializer(serializers.Serializer):
         for node in attrs['jobs']:
             if 'identifier' in node:
                 if node['identifier'] in identifiers:
-                    raise serializers.ValidationError(_(f"Identifier {identifier} not unique"))
+                    raise serializers.ValidationError(_(f"Identifier {node['identifier']} not unique"))
                 identifiers.add(node['identifier'])
             else:
                 node['identifier'] = str(uuid4())

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4489,7 +4489,7 @@ class BulkJobNodeSerializer(serializers.Serializer):
 
 class BulkJobLaunchSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=512, required=False)  # limited by max name of jobs
-    jobs = serializers.ListField(child=BulkJobNodeSerializer(), allow_empty=False, max_length=100)
+    jobs = BulkJobNodeSerializer(many=True, allow_empty=False, max_length=100)
 
     class Meta:
         fields = ('name', 'jobs')
@@ -4520,7 +4520,7 @@ class BulkJobLaunchSerializer(serializers.Serializer):
 
             requested_use_inventories = {job['inventory'].id for job in attrs['jobs'] if 'inventory' in job}
             if requested_use_inventories:
-                accessible_use_inventories = {tup[0] for tup in Inventory.accessible_pk_qs(request.user, 'use_role') }
+                accessible_use_inventories = {tup[0] for tup in Inventory.accessible_pk_qs(request.user, 'use_role')}
                 if requested_use_inventories - accessible_use_inventories:
                     not_allowed = requested_use_inventories - accessible_use_inventories
                     raise serializers.ValidationError(_(f"Inventories {not_allowed} not found."))

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4569,12 +4569,12 @@ class BulkJobLaunchView(APIView):
 
     def get(self, request):
         # TODO Return something sensible here, like the defaults
-        bulkjob_serializer = serializers.BulkJobLaunchSerializer(data={})
+        bulkjob_serializer = serializers.BulkJobLaunchSerializer(data={}, context={'request': request})
         bulkjob_serializer.is_valid()
         return Response(bulkjob_serializer.errors, status=status.HTTP_200_OK)
 
     def post(self, request):
-        bulkjob_serializer = serializers.BulkJobLaunchSerializer(data=request.data)
+        bulkjob_serializer = serializers.BulkJobLaunchSerializer(data=request.data, context={'request': request})
         if bulkjob_serializer.is_valid():
             result = bulkjob_serializer.create(bulkjob_serializer.validated_data)
             return Response(result, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
Fix how I was getting the request user, and do all the RBAC checks against just pk id's.

Then, if we pass that, get all the now vetted objects in a single query per object type. Then we can return the "objectified" jobs list so that the create function cando its magic.

This got me down to around 20 queries to create 100 jobs.

example post:
```
{"jobs": [
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]},
{"unified_job_template": 9, "credentials": [3]}
]}
```

queries:
```
HTTP 201 Created
Allow: GET, POST, OPTIONS
Content-Type: application/json
Vary: Accept
X-API-Node: awx_1
X-API-Product-Name: AWX
X-API-Product-Version: 21.6.1.dev146+g1619462fb0
X-API-Query-Count: 20
X-API-Query-Time: 0.115s
X-API-Time: 0.624s
```