### PR TITLE
Fixing LDAP users not being properly added to managed teams

### DIFF
--- a/awx/sso/backends.py
+++ b/awx/sso/backends.py
@@ -385,10 +385,10 @@ def on_populate_user(sender, **kwargs):
             logger.warning('LDAP user {} has {} > max {} characters'.format(user.username, field, max_len))
 
     org_map = getattr(backend.settings, 'ORGANIZATION_MAP', {})
-    team_map = getattr(backend.settings, 'TEAM_MAP', {})
+    team_map_settings = getattr(backend.settings, 'TEAM_MAP', {})
     orgs_list = list(org_map.keys())
     team_map = {}
-    for team_name, team_opts in team_map.items():
+    for team_name, team_opts in team_map_settings.items():
         if not team_opts.get('organization', None):
             # You can't save the LDAP config in the UI w/o an org (or '' or null as the org) so if we somehow got this condition its an error
             logger.error("Team named {} in LDAP team map settings is invalid due to missing organization".format(team_name))
@@ -416,7 +416,7 @@ def on_populate_user(sender, **kwargs):
 
     # Compute in memory what the state is of the different LDAP teams
     desired_team_states = {}
-    for team_name, team_opts in team_map.items():
+    for team_name, team_opts in team_map_settings.items():
         if 'organization' not in team_opts:
             continue
         users_opts = team_opts.get('users', None)


### PR DESCRIPTION
The SAML enhancements caused a regression where LDAP users were not being properly added to LDAP teams. This was due to a duplicate variable name being used to track both the orgs needing to be created from teams (`team_map`) along with the `team_map` settings. This PR changes the variable name for the settings to be `team_map_settings` to prevent this.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
