### PR TITLE
add handling for job call back status 'idle_timeout'

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -611,9 +611,9 @@ class BaseTask(object):
             status = res.status
             rc = res.rc
 
-            if status in ('timeout', 'error'):
+            if status in ('timeout', 'idle_timeout', 'error'):
                 self.runner_callback.delay_update(skip_if_already_set=True, job_explanation=f"Job terminated due to {status}")
-                if status == 'timeout':
+                if status in ('timeout', 'idle_timeout'):
                     status = 'failed'
             elif status == 'canceled':
                 self.instance = self.update_model(pk)


### PR DESCRIPTION
##### SUMMARY
help distinguish between different type of timeouts

won't have any effect until 
https://github.com/ansible/ansible-runner/pull/1200
is merged

but can be merged without the PR with no harm

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.12.1.dev37+gb74b9ca2ea
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
