### PR TITLE
[constructed-inventory] remove ability to add constructed inventories to input inventories

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2244,6 +2244,8 @@ class InventorySourceSerializer(UnifiedJobTemplateSerializer, InventorySourceOpt
         obj = super(InventorySourceSerializer, self).update(obj, validated_data)
         if deprecated_fields:
             self._update_deprecated_fields(deprecated_fields, obj)
+        if obj.source == 'constructed':
+            raise serializers.ValidationError({'error': _("Cannot edit source of type constructed.")})
         return obj
 
     # TODO: remove when old 'credential' fields are removed

--- a/awx/api/views/inventory.py
+++ b/awx/api/views/inventory.py
@@ -115,6 +115,15 @@ class InventoryInputInventoriesList(SubListAttachDetachAPIView):
     parent_model = Inventory
     relationship = 'input_inventories'
 
+    # Specifically overriding the post method on this view to disallow constructed inventories as input inventories
+    def post(self, request, *args, **kwargs):
+        obj = Inventory.objects.get(id=request.data.get('id'))
+        if obj.kind == 'constructed':
+            return Response(
+                dict(error=_('You cannot add a constructed inventory to another constructed inventory.')), status=status.HTTP_405_METHOD_NOT_ALLOWED
+            )
+        return super(InventoryInputInventoriesList, self).post(request, *args, **kwargs)
+
 
 class InventoryActivityStreamList(SubListAPIView):
     model = ActivityStream

--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -512,6 +512,14 @@ def group(inventory):
 
 
 @pytest.fixture
+def constructed_inventory(organization):
+    """
+    creates a new constructed inventory source
+    """
+    return Inventory.objects.create(name='dummy1', kind='constructed', organization=organization)
+
+
+@pytest.fixture
 def inventory_source(inventory):
     # by making it ec2, the credential is not required
     return InventorySource.objects.create(name='single-inv-src', inventory=inventory, source='ec2')

--- a/awx/main/tests/functional/test_inventory_input_constructed.py
+++ b/awx/main/tests/functional/test_inventory_input_constructed.py
@@ -1,0 +1,17 @@
+import pytest
+from awx.main.models import Inventory
+from awx.api.versioning import reverse
+
+
+@pytest.mark.django_db
+def test_constructed_inventory_post(post, organization, admin_user):
+    inventory1 = Inventory.objects.create(name='dummy1', kind='constructed', organization=organization)
+    inventory2 = Inventory.objects.create(name='dummy2', kind='constructed', organization=organization)
+    resp = post(
+        url=reverse('api:inventory_input_inventories', kwargs={'pk': inventory1.id}),
+        data={'id': inventory2.id},
+        user=admin_user,
+        expect=405,
+    )
+    print(resp)
+    assert resp.status_code == 405

--- a/awx/main/tests/functional/test_inventory_input_constructed.py
+++ b/awx/main/tests/functional/test_inventory_input_constructed.py
@@ -4,10 +4,11 @@ from awx.api.versioning import reverse
 
 
 @pytest.fixture
-def constructed_inventory(organization, inventory):
-    inv_source = Inventory.objects.create(name='dummy2', kind='constructed', organization=organization)
-
-    return inv_source
+def constructed_inventory(organization):
+    """
+    creates a new constructed inventory source
+    """
+    return Inventory.objects.create(name='dummy2', kind='constructed', organization=organization)
 
 
 @pytest.mark.django_db
@@ -15,8 +16,8 @@ def test_constructed_inventory_post(post, organization, admin_user):
     inventory1 = Inventory.objects.create(name='dummy1', kind='constructed', organization=organization)
     inventory2 = Inventory.objects.create(name='dummy2', kind='constructed', organization=organization)
     resp = post(
-        url=reverse('api:inventory_input_inventories', kwargs={'pk': inventory1.id}),
-        data={'id': inventory2.id},
+        url=reverse('api:inventory_input_inventories', kwargs={'pk': inventory1.pk}),
+        data={'id': inventory2.pk},
         user=admin_user,
         expect=405,
     )
@@ -26,7 +27,7 @@ def test_constructed_inventory_post(post, organization, admin_user):
 @pytest.mark.django_db
 def test_add_constructed_inventory_source(post, admin_user, constructed_inventory):
     resp = post(
-        url=reverse('api:inventory_inventory_sources_list', kwargs={'pk': constructed_inventory.id}),
+        url=reverse('api:inventory_inventory_sources_list', kwargs={'pk': constructed_inventory.pk}),
         data={'name': 'dummy1', 'source': 'constructed'},
         user=admin_user,
         expect=400,
@@ -50,6 +51,19 @@ def test_add_constructed_inventory_group(post, admin_user, constructed_inventory
     resp = post(
         reverse('api:inventory_groups_list', kwargs={'pk': constructed_inventory.pk}),
         data={'name': 'group-test'},
+        user=admin_user,
+        expect=400,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_edit_constructed_inventory_source(patch, admin_user, inventory):
+    inventory.inventory_sources.create(name="dummysrc", source="constructed")
+    inv_id = inventory.inventory_sources.get(name='dummysrc').id
+    resp = patch(
+        reverse('api:inventory_source_detail', kwargs={'pk': inv_id}),
+        data={'description': inventory.name},
         user=admin_user,
         expect=400,
     )

--- a/awx/main/tests/functional/test_inventory_input_constructed.py
+++ b/awx/main/tests/functional/test_inventory_input_constructed.py
@@ -3,26 +3,10 @@ from awx.main.models import Inventory
 from awx.api.versioning import reverse
 
 
-@pytest.fixture
-def constructed_inventory(organization):
-    """
-    creates a new constructed inventory source
-    """
-
-    def factory(name, org=organization):
-        try:
-            inv = Inventory.objects.get(name=name, organization=org, kind='constructed')
-        except Inventory.DoesNotExist:
-            inv = Inventory.objects.create(name=name, organization=org, kind='constructed')
-        return inv
-
-    return factory
-
-
 @pytest.mark.django_db
-def test_constructed_inventory_post(post, admin_user, constructed_inventory):
-    inv1 = constructed_inventory(name='dummy1')
-    inv2 = constructed_inventory(name='dummy2')
+def test_constructed_inventory_post(post, admin_user, organization):
+    inv1 = Inventory.objects.create(name='dummy1', kind='constructed', organization=organization)
+    inv2 = Inventory.objects.create(name='dummy2', kind='constructed', organization=organization)
     resp = post(
         url=reverse('api:inventory_input_inventories', kwargs={'pk': inv1.pk}),
         data={'id': inv2.pk},
@@ -34,9 +18,8 @@ def test_constructed_inventory_post(post, admin_user, constructed_inventory):
 
 @pytest.mark.django_db
 def test_add_constructed_inventory_source(post, admin_user, constructed_inventory):
-    inv1 = constructed_inventory(name='dummy1')
     resp = post(
-        url=reverse('api:inventory_inventory_sources_list', kwargs={'pk': inv1.pk}),
+        url=reverse('api:inventory_inventory_sources_list', kwargs={'pk': constructed_inventory.pk}),
         data={'name': 'dummy1', 'source': 'constructed'},
         user=admin_user,
         expect=400,
@@ -46,9 +29,8 @@ def test_add_constructed_inventory_source(post, admin_user, constructed_inventor
 
 @pytest.mark.django_db
 def test_add_constructed_inventory_host(post, admin_user, constructed_inventory):
-    inv1 = constructed_inventory(name='dummy1')
     resp = post(
-        url=reverse('api:inventory_hosts_list', kwargs={'pk': inv1.pk}),
+        url=reverse('api:inventory_hosts_list', kwargs={'pk': constructed_inventory.pk}),
         data={'name': 'dummy1'},
         user=admin_user,
         expect=400,
@@ -58,9 +40,8 @@ def test_add_constructed_inventory_host(post, admin_user, constructed_inventory)
 
 @pytest.mark.django_db
 def test_add_constructed_inventory_group(post, admin_user, constructed_inventory):
-    inv1 = constructed_inventory(name='dummy1')
     resp = post(
-        reverse('api:inventory_groups_list', kwargs={'pk': inv1.pk}),
+        reverse('api:inventory_groups_list', kwargs={'pk': constructed_inventory.pk}),
         data={'name': 'group-test'},
         user=admin_user,
         expect=400,
@@ -72,7 +53,7 @@ def test_add_constructed_inventory_group(post, admin_user, constructed_inventory
 def test_edit_constructed_inventory_source(patch, admin_user, inventory_source_factory):
     inv_src = inventory_source_factory(name='dummy1', source='constructed')
     resp = patch(
-        reverse('api:inventory_source_detail', kwargs={'pk': inv_src.id}),
+        reverse('api:inventory_source_detail', kwargs={'pk': inv_src.pk}),
         data={'description': inv_src.name},
         user=admin_user,
         expect=400,

--- a/awx/main/tests/functional/test_inventory_input_constructed.py
+++ b/awx/main/tests/functional/test_inventory_input_constructed.py
@@ -3,6 +3,13 @@ from awx.main.models import Inventory
 from awx.api.versioning import reverse
 
 
+@pytest.fixture
+def constructed_inventory(organization, inventory):
+    inv_source = Inventory.objects.create(name='dummy2', kind='constructed', organization=organization)
+
+    return inv_source
+
+
 @pytest.mark.django_db
 def test_constructed_inventory_post(post, organization, admin_user):
     inventory1 = Inventory.objects.create(name='dummy1', kind='constructed', organization=organization)
@@ -13,5 +20,37 @@ def test_constructed_inventory_post(post, organization, admin_user):
         user=admin_user,
         expect=405,
     )
-    print(resp)
     assert resp.status_code == 405
+
+
+@pytest.mark.django_db
+def test_add_constructed_inventory_source(post, admin_user, constructed_inventory):
+    resp = post(
+        url=reverse('api:inventory_inventory_sources_list', kwargs={'pk': constructed_inventory.id}),
+        data={'name': 'dummy1', 'source': 'constructed'},
+        user=admin_user,
+        expect=400,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_add_constructed_inventory_host(post, admin_user, constructed_inventory):
+    resp = post(
+        url=reverse('api:inventory_hosts_list', kwargs={'pk': constructed_inventory.pk}),
+        data={'name': 'dummy1'},
+        user=admin_user,
+        expect=400,
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.django_db
+def test_add_constructed_inventory_group(post, admin_user, constructed_inventory):
+    resp = post(
+        reverse('api:inventory_groups_list', kwargs={'pk': constructed_inventory.pk}),
+        data={'name': 'group-test'},
+        user=admin_user,
+        expect=400,
+    )
+    assert resp.status_code == 400


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
related: https://github.com/ansible/awx/issues/13540
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 21.11.1.dev90+gc28768cc08

```



