### PR TITLE
Fix typo in french message

### DIFF
--- a/awx/ui/src/locales/fr/messages.po
+++ b/awx/ui/src/locales/fr/messages.po
@@ -5048,7 +5048,7 @@ msgstr "Lancer"
 
 #: components/TemplateList/TemplateListItem.js:214
 msgid "Launch Template"
-msgstr "Lacer le modèle."
+msgstr "Lancer le modèle."
 
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.js:32
 #: screens/ManagementJob/ManagementJobList/LaunchManagementPrompt.js:34


### PR DESCRIPTION
Typo in "Launch Template" french message

##### SUMMARY
Fix a typo in a french translation message

Message with id "Launch Template" was missing a "n" in it's french translation

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev32848+gaa53f77
```


##### ADDITIONAL INFORMATION
_None_