### PR TITLE
Adding sonarcloud integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@ branch = True
 omit =
     awx/main/migrations/*
     awx/lib/site-packages/*
+relative_files = True
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -13,7 +13,7 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   api-test:
-    name: api-test
+    name: api-test with sonarcloud
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -25,8 +25,11 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
+      - name: Echo the varaible
+        run: echo Token should be Z${{ secrets.QUAY_USER }}Z
+
       - name: Run tests and generate coverage report
-        run: AWX_DOCKER_CMD='/start_tests.sh test_coverage' make github_ci_runner
+        run: AWX_DOCKER_CMD='/start_tests.sh' make github_ci_runner
 
       - name: SonarCloud Scan
         # We want this to run even if the tests fail

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,0 +1,37 @@
+---
+name: CI
+env:
+  LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
+  CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  DEV_DOCKER_TAG_BASE: ghcr.io/${{ github.repository_owner }}
+  COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
+on:
+  push:
+    branches:
+      - devel
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  api-test:
+    name: api-test
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Run tests and generate coverage report
+        run: AWX_DOCKER_CMD='/start_tests.sh test_coverage' make github_ci_runner
+
+      - name: SonarCloud Scan
+        # We want this to run even if the tests fail
+        if: (success() || failure()) && github.repository == 'ansible/awx'
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - name: api-test
-            command: /start_tests.sh
           - name: api-lint
             command: /var/lib/awx/venv/awx/bin/tox -e linters
           - name: api-swagger

--- a/Makefile
+++ b/Makefile
@@ -314,9 +314,10 @@ test:
 	if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider $(PYTEST_ARGS) $(TEST_DIRS)
+	PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider --create-db --cov=awx --cov-report=xml --junitxml=./reports/junit.xml $(PYTEST_ARGS) $(TEST_DIRS)
 	cd awxkit && $(VENV_BASE)/awx/bin/tox -re py3
 	awx-manage check_migrations --dry-run --check  -n 'missing_migration_file'
+
 
 ## Login to Github container image registry, pull image, then build image.
 github_ci_setup:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=ansible_awx
+sonar.organization=ansible
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=AWX
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR enables our pull requests and merge to kick off a sonarcloud analysis. This has been combined with the api-test check. We now run the tests with `make test_coverage` which will generate a coverage report in addition to running the tests. If the PR or Merge is happening in the ansible/awx repo we will also kick off a sonarcloud analysis. 

The results can be seen in our public sonarcloud repo: https://sonarcloud.io/project/pull_requests_list?id=ansible_awx

At this time, the sonarcloud analysis will not block any PR merging, its more of a reference for us. In the future we would like to include notification from sonarcloud into the PR and potentially also gate the code merge based on the analysis.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
