### PR TITLE
External users should not be able to change their password

### DIFF
--- a/awx/api/conf.py
+++ b/awx/api/conf.py
@@ -1,5 +1,4 @@
 # Django
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 # Django REST Framework
@@ -9,6 +8,7 @@ from rest_framework import serializers
 from awx.conf import fields, register, register_validate
 from awx.api.fields import OAuth2ProviderField
 from oauth2_provider.settings import oauth2_settings
+from awx.sso.common import is_remote_auth_enabled
 
 
 register(
@@ -108,19 +108,8 @@ register(
 
 
 def authentication_validate(serializer, attrs):
-    remote_auth_settings = [
-        'AUTH_LDAP_SERVER_URI',
-        'SOCIAL_AUTH_GOOGLE_OAUTH2_KEY',
-        'SOCIAL_AUTH_GITHUB_KEY',
-        'SOCIAL_AUTH_GITHUB_ORG_KEY',
-        'SOCIAL_AUTH_GITHUB_TEAM_KEY',
-        'SOCIAL_AUTH_SAML_ENABLED_IDPS',
-        'RADIUS_SERVER',
-        'TACACSPLUS_HOST',
-    ]
-    if attrs.get('DISABLE_LOCAL_AUTH', False):
-        if not any(getattr(settings, s, None) for s in remote_auth_settings):
-            raise serializers.ValidationError(_("There are no remote authentication systems configured."))
+    if attrs.get('DISABLE_LOCAL_AUTH', False) and not is_remote_auth_enabled():
+        raise serializers.ValidationError(_("There are no remote authentication systems configured."))
     return attrs
 
 

--- a/awx/main/models/oauth.py
+++ b/awx/main/models/oauth.py
@@ -14,7 +14,7 @@ from oauth2_provider.models import AbstractApplication, AbstractAccessToken
 from oauth2_provider.generators import generate_client_secret
 from oauthlib import oauth2
 
-from awx.main.utils import get_external_account
+from awx.sso.common import get_external_account
 from awx.main.fields import OAuth2ClientSecretField
 
 

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -80,7 +80,6 @@ __all__ = [
     'set_environ',
     'IllegalArgumentError',
     'get_custom_venv_choices',
-    'get_external_account',
     'ScheduleTaskManager',
     'ScheduleDependencyManager',
     'ScheduleWorkflowManager',
@@ -1087,30 +1086,6 @@ def get_search_fields(model):
 def has_model_field_prefetched(model_obj, field_name):
     # NOTE: Update this function if django internal implementation changes.
     return getattr(getattr(model_obj, field_name, None), 'prefetch_cache_name', '') in getattr(model_obj, '_prefetched_objects_cache', {})
-
-
-def get_external_account(user):
-    from django.conf import settings
-
-    account_type = None
-    if getattr(settings, 'AUTH_LDAP_SERVER_URI', None):
-        try:
-            if user.pk and user.profile.ldap_dn and not user.has_usable_password():
-                account_type = "ldap"
-        except AttributeError:
-            pass
-    if (
-        getattr(settings, 'SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', None)
-        or getattr(settings, 'SOCIAL_AUTH_GITHUB_KEY', None)
-        or getattr(settings, 'SOCIAL_AUTH_GITHUB_ORG_KEY', None)
-        or getattr(settings, 'SOCIAL_AUTH_GITHUB_TEAM_KEY', None)
-        or getattr(settings, 'SOCIAL_AUTH_SAML_ENABLED_IDPS', None)
-        or getattr(settings, 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY', None)
-    ) and user.social_auth.all():
-        account_type = "social"
-    if (getattr(settings, 'RADIUS_SERVER', None) or getattr(settings, 'TACACSPLUS_HOST', None)) and user.enterprise_auth.all():
-        account_type = "enterprise"
-    return account_type
 
 
 class classproperty:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1105,6 +1105,7 @@ def get_external_account(user):
         or getattr(settings, 'SOCIAL_AUTH_GITHUB_ORG_KEY', None)
         or getattr(settings, 'SOCIAL_AUTH_GITHUB_TEAM_KEY', None)
         or getattr(settings, 'SOCIAL_AUTH_SAML_ENABLED_IDPS', None)
+        or getattr(settings, 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY', None)
     ) and user.social_auth.all():
         account_type = "social"
     if (getattr(settings, 'RADIUS_SERVER', None) or getattr(settings, 'TACACSPLUS_HOST', None)) and user.enterprise_auth.all():

--- a/awx/sso/tests/functional/test_common.py
+++ b/awx/sso/tests/functional/test_common.py
@@ -2,9 +2,22 @@ import pytest
 from collections import Counter
 from django.core.exceptions import FieldError
 from django.utils.timezone import now
+from django.test.utils import override_settings
 
 from awx.main.models import Credential, CredentialType, Organization, Team, User
-from awx.sso.common import get_orgs_by_ids, reconcile_users_org_team_mappings, create_org_and_teams, get_or_create_org_with_default_galaxy_cred
+from awx.sso.common import (
+    get_orgs_by_ids,
+    reconcile_users_org_team_mappings,
+    create_org_and_teams,
+    get_or_create_org_with_default_galaxy_cred,
+    is_remote_auth_enabled,
+    get_external_account,
+)
+
+
+class MicroMockObject(object):
+    def all(self):
+        return True
 
 
 @pytest.mark.django_db
@@ -278,3 +291,87 @@ class TestCommonFunctions:
 
         for o in Organization.objects.all():
             assert o.galaxy_credentials.count() == 0
+
+    @pytest.mark.parametrize(
+        "enable_ldap, enable_social, enable_enterprise, expected_results",
+        [
+            (False, False, False, None),
+            (True, False, False, 'ldap'),
+            (True, True, False, 'social'),
+            (True, True, True, 'enterprise'),
+            (False, True, True, 'enterprise'),
+            (False, False, True, 'enterprise'),
+            (False, True, False, 'social'),
+        ],
+    )
+    def test_get_external_account(self, enable_ldap, enable_social, enable_enterprise, expected_results):
+        try:
+            user = User.objects.get(username="external_tester")
+        except User.DoesNotExist:
+            user = User(username="external_tester")
+            user.set_unusable_password()
+            user.save()
+
+        if enable_ldap:
+            user.profile.ldap_dn = 'test.dn'
+        if enable_social:
+            from social_django.models import UserSocialAuth
+
+            social_auth, _ = UserSocialAuth.objects.get_or_create(
+                uid='667ec049-cdf3-45d0-a4dc-0465f7505954',
+                provider='oidc',
+                extra_data={},
+                user_id=user.id,
+            )
+            user.social_auth.set([social_auth])
+        if enable_enterprise:
+            from awx.sso.models import UserEnterpriseAuth
+
+            enterprise_auth = UserEnterpriseAuth(user=user, provider='tacacs+')
+            enterprise_auth.save()
+
+        assert get_external_account(user) == expected_results
+
+    @pytest.mark.parametrize(
+        "setting, expected",
+        [
+            # Set none of the social auth settings
+            ('JUNK_SETTING', False),
+            # Set the hard coded settings
+            ('AUTH_LDAP_SERVER_URI', True),
+            ('SOCIAL_AUTH_SAML_ENABLED_IDPS', True),
+            ('RADIUS_SERVER', True),
+            ('TACACSPLUS_HOST', True),
+            # Set some SOCIAL_SOCIAL_AUTH_OIDC_KEYAUTH_*_KEY settings
+            ('SOCIAL_AUTH_AZUREAD_OAUTH2_KEY', True),
+            ('SOCIAL_AUTH_GITHUB_ENTERPRISE_KEY', True),
+            ('SOCIAL_AUTH_GITHUB_ENTERPRISE_ORG_KEY', True),
+            ('SOCIAL_AUTH_GITHUB_ENTERPRISE_TEAM_KEY', True),
+            ('SOCIAL_AUTH_GITHUB_KEY', True),
+            ('SOCIAL_AUTH_GITHUB_ORG_KEY', True),
+            ('SOCIAL_AUTH_GITHUB_TEAM_KEY', True),
+            ('SOCIAL_AUTH_GOOGLE_OAUTH2_KEY', True),
+            ('SOCIAL_AUTH_OIDC_KEY', True),
+            # Try a hypothetical future one
+            ('SOCIAL_AUTH_GIBBERISH_KEY', True),
+            # Do a SAML one
+            ('SOCIAL_AUTH_SAML_SP_PRIVATE_KEY', False),
+        ],
+    )
+    def test_is_remote_auth_enabled(self, setting, expected):
+        with override_settings(**{setting: True}):
+            assert is_remote_auth_enabled() == expected
+
+    @pytest.mark.parametrize(
+        "key_one, key_one_value, key_two, key_two_value, expected",
+        [
+            ('JUNK_SETTING', True, 'JUNK2_SETTING', True, False),
+            ('AUTH_LDAP_SERVER_URI', True, 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY', True, True),
+            ('JUNK_SETTING', True, 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY', True, True),
+            ('AUTH_LDAP_SERVER_URI', False, 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY', False, False),
+        ],
+    )
+    def test_is_remote_auth_enabled_multiple_keys(self, key_one, key_one_value, key_two, key_two_value, expected):
+        with override_settings(**{key_one: key_one_value}):
+            with override_settings(**{key_two: key_two_value}):
+                assert is_remote_auth_enabled() == expected


### PR DESCRIPTION
##### SUMMARY

When Azure AD (or other external source) is configured, a user can log in with their external credentials and then set a password on their user screen. Once that is set, the user can auth with the local password into AWX. That user should NOT be able to change their password via the AWX API/UI as authorization for that user is managed by Azure AD.  

In the UI, we can see that when editing that user, currently the password field is shown and can be edited when specific combinations of external authentication are configured. For example, if SAML is configured with Azure AD than the password is not editable. However, if just Azure AD is configured the password is editable.


This is happening because `external_account` for that user is being set to `null`, which is because this is evaluating false:

https://github.com/ansible/awx/blob/ac6a82eee41feb041ff3e4d16459d4b1a774175f/awx/main/utils/common.py#L1043-L1050

With this change, it will evaluate to true, which will set `external_account: "social"`

```
>>> bool(getattr(settings, 'SOCIAL_AUTH_AZUREAD_OAUTH2_KEY', None))
True

>>> bool(user.social_auth.all())
True
```

In addition, we are changing the requirements from looking at the current configuration of AWX to just looking at the existing user attributes. Including the current configuration was causing another issue where a user could login through SAML but later be able to set a local password if SAML is disabled. While this has a byproduct of allowing users to be converted to local if the auth configuration is removed 1) it only allows this for authenticated users. 2) If SAML is reconfigured the account can bypass SAML login by using the local password.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


cc @john-westcott-iv 