### PR TITLE
fix postgreSQL reconnection in case of DB failover or idle or instable connection

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -1,16 +1,10 @@
 import psycopg2
 import select
-import logging
-import time
-import os
-import signal
 
 from contextlib import contextmanager
 
 from django.conf import settings
-from django.db import connection as pg_connection, OperationalError, Error
-
-logger = logging.getLogger('awx.dispatch.init')
+from django.db import connection as pg_connection
 
 NOT_READY = ([], [], [])
 
@@ -42,6 +36,10 @@ class PubSub(object):
         while True:
             if select.select([self.conn], [], [], select_timeout) == NOT_READY:
                 if yield_timeouts:
+                    # this is a 'ping' to db connection to make sure it's still alive
+                    # and prevent the main thread from hanging
+                    # this error will be cathced by the main thread and we enter on reconnection loop
+                    self.conn.cursor().execute('SELECT 1')
                     yield None
             else:
                 self.conn.poll()
@@ -63,11 +61,7 @@ def pg_bus_conn(new_connection=False):
     so that messages follow postgres transaction rules
     https://www.postgresql.org/docs/current/sql-notify.html
     '''
-    conn = None
-    retry_conn = False
-    MAX_RETRIES = settings.DISPATCHER_DB_DOWNTOWN_TOLLERANCE
-    POLL_SECONDS = int(settings.DISPATCHER_DB_DOWNTOWN_TOLLERANCE / 10)
-    
+
     if new_connection:
         conf = settings.DATABASES['default']
         conn = psycopg2.connect(
@@ -77,23 +71,10 @@ def pg_bus_conn(new_connection=False):
         conn.set_session(autocommit=True)
     else:
         if pg_connection.connection is None:
-            for retry_count in range(MAX_RETRIES):
-                try:
-                    pg_connection.connect()
-                    conn = pg_connection.connection
-                except (psycopg2.OperationalError, OperationalError, Error) as reconn_error:
-                    logger.warning(f'Database unavailable. Retry with new connection in next {POLL_SECONDS} seconds. Attempt {retry_count}/{MAX_RETRIES}.')
-                    time.sleep(POLL_SECONDS)
-                    retry_conn = True
-                else: 
-                    if retry_conn:
-                        logger.warning('Run dispatcher restart due to database connection loss and restore.')
-                        os.kill(os.getppid(), signal.SIGTERM)
-                    break
-            else:
-                raise RuntimeError(f'Could not connect to postgres afer {MAX_RETRIES} retries.')
-        else:
-            conn = pg_connection.connection
+            pg_connection.connect()
+        if pg_connection.connection is None:
+            raise RuntimeError('Unexpectedly could not connect to postgres for pg_notify actions')
+        conn = pg_connection.connection
 
     pubsub = PubSub(conn)
     yield pubsub

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -190,7 +190,7 @@ class AWXConsumerPG(AWXConsumerBase):
             except psycopg2.InterfaceError:
                 logger.warning("Stale Postgres message bus connection, reconnecting")
                 continue
-            except (db.DatabaseError, psycopg2.OperationalError):
+            except (db.DatabaseError, psycopg2.OperationalError, db.Error):
                 # If we have attained stady state operation, tolerate short-term database hickups
                 if not self.pg_is_down:
                     logger.exception(f"Error consuming new events from postgres, will retry for {self.pg_max_wait} s")

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -190,7 +190,7 @@ class AWXConsumerPG(AWXConsumerBase):
             except psycopg2.InterfaceError:
                 logger.warning("Stale Postgres message bus connection, reconnecting")
                 continue
-            except (db.DatabaseError, psycopg2.OperationalError, db.Error):
+            except (db.DatabaseError, psycopg2.OperationalError):
                 # If we have attained stady state operation, tolerate short-term database hickups
                 if not self.pg_is_down:
                     logger.exception(f"Error consuming new events from postgres, will retry for {self.pg_max_wait} s")


### PR DESCRIPTION
##### SUMMARY
I notice that in case of instable connection with PostgreSQL or failover (in case of PostgreSQL HA configuration) awx.main.dispatcher lose the connection with DB and not reconnect it.

I opened a PR to try to fix this issue with a simple check of connection with some retry on pg_bus_conn function (as default 40 times every 4 seconds, as per default).
If connection is restored we need to kill dispatcher process on awx-task container and wait to restart it.

I don't know if different approach it's possibile but in that way we are sure that all process restart correctly.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 20.10.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
