### PR TITLE
Fix verbosity parameter choices for ad_hoc_command module

### DIFF
--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -123,7 +123,7 @@ def main():
         module_name=dict(required=True),
         module_args=dict(),
         forks=dict(type='int'),
-        verbosity=dict(type='int', choices=['0', '1', '2', '3', '4', '5']),
+        verbosity=dict(type='int', choices=[0, 1, 2, 3, 4, 5]),
         extra_vars=dict(type='dict'),
         become_enabled=dict(type='bool'),
         diff_mode=dict(type='bool'),


### PR DESCRIPTION
Signed-off-by: Oscar <oscar.bell@bell.local>

##### SUMMARY
Fix for #13377 

The verbosity parameter can't be used because the choices list in the module_args definition refers to strings instead of the required integer values. This pull request updates the choices list to an integer list which makes it possible to change the verbosity parameter.

When trying to change the verbosity parameter with the original module Ansible complains with an error message
```yaml
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of verbosity must be one of: 0, 1, 2, 3, 4, 5, got: 2"}
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
21.10.2
```


##### ADDITIONAL INFORMATION
To reproduce the bug add the verbosity parameter to the ad_hoc_command module call. 
```yaml
    - name: Execute ad_hoc command via awx collection
      awx.awx.ad_hoc_command:
        controller_host: "{{ controller_host }}"
        controller_username: "{{ controller_username }}"
        controller_password: "{{ controller_password }}"
        credential: "{{ credential_id }}"
        inventory: "{{ inventory_id }}"
        module_name: command
        module_args: hostname
        limit: "{{ limit_host }}"
        verbosity: 2
        wait: true
      register: ad_hoc_command_result
```

This will result in an Ansible validation error like below.
```yaml
fatal: [localhost]: FAILED! => {"changed": false, "msg": "value of verbosity must be one of: 0, 1, 2, 3, 4, 5, got: 2"}
``` 

After the change in the module code the ad_hoc_command is started on the AWX host and in the output and details of the job we can see the verbosity level being set to 2.
