### PR TITLE
Filter out constructed inventory hosts from smart host filter 

### DIFF
--- a/awx/ui/src/components/Lookup/HostFilterLookup.js
+++ b/awx/ui/src/components/Lookup/HostFilterLookup.js
@@ -84,6 +84,7 @@ const QS_CONFIG = getQSConfig(
     page: 1,
     page_size: 5,
     order_by: 'name',
+    not__inventory__kind: 'constructed',
   },
   ['id', 'page', 'page_size', 'inventory']
 );


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/13607

Remove constructed inventory hosts as an option in the smart inventory host lookup

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
