### PR TITLE
Fixes #6556 Expose SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL

### DIFF
--- a/awx/sso/conf.py
+++ b/awx/sso/conf.py
@@ -148,6 +148,16 @@ register(
     placeholder=['username', 'email'],
 )
 
+register(
+    'SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL',
+    field_class=fields.BooleanField,
+    default=False,
+    label=_('Use Email address for usernames'),
+    help_text=_('Enabling this setting will tell social auth to use the full Email as username instead of the full name'),
+    category=_('Authentication'),
+    category_slug='authentication',
+)
+
 ###############################################################################
 # LDAP AUTHENTICATION SETTINGS
 ###############################################################################

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationDetail/MiscAuthenticationDetail.test.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationDetail/MiscAuthenticationDetail.test.js
@@ -40,6 +40,7 @@ describe('<MiscAuthenticationDetail />', () => {
         SOCIAL_AUTH_ORGANIZATION_MAP: {},
         SOCIAL_AUTH_TEAM_MAP: {},
         SOCIAL_AUTH_USER_FIELDS: [],
+        SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL: false,
       },
     });
     await act(async () => {
@@ -79,6 +80,7 @@ describe('<MiscAuthenticationDetail />', () => {
     assertVariableDetail(wrapper, 'Social Auth Organization Map', '{}');
     assertVariableDetail(wrapper, 'Social Auth Team Map', '{}');
     assertVariableDetail(wrapper, 'Social Auth User Fields', '[]');
+    assertDetail(wrapper, 'Use Email address for usernames', 'Off');
     assertDetail(
       wrapper,
       'Allow External Users to Create OAuth2 Tokens',

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.js
@@ -53,7 +53,8 @@ function MiscAuthenticationEdit() {
         'SESSION_COOKIE_AGE',
         'SOCIAL_AUTH_ORGANIZATION_MAP',
         'SOCIAL_AUTH_TEAM_MAP',
-        'SOCIAL_AUTH_USER_FIELDS'
+        'SOCIAL_AUTH_USER_FIELDS',
+        'SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL'
       );
 
       const authenticationData = {
@@ -241,6 +242,10 @@ function MiscAuthenticationEdit() {
                 <ObjectField
                   name="SOCIAL_AUTH_USER_FIELDS"
                   config={authentication.SOCIAL_AUTH_USER_FIELDS}
+                />
+                <BooleanField
+                  name="SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL"
+                  config={authentication.SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL}
                 />
                 {submitError && <FormSubmitError error={submitError} />}
                 {revertError && <FormSubmitError error={revertError} />}

--- a/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.test.js
+++ b/awx/ui/src/screens/Setting/MiscAuthentication/MiscAuthenticationEdit/MiscAuthenticationEdit.test.js
@@ -32,6 +32,7 @@ const authenticationData = {
   SOCIAL_AUTH_ORGANIZATION_MAP: null,
   SOCIAL_AUTH_TEAM_MAP: null,
   SOCIAL_AUTH_USER_FIELDS: null,
+  SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL: false,
 };
 
 describe('<MiscAuthenticationEdit />', () => {

--- a/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
@@ -859,6 +859,15 @@
           "read_only": false
         }
       },
+      "SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL": {
+        "type": "boolean",
+        "required": false,
+        "label": "Use Email address for usernames",
+        "help_text": "Enabling this setting will tell social auth to use the full Email as username instead of the full name",
+        "category": "Authentication",
+        "category_slug": "authentication",
+        "default": false
+      },
       "SOCIAL_AUTH_OIDC_KEY": {
         "type": "string",
         "label": "OIDC Key",
@@ -4553,6 +4562,14 @@
         "child": {
           "type": "string"
         }
+      },
+      "SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL": {
+        "type": "boolean",
+        "label": "Use Email address for usernames",
+        "help_text": "Enabling this setting will tell social auth to use the full Email as username instead of the full name",
+        "category": "Authentication",
+        "category_slug": "authentication",
+        "default": false
       },
       "SOCIAL_AUTH_OIDC_KEY": {
         "type": "string",

--- a/awx/ui/src/screens/Setting/shared/data.allSettings.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettings.json
@@ -103,6 +103,7 @@
   "SOCIAL_AUTH_ORGANIZATION_MAP":null,
   "SOCIAL_AUTH_TEAM_MAP":null,
   "SOCIAL_AUTH_USER_FIELDS":null,
+  "SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL":false,
   "AUTH_LDAP_SERVER_URI":"ldap://ldap.example.com",
   "AUTH_LDAP_BIND_DN":"cn=eng_user1",
   "AUTH_LDAP_BIND_PASSWORD":"$encrypted$",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Hi, this should fix #6556 - with that change you are able to set the setting that allows to force new social accounts to use email as username.

This change exposes a current default setting  https://github.com/ansible/awx/blob/a47cfc55ab8a73777576e8acf4f69b290b6350ad/awx/settings/defaults.py#L493 to be overwrite able via awx settings boolean
 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
After rebasing on latest devel the local testing seems to work for me, I can see the setting in awx api and change it through ui


<!--- Paste verbatim command output below, e.g. before and after your change -->

