### PR TITLE
8049-expose execution node var for playbook

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -832,7 +832,8 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
                 r['{}_job_template_id'.format(name)] = self.job_template.pk
                 r['{}_job_template_name'.format(name)] = self.job_template.name
         if self.execution_node:
-            r['{}_execution_node'.format(name)] = self.execution_node
+            for name in JOB_VARIABLE_PREFIXES:
+                r['{}_execution_node'.format(name)] = self.execution_node
         return r
 
     '''

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -831,6 +831,8 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
             for name in JOB_VARIABLE_PREFIXES:
                 r['{}_job_template_id'.format(name)] = self.job_template.pk
                 r['{}_job_template_name'.format(name)] = self.job_template.name
+        if self.execution_node:
+            r['{}_execution_node'.format(name)] = self.execution_node
         return r
 
     '''

--- a/awx/main/tests/unit/models/test_unified_job_unit.py
+++ b/awx/main/tests/unit/models/test_unified_job_unit.py
@@ -107,7 +107,11 @@ class TestMetaVars:
             result_hash['{}_user_id'.format(name)] = 47
             result_hash['{}_inventory_id'.format(name)] = 45
             result_hash['{}_inventory_name'.format(name)] = 'example-inv'
-        assert Job(name='fake-job', pk=42, id=42, launch_type='manual', created_by=maker, inventory=inv).awx_meta_vars() == result_hash
+            result_hash['{}_execution_node'.format(name)] = 'example-exec-node'
+        assert (
+            Job(name='fake-job', pk=42, id=42, launch_type='manual', created_by=maker, inventory=inv, execution_node='example-exec-node').awx_meta_vars()
+            == result_hash
+        )
 
     def test_project_update_metavars(self):
         data = Job(


### PR DESCRIPTION
##### SUMMARY
**Feature Overview**
Expose the Execution Node name as a variable for playbooks(awx_execution_node).

**Background, and strategic fit**
Customers running jobs in Ansible Tower use the ansible_hostname as an identifier for external applications requests (i.e.: Splunk, Service Now, etc ). In the Ansible Automation platform, that value is the container hostname which is now known to the customer and is not useful.

**(Optional) Use Cases**
- delegate the job to the specific cluster node
- define an identifier for external services such as Splunk, Service Now, etc.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - CLI

##### AWX VERSION
```
2.3
```