### PR TITLE
Added additional requirements paths into project_update.yml playbook

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -214,6 +214,8 @@
       with_fileglob:
         - "{{project_path|quote}}/roles/requirements.yaml"
         - "{{project_path|quote}}/roles/requirements.yml"
+        - "{{project_path|quote}}/requirements.yaml"
+        - "{{project_path|quote}}/requirements.yml"
       changed_when: "'was installed successfully' in galaxy_result.stdout"
       environment: "{{ galaxy_task_env }}"
       when: roles_enabled|bool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There is logic issue with installing dependencies by ansible tower as single file requirements.yml can  contains roles and collections. (https://docs.ansible.com/ansible/latest/galaxy/user_guide.html)  If you are using ansible_builder you can define single file as dependency. 

This fix also resolve the problem with wrong displayed file in UI as it suggests it should be in main directory. 

![image](https://user-images.githubusercontent.com/117086012/210848259-303a6413-8c6e-4ab1-afb0-a7c765a64e06.png)

![image](https://user-images.githubusercontent.com/117086012/210848297-ea038911-e677-43f8-839b-21df7e523e27.png)


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI
 - UI
 - Other

