### PR TITLE
AAP-8038 - enable/disable services on reboot

### DIFF
--- a/tools/scripts/automation-controller-service
+++ b/tools/scripts/automation-controller-service
@@ -11,8 +11,11 @@ case "$1" in
 	status)
 		exec systemctl status automation-controller.service $CONTROLLER_SERVICES
 		;;
-        *)
-                echo "Usage: automation-controller-service start|stop|restart|status"
-                exit 1
-                ;;
+    enable|disable)
+           exec systemctl $1 automation-controller.service $CONTROLLER_SERVICES
+            ;;
+    *)
+            echo "Usage: automation-controller-service start|stop|restart|status|enable|disable"
+            exit 1
+            ;;
 esac

--- a/tools/scripts/automation-controller-service
+++ b/tools/scripts/automation-controller-service
@@ -11,11 +11,11 @@ case "$1" in
 	status)
 		exec systemctl status automation-controller.service $CONTROLLER_SERVICES
 		;;
-    enable|disable)
-           exec systemctl $1 automation-controller.service $CONTROLLER_SERVICES
-            ;;
-    *)
-            echo "Usage: automation-controller-service start|stop|restart|status|enable|disable"
-            exit 1
-            ;;
+	enable|disable)
+		exec systemctl $1 automation-controller.service $CONTROLLER_SERVICES
+		;;
+	*)
+		echo "Usage: automation-controller-service start|stop|restart|status|enable|disable"
+		exit 1
+		;;
 esac


### PR DESCRIPTION
##### SUMMARY
**Feature Overview**
Add enable and disable option for automation-controller-service service for quickly enabling/disabling start on boot for controller services.

**Background, and strategic fit**
Customers might want to enable/disable controller services on boot for important maintenance activities

**(Optional) Use Cases**
- kernel patching
- Filesystems corruption on reboot

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - CLI

##### AWX VERSION
```
2.3
```