### PR TITLE
Fixes #13527 CyberArk Conjur Secrets Manager Lookup Exception Bug

### DIFF
--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -70,7 +70,8 @@ def conjur_backend(**kwargs):
         auth_kwargs['verify'] = cert
         try:
             resp = requests.post(urljoin(url, '/'.join(['authn', account, username, 'authenticate'])), **auth_kwargs)
-        except requests.exceptions.ConnectionError:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError:
             resp = requests.post(urljoin(url, '/'.join(['api', 'authn', account, username, 'authenticate'])), **auth_kwargs)
     raise_for_status(resp)
     token = resp.content.decode('utf-8')
@@ -92,7 +93,8 @@ def conjur_backend(**kwargs):
         lookup_kwargs['verify'] = cert
         try:
             resp = requests.get(path, timeout=30, **lookup_kwargs)
-        except requests.exceptions.ConnectionError:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError:
             resp = requests.get(path_conjurcloud, timeout=30, **lookup_kwargs)
     raise_for_status(resp)
     return resp.text


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixing a bug in exception handling when targeting a Conjur Cloud instance instead of a self-hosted Conjur Secrets Manager or Conjur Open Source instance.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related #13527 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
0.1.dev32763+g3d73b80
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This has been successfully tested on self-hosted Conjur Secrets Manager, self-hosted Conjur Open Source, and Conjur Cloud by @infamousjoeg and @obaranov.
