### PR TITLE
fix receptor_dependencies to install on RHEL9

### DIFF
--- a/awx/api/templates/instance_install_bundle/group_vars/all.yml
+++ b/awx/api/templates/instance_install_bundle/group_vars/all.yml
@@ -1,3 +1,4 @@
+---
 receptor_user: awx
 receptor_group: awx
 receptor_verify: true
@@ -15,9 +16,11 @@ custom_ca_certfile: receptor/tls/ca/receptor-ca.crt
 receptor_protocol: 'tcp'
 receptor_listener: true
 receptor_port: {{ instance.listener_port }}
-receptor_dependencies:
-  - python39-pip
 {% verbatim %}
+receptor_dependencies:
+  - >
+    {{ ansible_distribution_major_version is version(9, '<')
+      | ternary('python39-pip', 'python3-pip') }}
 podman_user: "{{ receptor_user }}"
 podman_group: "{{ receptor_group }}"
 {% endverbatim %}


### PR DESCRIPTION
related #13287

Signed-off-by: Shihou Ono <shi_ono@ap-com.co.jp>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This change solves an issue where running install_receptor.yml fails for RHEL9 and clone machines.

fix #13287

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.7
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

I have tested this PR on Rocky8, Rocky9, Fedora28, Fedora34.

install_receptor.yml

```yaml
# {% verbatim %}
---
- hosts: all
  become: yes
  tasks:
    - name: Create the receptor user
      user:
        name: "{{ receptor_user }}"
        shell: /bin/bash
    - name: Enable Copr repo for Receptor
      command: dnf copr enable ansible-awx/receptor -y
    - import_role:
        name: ansible.receptor.podman
    - import_role:
        name: ansible.receptor.setup
    - name: Install ansible-runner
      pip:
        name: ansible-runner
        executable: pip3.9
# {% endverbatim %}
```

all.yml
```yaml
---
receptor_user: awx
receptor_group: awx
receptor_verify: true
receptor_tls: true
receptor_work_commands:
  ansible-runner:
    command: ansible-runner
    params: worker
    allowruntimeparams: true
    verifysignature: true
custom_worksign_public_keyfile: receptor/work-public-key.pem
custom_tls_certfile: receptor/tls/receptor.crt
custom_tls_keyfile: receptor/tls/receptor.key
custom_ca_certfile: receptor/tls/ca/receptor-ca.crt
receptor_protocol: 'tcp'
receptor_listener: true
receptor_port: 27199
# {% verbatim %}
receptor_dependencies:   # <= changed
  - >
    {{ ansible_distribution_major_version is version(9, '<')
      | ternary('python39-pip', 'python3-pip') }}
podman_user: "{{ receptor_user }}"
podman_group: "{{ receptor_group }}"
# {% endverbatim %}

```

inventory
```yaml
---
all:
  hosts:
    remote-execution:
      ansible_host: x.x.x.x
      ansible_user: test # user provided
      ansible_ssh_pass: ********
      ansible_become_pass: ********

```

logs

rocky9 (Although it ended with an error, the task "Install dependencies specific to the node type" related to this fix was passed)
```
$ ansible-playbook -i inventory.yml install_receptor.yml -v
Using /home/shihou_ono/awx/awx/api/templates/instance_install_bundle/ansible.cfg as config file

PLAY [all] ******************************************************************************

TASK [Gathering Facts] ******************************************************************
ok: [remote-execution]

TASK [Create the receptor user] *********************************************************
ok: [remote-execution] => {"append": false, "changed": false, "comment": "", "group": 1001, "home": "/home/awx", "move_home": false, "name": "awx", "shell": "/bin/bash", "state": "present", "uid": 1001}

TASK [Enable Copr repo for Receptor] ****************************************************
changed: [remote-execution] => {"changed": true, "cmd": ["dnf", "copr", "enable", "ansible-awx/receptor", "-y"], "delta": "0:00:00.826193", "end": "2022-12-21 08:32:52.290529", "msg": "", "rc": 0, "start": "2022-12-21 08:32:51.464336", "stderr": "Enabling a Copr repository. Please note that this repository is not part\nof the main distribution, and quality may vary.\n\nThe Fedora Project does not exercise any power over the contents of\nthis repository beyond the rules outlined in the Copr FAQ at\n<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,\nand packages are not held to any quality or security level.\n\nPlease do not file bug reports about these packages in Fedora\nBugzilla. In case of problems, contact the owner of this repository.", "stderr_lines": ["Enabling a Copr repository. Please note that this repository is not part", "of the main distribution, and quality may vary.", "", "The Fedora Project does not exercise any power over the contents of", "this repository beyond the rules outlined in the Copr FAQ at", "<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,", "and packages are not held to any quality or security level.", "", "Please do not file bug reports about these packages in Fedora", "Bugzilla. In case of problems, contact the owner of this repository."], "stdout": "Repository successfully enabled.", "stdout_lines": ["Repository successfully enabled."]}

TASK [ansible.receptor.podman : include_tasks] ******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/podman/tasks/variables.yml for remote-execution

TASK [ansible.receptor.podman : Include OS-specific variables (RedHat)] *****************
ok: [remote-execution] => {"ansible_facts": {"__podman_packages": ["podman", "crun"]}, "ansible_included_var_files": ["/home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/podman/vars/RedHat.yml"], "changed": false}

TASK [ansible.receptor.podman : Define podman_packages] *********************************
ok: [remote-execution] => {"ansible_facts": {"podman_packages": ["podman", "crun"]}, "changed": false}

TASK [ansible.receptor.podman : include_tasks] ******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/podman/tasks/setup-RedHat.yml for remote-execution

TASK [ansible.receptor.podman : Install podman packages] ********************************
ok: [remote-execution] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": []}

TASK [ansible.receptor.podman : Create directory for podman runtime config] *************
changed: [remote-execution] => {"changed": true, "gid": 1001, "group": "awx", "mode": "0700", "owner": "awx", "path": "/home/awx/.config/containers", "size": 4096, "state": "directory", "uid": 1001}

TASK [ansible.receptor.podman : Configure podman default runtime] ***********************
changed: [remote-execution] => {"changed": true, "checksum": "2fee71581081ffcbcc68d2deb2309d5f6635d565", "dest": "/home/awx/.config/containers/containers.conf", "gid": 1001, "group": "awx", "mode": "0600", "owner": "awx", "path": "/home/awx/.config/containers/containers.conf", "size": 54, "state": "file", "uid": 1001}

TASK [ansible.receptor.podman : Create empty mounts config file to avoid permissions error message] ***
ok: [remote-execution] => {"changed": false, "dest": "/home/awx/.config/containers/mounts.conf", "src": "/home/shihou_ono/.ansible/tmp/ansible-local-104960m5mr201w/tmplb_6qrbn"}

TASK [ansible.receptor.podman : Ensure registries.conf.d exists] ************************
changed: [remote-execution] => {"changed": true, "gid": 0, "group": "root", "mode": "0755", "owner": "root", "path": "/etc/containers/registries.conf.d/", "size": 4096, "state": "directory", "uid": 0}

TASK [ansible.receptor.podman : Force fully qualified image names to be provided to podman pull] ***
changed: [remote-execution] => {"changed": true, "checksum": "89306ecf2b88c93284116b1d6ccf1f33d27c4357", "dest": "/etc/containers/registries.conf.d/force-fully-qualified-images.conf", "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "/etc/containers/registries.conf.d/force-fully-qualified-images.conf", "size": 35, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/variables.yml for remote-execution

TASK [ansible.receptor.setup : Include OS-specific variables (RedHat)] ******************
ok: [remote-execution] => {"ansible_facts": {"__receptor_packages": ["receptor"]}, "ansible_included_var_files": ["/home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/vars/RedHat.yml"], "changed": false}

TASK [ansible.receptor.setup : Define receptor_packages] ********************************
ok: [remote-execution] => {"ansible_facts": {"receptor_packages": ["receptor"]}, "changed": false}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/setup-RedHat.yml for remote-execution

TASK [ansible.receptor.setup : Install receptor packages] *******************************
ok: [remote-execution] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": []}

TASK [ansible.receptor.setup : Install dependencies specific to the node type] **********  # <= this
changed: [remote-execution] => {"changed": true, "msg": "", "rc": 0, "results": ["Installed: python3-pip-21.2.3-6.el9.noarch", "Installed: python3-setuptools-53.0.0-10.el9.noarch"]}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/configure.yml for remote-execution

TASK [ansible.receptor.setup : Ensure soft/hard file descriptors limits] ****************
ok: [remote-execution] => {"changed": false, "checksum": "f0ad8e83287c1fa707dd9cac8142addb2bfa41ec", "dest": "/etc/security/limits.d/receptor.conf", "gid": 0, "group": "root", "mode": "0600", "owner": "root", "path": "/etc/security/limits.d/receptor.conf", "size": 60, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : Ensure systemd override directory exists] ****************
ok: [remote-execution] => {"changed": false, "gid": 0, "group": "root", "mode": "0755", "owner": "root", "path": "/etc/systemd/system/receptor.service.d", "size": 4096, "state": "directory", "uid": 0}

TASK [ansible.receptor.setup : Override receptor's systemd service runuser] *************
ok: [remote-execution] => {"changed": false, "checksum": "1a998bc47f28463410e198710d6cd9ee6e3a12d5", "dest": "/etc/systemd/system/receptor.service.d/override.conf", "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "/etc/systemd/system/receptor.service.d/override.conf", "size": 29, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : Configure the receptor socket directory] *****************
ok: [remote-execution] => {"changed": false, "gid": 1001, "group": "awx", "mode": "0750", "owner": "awx", "path": "/var/run/receptor", "size": 4096, "state": "directory", "uid": 1001}

TASK [ansible.receptor.setup : Create tmpfiles.d entry for receptor socket directory] ***
ok: [remote-execution] => {"changed": false, "checksum": "9d47f12d0338f74e8c8899dc6aad09255b605a84", "dest": "/etc/tmpfiles.d/receptor.conf", "gid": 0, "group": "root", "mode": "0640", "owner": "root", "path": "/etc/tmpfiles.d/receptor.conf", "size": 35, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/tls.yml for remote-execution

TASK [ansible.receptor.setup : Create Receptor cert directories] ************************
ok: [remote-execution] => (item=/etc/receptor/tls) => {"ansible_loop_var": "item", "changed": false, "gid": 1001, "group": "awx", "item": "/etc/receptor/tls", "mode": "0750", "owner": "awx", "path": "/etc/receptor/tls", "size": 4096, "state": "directory", "uid": 1001}
ok: [remote-execution] => (item=/etc/receptor/tls/ca) => {"ansible_loop_var": "item", "changed": false, "gid": 1001, "group": "awx", "item": "/etc/receptor/tls/ca", "mode": "0750", "owner": "awx", "path": "/etc/receptor/tls/ca", "size": 4096, "state": "directory", "uid": 1001}

TASK [ansible.receptor.setup : Process provided TLS files] ******************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/tls_local.yml for remote-execution

TASK [ansible.receptor.setup : Ensure both TLS files are provided] **********************
ok: [remote-execution] => {"changed": false, "msg": "All assertions passed"}

TASK [ansible.receptor.setup : Ensure CA certfile is provided] **************************
ok: [remote-execution] => {"changed": false, "msg": "All assertions passed"}

TASK [ansible.receptor.setup : Check TLS private key modulus] ***************************
fatal: [remote-execution -> localhost]: FAILED! => {"changed": false, "cmd": ["openssl", "rsa", "-modulus", "-noout", "-in", "receptor/tls/receptor.key"], "delta": "0:00:00.003790", "end": "2022-12-21 17:33:03.913644", "msg": "non-zero return code", "rc": 1, "start": "2022-12-21 17:33:03.909854", "stderr": "Could not open file or uri for loading private key from receptor/tls/receptor.key\n4057B157A07F0000:error:16000069:STORE routines:ossl_store_get0_loader_int:unregistered scheme:../crypto/store/store_register.c:237:scheme=file\n4057B157A07F0000:error:80000002:system library:file_open:No such file or directory:../providers/implementations/storemgmt/file_store.c:267:calling stat(receptor/tls/receptor.key)", "stderr_lines": ["Could not open file or uri for loading private key from receptor/tls/receptor.key", "4057B157A07F0000:error:16000069:STORE routines:ossl_store_get0_loader_int:unregistered scheme:../crypto/store/store_register.c:237:scheme=file", "4057B157A07F0000:error:80000002:system library:file_open:No such file or directory:../providers/implementations/storemgmt/file_store.c:267:calling stat(receptor/tls/receptor.key)"], "stdout": "", "stdout_lines": []}

PLAY RECAP ******************************************************************************
remote-execution           : ok=30   changed=6    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

```

rocky8 (Although it ended with an error, the task "Install dependencies specific to the node type" related to this fix was passed)

```
$ ansible-playbook -i inventory.yml install_receptor.yml -v
Using /home/shihou_ono/awx/awx/api/templates/instance_install_bundle/ansible.cfg as config file

PLAY [all] ******************************************************************************

TASK [Gathering Facts] ******************************************************************
ok: [remote-execution]

TASK [Create the receptor user] *********************************************************
ok: [remote-execution] => {"append": false, "changed": false, "comment": "", "group": 1001, "home": "/home/awx", "move_home": false, "name": "awx", "shell": "/bin/bash", "state": "present", "uid": 1001}

TASK [Enable Copr repo for Receptor] ****************************************************
changed: [remote-execution] => {"changed": true, "cmd": ["dnf", "copr", "enable", "ansible-awx/receptor", "-y"], "delta": "0:00:01.555510", "end": "2022-12-22 00:17:11.980028", "msg": "", "rc": 0, "start": "2022-12-22 00:17:10.424518", "stderr": "Enabling a Copr repository. Please note that this repository is not part\nof the main distribution, and quality may vary.\n\nThe Fedora Project does not exercise any power over the contents of\nthis repository beyond the rules outlined in the Copr FAQ at\n<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,\nand packages are not held to any quality or security level.\n\nPlease do not file bug reports about these packages in Fedora\nBugzilla. In case of problems, contact the owner of this repository.", "stderr_lines": ["Enabling a Copr repository. Please note that this repository is not part", "of the main distribution, and quality may vary.", "", "The Fedora Project does not exercise any power over the contents of", "this repository beyond the rules outlined in the Copr FAQ at", "<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,", "and packages are not held to any quality or security level.", "", "Please do not file bug reports about these packages in Fedora", "Bugzilla. In case of problems, contact the owner of this repository."], "stdout": "Repository successfully enabled.", "stdout_lines": ["Repository successfully enabled."]}

TASK [ansible.receptor.podman : include_tasks] ******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/podman/tasks/variables.yml for remote-execution

TASK [ansible.receptor.podman : Include OS-specific variables (RedHat)] *****************
ok: [remote-execution] => {"ansible_facts": {"__podman_packages": ["podman", "crun"]}, "ansible_included_var_files": ["/home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/podman/vars/RedHat.yml"], "changed": false}

TASK [ansible.receptor.podman : Define podman_packages] *********************************
ok: [remote-execution] => {"ansible_facts": {"podman_packages": ["podman", "crun"]}, "changed": false}

TASK [ansible.receptor.podman : include_tasks] ******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/podman/tasks/setup-RedHat.yml for remote-execution

TASK [ansible.receptor.podman : Install podman packages] ********************************
ok: [remote-execution] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": []}

TASK [ansible.receptor.podman : Create directory for podman runtime config] *************
changed: [remote-execution] => {"changed": true, "gid": 1001, "group": "awx", "mode": "0700", "owner": "awx", "path": "/home/awx/.config/containers", "size": 4096, "state": "directory", "uid": 1001}

TASK [ansible.receptor.podman : Configure podman default runtime] ***********************
changed: [remote-execution] => {"changed": true, "checksum": "2fee71581081ffcbcc68d2deb2309d5f6635d565", "dest": "/home/awx/.config/containers/containers.conf", "gid": 1001, "group": "awx", "mode": "0600", "owner": "awx", "path": "/home/awx/.config/containers/containers.conf", "size": 54, "state": "file", "uid": 1001}

TASK [ansible.receptor.podman : Create empty mounts config file to avoid permissions error message] ***
ok: [remote-execution] => {"changed": false, "dest": "/home/awx/.config/containers/mounts.conf", "src": "/home/shihou_ono/.ansible/tmp/ansible-local-112501nghbbhuw/tmpymehrh6i"}

TASK [ansible.receptor.podman : Ensure registries.conf.d exists] ************************
changed: [remote-execution] => {"changed": true, "gid": 0, "group": "root", "mode": "0755", "owner": "root", "path": "/etc/containers/registries.conf.d/", "size": 4096, "state": "directory", "uid": 0}

TASK [ansible.receptor.podman : Force fully qualified image names to be provided to podman pull] ***
changed: [remote-execution] => {"changed": true, "checksum": "89306ecf2b88c93284116b1d6ccf1f33d27c4357", "dest": "/etc/containers/registries.conf.d/force-fully-qualified-images.conf", "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "/etc/containers/registries.conf.d/force-fully-qualified-images.conf", "size": 35, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/variables.yml for remote-execution

TASK [ansible.receptor.setup : Include OS-specific variables (RedHat)] ******************
ok: [remote-execution] => {"ansible_facts": {"__receptor_packages": ["receptor"]}, "ansible_included_var_files": ["/home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/vars/RedHat.yml"], "changed": false}

TASK [ansible.receptor.setup : Define receptor_packages] ********************************
ok: [remote-execution] => {"ansible_facts": {"receptor_packages": ["receptor"]}, "changed": false}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/setup-RedHat.yml for remote-execution

TASK [ansible.receptor.setup : Install receptor packages] *******************************
ok: [remote-execution] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": []}

TASK [ansible.receptor.setup : Install dependencies specific to the node type] **********
changed: [remote-execution] => {"changed": true, "msg": "", "rc": 0, "results": ["Installed: python39-libs-3.9.13-2.module+el8.7.0+1092+55aa9635.x86_64", "Installed: python39-pip-20.2.4-7.module+el8.7.0+1064+ad564229.noarch", "Installed: python39-pip-wheel-20.2.4-7.module+el8.7.0+1064+ad564229.noarch", "Installed: python39-setuptools-50.3.2-4.module+el8.5.0+673+10283621.noarch", "Installed: python39-3.9.13-2.module+el8.7.0+1092+55aa9635.x86_64", "Installed: python39-setuptools-wheel-50.3.2-4.module+el8.5.0+673+10283621.noarch"]}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/configure.yml for remote-execution

TASK [ansible.receptor.setup : Ensure soft/hard file descriptors limits] ****************
ok: [remote-execution] => {"changed": false, "checksum": "f0ad8e83287c1fa707dd9cac8142addb2bfa41ec", "dest": "/etc/security/limits.d/receptor.conf", "gid": 0, "group": "root", "mode": "0600", "owner": "root", "path": "/etc/security/limits.d/receptor.conf", "size": 60, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : Ensure systemd override directory exists] ****************
ok: [remote-execution] => {"changed": false, "gid": 0, "group": "root", "mode": "0755", "owner": "root", "path": "/etc/systemd/system/receptor.service.d", "size": 4096, "state": "directory", "uid": 0}

TASK [ansible.receptor.setup : Override receptor's systemd service runuser] *************
ok: [remote-execution] => {"changed": false, "checksum": "1a998bc47f28463410e198710d6cd9ee6e3a12d5", "dest": "/etc/systemd/system/receptor.service.d/override.conf", "gid": 0, "group": "root", "mode": "0644", "owner": "root", "path": "/etc/systemd/system/receptor.service.d/override.conf", "size": 29, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : Configure the receptor socket directory] *****************
ok: [remote-execution] => {"changed": false, "gid": 1001, "group": "awx", "mode": "0750", "owner": "awx", "path": "/var/run/receptor", "size": 4096, "state": "directory", "uid": 1001}

TASK [ansible.receptor.setup : Create tmpfiles.d entry for receptor socket directory] ***
ok: [remote-execution] => {"changed": false, "checksum": "9d47f12d0338f74e8c8899dc6aad09255b605a84", "dest": "/etc/tmpfiles.d/receptor.conf", "gid": 0, "group": "root", "mode": "0640", "owner": "root", "path": "/etc/tmpfiles.d/receptor.conf", "size": 35, "state": "file", "uid": 0}

TASK [ansible.receptor.setup : include_tasks] *******************************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/tls.yml for remote-execution

TASK [ansible.receptor.setup : Create Receptor cert directories] ************************
ok: [remote-execution] => (item=/etc/receptor/tls) => {"ansible_loop_var": "item", "changed": false, "gid": 1001, "group": "awx", "item": "/etc/receptor/tls", "mode": "0750", "owner": "awx", "path": "/etc/receptor/tls", "size": 4096, "state": "directory", "uid": 1001}
ok: [remote-execution] => (item=/etc/receptor/tls/ca) => {"ansible_loop_var": "item", "changed": false, "gid": 1001, "group": "awx", "item": "/etc/receptor/tls/ca", "mode": "0750", "owner": "awx", "path": "/etc/receptor/tls/ca", "size": 4096, "state": "directory", "uid": 1001}

TASK [ansible.receptor.setup : Process provided TLS files] ******************************
included: /home/shihou_ono/.ansible/collections/ansible_collections/ansible/receptor/roles/setup/tasks/tls_local.yml for remote-execution

TASK [ansible.receptor.setup : Ensure both TLS files are provided] **********************
ok: [remote-execution] => {"changed": false, "msg": "All assertions passed"}

TASK [ansible.receptor.setup : Ensure CA certfile is provided] **************************
ok: [remote-execution] => {"changed": false, "msg": "All assertions passed"}

TASK [ansible.receptor.setup : Check TLS private key modulus] ***************************
fatal: [remote-execution -> localhost]: FAILED! => {"changed": false, "cmd": ["openssl", "rsa", "-modulus", "-noout", "-in", "receptor/tls/receptor.key"], "delta": "0:00:00.007101", "end": "2022-12-22 09:17:26.119815", "msg": "non-zero return code", "rc": 1, "start": "2022-12-22 09:17:26.112714", "stderr": "Could not open file or uri for loading private key from receptor/tls/receptor.key\n404732906E7F0000:error:16000069:STORE routines:ossl_store_get0_loader_int:unregistered scheme:../crypto/store/store_register.c:237:scheme=file\n404732906E7F0000:error:80000002:system library:file_open:No such file or directory:../providers/implementations/storemgmt/file_store.c:267:calling stat(receptor/tls/receptor.key)", "stderr_lines": ["Could not open file or uri for loading private key from receptor/tls/receptor.key", "404732906E7F0000:error:16000069:STORE routines:ossl_store_get0_loader_int:unregistered scheme:../crypto/store/store_register.c:237:scheme=file", "404732906E7F0000:error:80000002:system library:file_open:No such file or directory:../providers/implementations/storemgmt/file_store.c:267:calling stat(receptor/tls/receptor.key)"], "stdout": "", "stdout_lines": []}

PLAY RECAP ******************************************************************************
remote-execution           : ok=30   changed=6    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

```

I also tried on Fedora28 and 34 but it ended with an error before the task related to this fix.

```
$ ansible-playbook -i inventory.yml install_receptor.yml -v
Using /home/shihou_ono/awx/awx/api/templates/instance_install_bundle/ansible.cfg as config file

PLAY [all] ******************************************************************************

TASK [Gathering Facts] ******************************************************************
ok: [remote-execution]

TASK [Create the receptor user] *********************************************************
ok: [remote-execution] => {"append": false, "changed": false, "comment": "", "group": 1001, "home": "/home/awx", "move_home": false, "name": "awx", "shell": "/bin/bash", "state": "present", "uid": 1001}

TASK [Enable Copr repo for Receptor] ****************************************************
fatal: [remote-execution]: FAILED! => {"changed": true, "cmd": ["dnf", "copr", "enable", "ansible-awx/receptor", "-y"], "delta": "0:00:01.718808", "end": "2022-12-22 00:21:55.161384", "msg": "non-zero return code", "rc": 1, "start": "2022-12-22 00:21:53.442576", "stderr": "Error: This repository does not have any builds yet so you cannot enable it now.", "stderr_lines": ["Error: This repository does not have any builds yet so you cannot enable it now."], "stdout": "", "stdout_lines": []}

PLAY RECAP ******************************************************************************
remote-execution           : ok=2    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
```

So, I checked with the following playbook.
```yaml
---
- hosts: all
  gather_facts: true
  become: true

  tasks:
    - name: "debug distribution and version"
      ansible.builtin.debug:
        msg: "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}"

    - name: "debug"
      ansible.builtin.debug:
        msg: "{{ ansible_distribution_major_version is version(9, '<') }}"

    - name: "install pip"
      ansible.builtin.dnf:
        name: "{{ receptor_dependencies | default([]) }}"
        state: present

```

and logs here

Fedora28

```
$ ansible-playbook -i inventory.yml install_pip_test.yaml -v
Using /home/shihou_ono/awx/awx/api/templates/instance_install_bundle/ansible.cfg as config file

PLAY [all] *********************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************
ok: [remote-execution]

TASK [debug distribution and version] ******************************************************************************
ok: [remote-execution] => {
    "msg": "Fedora_28"
}

TASK [debug] *******************************************************************************************************
ok: [remote-execution] => {
    "msg": false
}

TASK [install pip] *************************************************************************************************
ok: [remote-execution] => {"changed": false, "msg": "Nothing to do", "rc": 0, "results": []}

PLAY RECAP *********************************************************************************************************
remote-execution           : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

And, checked the existance of pip in a container using very raw image

```
$ docker run -it --rm fedora:28
[root@71e017ba2f4e /]# dnf list --installed | grep pip
python3-pip.noarch                 9.0.3-2.fc28                 @koji-override-0
```

Fedora34

```
$ ansible-playbook -i inventory.yml install_pip_test.yaml -v
Using /home/shihou_ono/awx/awx/api/templates/instance_install_bundle/ansible.cfg as config file

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [remote-execution]

TASK [debug distribution and version] ******************************************
ok: [remote-execution] => {
    "msg": "Fedora_34"
}

TASK [debug] *******************************************************************
ok: [remote-execution] => {
    "msg": false
}

TASK [install pip] *************************************************************
changed: [remote-execution] => {"changed": true, "msg": "", "rc": 0, "results": ["Installed: python3-setuptools-53.0.0-3.fc34.noarch", "Installed: libxcrypt-compat-4.4.28-1.fc34.x86_64", "Installed: python3-pip-21.0.1-4.fc34.noarch"]}

PLAY RECAP *********************************************************************
remote-execution           : ok=4    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```