### PR TITLE
Fix OPTIONS permissions bug in groups list

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1027,7 +1027,9 @@ class GroupAccess(BaseAccess):
         return Group.objects.filter(inventory__in=Inventory.accessible_pk_qs(self.user, 'read_role'))
 
     def can_add(self, data):
-        if not data or 'inventory' not in data:
+        if not data:  # So the browseable API will work
+            return Inventory.accessible_objects(self.user, 'admin_role').exists()
+        if 'inventory' not in data:
             return False
         # Checks for admin or change permission on inventory.
         return self.check_related('inventory', Inventory, data)


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/13484

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
This is an API fix for the sake of the CLI. If you look at `HostAccess`, it follows this pattern exactly, groups were an exception for no reason, which caused the bug mentioned in the issue.
