### PR TITLE
Consolidate Makefile flow for building and testing collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Get tags so version is correctly built
+        run: git fetch --tags origin
+
       # The containers that GitHub Actions use have Ansible installed, so upgrade to make sure we have the latest version.
       - name: Upgrade ansible-core
         run: python3 -m pip install --upgrade ansible-core

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ I18N_FLAG_FILE = .i18n_built
 .PHONY: awx-link clean clean-tmp clean-venv requirements requirements_dev \
 	develop refresh adduser migrate dbchange \
 	receiver test test_unit test_coverage coverage_html \
+	awx_collection_build \
 	sdist \
 	ui-release ui-devel \
 	VERSION PYTHON_VERSION docker-compose-sources \
@@ -323,7 +324,7 @@ symlink_collection:
 	mkdir -p ~/.ansible/collections/ansible_collections/$(COLLECTION_NAMESPACE)  # in case it does not exist
 	ln -s $(shell pwd)/awx_collection $(COLLECTION_INSTALL)
 
-awx_collection_build: $(shell find awx_collection -type f)
+awx_collection_build:
 	ansible-playbook -i localhost, awx_collection/tools/template_galaxy.yml \
 	  -e collection_package=$(COLLECTION_PACKAGE) \
 	  -e collection_namespace=$(COLLECTION_NAMESPACE) \
@@ -331,18 +332,16 @@ awx_collection_build: $(shell find awx_collection -type f)
 	  -e '{"awx_template_version": $(COLLECTION_TEMPLATE_VERSION)}'
 	ansible-galaxy collection build awx_collection_build --force --output-path=awx_collection_build
 
-build_collection: awx_collection_build
+build_collection: awx_collection_build  # deprecated, may be removed in the future
 
-install_collection: build_collection
+install_collection: awx_collection_build
 	rm -rf $(COLLECTION_INSTALL)
 	ansible-galaxy collection install awx_collection_build/$(COLLECTION_NAMESPACE)-$(COLLECTION_PACKAGE)-$(COLLECTION_VERSION).tar.gz
 
-test_collection_sanity:
-	rm -rf awx_collection_build/
-	rm -rf $(COLLECTION_INSTALL)
+test_collection_sanity: install_collection
 	if ! [ -x "$(shell command -v ansible-test)" ]; then pip install ansible-core; fi
 	ansible --version
-	COLLECTION_VERSION=1.0.0 make install_collection
+	echo $(COLLECTION_VERSION)  # version of collection for debugging, needs to be semver compliant
 	cd $(COLLECTION_INSTALL) && ansible-test sanity $(COLLECTION_SANITY_ARGS)
 
 test_collection_integration: install_collection


### PR DESCRIPTION
##### SUMMARY
This is very minor followup cleanup after https://github.com/ansible/awx/pull/13361 and others.

Changes it so that `make awx_collection_build` will _always_ re-build, and then there are some cascading changes in other targets in response to that. If you use the target to install or build the collection, then it is assumed that those targets properly clean their target directories.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection



##### ADDITIONAL INFORMATION
The CI should clear up whether we have the right version number. Out of fear of breaking passing tests I didn't remove our hacks earlier. I hope this version makes more sense... and still runs.
