### PR TITLE
Fix error for byweekday in schedule_rruleset

### DIFF
--- a/awx_collection/plugins/lookup/schedule_rruleset.py
+++ b/awx_collection/plugins/lookup/schedule_rruleset.py
@@ -210,6 +210,7 @@ class LookupModule(LookupBase):
 
     def process_list(self, field_name, rule, valid_list, rule_number):
         return_values = []
+        # If its not a list, we need to split it into a list
         if not isinstance(rule[field_name], list):
             rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:

--- a/awx_collection/plugins/lookup/schedule_rruleset.py
+++ b/awx_collection/plugins/lookup/schedule_rruleset.py
@@ -196,7 +196,7 @@ class LookupModule(LookupBase):
         if isinstance(rule[field_name], int):
             rule[field_name] = [rule[field_name]]
         # If its not a list, we need to split it into a list
-        if isinstance(rule[field_name], list):
+        if not isinstance(rule[field_name], list):
             rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:
             # If they have a list of strs we want to strip the str incase its space delineated
@@ -210,7 +210,8 @@ class LookupModule(LookupBase):
 
     def process_list(self, field_name, rule, valid_list, rule_number):
         return_values = []
-        rule[field_name] = rule[field_name].split(',')
+        if not isinstance(rule[field_name], list):
+            rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:
             value = value.strip()
             if value not in valid_list:

--- a/awx_collection/plugins/lookup/schedule_rruleset.py
+++ b/awx_collection/plugins/lookup/schedule_rruleset.py
@@ -210,8 +210,7 @@ class LookupModule(LookupBase):
 
     def process_list(self, field_name, rule, valid_list, rule_number):
         return_values = []
-        if isinstance(rule[field_name], list):
-            rule[field_name] = rule[field_name].split(',')
+        rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:
             value = value.strip()
             if value not in valid_list:

--- a/awx_collection/tests/integration/targets/lookup_rruleset/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/lookup_rruleset/tasks/main.yml
@@ -95,6 +95,22 @@
       - results is failed
       - "'In rule 2 end_on must either be an integer or in the format YYYY-MM-DD [HH:MM:SS]' in results.msg"
 
+- name: Every Mondays
+  set_fact:
+    complex_rule: "{{ query(ruleset_plugin_name, '2022-04-30 10:30:45', rules=rrules, timezone='UTC' ) }}"
+  ignore_errors: True
+  register: results
+  vars:
+    rrules:
+      - frequency: 'day'
+        interval: 1
+        byweekday: 'monday'
+
+- assert:
+    that:
+      - results is success
+      - "'DTSTART;TZID=UTC:20220430T103045 RRULE:FREQ=DAILY;BYDAY=MO;INTERVAL=1' == complex_rule"
+
 
 - name: call rruleset with an invalid byweekday
   set_fact:


### PR DESCRIPTION
Fix error:
```
fatal: [localhost]: FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'awx.awx.schedule_rruleset'. Error was a <class 'ansible.errors.AnsibleError'>, original message: In rule 1 byweekday must only contain values in monday, tuesday, wednesday, thursday, friday, saturday, sunday. In rule 1 byweekday must only contain values in monday, tuesday, wednesday, thursday, friday, saturday, sunday"
}
```

with:
```
    - name: Build a complex schedule for every monday using the rruleset plugin
      awx.awx.schedule:
        name: "Test build complex schedule"
        state: present
        unified_job_template: "template name"
        rrule: "{{ query('awx.awx.schedule_rruleset', '2030-04-30 10:30:45', rules=rrules, timezone='Europe/Paris' ) }}"
      vars:
        rrules:
          - frequency: 'day'
            interval: 1
            byweekday: 'monday'
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
AWX 21.11.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Tested with:
- byweekday: 'monday'
- byweekday: 'monday, friday'
- byweekday: monday
```
