### PR TITLE
Pin hiredis to 2.0.0

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -157,6 +157,15 @@ For now, we pin to the old version, 3.4.1
 * https://github.com/django/channels_redis/issues/332
 * https://github.com/ansible/awx/issues/13313
 
+### hiredis
+
+The hiredis 2.1.0 release doesn't provide source distribution on PyPI which prevents users to build that python package from the
+sources.
+Downgrading to 2.0.0 (which provides source distribution) until the channels-redis issue is fixed or a newer hiredis version is
+available on PyPi with source distribution.
+
+* https://github.com/redis/hiredis-py/issues/138
+
 ## Library Notes
 
 ### pexpect

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -26,6 +26,7 @@ djangorestframework==3.13.1
 djangorestframework-yaml
 filelock
 GitPython
+hiredis==2.0.0  # see UPGRADE BLOCKERs
 irc
 jinja2
 JSON-log-formatter

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -158,8 +158,10 @@ gitpython==3.1.29
     # via -r /awx_devel/requirements/requirements.in
 google-auth==2.14.1
     # via kubernetes
-hiredis==2.1.0
-    # via aioredis
+hiredis==2.0.0
+    # via
+    #   -r /awx_devel/requirements/requirements.in
+    #   aioredis
 hyperlink==21.0.0
     # via
     #   autobahn


### PR DESCRIPTION
The hiredis 2.1.0 release doesn't provide source distribution on PyPi so users can't build that python package from sources.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other
