### PR TITLE
Add HOST_PROJECTS_ROOT setting

### DIFF
--- a/awx/main/management/commands/provision_instance.py
+++ b/awx/main/management/commands/provision_instance.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         parser.add_argument('--uuid', type=str, help="Instance UUID")
 
     def _register_hostname(self, hostname, node_type, uuid):
-        if not hostname:
+        if settings.IS_K8S:
             if not settings.AWX_AUTO_DEPROVISION_INSTANCES:
                 raise CommandError('Registering with values from settings only intended for use in K8s installs')
 
@@ -47,8 +47,10 @@ class Command(BaseCommand):
                 max_forks=settings.DEFAULT_EXECUTION_QUEUE_MAX_FORKS,
                 max_concurrent_jobs=settings.DEFAULT_EXECUTION_QUEUE_MAX_CONCURRENT_JOBS,
             ).register()
-        else:
+        elif hostname:
             (changed, instance) = Instance.objects.register(hostname=hostname, node_type=node_type, uuid=uuid)
+        else:
+            return
         if changed:
             print("Successfully registered instance {}".format(hostname))
         else:

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -196,10 +196,22 @@ class ProjectOptions(models.Model):
             if not check_if_exists or os.path.exists(smart_str(proj_path)):
                 return proj_path
 
+    def get_host_project_path(self, check_if_exists=True):
+        local_path = os.path.basename(self.local_path)
+        if local_path and not local_path.startswith('.'):
+            proj_path = os.path.join(settings.HOST_PROJECTS_ROOT or settings.PROJECTS_ROOT, local_path)
+            if not check_if_exists or os.path.exists(smart_str(proj_path)):
+                return proj_path
+
     def get_cache_path(self):
         local_path = os.path.basename(self.local_path)
         if local_path:
             return os.path.join(settings.PROJECTS_ROOT, '.__awx_cache', local_path)
+
+    def get_host_cache_path(self):
+        local_path = os.path.basename(self.local_path)
+        if local_path:
+            return os.path.join(settings.HOST_PROJECTS_ROOT or settings.PROJECTS_ROOT, '.__awx_cache', local_path)
 
     @property
     def playbooks(self):

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1406,12 +1406,14 @@ class RunProjectUpdate(BaseTask):
 
         params = super(RunProjectUpdate, self).build_execution_environment_params(instance, private_data_dir)
         project_path = instance.get_project_path(check_if_exists=False)
+        host_project_path = instance.get_host_project_path(check_if_exists=False)
         cache_path = instance.get_cache_path()
+        host_cache_path = instance.get_host_cache_path()
         params.setdefault('container_volume_mounts', [])
         params['container_volume_mounts'].extend(
             [
-                f"{project_path}:{project_path}:z",
-                f"{cache_path}:{cache_path}:z",
+                f"{host_project_path}:{project_path}:z",
+                f"{host_cache_path}:{cache_path}:z",
             ]
         )
         return params

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -108,6 +108,10 @@ LOGIN_URL = '/api/login/'
 # This directory should not be web-accessible.
 PROJECTS_ROOT = '/var/lib/awx/projects/'
 
+# Absolute filesystem path to the directory to host projects (with playbooks) in the host.
+# This setting is used when running containerized AWX receptor
+HOST_PROJECTS_ROOT = None
+
 # Absolute filesystem path to the directory for job status stdout (default for
 # development and tests, default for production defined in production.py). This
 # directory should not be web-accessible


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When doing a project update, the execution environment mounts project_path:project_path and cache_path:cache_path. 
This prevents from running a containerized receptor, as the project_path/cache_path on host may differ to the container, specially when running containerized receptor rootless.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev32846+gcacb0c9
```

