### PR TITLE
Pin rsyslog to avoid crash

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -116,7 +116,7 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     python3-psycopg2 \
     python3-setuptools \
     rsync \
-    "rsyslog >= 8.1911.0" \
+    rsyslog-8.2102.0-106.el9 \
     subversion \
     sudo \
     vim-minimal \


### PR DESCRIPTION
##### SUMMARY
With the latest version of rsyslog we had a test failing with:

```
AssertionError: Response data: {'error': "b'rsyslog internal message (3,-2455): could not transfer  the  specified  internal posix  capabilities settings to the kernel, capng_apply=-5\\n [v8.2102.0-107.el9 try https://www.rsyslog.com/e/2455 ]\\n'"}
```

Downgrading fixes it. Not a long-term solution but this works until we can figure out another solution or it gets resolved upstream.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change


Related: https://github.com/ansible/awx/issues/13394