### PR TITLE
Revert "Remove trailing $ from websocket_urlpatterns to work with cus…

### DIFF
--- a/awx/main/routing.py
+++ b/awx/main/routing.py
@@ -27,8 +27,8 @@ class AWXProtocolTypeRouter(ProtocolTypeRouter):
 
 
 websocket_urlpatterns = [
-    re_path(r'websocket/', consumers.EventConsumer.as_asgi()),
-    re_path(r'websocket/broadcast/', consumers.BroadcastConsumer.as_asgi()),
+    re_path(r'websocket/$', consumers.EventConsumer.as_asgi()),
+    re_path(r'websocket/broadcast/$', consumers.BroadcastConsumer.as_asgi()),
 ]
 
 application = AWXProtocolTypeRouter(


### PR DESCRIPTION
…tom path to fix #12241"

This reverts commit 5e28f5dca162ec01d6fd32207404f66fa2276604.

##### SUMMARY

this undoes a change which caused wsbroadcast (wsrelay in the new world) to get routed to the event consumer instead of the relay consumer.

This showed up as this in the logs, but is not very useful to understanding what happened:
```
2023-03-02 21:00:06,837 ERROR    [-] awx.main.consumers Request user is not authenticated to use websocket.
2023-03-02 21:00:06,837 ERROR    [-] awx.main.consumers Request user is not authenticated to use websocket.
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.12.1.dev54+g2ca0b7bc01
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
