### PR TITLE
Attempt to consolidate CI logic with github_ci_runner target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,11 @@
 ---
 name: CI
 env:
-  BRANCH: ${{ github.base_ref || 'devel' }}
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
+  py_version: "3.9"
+  CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DEV_DOCKER_TAG_BASE: ghcr.io/${{ github.repository_owner }}
+  COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
 on:
   pull_request:
 jobs:
@@ -43,60 +46,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get python version from Makefile
-        run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
+      - name: Run check ${{ matrix.tests.label }}
+        run: make github_ci_runner
+        env:
+          CI_GITHUB_COMMAND: ${{ matrix.tests.command }}
 
-      - name: Install python ${{ env.py_version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.py_version }}
-
-      - name: Log in to registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Pre-pull image to warm build cache
-        run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/awx_devel:${{ env.BRANCH }} || :
-
-      - name: Build image
-        run: |
-          DEV_DOCKER_TAG_BASE=ghcr.io/${{ github.repository_owner }} COMPOSE_TAG=${{ env.BRANCH }} make docker-compose-build
-
-      - name: ${{ matrix.texts.label }}
-        run: |
-          docker run -u $(id -u) --rm -v ${{ github.workspace}}:/awx_devel/:Z \
-            --workdir=/awx_devel ghcr.io/${{ github.repository_owner }}/awx_devel:${{ env.BRANCH }} ${{ matrix.tests.command }}
   dev-env:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get python version from Makefile
-        run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
-
       - name: Install python ${{ env.py_version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ env.py_version }}
 
-      - name: Log in to registry
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Pre-pull image to warm build cache
-        run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/awx_devel:${{ env.BRANCH }} || :
-
-      - name: Build image
-        run: |
-          DEV_DOCKER_TAG_BASE=ghcr.io/${{ github.repository_owner }} COMPOSE_TAG=${{ env.BRANCH }} make docker-compose-build
-
       - name: Run smoke test
-        run: |
-          export DEV_DOCKER_TAG_BASE=ghcr.io/${{ github.repository_owner }}
-          export COMPOSE_TAG=${{ env.BRANCH }}
-          ansible-playbook tools/docker-compose/ansible/smoke-test.yml -e repo_dir=$(pwd) -v
+        run: make github_ci_setup && ansible-playbook tools/docker-compose/ansible/smoke-test.yml -v
 
   awx-operator:
     runs-on: ubuntu-latest
@@ -111,10 +77,6 @@ jobs:
         with:
           repository: ansible/awx-operator
           path: awx-operator
-
-      - name: Get python version from Makefile
-        working-directory: awx
-        run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
 
       - name: Install python ${{ env.py_version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,32 +20,24 @@ jobs:
         tests:
           - name: api-test
             command: /start_tests.sh
-            label: Run API Tests
           - name: api-lint
             command: /var/lib/awx/venv/awx/bin/tox -e linters
-            label: Run API Linters
           - name: api-swagger
             command: /start_tests.sh swagger
-            label: Generate API Reference
           - name: awx-collection
             command: /start_tests.sh test_collection_all
-            label: Run Collection Tests
           - name: api-schema
-            label: Check API Schema
             command: /start_tests.sh detect-schema-change SCHEMA_DIFF_BASE_BRANCH=${{ github.event.pull_request.base.ref }}
           - name: ui-lint
-            label: Run UI Linters
             command: make ui-lint
           - name: ui-test-screens
-            label: Run UI Screens Tests
             command: make ui-test-screens
           - name: ui-test-general
-            label: Run UI General Tests
             command: make ui-test-general
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run check ${{ matrix.tests.label }}
+      - name: Run check ${{ matrix.tests.name }}
         run: AWX_DOCKER_CMD='${{ matrix.tests.command }}' make github_ci_runner
 
   dev-env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@
 name: CI
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
-  py_version: "3.9"
   CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DEV_DOCKER_TAG_BASE: ghcr.io/${{ github.repository_owner }}
   COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
@@ -56,11 +55,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Install python ${{ env.py_version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ env.py_version }}
-
       - name: Run smoke test
         run: make github_ci_setup && ansible-playbook tools/docker-compose/ansible/smoke-test.yml -v
 
@@ -77,6 +71,10 @@ jobs:
         with:
           repository: ansible/awx-operator
           path: awx-operator
+
+      - name: Get python version from Makefile
+        working-directory: awx
+        run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
 
       - name: Install python ${{ env.py_version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Run check ${{ matrix.tests.label }}
-        run: make github_ci_runner
-        env:
-          CI_GITHUB_COMMAND: ${{ matrix.tests.command }}
+        run: AWX_DOCKER_CMD='${{ matrix.tests.command }}' make github_ci_runner
 
   dev-env:
     runs-on: ubuntu-latest

--- a/tools/docker-compose/ansible/smoke-test.yml
+++ b/tools/docker-compose/ansible/smoke-test.yml
@@ -17,7 +17,7 @@
       environment:
         COMPOSE_UP_OPTS: -d
       args:
-        chdir: "{{ repo_dir }}"
+        chdir: "{{ playbook_dir }}/../../../"
 
     # Takes a while for migrations to finish
     - name: Wait for the dev environment to be ready


### PR DESCRIPTION
##### SUMMARY
I want to get more logic reuse, and also, move logic away from the github actions YAML and into the Makefile.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION
Related to https://github.com/ansible/awx/pull/13467, but trying to be more conservative to clean up before we undertake larger undertakings.
