### PR TITLE
Fix a typo in the help text for Generic OIDC

### DIFF
--- a/awx/sso/conf.py
+++ b/awx/sso/conf.py
@@ -1258,7 +1258,7 @@ register(
     field_class=fields.BooleanField,
     default=True,
     label=_('Verify OIDC Provider Certificate'),
-    help_text=_('Verify the OIDV provider ssl certificate.'),
+    help_text=_('Verify the OIDC provider ssl certificate.'),
     category=_('Generic OIDC'),
     category_slug='oidc',
 )

--- a/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
@@ -868,7 +868,7 @@
         "type": "boolean",
         "required": false,
         "label": "Verify OIDC Provider Certificate",
-        "help_text": "Verify the OIDV provider ssl certificate.",
+        "help_text": "Verify the OIDC provider ssl certificate.",
         "category": "Generic OIDC",
         "category_slug": "oidc",
         "default": true
@@ -4545,7 +4545,7 @@
       "SOCIAL_AUTH_OIDC_VERIFY_SSL": {
         "type": "boolean",
         "label": "Verify OIDC Provider Certificate",
-        "help_text": "Verify the OIDV provider ssl certificate.",
+        "help_text": "Verify the OIDC provider ssl certificate.",
         "category": "Generic OIDC",
         "category_slug": "oidc",
         "default": true


### PR DESCRIPTION
##### SUMMARY
Fixed a typo in the help texts for the generic OIDC IDP.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 0.1.dev32834+g67562a6
```
