### PR TITLE
Make /api/v2/workflow_approvals/ endpoint read-only

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4288,7 +4288,7 @@ class WorkflowApprovalTemplateJobsList(SubListAPIView):
     parent_key = 'workflow_approval_template'
 
 
-class WorkflowApprovalList(ListCreateAPIView):
+class WorkflowApprovalList(ListAPIView):
     model = models.WorkflowApproval
     serializer_class = serializers.WorkflowApprovalListSerializer
 

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -16,7 +16,7 @@ import glob
 # Normally a read-only endpoint should not have a module (i.e. /api/v2/me) but sometimes we reuse a name
 # For example, we have a role module but /api/v2/roles is a read only endpoint.
 # This list indicates which read-only endpoints have associated modules with them.
-read_only_endpoints_with_modules = ['settings', 'role', 'project_update']
+read_only_endpoints_with_modules = ['settings', 'role', 'project_update', 'workflow_approval']
 
 # If a module should not be created for an endpoint and the endpoint is not read-only add it here
 # THINK HARD ABOUT DOING THIS


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently the workflow_approvals endpoint allows posts which are unnecessary and by themselves are not useful. This changes the parent class to one which only allows list.

If someone is trying to approve or deny a workflow approval the correct endpoint would be:
/api/v2/workflow_approvals/N/approve/
api/v2/workflow_approvals/N/deny/

Where N is the id of the approval.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 21.11.1.dev79+gbbe2a4d669

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
