### PR TITLE
[constructed-inventory] add 'constructed' kind to inventory module for awx-collection

### DIFF
--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -54,7 +54,7 @@ options:
     kind:
       description:
         - The kind field. Cannot be modified after created.
-      choices: ["", "smart"]
+      choices: ["", "smart", "constructed"]
       type: str
     host_filter:
       description:
@@ -63,6 +63,11 @@ options:
     instance_groups:
       description:
         - list of Instance Groups for this Organization to run on.
+      type: list
+      elements: str
+    input_inventories:
+      description:
+        - List of Inventories to use as input for Constructed Inventory.
       type: list
       elements: str
     prevent_instance_group_fallback:
@@ -111,11 +116,12 @@ def main():
         description=dict(),
         organization=dict(required=True),
         variables=dict(type='dict'),
-        kind=dict(choices=['', 'smart']),
+        kind=dict(choices=['', 'smart', 'constructed']),
         host_filter=dict(),
         instance_groups=dict(type="list", elements='str'),
         prevent_instance_group_fallback=dict(type='bool'),
         state=dict(choices=['present', 'absent'], default='present'),
+        input_inventories=dict(type='list', elements='str'),
     )
 
     # Create a module for ourselves
@@ -180,6 +186,13 @@ def main():
     # We need to perform a check to make sure you are not trying to convert a regular inventory into a smart one.
     if inventory and inventory['kind'] == '' and inventory_fields['kind'] == 'smart':
         module.fail_json(msg='You cannot turn a regular inventory into a "smart" inventory.')
+
+    if kind == 'constructed':
+        input_inventory_names = module.params.get('input_inventories')
+        if input_inventory_names is not None:
+            association_fields['input_inventories'] = []
+            for item in input_inventory_names:
+                association_fields['input_inventories'].append(module.resolve_name_to_id('inventories', item))
 
     # If the state was present and we can let the module build or update the existing inventory, this will return on its own
     module.create_or_update_if_needed(

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -20,7 +20,9 @@ read_only_endpoints_with_modules = ['settings', 'role', 'project_update']
 
 # If a module should not be created for an endpoint and the endpoint is not read-only add it here
 # THINK HARD ABOUT DOING THIS
-no_module_for_endpoint = []
+no_module_for_endpoint = [
+    'constructed_inventories',  # This is a view for inventory with kind=constructed
+]
 
 # Some modules work on the related fields of an endpoint. These modules will not have an auto-associated endpoint
 no_endpoint_for_module = [


### PR DESCRIPTION
##### SUMMARY
related to [[constructed-inventory] add constructed inventory to awx module](https://github.com/ansible/awx/issues/13495) 

- add kind 'constructed' to inventory module for awx_collection
- add 'input_inventories' to argspec of inventory module for awx_collection
- add 'constructed_inventories' to no_module_for_endpoint for 'test_completeness' to ignore lack of module test failure for awx-collection


Test playbook https://github.com/TheRealHaoLiu/awx-constructed-inventory-demo/commit/a7bd5ff57482a62f41fbb275606654ba6721c252


