### PR TITLE
Fix console color logs

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -103,6 +103,10 @@ ColorHandler = logging.StreamHandler
 if settings.COLOR_LOGS is True:
     try:
         from logutils.colorize import ColorizingStreamHandler
+        import colorama
+
+        colorama.deinit()
+        colorama.init(wrap=False, convert=False, strip=False)
 
         class ColorHandler(ColorizingStreamHandler):
             def colorize(self, line, record):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
colorama tries to detect if log stream is a terminal (`isatty`). If not, it strips any color ANSI characters from the log message.

running python processes under supervisord is not tty, so it strips the characters. We can override the behavior by re-running the init for colorama.

![image](https://user-images.githubusercontent.com/8745776/210848514-c1d63ac7-4506-4a9a-8e4a-9bcbf482f3d2.png)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change
