### PR TITLE
[constructed-inventory] pushing limit to inventory sources

### DIFF
--- a/awx/main/migrations/0175_constructed_inventory.py
+++ b/awx/main/migrations/0175_constructed_inventory.py
@@ -79,4 +79,14 @@ class Migration(migrations.Migration):
                 max_length=32,
             ),
         ),
+        migrations.AddField(
+            model_name='inventorysource',
+            name='limit',
+            field=models.TextField(blank=True, default='', help_text='Enter host, group or pattern match'),
+        ),
+        migrations.AddField(
+            model_name='inventoryupdate',
+            name='limit',
+            field=models.TextField(blank=True, default='', help_text='Enter host, group or pattern match'),
+        ),
     ]

--- a/awx/main/migrations/0175_constructed_inventory.py
+++ b/awx/main/migrations/0175_constructed_inventory.py
@@ -89,4 +89,22 @@ class Migration(migrations.Migration):
             name='limit',
             field=models.TextField(blank=True, default='', help_text='Enter host, group or pattern match'),
         ),
+        migrations.AlterField(
+            model_name='inventorysource',
+            name='host_filter',
+            field=models.TextField(
+                blank=True,
+                default='',
+                help_text='This field is deprecated and will be removed in a future release. Regex where only matching hosts will be imported.',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='inventoryupdate',
+            name='host_filter',
+            field=models.TextField(
+                blank=True,
+                default='',
+                help_text='This field is deprecated and will be removed in a future release. Regex where only matching hosts will be imported.',
+            ),
+        ),
     ]

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -925,7 +925,7 @@ class InventorySourceOptions(BaseModel):
     host_filter = models.TextField(
         blank=True,
         default='',
-        help_text=_('Regex where only matching hosts will be imported.'),
+        help_text=_('This field is deprecated and will be removed in a future release. Regex where only matching hosts will be imported.'),
     )
     overwrite = models.BooleanField(
         default=False,
@@ -944,6 +944,11 @@ class InventorySourceOptions(BaseModel):
         choices=INVENTORY_UPDATE_VERBOSITY_CHOICES,
         blank=True,
         default=1,
+    )
+    limit = models.TextField(
+        blank=True,
+        default='',
+        help_text=_("Enter host, group or pattern match"),
     )
 
     @staticmethod

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1539,6 +1539,11 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
 
         args.append('-i')
         args.append(container_location)
+        # Added this in order to allow older versions of ansible-inventory https://github.com/ansible/ansible/pull/79596
+        # limit should be usable in ansible-inventory 2.15+
+        if inventory_update.limit:
+            args.append('--limit')
+            args.append(inventory_update.limit)
 
         args.append('--output')
         args.append(os.path.join(CONTAINER_ROOT, 'artifacts', str(inventory_update.id), 'output.json'))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This is a pull request to add the limit field to inventory source for issue: https://github.com/ansible/awx/issues/13436

 - added inventorysource limit via model
 - added migration to add database fields
 - plugged in conditional logic to add limit to inventory syncs

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
