### PR TITLE
Fixes #13439 Add exception handling for `/api` on url

### DIFF
--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -72,8 +72,6 @@ def conjur_backend(**kwargs):
             resp = requests.post(urljoin(url, '/'.join(['authn', account, username, 'authenticate'])), **auth_kwargs)
         except requests.exceptions.ConnectionError:
             resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
-        except:
-            resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
     raise_for_status(resp)
     token = resp.content.decode('utf-8')
 
@@ -95,8 +93,6 @@ def conjur_backend(**kwargs):
         try:
             resp = requests.get(path, timeout=30, **lookup_kwargs)
         except requests.exceptions.ConnectionError:
-            resp = requests.get(path_conjurcloud, timeout=30, **lookup_kwargs)
-        except:
             resp = requests.get(path_conjurcloud, timeout=30, **lookup_kwargs)
     raise_for_status(resp)
     return resp.text

--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -68,7 +68,12 @@ def conjur_backend(**kwargs):
     with CertFiles(cacert) as cert:
         # https://www.conjur.org/api.html#authentication-authenticate-post
         auth_kwargs['verify'] = cert
-        resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
+        try:
+            resp = requests.post(urljoin(url, '/'.join(['authn', account, username, 'authenticate'])), **auth_kwargs)
+        except requests.exceptions.ConnectionError:
+            resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
+        except:
+            raise
     raise_for_status(resp)
     token = resp.content.decode('utf-8')
 
@@ -78,14 +83,21 @@ def conjur_backend(**kwargs):
     }
 
     # https://www.conjur.org/api.html#secrets-retrieve-a-secret-get
-    path = urljoin(url, '/'.join(['api', 'secrets', account, 'variable', secret_path]))
+    path = urljoin(url, '/'.join(['secrets', account, 'variable', secret_path]))
+    path_conjurcloud = urljoin(url, '/'.join(['api', 'secrets', account, 'variable', secret_path]))
     if version:
         ver = "version={}".format(version)
         path = '?'.join([path, ver])
+        path_conjurcloud = '?'.join([path_conjurcloud, ver])
 
     with CertFiles(cacert) as cert:
         lookup_kwargs['verify'] = cert
-        resp = requests.get(path, timeout=30, **lookup_kwargs)
+        try:
+            resp = requests.get(path, timeout=30, **lookup_kwargs)
+        except requests.exceptions.ConnectionError:
+            resp = requests.get(path_conjurcloud, timeout=30, **lookup_kwargs)
+        except:
+            raise
     raise_for_status(resp)
     return resp.text
 

--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -73,7 +73,7 @@ def conjur_backend(**kwargs):
         except requests.exceptions.ConnectionError:
             resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
         except:
-            raise
+            resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
     raise_for_status(resp)
     token = resp.content.decode('utf-8')
 
@@ -97,7 +97,7 @@ def conjur_backend(**kwargs):
         except requests.exceptions.ConnectionError:
             resp = requests.get(path_conjurcloud, timeout=30, **lookup_kwargs)
         except:
-            raise
+            resp = requests.get(path_conjurcloud, timeout=30, **lookup_kwargs)
     raise_for_status(resp)
     return resp.text
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Self-Hosted Conjur Secrets Manager Enterprise and Conjur Cloud both support the usage of `/api` after the Base URL of the Conjur service.  In the case of Conjur Cloud, it is a requirement to interact with Conjur's API.  However, Conjur Open Source does not support the usage of `/api` after the Base URL for the Conjur service.

The change implemented in this PR adds a `try...exception...except` block to every `requests` command used in the Credential Plugin to first try without `/api` and if a `requests.exceptions.HTTPConnection` exception is captured, try with `/api` provided.  If that then fails, an error will be raised properly based on the response from the Conjur service API.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Related #13439 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev32760+g4470b80
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This was tested successfully using the Conjur Open Source Quick-Start Guide available at https://www.conjur.org/get-started/quick-start/oss-environment.
