### PR TITLE
Update "one or more" fields in SAML documentation.

### DIFF
--- a/docs/auth/saml.md
+++ b/docs/auth/saml.md
@@ -107,12 +107,12 @@ Below is an example of a SAML attribute that contains admin attributes:
 These properties can be defined either by a role or an attribute with the following configuration options:
 ```
 {
-  "is_superuser_role": "awx_admins",
+  "is_superuser_role": ["awx_admins"],
   "is_superuser_attr": "is_superuser",
-  "is_superuser_value": "IT-Superadmin",
-  "is_system_auditor_role": "awx_auditors",
+  "is_superuser_value": ["IT-Superadmin"],
+  "is_system_auditor_role": ["awx_auditors"],
   "is_system_auditor_attr": "is_system_auditor",
-  "is_system_auditor_value": "Auditor"
+  "is_system_auditor_value": ["Auditor"]
 }
 ```
 


### PR DESCRIPTION
According to latest documentation, role and value are now "one or more" fields. So they both need to be arrays.  Entering the json data as you have in this article doesn't work. But when I added the brackets, it then worked.   Thank you

Replaces https://github.com/ansible/awx/pull/13355

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
