### PR TITLE
[fix] adding Schedule to dependent_export to allow previous behavior on job template export

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -38,9 +38,12 @@ EXPORTABLE_RELATIONS = ['Roles', 'NotificationTemplates', 'WorkflowJobTemplateNo
 DEPENDENT_EXPORT = [
     ('JobTemplate', 'Label'),
     ('JobTemplate', 'SurveySpec'),
+    ('JobTemplate', 'Schedule'),
     ('WorkflowJobTemplate', 'Label'),
     ('WorkflowJobTemplate', 'SurveySpec'),
+    ('WorkflowJobTemplate', 'Schedule'),
     ('WorkflowJobTemplate', 'WorkflowJobTemplateNode'),
+    ('InventorySource', 'Schedule'),
     ('Inventory', 'Group'),
     ('Inventory', 'Host'),
     ('Inventory', 'Label'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Previously awxkit would allow individual job template, inventory_source, workflow template schedules to be exported as a related field to the resource json returned on `export`. This change reintroduces that behavior.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
  - CLI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 21.11.1.dev65+g0d7bbb4389
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
