### PR TITLE
update kind development environment instruction

### DIFF
--- a/docs/development/kind.md
+++ b/docs/development/kind.md
@@ -75,7 +75,8 @@ In the root of awx-operator:
     -e image_version=devel \
     -e image_pull_policy=Always \
     -e service_type=nodeport \
-    -e namespace=awx
+    -e namespace=awx \
+    -e nodeport_port=30080
 ```
 Check the operator with the following commands:
 


### PR DESCRIPTION
##### SUMMARY
old instruction is broken by https://github.com/ansible/awx-operator/commit/1ef1f00b3d5ec20669f8613d8016612800b07009

https://github.com/ansible/awx-operator/pull/1252/files

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.12.1.dev19+g3a303875bb
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
