### PR TITLE
Re-add workflow approval bulk actions to workflow approvals list

### DIFF
--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.js
@@ -1,0 +1,76 @@
+import React, { useContext } from 'react';
+
+import { t } from '@lingui/macro';
+import PropTypes from 'prop-types';
+import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
+import { KebabifiedContext } from 'contexts/Kebabified';
+import { WorkflowApproval } from 'types';
+
+function cannotApprove(item) {
+  return !item.can_approve_or_deny;
+}
+
+function WorkflowApprovalListApproveButton({ onApprove, selectedItems }) {
+  const { isKebabified } = useContext(KebabifiedContext);
+
+  const renderTooltip = () => {
+    if (selectedItems.length === 0) {
+      return t`Select a row to approve`;
+    }
+
+    const itemsUnableToApprove = selectedItems
+      .filter(cannotApprove)
+      .map((item) => item.name)
+      .join(', ');
+
+    if (selectedItems.some(cannotApprove)) {
+      return t`You are unable to act on the following workflow approvals: ${itemsUnableToApprove}`;
+    }
+
+    return t`Approve`;
+  };
+
+  const isDisabled =
+    selectedItems.length === 0 || selectedItems.some(cannotApprove);
+
+  return (
+    /* eslint-disable-next-line react/jsx-no-useless-fragment */
+    <>
+      {isKebabified ? (
+        <DropdownItem
+          key="approve"
+          isDisabled={isDisabled}
+          component="button"
+          onClick={onApprove}
+        >
+          {t`Approve`}
+        </DropdownItem>
+      ) : (
+        <Tooltip content={renderTooltip()} position="top">
+          <div>
+            <Button
+              ouiaId="workflow-approval-approve-button"
+              isDisabled={isDisabled}
+              aria-label={t`Approve`}
+              variant="primary"
+              onClick={onApprove}
+            >
+              {t`Approve`}
+            </Button>
+          </div>
+        </Tooltip>
+      )}
+    </>
+  );
+}
+
+WorkflowApprovalListApproveButton.propTypes = {
+  onApprove: PropTypes.func.isRequired,
+  selectedItems: PropTypes.arrayOf(WorkflowApproval),
+};
+
+WorkflowApprovalListApproveButton.defaultProps = {
+  selectedItems: [],
+};
+
+export default WorkflowApprovalListApproveButton;

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListApproveButton.test.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import WorkflowApprovalListApproveButton from './WorkflowApprovalListApproveButton';
+
+const workflowApproval = {
+  id: 1,
+  name: 'Foo',
+  can_approve_or_deny: true,
+  url: '/api/v2/workflow_approvals/218/',
+};
+
+describe('<WorkflowApprovalListApproveButton />', () => {
+  test('should render button', () => {
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListApproveButton
+        onApprove={() => {}}
+        selectedItems={[]}
+      />
+    );
+    expect(wrapper.find('button')).toHaveLength(1);
+  });
+
+  test('should invoke onApprove prop', () => {
+    const onApprove = jest.fn();
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListApproveButton
+        onApprove={onApprove}
+        selectedItems={[workflowApproval]}
+      />
+    );
+    wrapper.find('button').simulate('click');
+    wrapper.update();
+    expect(onApprove).toHaveBeenCalled();
+  });
+
+  test('should disable button when no approve/deny permissions', () => {
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListApproveButton
+        onApprove={() => {}}
+        selectedItems={[{ ...workflowApproval, can_approve_or_deny: false }]}
+      />
+    );
+    expect(wrapper.find('button[disabled]')).toHaveLength(1);
+  });
+
+  test('should render tooltip', () => {
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListApproveButton
+        onApprove={() => {}}
+        selectedItems={[workflowApproval]}
+      />
+    );
+    expect(wrapper.find('Tooltip')).toHaveLength(1);
+    expect(wrapper.find('Tooltip').prop('content')).toEqual('Approve');
+  });
+});

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListDenyButton.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListDenyButton.js
@@ -1,0 +1,76 @@
+import React, { useContext } from 'react';
+
+import { t } from '@lingui/macro';
+import PropTypes from 'prop-types';
+import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
+import { KebabifiedContext } from 'contexts/Kebabified';
+import { WorkflowApproval } from 'types';
+
+function cannotDeny(item) {
+  return !item.can_approve_or_deny;
+}
+
+function WorkflowApprovalListDenyButton({ onDeny, selectedItems }) {
+  const { isKebabified } = useContext(KebabifiedContext);
+
+  const renderTooltip = () => {
+    if (selectedItems.length === 0) {
+      return t`Select a row to deny`;
+    }
+
+    const itemsUnableToDeny = selectedItems
+      .filter(cannotDeny)
+      .map((item) => item.name)
+      .join(', ');
+
+    if (selectedItems.some(cannotDeny)) {
+      return t`You are unable to act on the following workflow approvals: ${itemsUnableToDeny}`;
+    }
+
+    return t`Deny`;
+  };
+
+  const isDisabled =
+    selectedItems.length === 0 || selectedItems.some(cannotDeny);
+
+  return (
+    /* eslint-disable-next-line react/jsx-no-useless-fragment */
+    <>
+      {isKebabified ? (
+        <DropdownItem
+          key="deny"
+          isDisabled={isDisabled}
+          component="button"
+          onClick={onDeny}
+        >
+          {t`Deny`}
+        </DropdownItem>
+      ) : (
+        <Tooltip content={renderTooltip()} position="top">
+          <div>
+            <Button
+              ouiaId="workflow-approval-deny-button"
+              isDisabled={isDisabled}
+              aria-label={t`Deny`}
+              variant="danger"
+              onClick={onDeny}
+            >
+              {t`Deny`}
+            </Button>
+          </div>
+        </Tooltip>
+      )}
+    </>
+  );
+}
+
+WorkflowApprovalListDenyButton.propTypes = {
+  onDeny: PropTypes.func.isRequired,
+  selectedItems: PropTypes.arrayOf(WorkflowApproval),
+};
+
+WorkflowApprovalListDenyButton.defaultProps = {
+  selectedItems: [],
+};
+
+export default WorkflowApprovalListDenyButton;

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListDenyButton.test.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovalList/WorkflowApprovalListDenyButton.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
+import WorkflowApprovalListDenyButton from './WorkflowApprovalListDenyButton';
+
+const workflowApproval = {
+  id: 1,
+  name: 'Foo',
+  can_approve_or_deny: true,
+  url: '/api/v2/workflow_approvals/218/',
+};
+
+describe('<WorkflowApprovalListDenyButton />', () => {
+  test('should render button', () => {
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListDenyButton onDeny={() => {}} selectedItems={[]} />
+    );
+    expect(wrapper.find('button')).toHaveLength(1);
+  });
+
+  test('should invoke onDeny prop', () => {
+    const onDeny = jest.fn();
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListDenyButton
+        onDeny={onDeny}
+        selectedItems={[workflowApproval]}
+      />
+    );
+    wrapper.find('button').simulate('click');
+    wrapper.update();
+    expect(onDeny).toHaveBeenCalled();
+  });
+
+  test('should disable button when no approve/deny permissions', () => {
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListDenyButton
+        onDeny={() => {}}
+        selectedItems={[{ ...workflowApproval, can_approve_or_deny: false }]}
+      />
+    );
+    expect(wrapper.find('button[disabled]')).toHaveLength(1);
+  });
+
+  test('should render tooltip', () => {
+    const wrapper = mountWithContexts(
+      <WorkflowApprovalListDenyButton
+        onDeny={() => {}}
+        selectedItems={[workflowApproval]}
+      />
+    );
+    expect(wrapper.find('Tooltip')).toHaveLength(1);
+    expect(wrapper.find('Tooltip').prop('content')).toEqual('Deny');
+  });
+});


### PR DESCRIPTION
##### SUMMARY
These buttons were moved to a kabob here: https://github.com/ansible/awx/pull/11920
Then they were moved into row actions here: https://github.com/ansible/awx/pull/12548

This PR rolls the bulk actions back to a state before #11920 while keeping the row actions in place.

The expectation is that a user will be able to select any number of pending workflow approvals and do a bulk approve or deny.  Workflow cancel will still only be supported at the row level.

<img width="1496" alt="Screen Shot 2023-01-19 at 12 23 34 PM" src="https://user-images.githubusercontent.com/9889020/213526176-86ecad59-869e-4793-afc5-dddb38b52fda.png">

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - UI
