### PR TITLE
Add selective type enforcement to a test fixture

### DIFF
--- a/awx/main/tests/functional/api/test_deprecated_credential_assignment.py
+++ b/awx/main/tests/functional/api/test_deprecated_credential_assignment.py
@@ -140,7 +140,7 @@ def test_deprecated_credential_activity_stream(patch, admin_user, machine_creden
     job_template.credentials.add(machine_credential)
     starting_entries = job_template.activitystream_set.count()
     # no-op patch
-    patch(job_template.get_absolute_url(), admin_user, data={'credential': machine_credential.pk}, expect=200)
+    patch(job_template.get_absolute_url(), user=admin_user, data={'credential': machine_credential.pk}, expect=200)
     # no-op should not produce activity stream entries
     assert starting_entries == job_template.activitystream_set.count()
 
@@ -157,7 +157,7 @@ def test_multi_vault_preserved_on_put(get, put, admin_user, job_template, vault_
     )
     job_template.credentials.add(vault_credential, vault2)
     assert job_template.credentials.count() == 2  # sanity check
-    r = get(job_template.get_absolute_url(), admin_user, expect=200)
+    r = get(job_template.get_absolute_url(), user=admin_user, expect=200)
     # should be a no-op PUT request
-    put(job_template.get_absolute_url(), admin_user, data=r.data, expect=200)
+    put(job_template.get_absolute_url(), user=admin_user, data=dict(r.data), expect=200)
     assert job_template.credentials.count() == 2

--- a/awx/main/tests/functional/api/test_instance_group.py
+++ b/awx/main/tests/functional/api/test_instance_group.py
@@ -94,7 +94,7 @@ def source_model(request):
 @pytest.mark.django_db
 def test_delete_instance_group_jobs(delete, instance_group_jobs_successful, instance_group, admin):
     url = reverse("api:instance_group_detail", kwargs={'pk': instance_group.pk})
-    delete(url, None, admin, expect=204)
+    delete(url, user=admin, expect=204)
 
 
 @pytest.mark.django_db
@@ -103,7 +103,7 @@ def test_delete_instance_group_jobs_running(delete, instance_group_jobs_running,
         return (x['type'], str(x['id']))
 
     url = reverse("api:instance_group_detail", kwargs={'pk': instance_group.pk})
-    response = delete(url, None, admin, expect=409)
+    response = delete(url, user=admin, expect=409)
 
     expect_transformed = [dict(id=j.id, type=j.model_to_str()) for j in instance_group_jobs_running]
     response_sorted = sorted(response.data['active_jobs'], key=sort_keys)
@@ -120,9 +120,9 @@ def test_delete_rename_tower_instance_group_prevented(
     url = reverse("api:instance_group_detail", kwargs={'pk': tower_instance_group.pk})
     super_user = user('bob', True)
 
-    delete(url, None, super_user, expect=403)
+    delete(url, user=super_user, expect=403)
 
-    resp = options(url, None, super_user, expect=200)
+    resp = options(url, user=super_user, expect=200)
     assert len(resp.data['actions'].keys()) == 2
     assert 'DELETE' not in resp.data['actions']
     assert 'GET' in resp.data['actions']

--- a/awx/main/tests/functional/api/test_job_runtime_params.py
+++ b/awx/main/tests/functional/api/test_job_runtime_params.py
@@ -443,7 +443,7 @@ def test_job_launch_fails_with_missing_vault_password(machine_credential, vault_
     deploy_jobtemplate.execute_role.members.add(rando)
     deploy_jobtemplate.save()
 
-    response = post(reverse('api:job_template_launch', kwargs={'pk': deploy_jobtemplate.pk}), rando, expect=400)
+    response = post(reverse('api:job_template_launch', kwargs={'pk': deploy_jobtemplate.pk}), user=rando, expect=400)
     assert response.data['passwords_needed_to_start'] == ['vault_password']
 
 
@@ -547,7 +547,7 @@ def test_job_launch_fails_with_missing_multivault_password(machine_credential, v
         [cred['passwords_needed'] for cred in resp.data['defaults']['credentials'] if cred['credential_type'] == vault_credential.credential_type_id], []
     ) == ['vault_password.abc', 'vault_password.xyz']
 
-    resp = post(url, rando, expect=400)
+    resp = post(url, user=rando, expect=400)
     assert resp.data['passwords_needed_to_start'] == ['vault_password.abc', 'vault_password.xyz']
 
     with mock.patch.object(Job, 'signal_start') as signal_start:
@@ -563,7 +563,7 @@ def test_job_launch_fails_with_missing_ssh_password(machine_credential, deploy_j
     deploy_jobtemplate.execute_role.members.add(rando)
     deploy_jobtemplate.save()
 
-    response = post(reverse('api:job_template_launch', kwargs={'pk': deploy_jobtemplate.pk}), rando, expect=400)
+    response = post(reverse('api:job_template_launch', kwargs={'pk': deploy_jobtemplate.pk}), user=rando, expect=400)
     assert response.data['passwords_needed_to_start'] == ['ssh_password']
 
 
@@ -578,7 +578,7 @@ def test_job_launch_fails_with_missing_vault_and_ssh_password(machine_credential
     deploy_jobtemplate.execute_role.members.add(rando)
     deploy_jobtemplate.save()
 
-    response = post(reverse('api:job_template_launch', kwargs={'pk': deploy_jobtemplate.pk}), rando, expect=400)
+    response = post(reverse('api:job_template_launch', kwargs={'pk': deploy_jobtemplate.pk}), user=rando, expect=400)
     assert sorted(response.data['passwords_needed_to_start']) == ['ssh_password', 'vault_password']
 
 

--- a/awx/main/tests/functional/api/test_notifications.py
+++ b/awx/main/tests/functional/api/test_notifications.py
@@ -114,7 +114,7 @@ def test_post_wfjt_running_notification(get, post, admin, notification_template,
 @pytest.mark.django_db
 def test_search_on_notification_configuration_is_prevented(get, admin):
     url = reverse('api:notification_template_list')
-    response = get(url, {'notification_configuration__regex': 'ABCDEF'}, admin)
+    response = get(url, data={'notification_configuration__regex': 'ABCDEF'}, user=admin)
     assert response.status_code == 403
     assert response.data == {"detail": "Filtering on notification_configuration is not allowed."}
 

--- a/awx/main/tests/functional/api/test_settings.py
+++ b/awx/main/tests/functional/api/test_settings.py
@@ -147,7 +147,7 @@ def test_empty_ldap_dn(get, put, patch, delete, admin, setting):
 def test_radius_settings(get, put, patch, delete, admin, settings):
     url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'radius'})
     response = get(url, user=admin, expect=200)
-    put(url, user=admin, data=response.data, expect=200)
+    put(url, user=admin, data=dict(response.data), expect=200)
     # Set secret via the API.
     patch(url, user=admin, data={'RADIUS_SECRET': 'mysecret'}, expect=200)
     response = get(url, user=admin, expect=200)
@@ -179,7 +179,7 @@ def test_radius_settings(get, put, patch, delete, admin, settings):
 def test_tacacsplus_settings(get, put, patch, admin):
     url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'tacacsplus'})
     response = get(url, user=admin, expect=200)
-    put(url, user=admin, data=response.data, expect=200)
+    put(url, user=admin, data=dict(response.data), expect=200)
     patch(url, user=admin, data={'TACACSPLUS_SECRET': 'mysecret'}, expect=200)
     patch(url, user=admin, data={'TACACSPLUS_SECRET': ''}, expect=200)
     patch(url, user=admin, data={'TACACSPLUS_HOST': 'localhost'}, expect=400)
@@ -196,7 +196,7 @@ def test_ui_settings(get, put, patch, delete, admin):
     response = get(url, user=admin, expect=200)
     assert not response.data['CUSTOM_LOGO']
     assert not response.data['CUSTOM_LOGIN_INFO']
-    put(url, user=admin, data=response.data, expect=200)
+    put(url, user=admin, data=dict(response.data), expect=200)
     patch(url, user=admin, data={'CUSTOM_LOGO': 'data:text/plain;base64,'}, expect=400)
     patch(url, user=admin, data={'CUSTOM_LOGO': 'data:image/png;base64,00'}, expect=400)
     patch(url, user=admin, data={'CUSTOM_LOGO': TEST_GIF_LOGO}, expect=200)

--- a/awx/main/tests/functional/api/test_unified_job_template.py
+++ b/awx/main/tests/functional/api/test_unified_job_template.py
@@ -7,7 +7,7 @@ from awx.main import models
 @pytest.mark.django_db
 def test_aliased_forward_reverse_field_searches(instance, options, get, admin):
     url = reverse('api:unified_job_template_list')
-    response = options(url, None, admin)
+    response = options(url, admin)
     assert 'job_template__search' in response.data['related_search_fields']
     get(reverse("api:unified_job_template_list") + "?job_template__search=anything", user=admin, expect=200)
 

--- a/awx/main/tests/functional/api/test_unified_jobs_view.py
+++ b/awx/main/tests/functional/api/test_unified_jobs_view.py
@@ -90,7 +90,7 @@ def test_job_redaction_disabled(get, format, content_type, negative_test_cases, 
 @pytest.mark.django_db
 def test_options_fields_choices(instance, options, user):
     url = reverse('api:unified_job_list')
-    response = options(url, None, user('admin', True))
+    response = options(url, user('admin', True))
 
     assert 'launch_type' in response.data['actions']['GET']
     assert 'choice' == response.data['actions']['GET']['launch_type']['type']
@@ -104,7 +104,7 @@ def test_options_fields_choices(instance, options, user):
 def test_delete_job_in_active_state(job_factory, delete, admin, status):
     j = job_factory(initial_state=status)
     url = reverse('api:job_detail', kwargs={'pk': j.pk})
-    delete(url, None, admin, expect=403)
+    delete(url, admin, expect=403)
 
 
 @pytest.mark.parametrize("status", list(TEST_STATES))
@@ -113,7 +113,7 @@ def test_delete_project_update_in_active_state(project, delete, admin, status):
     p = ProjectUpdate(project=project, status=status)
     p.save()
     url = reverse('api:project_update_detail', kwargs={'pk': p.pk})
-    delete(url, None, admin, expect=403)
+    delete(url, user=admin, expect=403)
 
 
 @pytest.mark.parametrize("status", list(TEST_STATES))
@@ -121,7 +121,7 @@ def test_delete_project_update_in_active_state(project, delete, admin, status):
 def test_delete_inventory_update_in_active_state(inventory_source, delete, admin, status):
     i = InventoryUpdate.objects.create(inventory_source=inventory_source, status=status, source=inventory_source.source)
     url = reverse('api:inventory_update_detail', kwargs={'pk': i.pk})
-    delete(url, None, admin, expect=403)
+    delete(url, user=admin, expect=403)
 
 
 @pytest.mark.parametrize("status", list(TEST_STATES))
@@ -129,7 +129,7 @@ def test_delete_inventory_update_in_active_state(inventory_source, delete, admin
 def test_delete_workflow_job_in_active_state(workflow_job_factory, delete, admin, status):
     wj = workflow_job_factory(initial_state=status)
     url = reverse('api:workflow_job_detail', kwargs={'pk': wj.pk})
-    delete(url, None, admin, expect=403)
+    delete(url, user=admin, expect=403)
 
 
 @pytest.mark.parametrize("status", list(TEST_STATES))
@@ -137,7 +137,7 @@ def test_delete_workflow_job_in_active_state(workflow_job_factory, delete, admin
 def test_delete_system_job_in_active_state(system_job_factory, delete, admin, status):
     sys_j = system_job_factory(initial_state=status)
     url = reverse('api:system_job_detail', kwargs={'pk': sys_j.pk})
-    delete(url, None, admin, expect=403)
+    delete(url, user=admin, expect=403)
 
 
 @pytest.mark.parametrize("status", list(TEST_STATES))
@@ -145,4 +145,4 @@ def test_delete_system_job_in_active_state(system_job_factory, delete, admin, st
 def test_delete_ad_hoc_command_in_active_state(ad_hoc_command_factory, delete, admin, status):
     adhoc = ad_hoc_command_factory(initial_state=status)
     url = reverse('api:ad_hoc_command_detail', kwargs={'pk': adhoc.pk})
-    delete(url, None, admin, expect=403)
+    delete(url, user=admin, expect=403)

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -114,7 +114,7 @@ def run_module(request, collection_import):
             # make request
             with transaction.atomic():
                 rf = _request(method.lower())
-                django_response = rf(url, user=request_user, expect=None, **kwargs_copy)
+                django_response = rf(url, user=request_user, **kwargs_copy)
 
             # requests library response object is different from the Django response, but they are the same concept
             # this converts the Django response object into a requests response object for consumption
@@ -253,9 +253,7 @@ def vault_credential(organization):
 def kube_credential():
     ct = CredentialType.defaults['kubernetes_bearer_token']()
     ct.save()
-    return Credential.objects.create(
-        credential_type=ct, name='kube-cred', inputs={'host': 'my.cluster', 'bearer_token': 'my-token', 'verify_ssl': False}
-    )
+    return Credential.objects.create(credential_type=ct, name='kube-cred', inputs={'host': 'my.cluster', 'bearer_token': 'my-token', 'verify_ssl': False})
 
 
 @pytest.fixture

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -226,7 +226,6 @@ def test_completeness(collection_import, request, admin_user, job_template, exec
     endpoint_response = _request('get')(
         url='/api/v2/',
         user=admin_user,
-        expect=None,
     )
     for endpoint in endpoint_response.data.keys():
         # Module names are singular and endpoints are plural so we need to convert to singular
@@ -253,7 +252,6 @@ def test_completeness(collection_import, request, admin_user, job_template, exec
         options_response = _request('options')(
             url=endpoint_url,
             user=admin_user,
-            expect=None,
         )
         if 'POST' in options_response.data.get('actions', {}):
             option_comparison[module_name]['api_options'] = options_response.data.get('actions').get('POST')

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -5,6 +5,7 @@ django-rest-swagger
 ipython>=7.31.1 # https://github.com/ansible/awx/security/dependabot/30
 unittest2
 black
+type-enforced
 pytest!=7.0.0
 pytest-cov
 pytest-django


### PR DESCRIPTION
##### SUMMARY
We want to use some newer python stuff, so I wanted to use the request fixtures as a foot-in-the-door towards more type hinting. This jives well, because the method signature is a bit of a mess as it stands.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

