### PR TITLE
Do not create setting with invalid value in data migration

### DIFF
--- a/awx/conf/migrations/_ldap_group_type.py
+++ b/awx/conf/migrations/_ldap_group_type.py
@@ -1,7 +1,11 @@
 import inspect
 
 from django.conf import settings
-from django.utils.timezone import now
+
+import logging
+
+
+logger = logging.getLogger('awx.conf.migrations')
 
 
 def fill_ldap_group_type_params(apps, schema_editor):
@@ -15,7 +19,7 @@ def fill_ldap_group_type_params(apps, schema_editor):
         entry = qs[0]
         group_type_params = entry.value
     else:
-        entry = Setting(key='AUTH_LDAP_GROUP_TYPE_PARAMS', value=group_type_params, created=now(), modified=now())
+        return  # for new installs we prefer to use the default value
 
     init_attrs = set(inspect.getfullargspec(group_type.__init__).args[1:])
     for k in list(group_type_params.keys()):
@@ -23,4 +27,5 @@ def fill_ldap_group_type_params(apps, schema_editor):
             del group_type_params[k]
 
     entry.value = group_type_params
+    logger.warning(f'Migration updating AUTH_LDAP_GROUP_TYPE_PARAMS with value {entry.value}')
     entry.save()

--- a/awx/conf/tests/functional/test_migrations.py
+++ b/awx/conf/tests/functional/test_migrations.py
@@ -1,0 +1,25 @@
+import pytest
+
+from awx.conf.migrations._ldap_group_type import fill_ldap_group_type_params
+from awx.conf.models import Setting
+
+from django.apps import apps
+
+
+@pytest.mark.django_db
+def test_fill_group_type_params_no_op():
+    fill_ldap_group_type_params(apps, 'dont-use-me')
+    assert Setting.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_keep_old_setting_with_default_value():
+    Setting.objects.create(key='AUTH_LDAP_GROUP_TYPE', value={'name_attr': 'cn', 'member_attr': 'member'})
+    fill_ldap_group_type_params(apps, 'dont-use-me')
+    assert Setting.objects.count() == 1
+    s = Setting.objects.first()
+    assert s.value == {'name_attr': 'cn', 'member_attr': 'member'}
+
+
+# NOTE: would be good to test the removal of attributes by migration
+# but this requires fighting with the validator and is not done here


### PR DESCRIPTION
##### SUMMARY
Do a new install and check `/api/v2/settings/ldap/`

```json
    "AUTH_LDAP_GROUP_TYPE_PARAMS": {},
```

This is an invalid value, and will fail the validation not for itself, but for `AUTH_LDAP_GROUP_TYPE`, which uses these params to initialize a library object. The class of that object takes a positional argument, so `{}` throws an exception, not meeting the method signature.

Check the settings in the database.

```python
In [1]: Setting.objects.all()
Out[1]: <QuerySet [<Setting: AUTH_LDAP_GROUP_TYPE_PARAMS = {}>, <Setting: INSTALL_UUID = "19f61c3a-b386-43f8-a31d-8e744bc2fa50">]>
```

The data migration created an entry for this key.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

