### PR TITLE
Additional CI and Make flow changes for the collection testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           DEV_DOCKER_TAG_BASE=ghcr.io/${{ github.repository_owner }} COMPOSE_TAG=${{ env.BRANCH }} make docker-compose-build
 
-      - name: ${{ matrix.texts.label }}
+      - name: ${{ matrix.tests.label }}
         run: |
           docker run -u $(id -u) --rm -v ${{ github.workspace}}:/awx_devel/:Z \
             --workdir=/awx_devel ghcr.io/${{ github.repository_owner }}/awx_devel:${{ env.BRANCH }} ${{ matrix.tests.command }}


### PR DESCRIPTION
##### SUMMARY
Some followup from comments when adding the sanity test check for the awx.awx collection. Has a type found by @relrod 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
There was pretty good agreement that `make awx_collection_build` shouldn't be skipped if the folder already exists, so adding to .PHONY here. I got bit by that a few times myself.
