### PR TITLE
fix inventory prompt on launch for workflow nodes

### DIFF
--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -493,6 +493,7 @@
       workflow_job_template:
         name: "copy_{{ wfjt_name }}"
         organization: Default
+        ask_inventory_on_launch: true
         survey_spec:
           name: Basic Survey
           description: Basic Survey
@@ -737,6 +738,10 @@
               timeout: 23
               execution_environment:
                 name: "{{ ee1 }}"
+              inventory:
+                name: Test inventory
+                organization:
+                  name: Default
               related:
                 credentials:
                   - name: "{{ scm_cred_name }}"


### PR DESCRIPTION
##### SUMMARY
I was mistaken on the fix for #12721, The previous bugfix does not account for the form of the export output from the awx cli command. It also does not update the documentation, I've reverted the previous change and corrected it. I've also updated tests in regards to this. I should not have closed #13588, should have just left it open for the weekend and amended. As penance I've fixed the code to be backwards compatible with the previous fix.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.12.0
```


##### ADDITIONAL INFORMATION
@AlanCoding I was wrong on the previous PR, was trying to do it quickly instead of well, While it Worked, it did not match the export output. I went and got a full workflow node output that I've provided below. While inventory: "inventory_name" did work, it was not export compatible which is what the schema was designed to match.

```
  workflow_job_templates:
    - name: testinventory
      related:
        workflow_nodes:
          - all_parents_must_converge: false
            diff_mode: true
            execution_environment:
              name: creator_ee
              type: execution_environment
            extra_data:
              stuff: foo
            forks: 2
            identifier: 5d8004c6-1e36-430e-93bb-dc2f3ba18636
            inventory:
              name: RHVM-01
              organization:
                name: Default
                type: organization
              type: inventory
            job_slice_count: 1
            job_tags: asdf
            job_type: run
            limit: '3'
            related:
              always_nodes:
                - identifier: 86d0c429-e4ba-4a07-925a-06dbda7eb415
                  type: workflow_job_template_node
                  workflow_job_template:
                    name: testinventory
                    organization: null
                    type: workflow_job_template
              credentials:
                - credential_type:
                    kind: ssh
                    name: Machine
                    type: credential_type
                  name: Demo Credential
                  organization: null
                  type: credential
              failure_nodes:
                - identifier: f2275ace-3981-4815-a7a2-5ecfdc8270e1
                  type: workflow_job_template_node
                  workflow_job_template:
                    name: testinventory
                    organization: null
                    type: workflow_job_template
              success_nodes:
                - identifier: f85d058b-6c05-4b80-aa66-f8cc9c23e1ad
                  type: workflow_job_template_node
                  workflow_job_template:
                    name: testinventory
                    organization: null
                    type: workflow_job_template
            scm_branch: asdf
            skip_tags: fdas
            timeout: 31
            unified_job_template:
              name: Demo Job Template
              organization:
                name: Default
                type: organization
              type: job_template
            verbosity: 2
```
