### PR TITLE
Fix for Save button not responding on Job Settings page

### DIFF
--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -141,14 +141,14 @@ function JobsEdit() {
               <FormColumnLayout>
                 <InputField
                   name="AWX_ISOLATION_BASE_PATH"
-                  config={jobs.AWX_ISOLATION_BASE_PATH}
-                  isRequired
+                  config={jobs.AWX_ISOLATION_BASE_PATH ?? null}
+                  isRequired={Boolean(options?.AWX_ISOLATION_BASE_PATH)}
                 />
                 <InputField
                   name="SCHEDULE_MAX_JOBS"
-                  config={jobs.SCHEDULE_MAX_JOBS}
-                  type="number"
-                  isRequired
+                  config={jobs.SCHEDULE_MAX_JOBS ?? null}
+                  type={options?.SCHEDULE_MAX_JOBS ? 'number' : undefined}
+                  isRequired={Boolean(options?.SCHEDULE_MAX_JOBS)}
                 />
                 <InputField
                   name="DEFAULT_JOB_TIMEOUT"

--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.test.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.test.js
@@ -122,4 +122,22 @@ describe('<JobsEdit />', () => {
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('ContentError').length).toBe(1);
   });
+
+  test('Form input fields that are invisible (due to being set manually via a settings file) should not prevent submitting the form', async () => {
+    const mockOptions = Object.assign({}, mockAllOptions);
+    // If AWX_ISOLATION_BASE_PATH has been set in a settings file it will be absent in the PUT options
+    delete mockOptions['actions']['PUT']['AWX_ISOLATION_BASE_PATH'];
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <SettingsProvider value={mockOptions.actions}>
+          <JobsEdit />
+        </SettingsProvider>
+      );
+    });
+    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+    await act(async () => {
+      wrapper.find('Form').invoke('onSubmit')();
+    });
+    expect(SettingsAPI.updateAll).toHaveBeenCalledTimes(1);
+  });
 });

--- a/awx/ui/src/screens/Setting/shared/SharedFields.js
+++ b/awx/ui/src/screens/Setting/shared/SharedFields.js
@@ -397,7 +397,10 @@ const InputField = ({ name, config, type = 'text', isRequired = false }) => {
 };
 InputField.propTypes = {
   name: string.isRequired,
-  config: shape({}).isRequired,
+  config: shape({}),
+};
+InputField.defaultProps = {
+  config: null,
 };
 
 const TextAreaField = ({ name, config, isRequired = false }) => {


### PR DESCRIPTION
Signed-off-by: Vidya Nambiar <vnambiar@redhat.com>

Issue: https://github.com/ansible/awx/issues/13371

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The reason for this issue is that when fields like AWX_ISOLATION_BASE_PATH and SCHEDULE_MAX_JOBS are set manually via a settings file, they are excluded from the Edit Job Settings form view. However, they were still marked as "required" fields and this was silently causing the "Save" to fail.

With this PR:
AWX_ISOLATION_BASE_PATH and SCHEDULE_MAX_JOBS are only marked as required fields if their respective keys are returned by the PUT OPTIONS request (indicating that they have not been previously manually set)

[Reproducer for AAP-7757.pdf](https://github.com/ansible/awx/files/10288974/Reproducer.for.AAP-7757.pdf)
