### PR TITLE
Changing how associations work in awx collection

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -56,6 +56,8 @@ class ControllerModule(AnsibleModule):
         ),
         controller_config_file=dict(type='path', aliases=['tower_config_file'], required=False, default=None),
     )
+    # Associations of these types are ordered and have special consideration in the modified associations function
+    ordered_associations = ['instance_groups', 'galaxy_credentials']
     short_params = {
         'host': 'controller_host',
         'username': 'controller_username',
@@ -681,7 +683,7 @@ class ControllerAPIModule(ControllerModule):
         existing_associated_ids = [association['id'] for association in response['json']['results']]
 
         # Some associations can be ordered (like galaxy credentials)
-        if association_endpoint.strip('/').split('/')[-1] in ('instance_groups', 'galaxy_credentials'):
+        if association_endpoint.strip('/').split('/')[-1] in self.ordered_associations:
             if existing_associated_ids == new_association_list:
                 return  # If the current associations EXACTLY match the desired associations then we can return
             removal_list = existing_associated_ids  # because of ordering, we have to remove everything

--- a/awx_collection/test/awx/test_organization.py
+++ b/awx_collection/test/awx/test_organization.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import pytest
+import random
 
-from awx.main.models import Organization
+from awx.main.models import Organization, Credential, CredentialType
 
 
 @pytest.mark.django_db
@@ -30,3 +31,63 @@ def test_create_organization(run_module, admin_user):
     assert result == {"name": "foo", "changed": True, "id": org.id, "invocation": {"module_args": module_args}}
 
     assert org.description == 'barfoo'
+
+
+@pytest.mark.django_db
+def test_galaxy_credential_order(run_module, admin_user):
+    org = Organization.objects.create(name='foo')
+    cred_type = CredentialType.defaults['galaxy_api_token']()
+    cred_type.save()
+
+    cred_ids = []
+    for number in range(1, 10):
+        new_cred = Credential.objects.create(name=f"Galaxy Credential {number}", credential_type=cred_type, organization=org, inputs={'url': 'www.redhat.com'})
+        cred_ids.append(new_cred.id)
+
+    random.shuffle(cred_ids)
+
+    module_args = {
+        'name': 'foo',
+        'state': 'present',
+        'controller_host': None,
+        'controller_username': None,
+        'controller_password': None,
+        'validate_certs': None,
+        'controller_oauthtoken': None,
+        'controller_config_file': None,
+        'galaxy_credentials': cred_ids,
+    }
+
+    result = run_module('organization', module_args, admin_user)
+    print(result)
+    assert result['changed'] is True
+
+    cred_order_in_org = []
+    for a_cred in org.galaxy_credentials.all():
+        cred_order_in_org.append(a_cred.id)
+
+    assert cred_order_in_org == cred_ids
+
+    # Shuffle them up and try again to make sure a new order is honored
+    random.shuffle(cred_ids)
+
+    module_args = {
+        'name': 'foo',
+        'state': 'present',
+        'controller_host': None,
+        'controller_username': None,
+        'controller_password': None,
+        'validate_certs': None,
+        'controller_oauthtoken': None,
+        'controller_config_file': None,
+        'galaxy_credentials': cred_ids,
+    }
+
+    result = run_module('organization', module_args, admin_user)
+    assert result['changed'] is True
+
+    cred_order_in_org = []
+    for a_cred in org.galaxy_credentials.all():
+        cred_order_in_org.append(a_cred.id)
+
+    assert cred_order_in_org == cred_ids


### PR DESCRIPTION
Some associations, like galaxy_credentials are ordered. The association logic tried to minimize the number of calls to the server when performing associations but this had the side affect of loosing order of associations for ordered fields. The new logic will ensure that order is preserved.

NOTE: There was several changes to satisfy `black` in here.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
