### PR TITLE
fix(sec): upgrade gitpython to 3.1.27

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -143,7 +143,7 @@ filelock==3.8.0
     #   django-radius
 gitdb==4.0.2
     # via gitpython
-gitpython==3.1.7
+gitpython==3.1.27
     # via -r /awx_devel/requirements/requirements.in
 google-auth==1.35.0
     # via kubernetes


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gitpython 3.1.7
- [MPS-2022-14928](https://www.oscs1024.com/hd/MPS-2022-14928)


### What did I do？
Upgrade gitpython from 3.1.7 to 3.1.27 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS