### PR TITLE
fix(sec): upgrade django to 4.1.2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -86,7 +86,7 @@ defusedxml==0.6.0
     #   social-auth-core
 distro==1.5.0
     # via -r /awx_devel/requirements/requirements.in
-django==3.2.13
+django==4.1.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in django 3.2.13
- [CVE-2022-34265](https://www.oscs1024.com/hd/CVE-2022-34265)


### What did I do？
Upgrade django from 3.2.13 to 4.1.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS