### PR TITLE
Fix a bug in clean languages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ clean-schema:
 
 clean-languages:
 	rm -f $(I18N_FLAG_FILE)
-	find ./awx/locale/ -type f -regex ".*\.mo$" -delete
+	find ./awx/locale/ -type f -regex '.*\.mo$$' -delete
 
 ## Remove temporary build files, compiled Python files.
 clean: clean-ui clean-api clean-awxkit clean-dist


### PR DESCRIPTION
The `$` was not escaped for make or shell.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make will try to expand '$', and even if it does not, having a bare one like this breaks some syntax highlighting. Additionally, the shell could try to expand "$" since it's in double quotes instead of single quotes.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev32848+gaf6549f
```

