### PR TITLE
[wip] Bulk host add

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -110,6 +110,7 @@ from awx.main.utils import (
     prefetch_page_capabilities,
     get_external_account,
     truncate_stdout,
+    get_licenser,
 )
 from awx.main.utils.filters import SmartFilter
 from awx.main.utils.named_url_graph import reset_counters
@@ -1879,7 +1880,7 @@ class HostSerializer(BaseSerializerWithVariables):
             vars_dict = parse_yaml_or_json(variables)
             vars_dict['ansible_ssh_port'] = port
             attrs['variables'] = json.dumps(vars_dict)
-        if Group.objects.filter(name=name, inventory=inventory).exists():
+        if inventory and Group.objects.filter(name=name, inventory=inventory).exists():
             raise serializers.ValidationError(_('A Group with that name already exists.'))
 
         return super(HostSerializer, self).validate(attrs)
@@ -1969,6 +1970,107 @@ class GroupSerializer(BaseSerializerWithVariables):
         if obj is not None and 'inventory' in ret and not obj.inventory:
             ret['inventory'] = None
         return ret
+
+
+class BulkHostSerializer(HostSerializer):
+    name = serializers.CharField(required=True, allow_blank=False, max_length=512)
+    instance_id = serializers.CharField(required=False, max_length=1024)
+    description = serializers.CharField(required=False)
+    enabled = serializers.BooleanField(default=True, required=False)
+    variables = serializers.CharField(allow_blank=True, required=False)
+
+    class Meta:
+        fields = (
+            'name',
+            'enabled',
+            'instance_id',
+            'description',
+            'variables',
+        )
+
+
+class BulkHostCreateSerializer(serializers.Serializer):
+    inventory = serializers.PrimaryKeyRelatedField(
+        queryset=Inventory.objects.all(), required=True, write_only=True, help_text=_('Primary Key ID of inventory to add hosts to.')
+    )
+    hosts = serializers.ListField(child=BulkHostSerializer(), allow_empty=False, max_length=1000, write_only=True, help_text=_('Hosts to be created.'))
+
+    class Meta:
+        fields = ('inventory', 'hosts')
+        read_only_fields = ()
+
+    def raise_if_cannot_add_hosts(self, attrs):
+        validation_info = get_licenser().validate()
+
+        org = attrs['inventory'].organization
+
+        if org:
+            org_active_count = Host.objects.org_active_count(org.id)
+            new_hosts = [h['name'] for h in attrs['hosts']]
+            org_net_new_host_count = Host.objects.filter(inventory__organization=org.id).exclude(name__in=new_hosts).count()
+            if org.max_hosts > 0 and org_active_count + org_net_new_host_count > org.max_hosts:
+                raise PermissionDenied(
+                    _(
+                        "You have already reached the maximum number of %s hosts"
+                        " allowed for your organization. Contact your System Administrator"
+                        " for assistance." % org.max_hosts
+                    )
+                )
+
+            # Don't check license if it is open license
+        if validation_info.get('license_type', 'UNLICENSED') == 'open':
+            return True
+
+        sys_free_instances = validation_info.get('free_instances', 0)
+        system_net_new_host_count = Host.objects.exclude(name__in=new_hosts).count()
+
+        if system_net_new_host_count > sys_free_instances:
+            hard_error = validation_info.get('trial', False) is True or validation_info['instance_count'] == 10
+            if hard_error:
+                # Only raise permission error for trial, otherwise just log a warning as we do in other inventory import situations
+                raise PermissionDenied(_("Host count exceeds available instances."))
+            logger.warning(_("Number of hosts allowed by license has been exceeded."))
+
+        return True
+
+    def validate(self, attrs):
+        request = self.context.get('request', None)
+        inv = attrs['inventory']
+        if request and not request.user.is_superuser:
+            if inv.organization:
+                org_admin_orgs = {tup[0] for tup in Organization.accessible_pk_qs(request.user, 'admin_role')}
+                inv_admin_orgs = {tup[0] for tup in Organization.accessible_pk_qs(request.user, 'inventory_admin_role')}
+                is_org_admin = inv.organization.id in org_admin_orgs
+                is_org_inv_admin = inv.organization.id in inv_admin_orgs
+            else:
+                is_org_admin = False
+                is_org_inv_admin = False
+            # This may not work, need to figure out what the role is called
+            is_inventory_admin = Inventory.accessible_pk_qs(request.user, 'inventory_admin_role').filter(id=inv.id).exists()
+            if not any([is_inventory_admin, is_org_admin, is_org_inv_admin]):
+                raise serializers.ValidationError(_(f'Inventory with id {inv.id} not found or lack permissions to add hosts.'))
+        current_hostnames = {h[0] for h in Host.objects.filter(inventory=inv).values_list('name').all()}
+        new_names = [host['name'] for host in attrs['hosts']]
+        duplicate_new_names = [n for n in new_names if n in current_hostnames or new_names.count(n) > 1]
+        if duplicate_new_names:
+            raise serializers.ValidationError(_(f'Hostnames must be unique in an inventory. Duplicates found: {duplicate_new_names}'))
+
+        self.raise_if_cannot_add_hosts(attrs)
+
+        _now = now()
+        for host in attrs['hosts']:
+            host['created'] = _now
+            host['modified'] = _now
+            host['inventory'] = inv
+        return attrs
+
+    def create(self, validated_data):
+        result = [Host(**attrs) for attrs in validated_data['hosts']]
+        try:
+            Host.objects.bulk_create(result)
+        except Exception as e:
+            raise serializers.ValidationError({"detail": _(f"{e}")})
+        return {"created": len(result), "url": InventorySerializer().get_related(validated_data['inventory'])['hosts']}
 
 
 class GroupTreeSerializer(GroupSerializer):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2046,7 +2046,7 @@ class BulkHostCreateSerializer(serializers.Serializer):
                 is_org_admin = False
                 is_org_inv_admin = False
             # This may not work, need to figure out what the role is called
-            is_inventory_admin = Inventory.accessible_pk_qs(request.user, 'inventory_admin_role').filter(id=inv.id).exists()
+            is_inventory_admin = inv.admin_role.members.filter(id=request.user.id).exists()
             if not any([is_inventory_admin, is_org_admin, is_org_inv_admin]):
                 raise serializers.ValidationError(_(f'Inventory with id {inv.id} not found or lack permissions to add hosts.'))
         current_hostnames = {h[0] for h in Host.objects.filter(inventory=inv).values_list('name').all()}

--- a/awx/api/templates/api/bulk_host_create_view.md
+++ b/awx/api/templates/api/bulk_host_create_view.md
@@ -1,0 +1,16 @@
+# Bulk Host Create
+
+This endpoint allows the client to create multiple hosts and associate them with an inventory. They may do this by providing the inventory ID and a list of json that would normally be provided to create hosts.
+
+Example:
+
+```
+{
+"inventory": 1,
+"hosts": [
+    {"name": "example1.com"},
+    {"name": "example2.com"}
+]
+
+}
+```

--- a/awx/api/templates/api/bulk_view.md
+++ b/awx/api/templates/api/bulk_view.md
@@ -1,0 +1,3 @@
+# Bulk Actions
+
+This endpoint lists available bulk action APIs. 

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -31,6 +31,10 @@ from awx.api.views import (
     ApplicationOAuth2TokenList,
     OAuth2ApplicationDetail,
 )
+from awx.api.views.bulk import (
+    BulkView,
+    BulkHostCreateView,
+)
 from awx.api.views.mesh_visualizer import MeshVisualizer
 
 from awx.api.views.metrics import MetricsView
@@ -136,6 +140,8 @@ v2_urls = [
     re_path(r'^activity_stream/', include(activity_stream_urls)),
     re_path(r'^workflow_approval_templates/', include(workflow_approval_template_urls)),
     re_path(r'^workflow_approvals/', include(workflow_approval_urls)),
+    re_path(r'^bulk/host_create/$', BulkHostCreateView.as_view(), name='bulk_host_create'),
+    re_path(r'^bulk/$', BulkView.as_view(), name='bulk'),
 ]
 
 

--- a/awx/api/views/bulk.py
+++ b/awx/api/views/bulk.py
@@ -1,0 +1,49 @@
+from collections import OrderedDict
+
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import JSONRenderer
+from rest_framework.reverse import reverse
+from rest_framework import status
+from rest_framework.response import Response
+
+from awx.api.generics import (
+    GenericAPIView,
+    APIView,
+)
+from awx.api import (
+    serializers,
+    renderers,
+)
+
+
+class BulkView(APIView):
+    _ignore_model_permissions = True
+    permission_classes = [IsAuthenticated]
+    renderer_classes = [
+        renderers.BrowsableAPIRenderer,
+        JSONRenderer,
+    ]
+    allowed_methods = ['GET', 'OPTIONS']
+
+    def get(self, request, format=None):
+        '''List top level resources'''
+        data = OrderedDict()
+        data['bulk_host_create'] = reverse('api:bulk_host_create', request=request)
+        return Response(data)
+
+
+class BulkHostCreateView(GenericAPIView):
+    _ignore_model_permissions = True
+    permission_classes = [IsAuthenticated]
+    serializer_class = serializers.BulkHostCreateSerializer
+    allowed_methods = ['GET', 'POST', 'OPTIONS']
+
+    def get(self, request):
+        return Response({"detail": "Bulk create hosts with this endpoint"}, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        serializer = serializers.BulkHostCreateSerializer(data=request.data, context={'request': request})
+        if serializer.is_valid():
+            result = serializer.create(serializer.validated_data)
+            return Response(result, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -124,6 +124,7 @@ class ApiVersionRootView(APIView):
         data['workflow_job_template_nodes'] = reverse('api:workflow_job_template_node_list', request=request)
         data['workflow_job_nodes'] = reverse('api:workflow_job_node_list', request=request)
         data['mesh_visualizer'] = reverse('api:mesh_visualizer_view', request=request)
+        data['bulk'] = reverse('api:bulk', request=request)
         return Response(data)
 
 

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -34,13 +34,14 @@ def test_bulk_host_create_num_queries(organization, inventory, post, get, user, 
     inventory_admin = user('inventory_admin', False)
     org_admin = user('org_admin', False)
     org_inv_admin = user('org_admin', False)
+    superuser = user('admin', True)
     for u in [org_admin, org_inv_admin, inventory_admin]:
         organization.member_role.members.add(u)
     organization.admin_role.members.add(org_admin)
     organization.inventory_admin_role.members.add(org_inv_admin)
     inventory.admin_role.members.add(inventory_admin)
 
-    for u in [org_admin, inventory_admin, org_inv_admin]:
+    for u in [org_admin, inventory_admin, org_inv_admin, superuser]:
         hosts = [{'name': uuid4()} for i in range(num_hosts)]
         with withAssertNumQueriesLessThan(num_queries):
             bulk_host_create_response = post(reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': hosts}, u, expect=201).data

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -1,0 +1,85 @@
+import pytest
+
+from uuid import uuid4
+
+from awx.api.versioning import reverse
+
+import json
+from contextlib import contextmanager
+from django.test.utils import CaptureQueriesContext
+from django.db import connections
+
+
+@contextmanager
+def withAssertNumQueriesLessThan(num_queries):
+    with CaptureQueriesContext(connections['default']) as context:
+        yield
+        fail_msg = f"\r\n{json.dumps(context.captured_queries, indent=4)}"
+    assert len(context.captured_queries) < num_queries, fail_msg
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('num_hosts, num_queries', [(9, 15), (99, 20), (999, 25)])
+def test_bulk_host_create_num_queries(organization, inventory, post, get, user, num_hosts, num_queries):
+    '''
+    If I am a...
+      org admin
+      inventory admin at org level
+      admin of a particular inventory
+      superuser
+
+    Bulk Host create should take under a certain number of queries
+    '''
+    inventory.organization = organization
+    inventory_admin = user('inventory_admin', False)
+    org_admin = user('org_admin', False)
+    org_inv_admin = user('org_admin', False)
+    for u in [org_admin, org_inv_admin, inventory_admin]:
+        organization.member_role.members.add(u)
+    organization.admin_role.members.add(org_admin)
+    organization.inventory_admin_role.members.add(org_inv_admin)
+    inventory.admin_role.members.add(inventory_admin)
+
+    for u in [org_admin, inventory_admin, org_inv_admin]:
+        hosts = [{'name': uuid4()} for i in range(num_hosts)]
+        with withAssertNumQueriesLessThan(num_queries):
+            bulk_host_create_response = post(reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': hosts}, u, expect=201).data
+            assert bulk_host_create_response['created'] == len(hosts), f"unexpected number of hosts created for user {u}"
+
+
+@pytest.mark.django_db
+def test_bulk_host_create_rbac(organization, inventory, post, get, user):
+    '''
+    If I am a...
+      org admin
+      inventory admin at org level
+      admin of a particular invenotry
+          ... I can bulk add hosts
+
+    Everyone else cannot
+    '''
+    inventory.organization = organization
+    inventory_admin = user('inventory_admin', False)
+    org_admin = user('org_admin', False)
+    org_inv_admin = user('org_admin', False)
+    auditor = user('auditor', False)
+    member = user('member', False)
+    use_inv_member = user('member', False)
+    for u in [org_admin, org_inv_admin, auditor, member, inventory_admin, use_inv_member]:
+        organization.member_role.members.add(u)
+    organization.admin_role.members.add(org_admin)
+    organization.inventory_admin_role.members.add(org_inv_admin)
+    inventory.admin_role.members.add(inventory_admin)
+    inventory.use_role.members.add(use_inv_member)
+    organization.auditor_role.members.add(auditor)
+
+    for indx, u in enumerate([org_admin, inventory_admin, org_inv_admin]):
+        bulk_host_create_response = post(
+            reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': [{'name': f'foobar-{indx}'}]}, u, expect=201
+        ).data
+        assert bulk_host_create_response['created'] == 1, f"unexpected number of hosts created for user {u}"
+
+    for indx, u in enumerate([member, auditor, use_inv_member]):
+        bulk_host_create_response = post(
+            reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': [{'name': f'foobar2-{indx}'}]}, u, expect=400
+        ).data

--- a/awx/main/tests/functional/test_rbac_inventory.py
+++ b/awx/main/tests/functional/test_rbac_inventory.py
@@ -12,8 +12,6 @@ from awx.main.access import (
     ScheduleAccess,
 )
 
-from awx.api.versioning import reverse
-
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("role", ["admin_role", "inventory_admin_role"])
@@ -101,44 +99,6 @@ def test_host_access(organization, inventory, group, user, group_factory):
     host.save()
 
     assert inventory_admin_access.can_read(host) is False
-
-
-@pytest.mark.django_db
-def test_bulk_host_create_rbac(organization, inventory, post, get, user):
-    '''
-    If I am a...
-      org admin
-      inventory admin at org level
-      admin of a particular invenotry
-          ... I can bulk add hosts
-
-    Everyone else cannot
-    '''
-    inventory.organization = organization
-    inventory_admin = user('inventory_admin', False)
-    org_admin = user('org_admin', False)
-    org_inv_admin = user('org_admin', False)
-    auditor = user('auditor', False)
-    member = user('member', False)
-    use_inv_member = user('member', False)
-    for u in [org_admin, org_inv_admin, auditor, member, inventory_admin, use_inv_member]:
-        organization.member_role.members.add(u)
-    organization.admin_role.members.add(org_admin)
-    organization.inventory_admin_role.members.add(org_inv_admin)
-    inventory.admin_role.members.add(inventory_admin)
-    inventory.use_role.members.add(use_inv_member)
-    organization.auditor_role.members.add(auditor)
-
-    for indx, u in enumerate([org_admin, inventory_admin, org_inv_admin]):
-        bulk_host_create_response = post(
-            reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': [{'name': f'foobar-{indx}'}]}, u, expect=201
-        ).data
-        assert bulk_host_create_response['created'] == 1, f"unexpected number of hosts created for user {u}"
-
-    for indx, u in enumerate([member, auditor, use_inv_member]):
-        bulk_host_create_response = post(
-            reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': [{'name': f'foobar2-{indx}'}]}, u, expect=400
-        ).data
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
@ffirg :gift: 

related: https://github.com/ansible/awx/issues/6682
This RFE was previously closed, but I propose this proof of concept as a counterpoint to the arguments against this. I don't think its an unreasonable lift, and I think we can respect our contracts around:
  * RBAC Roles that dictate who can add hosts to an inventory (even be more restrictive if we want to be)
  * Host uniqueness in an inventory
  * Host limits at org level
  * Host limits at system level
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Many users administer their inventories in systems outside controller and want to be able to create inventories via the api, but adding them one by one is too slow. Instead, let's do all the uniqueness, RBAC and system/organization limit checks in one go as well as leverage `bulk_create` to minimize our interaction with database. Additionally rendering the return objects is relatively expensive. Instead, just return a link to the host list if you want to go see.


Example use:

POST to `/api/v2/bulk/host_create` (I think for #13358 I want to move that API endpoint to /api/v2/bulk/job_launch)
```
{"inventory": 1, "hosts": [{"name": "foo-0-2022-12-22 01:29:08.995393"}, {"name": "foo-1-2022-12-22 01:29:08.995393"}, {"name": "foo-2-2022-12-22 01:29:08.995393"}, {"name": "foo-3-2022-12-22 01:29:08.995393"}, {"name": "foo-4-2022-12-22 01:29:08.995393"}, {"name": "foo-5-2022-12-22 01:29:08.995393"}, {"name": "foo-6-2022-12-22 01:29:08.995393"}, {"name": "foo-7-2022-12-22 01:29:08.995393"}, {"name": "foo-8-2022-12-22 01:29:08.995393"}, {"name": "foo-9-2022-12-22 01:29:08.995393"}, {"name": "foo-10-2022-12-22 01:29:08.995393"}, {"name": "foo-11-2022-12-22 01:29:08.995393"}, {"name": "foo-12-2022-12-22 01:29:08.995393"}, {"name": "foo-13-2022-12-22 01:29:08.995393"}, {"name": "foo-14-2022-12-22 01:29:08.995393"}, {"name": "foo-15-2022-12-22 01:29:08.995393"}, {"name": "foo-16-2022-12-22 01:29:08.995393"}, {"name": "foo-17-2022-12-22 01:29:08.995393"}, {"name": "foo-18-2022-12-22 01:29:08.995393"}, {"name": "foo-19-2022-12-22 01:29:08.995393"}, {"name": "foo-20-2022-12-22 01:29:08.995393"}, {"name": "foo-21-2022-12-22 01:29:08.995393"}, {"name": "foo-22-2022-12-22 01:29:08.995393"}, {"name": "foo-23-2022-12-22 01:29:08.995393"}, {"name": "foo-24-2022-12-22 01:29:08.995393"}, {"name": "foo-25-2022-12-22 01:29:08.995393"}, {"name": "foo-26-2022-12-22 01:29:08.995393"}, {"name": "foo-27-2022-12-22 01:29:08.995393"}, {"name": "foo-28-2022-12-22 01:29:08.995393"}, {"name": "foo-29-2022-12-22 01:29:08.995393"}, {"name": "foo-30-2022-12-22 01:29:08.995393"}, {"name": "foo-31-2022-12-22 01:29:08.995393"}, {"name": "foo-32-2022-12-22 01:29:08.995393"}, {"name": "foo-33-2022-12-22 01:29:08.995393"}, {"name": "foo-34-2022-12-22 01:29:08.995393"}, {"name": "foo-35-2022-12-22 01:29:08.995393"}, {"name": "foo-36-2022-12-22 01:29:08.995393"}, {"name": "foo-37-2022-12-22 01:29:08.995393"}, {"name": "foo-38-2022-12-22 01:29:08.995393"}, {"name": "foo-39-2022-12-22 01:29:08.995393"}, {"name": "foo-40-2022-12-22 01:29:08.995393"}, {"name": "foo-41-2022-12-22 01:29:08.995393"}, {"name": "foo-42-2022-12-22 01:29:08.995393"}, {"name": "foo-43-2022-12-22 01:29:08.995393"}, {"name": "foo-44-2022-12-22 01:29:08.995393"}, {"name": "foo-45-2022-12-22 01:29:08.995393"}, {"name": "foo-46-2022-12-22 01:29:08.995393"}, {"name": "foo-47-2022-12-22 01:29:08.995393"}, {"name": "foo-48-2022-12-22 01:29:08.995393"}, {"name": "foo-49-2022-12-22 01:29:08.995393"}, {"name": "foo-50-2022-12-22 01:29:08.995393"}, {"name": "foo-51-2022-12-22 01:29:08.995393"}, {"name": "foo-52-2022-12-22 01:29:08.995393"}, {"name": "foo-53-2022-12-22 01:29:08.995393"}, {"name": "foo-54-2022-12-22 01:29:08.995393"}, {"name": "foo-55-2022-12-22 01:29:08.995393"}, {"name": "foo-56-2022-12-22 01:29:08.995393"}, {"name": "foo-57-2022-12-22 01:29:08.995393"}, {"name": "foo-58-2022-12-22 01:29:08.995393"}, {"name": "foo-59-2022-12-22 01:29:08.995393"}, {"name": "foo-60-2022-12-22 01:29:08.995393"}, {"name": "foo-61-2022-12-22 01:29:08.995393"}, {"name": "foo-62-2022-12-22 01:29:08.995393"}, {"name": "foo-63-2022-12-22 01:29:08.995393"}, {"name": "foo-64-2022-12-22 01:29:08.995393"}, {"name": "foo-65-2022-12-22 01:29:08.995393"}, {"name": "foo-66-2022-12-22 01:29:08.995393"}, {"name": "foo-67-2022-12-22 01:29:08.995393"}, {"name": "foo-68-2022-12-22 01:29:08.995393"}, {"name": "foo-69-2022-12-22 01:29:08.995393"}, {"name": "foo-70-2022-12-22 01:29:08.995393"}, {"name": "foo-71-2022-12-22 01:29:08.995393"}, {"name": "foo-72-2022-12-22 01:29:08.995393"}, {"name": "foo-73-2022-12-22 01:29:08.995393"}, {"name": "foo-74-2022-12-22 01:29:08.995393"}, {"name": "foo-75-2022-12-22 01:29:08.995393"}, {"name": "foo-76-2022-12-22 01:29:08.995393"}, {"name": "foo-77-2022-12-22 01:29:08.995393"}, {"name": "foo-78-2022-12-22 01:29:08.995393"}, {"name": "foo-79-2022-12-22 01:29:08.995393"}, {"name": "foo-80-2022-12-22 01:29:08.995393"}, {"name": "foo-81-2022-12-22 01:29:08.995393"}, {"name": "foo-82-2022-12-22 01:29:08.995393"}, {"name": "foo-83-2022-12-22 01:29:08.995393"}, {"name": "foo-84-2022-12-22 01:29:08.995393"}, {"name": "foo-85-2022-12-22 01:29:08.995393"}, {"name": "foo-86-2022-12-22 01:29:08.995393"}, {"name": "foo-87-2022-12-22 01:29:08.995393"}, {"name": "foo-88-2022-12-22 01:29:08.995393"}, {"name": "foo-89-2022-12-22 01:29:08.995393"}, {"name": "foo-90-2022-12-22 01:29:08.995393"}, {"name": "foo-91-2022-12-22 01:29:08.995393"}, {"name": "foo-92-2022-12-22 01:29:08.995393"}, {"name": "foo-93-2022-12-22 01:29:08.995393"}, {"name": "foo-94-2022-12-22 01:29:08.995393"}, {"name": "foo-95-2022-12-22 01:29:08.995393"}, {"name": "foo-96-2022-12-22 01:29:08.995393"}, {"name": "foo-97-2022-12-22 01:29:08.995393"}, {"name": "foo-98-2022-12-22 01:29:08.995393"}, {"name": "foo-99-2022-12-22 01:29:08.995393"}]}
```

Response:
```
HTTP 201 Created
Allow: GET, POST
Content-Type: application/json
Vary: Accept
X-API-Node: awx_1
X-API-Product-Name: AWX
X-API-Product-Version: 21.6.1.dev146+g1619462fb0
X-API-Query-Count: 11
X-API-Query-Time: 0.011s
X-API-Time: 0.143s

{
    "created": 100,
    "url": "[/api/v2/inventories/1/hosts/](https://localhost:8043/api/v2/inventories/1/hosts/)"
}
```
# Definition of Done

## General API:
- [x] OPTIONS request responds with description of schema accepted
- [x] POST accepts inventory and hosts desired to create, responds with how many hosts created, and link to inventory
- [ ] TODO: Discuss what POST should return. Some suggestions have been raised that we add filter to link to filter down to hosts just created or other similar idea, we could alternatively have list of hosts just not whole host -- because rendering the summary fields is really expensive
- [x] TODO determine sensible ActivityStream entry/entries to create 

## RBAC
- [x] org admin for org on inventory can add hosts
- [x] inventory admin at org level for org of inventory can add hosts
- [x] superuser can add hosts, bypass rbac
- [x] inventory admin of particular inventory can add hosts

# CLI/collection/awxkit
- [ ] add collection module for bulk inventory add
- [ ] add cli support for bulk inventory add
- [ ] add awxkit support for bulk inventory add

## Testing
- [x] add awx functional test asserting on number of queries it takes 
- [x] add awx functional test for RBAC
- [ ] add integration tests for api
- [ ] add integration tests for collection
- [ ] add integraiton tests for cli