### PR TITLE
Fixes #13597 webservice_id default value added

### DIFF
--- a/awx/main/credential_plugins/aim.py
+++ b/awx/main/credential_plugins/aim.py
@@ -70,7 +70,7 @@ def aim_backend(**kwargs):
     client_cert = kwargs.get('client_cert', None)
     client_key = kwargs.get('client_key', None)
     verify = kwargs['verify']
-    webservice_id = kwargs['webservice_id']
+    webservice_id = kwargs['webservice_id', '']
     app_id = kwargs['app_id']
     object_query = kwargs['object_query']
     object_query_format = kwargs['object_query_format']

--- a/awx/main/credential_plugins/aim.py
+++ b/awx/main/credential_plugins/aim.py
@@ -70,7 +70,7 @@ def aim_backend(**kwargs):
     client_cert = kwargs.get('client_cert', None)
     client_key = kwargs.get('client_key', None)
     verify = kwargs['verify']
-    webservice_id = kwargs['webservice_id', '']
+    webservice_id = kwargs.get('webservice_id', '')
     app_id = kwargs['app_id']
     object_query = kwargs['object_query']
     object_query_format = kwargs['object_query_format']


### PR DESCRIPTION
##### SUMMARY
The kwarg `webservice_id` was being set without a default value when one is not present. This was successfully testing in the AWX UI, but was failing when testing via API using awxkit. The fix included in this PR is to add a default value to please awxkit tests.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Related #13597 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev32873+g98b2f51
```


##### ADDITIONAL INFORMATION
Tests should be done using awxkit along with AWX UI testing.