### PR TITLE
set the real ip to logs  (login)

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -145,19 +145,6 @@ class APIView(views.APIView):
         if getattr(settings, 'SQL_DEBUG', False):
             self.queries_before = len(connection.queries)
 
-        # If there are any custom headers in REMOTE_HOST_HEADERS, make sure
-        # they respect the allowed proxy list
-        if all(
-            [
-                settings.PROXY_IP_ALLOWED_LIST,
-                request.environ.get('REMOTE_ADDR') not in settings.PROXY_IP_ALLOWED_LIST,
-                request.environ.get('REMOTE_HOST') not in settings.PROXY_IP_ALLOWED_LIST,
-            ]
-        ):
-            for custom_header in settings.REMOTE_HOST_HEADERS:
-                if custom_header.startswith('HTTP_'):
-                    request.environ.pop(custom_header, None)
-
         drf_request = super(APIView, self).initialize_request(request, *args, **kwargs)
         request.drf_request = drf_request
         try:

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -207,8 +207,9 @@ class MigrationRanCheckMiddleware(MiddlewareMixin):
 
 
 class SetRemoteAddrFromRemoteHostHeader(MiddlewareMixin):
-    def process_request(self, request):
+    environ = {}
 
+    def process_request(self, request):
         # If there are any custom headers in REMOTE_HOST_HEADERS, make sure
         # they respect the allowed proxy list
         if all(
@@ -222,13 +223,6 @@ class SetRemoteAddrFromRemoteHostHeader(MiddlewareMixin):
                 if custom_header.startswith('HTTP_'):
                     request.environ.pop(custom_header, None)
 
-        for custom_header in settings.REMOTE_HOST_HEADERS:
-            for value in request.META.get(custom_header, '').split(','):
-                value = value.strip()
-                if value:
-                    request.META['REMOTE_ADDR'] = value
-                    break
-
-            else:
-                continue
-            break
+    def process_response(self, request, response):
+        self.environ = request.environ
+        return response

--- a/awx/main/tests/functional/api/test_generic.py
+++ b/awx/main/tests/functional/api/test_generic.py
@@ -1,6 +1,7 @@
 import pytest
 
 from awx.api.versioning import reverse
+from awx.main.middleware import SetRemoteAddrFromRemoteHostHeader
 
 
 @pytest.mark.django_db
@@ -8,18 +9,9 @@ def test_proxy_ip_allowed(get, patch, admin):
     url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'system'})
     patch(url, user=admin, data={'REMOTE_HOST_HEADERS': ['HTTP_X_FROM_THE_LOAD_BALANCER', 'REMOTE_ADDR', 'REMOTE_HOST']})
 
-    class HeaderTrackingMiddleware(object):
-        environ = {}
-
-        def process_request(self, request):
-            pass
-
-        def process_response(self, request, response):
-            self.environ = request.environ
-
     # By default, `PROXY_IP_ALLOWED_LIST` is disabled, so custom `REMOTE_HOST_HEADERS`
     # should just pass through
-    middleware = HeaderTrackingMiddleware()
+    middleware = SetRemoteAddrFromRemoteHostHeader()
     get(url, user=admin, middleware=middleware, HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
 
@@ -27,20 +19,20 @@ def test_proxy_ip_allowed(get, patch, admin):
     # from 8.9.10.11, the custom `HTTP_X_FROM_THE_LOAD_BALANCER` header should
     # be stripped
     patch(url, user=admin, data={'PROXY_IP_ALLOWED_LIST': ['10.0.1.100']})
-    middleware = HeaderTrackingMiddleware()
+    middleware = SetRemoteAddrFromRemoteHostHeader()
     get(url, user=admin, middleware=middleware, REMOTE_ADDR='8.9.10.11', HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert 'HTTP_X_FROM_THE_LOAD_BALANCER' not in middleware.environ
 
     # If 8.9.10.11 is added to `PROXY_IP_ALLOWED_LIST` the
     # `HTTP_X_FROM_THE_LOAD_BALANCER` header should be passed through again
     patch(url, user=admin, data={'PROXY_IP_ALLOWED_LIST': ['10.0.1.100', '8.9.10.11']})
-    middleware = HeaderTrackingMiddleware()
+    middleware = SetRemoteAddrFromRemoteHostHeader()
     get(url, user=admin, middleware=middleware, REMOTE_ADDR='8.9.10.11', HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
 
     # Allow allowed list of proxy hostnames in addition to IP addresses
     patch(url, user=admin, data={'PROXY_IP_ALLOWED_LIST': ['my.proxy.example.org']})
-    middleware = HeaderTrackingMiddleware()
+    middleware = SetRemoteAddrFromRemoteHostHeader()
     get(url, user=admin, middleware=middleware, REMOTE_ADDR='8.9.10.11', REMOTE_HOST='my.proxy.example.org', HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
 

--- a/awx/main/tests/functional/api/test_generic.py
+++ b/awx/main/tests/functional/api/test_generic.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import MagicMock
 
 from awx.api.versioning import reverse
 from awx.main.middleware import SetRemoteAddrFromRemoteHostHeader
@@ -6,12 +7,13 @@ from awx.main.middleware import SetRemoteAddrFromRemoteHostHeader
 
 @pytest.mark.django_db
 def test_proxy_ip_allowed(get, patch, admin):
+    get_response = MagicMock()
     url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'system'})
-    patch(url, user=admin, data={'REMOTE_HOST_HEADERS': ['HTTP_X_FROM_THE_LOAD_BALANCER', 'REMOTE_ADDR', 'REMOTE_HOST']})
+    middleware = SetRemoteAddrFromRemoteHostHeader(get_response)
 
     # By default, `PROXY_IP_ALLOWED_LIST` is disabled, so custom `REMOTE_HOST_HEADERS`
     # should just pass through
-    middleware = SetRemoteAddrFromRemoteHostHeader()
+    patch(url, user=admin, data={'REMOTE_HOST_HEADERS': ['HTTP_X_FROM_THE_LOAD_BALANCER', 'REMOTE_ADDR', 'REMOTE_HOST']})
     get(url, user=admin, middleware=middleware, HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
 
@@ -19,20 +21,17 @@ def test_proxy_ip_allowed(get, patch, admin):
     # from 8.9.10.11, the custom `HTTP_X_FROM_THE_LOAD_BALANCER` header should
     # be stripped
     patch(url, user=admin, data={'PROXY_IP_ALLOWED_LIST': ['10.0.1.100']})
-    middleware = SetRemoteAddrFromRemoteHostHeader()
     get(url, user=admin, middleware=middleware, REMOTE_ADDR='8.9.10.11', HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert 'HTTP_X_FROM_THE_LOAD_BALANCER' not in middleware.environ
 
     # If 8.9.10.11 is added to `PROXY_IP_ALLOWED_LIST` the
     # `HTTP_X_FROM_THE_LOAD_BALANCER` header should be passed through again
     patch(url, user=admin, data={'PROXY_IP_ALLOWED_LIST': ['10.0.1.100', '8.9.10.11']})
-    middleware = SetRemoteAddrFromRemoteHostHeader()
     get(url, user=admin, middleware=middleware, REMOTE_ADDR='8.9.10.11', HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
 
     # Allow allowed list of proxy hostnames in addition to IP addresses
     patch(url, user=admin, data={'PROXY_IP_ALLOWED_LIST': ['my.proxy.example.org']})
-    middleware = SetRemoteAddrFromRemoteHostHeader()
     get(url, user=admin, middleware=middleware, REMOTE_ADDR='8.9.10.11', REMOTE_HOST='my.proxy.example.org', HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -961,6 +961,7 @@ RECEPTOR_RELEASE_WORK = True
 
 MIDDLEWARE = [
     'django_guid.middleware.guid_middleware',
+    'awx.main.middleware.SetRemoteAddrFromRemoteHostHeader',
     'awx.main.middleware.SettingsCacheMiddleware',
     'awx.main.middleware.TimingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
##### SUMMARY
The value of (settings.REMOTE_HOST_HEADERS) is used to replace the REMOTE_ADDR.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
 - Settings
 - Middleware
 
##### AWX VERSION
```
awx: 21.10.3.dev9+g132158586e
```