### PR TITLE
[constructed-inventory] Add views and serializers for special constructed inventory endpoints

### DIFF
--- a/awx/api/urls/inventory.py
+++ b/awx/api/urls/inventory.py
@@ -6,6 +6,8 @@ from django.urls import re_path
 from awx.api.views.inventory import (
     InventoryList,
     InventoryDetail,
+    ConstructedInventoryDetail,
+    ConstructedInventoryList,
     InventoryActivityStreamList,
     InventorySourceInventoriesList,
     InventoryJobTemplateList,
@@ -50,4 +52,10 @@ urls = [
     re_path(r'^(?P<pk>[0-9]+)/copy/$', InventoryCopy.as_view(), name='inventory_copy'),
 ]
 
-__all__ = ['urls']
+# Constructed inventory special views
+constructed_inventory_urls = [
+    re_path(r'^$', ConstructedInventoryList.as_view(), name='constructed_inventory_list'),
+    re_path(r'^(?P<pk>[0-9]+)/$', ConstructedInventoryDetail.as_view(), name='constructed_inventory_detail'),
+]
+
+__all__ = ['urls', 'constructed_inventory_urls']

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -39,7 +39,7 @@ from .organization import urls as organization_urls
 from .user import urls as user_urls
 from .project import urls as project_urls
 from .project_update import urls as project_update_urls
-from .inventory import urls as inventory_urls
+from .inventory import urls as inventory_urls, constructed_inventory_urls
 from .execution_environments import urls as execution_environment_urls
 from .team import urls as team_urls
 from .host import urls as host_urls
@@ -110,6 +110,7 @@ v2_urls = [
     re_path(r'^project_updates/', include(project_update_urls)),
     re_path(r'^teams/', include(team_urls)),
     re_path(r'^inventories/', include(inventory_urls)),
+    re_path(r'^constructed_inventories/', include(constructed_inventory_urls)),
     re_path(r'^hosts/', include(host_urls)),
     re_path(r'^groups/', include(group_urls)),
     re_path(r'^inventory_sources/', include(inventory_source_urls)),

--- a/awx/api/views/inventory.py
+++ b/awx/api/views/inventory.py
@@ -31,6 +31,7 @@ from awx.api.views.labels import LabelSubListCreateAttachDetachView
 
 from awx.api.serializers import (
     InventorySerializer,
+    ConstructedInventorySerializer,
     ActivityStreamSerializer,
     RoleSerializer,
     InstanceGroupSerializer,
@@ -82,7 +83,9 @@ class InventoryDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAPIVie
 
         # Do not allow changes to an Inventory kind.
         if kind is not None and obj.kind != kind:
-            return Response(dict(error=_('You cannot turn a regular inventory into a "smart" inventory.')), status=status.HTTP_405_METHOD_NOT_ALLOWED)
+            return Response(
+                dict(error=_('You cannot turn a regular inventory into a "smart" or "constructed" inventory.')), status=status.HTTP_405_METHOD_NOT_ALLOWED
+            )
         return super(InventoryDetail, self).update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
@@ -95,6 +98,20 @@ class InventoryDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAPIVie
             return Response(status=status.HTTP_202_ACCEPTED)
         except RuntimeError as e:
             return Response(dict(error=_("{0}".format(e))), status=status.HTTP_400_BAD_REQUEST)
+
+
+class ConstructedInventoryDetail(InventoryDetail):
+
+    serializer_class = ConstructedInventorySerializer
+
+
+class ConstructedInventoryList(InventoryList):
+
+    serializer_class = ConstructedInventorySerializer
+
+    def get_queryset(self):
+        r = super().get_queryset()
+        return r.filter(kind='constructed')
 
 
 class InventorySourceInventoriesList(SubListAttachDetachAPIView):

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -101,6 +101,7 @@ class ApiVersionRootView(APIView):
         data['tokens'] = reverse('api:o_auth2_token_list', request=request)
         data['metrics'] = reverse('api:metrics_view', request=request)
         data['inventory'] = reverse('api:inventory_list', request=request)
+        data['constructed_inventory'] = reverse('api:constructed_inventory_list', request=request)
         data['inventory_sources'] = reverse('api:inventory_source_list', request=request)
         data['inventory_updates'] = reverse('api:inventory_update_list', request=request)
         data['groups'] = reverse('api:group_list', request=request)


### PR DESCRIPTION
##### SUMMARY
This adds special endpoints for constructed inventory, as outlined in https://github.com/ansible/awx/issues/13447 so that the UI can work with it as a single form.

I come into this with some opinions, so all the special logic is generally implemented in the serializer.

We need to add validation (or some other read_only status to the field) so that `kind` cannot be given any value other than "constructed" in these views, because that would not make any sense. I do not intend to do that here, I just mention it because it becomes another item in the long list of validation cases we need to add for this feature.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
