### PR TITLE
Added readonly api endpoint for constructed hosts

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1702,6 +1702,7 @@ class InventorySerializer(LabelsListMixin, BaseSerializerWithVariables):
         if obj.organization:
             res['organization'] = self.reverse('api:organization_detail', kwargs={'pk': obj.organization.pk})
         if obj.kind == 'constructed':
+            res['hosts'] = self.reverse('api:constructed_inventory_host_list', kwargs={'pk': obj.pk})
             res['input_inventories'] = self.reverse('api:inventory_input_inventories', kwargs={'pk': obj.pk})
             res['constructed_url'] = self.reverse('api:constructed_inventory_detail', kwargs={'pk': obj.pk})
         return res

--- a/awx/api/urls/inventory.py
+++ b/awx/api/urls/inventory.py
@@ -27,6 +27,7 @@ from awx.api.views import (
     InventoryScriptView,
     InventoryTreeView,
     InventoryVariableData,
+    ConstructedInventoryHostList,
 )
 
 
@@ -56,6 +57,7 @@ urls = [
 constructed_inventory_urls = [
     re_path(r'^$', ConstructedInventoryList.as_view(), name='constructed_inventory_list'),
     re_path(r'^(?P<pk>[0-9]+)/$', ConstructedInventoryDetail.as_view(), name='constructed_inventory_detail'),
+    re_path(r'^(?P<pk>[0-9]+)/hosts/', ConstructedInventoryHostList.as_view(), name='constructed_inventory_host_list'),
 ]
 
 __all__ = ['urls', 'constructed_inventory_urls']

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1582,6 +1582,21 @@ class InventoryHostsList(HostRelatedSearchMixin, SubListCreateAttachDetachAPIVie
         return qs
 
 
+class ConstructedInventoryHostList(HostRelatedSearchMixin, SubListAPIView):
+    model = models.Host
+    serializer_class = serializers.HostSerializer
+    parent_model = models.Inventory
+    relationship = 'hosts'
+    parent_key = 'inventory'
+
+    def get_queryset(self):
+        inventory = self.get_parent_object()
+        qs = getattrd(inventory, self.relationship).all()
+        # Apply queryset optimizations
+        qs = qs.select_related(*HostAccess.select_related).prefetch_related(*HostAccess.prefetch_related)
+        return qs
+
+
 class HostGroupsList(SubListCreateAttachDetachAPIView):
     '''the list of groups a host is directly a member of'''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Constructed inventories should not allow adding hosts directly to it, created a new inventory list endpoint specifically for constructed inventories

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature
 - 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 21.11.1.dev87+g4e6e9bb074
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
