### PR TITLE
add '--order_by' option to awx CLI

### DIFF
--- a/awxkit/awxkit/cli/options.py
+++ b/awxkit/awxkit/cli/options.py
@@ -122,6 +122,15 @@ class ResourceOptionsParser(object):
                     action='store_true',
                     help=('fetch all pages of content from the API when ' 'returning results (instead of just the first page)'),
                 )
+                parser.add_argument(
+                    '--order_by',
+                    dest='order_by',
+                    help=(
+                        'order results by given field name, '
+                        'prefix the field name with a dash (-) to sort in reverse eg --order_by=\'-name\','
+                        'multiple sorting fields may be specified by separating the field names with a comma (,)'
+                    ),
+                )
                 add_output_formatting_arguments(parser, {})
 
     def build_detail_actions(self):


### PR DESCRIPTION
##### SUMMARY
It looks simple but it just works... 

Related:  https://github.com/ansible/awx/issues/5568

Sorting is a feature implemented by the AWX API (see Additional Information below). By adding the additional query parameter to methods of type "list", I was able to successfully sort the response server side. 

See the successful output below.

```
❯ python ./awxkit jobs list --order_by='name' | jq '.results[0].name'
"actions/gitlab/upgrade.yaml"

❯ python ./awxkit jobs list --order_by='-name' | jq '.results[0].name'
"validate-repaired-host.yaml - Production"
```

In theory `--all` should still work just fine as each page will be returned in the proper sorted order and then appended to the list tracking the results, see: https://github.com/ansible/awx/blob/devel/awxkit/awxkit/api/pages/page.py#L261


##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - CLI

##### ADDITIONAL INFORMATION
See: https://docs.ansible.com/ansible-tower/latest/html/towerapi/sorting.html

