### PR TITLE
force kind to readonly field and set kind to constructed in create

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1805,6 +1805,7 @@ class ConstructedInventorySerializer(InventorySerializer):
     class Meta:
         model = Inventory
         fields = ('*', '-host_filter', 'source_vars', 'update_cache_timeout', 'limit', 'verbosity')
+        read_only_fields = ('*', 'kind')
 
     def pop_inv_src_data(self, data):
         inv_src_data = {}
@@ -1828,6 +1829,7 @@ class ConstructedInventorySerializer(InventorySerializer):
                 inv_src.save(update_fields=update_fields)
 
     def create(self, validated_data):
+        validated_data['kind'] = 'constructed'
         inv_src_data = self.pop_inv_src_data(validated_data)
         inventory = super().create(validated_data)
         self.apply_inv_src_data(inventory, inv_src_data)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Made 'kind' read only in the constructed inventory serializer and set kind to constructed in create.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 21.11.1.dev41+gc2ec8396cd

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
