### PR TITLE
Add error handling to scm_version.py script

### DIFF
--- a/tools/scripts/scm_version.py
+++ b/tools/scripts/scm_version.py
@@ -14,15 +14,7 @@ except ModuleNotFoundError:
         result = subprocess.run(cmd, capture_output=True)
         if result.returncode:
             # failed, we have no version, so print output so that users can debug
-            print(f'\nCommand `{" ".join(cmd)}` failed (rc={result.returncode}).\n\nstdout:')
-            sys.stdout.buffer.write(result.stdout)
-            sys.stdout.flush()
-            sys.stderr.flush()
-            print('\nstderr:\n')
-            sys.stderr.buffer.write(result.stderr)
-            sys.stderr.flush()
-            print('\n')
-            result.check_returncode()  # raise exception from subprocess
+            raise Exception(f'\nCommand `{" ".join(cmd)}` failed (rc={result.returncode}).\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}')
 
     from setuptools_scm import get_version
 

--- a/tools/scripts/scm_version.py
+++ b/tools/scripts/scm_version.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import subprocess
-import traceback
 
 try:
     from setuptools_scm import get_version
@@ -9,8 +8,21 @@ except ModuleNotFoundError:
     sys.stderr.write("Unable to import setuptools-scm, attempting to install now...\n")
 
     os.environ['PIP_DISABLE_PIP_VERSION_CHECK'] = '1'
-    subprocess.check_output([sys.executable, '-m', 'ensurepip'])
-    subprocess.check_output([sys.executable, '-m', 'pip', 'install', 'setuptools-scm'])
+    COMMANDS = ([sys.executable, '-m', 'ensurepip'], [sys.executable, '-m', 'pip', 'install', 'setuptools-scm'])
+    for cmd in COMMANDS:
+        # capture_output because we only want to print version to stdout if successful
+        result = subprocess.run(cmd, capture_output=True)
+        if result.returncode:
+            # failed, we have no version, so print output so that users can debug
+            print(f'\nCommand `{" ".join(cmd)}` failed (rc={result.returncode}).\n\nstdout:')
+            sys.stdout.buffer.write(result.stdout)
+            sys.stdout.flush()
+            sys.stderr.flush()
+            print('\nstderr:\n')
+            sys.stderr.buffer.write(result.stderr)
+            sys.stderr.flush()
+            print('\n')
+            result.check_returncode()  # raise exception from subprocess
 
     from setuptools_scm import get_version
 


### PR DESCRIPTION
##### SUMMARY
I hit cases where this script failed in CI, but then all it tells you is that the subprocess failed, but doesn't give the output of the subprocess.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

