### PR TITLE
[fix] switch from head to tail in project update playbook when clearing project dir

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -26,7 +26,7 @@
   name: Update source tree if necessary
   tasks:
     - name: Delete project directory before update
-      ansible.builtin.shell: set -o pipefail && find . -delete -print | head -2  # volume mounted, cannot delete folder itself
+      ansible.builtin.shell: set -o pipefail && find . -delete -print | tail -2  # volume mounted, cannot delete folder itself
       register: reg
       changed_when: reg.stdout_lines | length > 1
       args:


### PR DESCRIPTION

##### SUMMARY
from @relrod

`head` will close the input fd when it no longer needs it (or exits). find will try to write to the closed fd and somewhere along the way, it will receive SIGPIPE as a result. This is why `yes | head -5 ` doesn't run forever.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.12.1.dev23+g89e41597a6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
