### PR TITLE
Fix for Issue https://github.com/ansible/awx/issues/13384

### DIFF
--- a/awx/main/credential_plugins/tss.py
+++ b/awx/main/credential_plugins/tss.py
@@ -48,9 +48,6 @@ def tss_backend(**kwargs):
     secret_server = SecretServer(kwargs['server_url'], authorizer)
     secret_dict = secret_server.get_secret(kwargs['secret_id'])
     secret = ServerSecret(**secret_dict)
-    #Fix Issue https://github.com/ansible/awx/issues/13384
-    # For SSH Key types thycotic is returning a Object of Type <class 'requests.models.Response'>
-    # So we need to check whether response is a string or object and based on that we need return value
     
     if type(secret.fields[kwargs['secret_field']].value) != str :
         return secret.fields[kwargs['secret_field']].value.text

--- a/awx/main/credential_plugins/tss.py
+++ b/awx/main/credential_plugins/tss.py
@@ -48,8 +48,16 @@ def tss_backend(**kwargs):
     secret_server = SecretServer(kwargs['server_url'], authorizer)
     secret_dict = secret_server.get_secret(kwargs['secret_id'])
     secret = ServerSecret(**secret_dict)
+    #Fix Issue https://github.com/ansible/awx/issues/13384
+    # For SSH Key types thycotic is returning a Object of Type <class 'requests.models.Response'>
+    # So we need to check whether response is a string or object and based on that we need return value
+    
+    if type(secret.fields[kwargs['secret_field']].value) != str :
+        return secret.fields[kwargs['secret_field']].value.text
+    else:
+        return secret.fields[kwargs['secret_field']].value
 
-    return secret.fields[kwargs['secret_field']].value
+    
 
 
 tss_plugin = CredentialPlugin(


### PR DESCRIPTION
# For SSH Key types thycotic is returning a Object of Type <class 'requests.models.Response'>
    # So we need to check whether response is a string or object and based on that we need return value

##### SUMMARY
<!--- 
   For SSH Key types thycotic is returning a Object of Type  class 'requests.models.Response'
    So we need to check whether response is a string or object and based on that we need return value
-->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
