### PR TITLE
Update inventory import to cancel on failure from cli.

### DIFF
--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -27,9 +27,9 @@ from awx.main.utils.mem_inventory import MemInventory, dict_to_mem_data
 from awx.main.utils.safe_yaml import sanitize_jinja
 
 # other AWX imports
-from awx.main.models.execution_environments import ExecutionEnvironment
 from awx.main.models.rbac import batch_role_ancestor_rebuilding
 from awx.main.utils import ignore_inventory_computed_fields, get_licenser
+from awx.main.utils.execution_environments import get_default_execution_environment
 from awx.main.signals import disable_activity_stream
 from awx.main.constants import STANDARD_INVENTORY_UPDATE_ENV
 from awx.main.utils.pglock import advisory_lock
@@ -67,17 +67,16 @@ class AnsibleInventoryLoader(object):
         /usr/bin/ansible/ansible-inventory -i hosts --list
     """
 
-    def __init__(self, source, execution_environment, verbosity=0):
+    def __init__(self, source, verbosity=0):
         self.source = source
         self.verbosity = verbosity
-        self.execution_environment = execution_environment
 
     def get_base_args(self):
         bargs = ['podman', 'run', '--user=root', '--quiet']
         bargs.extend(['-v', '{0}:{0}:Z'.format(self.source)])
         for key, value in STANDARD_INVENTORY_UPDATE_ENV.items():
             bargs.extend(['-e', '{0}={1}'.format(key, value)])
-        ee = self.execution_environment
+        ee = get_default_execution_environment()
 
         if settings.IS_K8S:
             logger.warning('This command is not able to run on kubernetes-based deployment. This action should be done using the API.')
@@ -163,13 +162,6 @@ class Command(BaseCommand):
             default=None,
             metavar='v',
             help='value of host variable specified by --enabled-var that indicates host is enabled/online.',
-        )
-        parser.add_argument(
-            '--execution-environment',
-            dest='execution_environment',
-            type=str,
-            default='Default execution environment',
-            help='name of the execution environment to use'
         )
         parser.add_argument(
             '--group-filter',
@@ -859,7 +851,7 @@ class Command(BaseCommand):
             logger.info('Updating inventory %d: %s' % (inventory.pk, inventory.name))
 
             # Create ad-hoc inventory source and inventory update objects
-            ee = ExecutionEnvironment.objects.get(name=options.get('execution_environment'))
+            ee = get_default_execution_environment()
             with ignore_inventory_computed_fields():
                 source = Command.get_source_absolute_path(raw_source)
 
@@ -872,11 +864,13 @@ class Command(BaseCommand):
                     execution_environment=ee,
                 )
                 inventory_update = inventory_source.create_inventory_update(
-                    _eager_fields=dict(status='running', job_args=json.dumps(sys.argv), job_env=dict(os.environ.items()), job_cwd=os.getcwd(), execution_environment=ee)
+                    _eager_fields=dict(
+                        status='running', job_args=json.dumps(sys.argv), job_env=dict(os.environ.items()), job_cwd=os.getcwd(), execution_environment=ee
+                    )
                 )
-            
+
             try:
-                data = AnsibleInventoryLoader(source=source,execution_environment=ee, verbosity=verbosity).load()
+                data = AnsibleInventoryLoader(source=source, verbosity=verbosity).load()
                 logger.debug('Finished loading from source: %s', source)
 
             except SystemExit:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently if a user runs awx-manage inventory_import as "root" or if the default execution environment has not yet been pulled on the system, the inventory update is created but never updated which causes the job to stay in "running" forever.
This change puts the ansibleinventoryloader into try/except and cancels the inventory_update prior to exiting. It also includes the execution environment to the inventory_source/inventory_update.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 21.12.1.dev57+g3aba5b5a04

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx-manage inventory_import --source /tmp/hosts --inventory-id=1 -v 3
    0.837 INFO     Updating inventory 1: Demo Inventory
    0.910 WARNING  The default execution environment (id=3, name=Default execution environment, image=registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest) is not available on this node. The image needs to be available locally before using this command, due to registry authentication. To pull this image, either run a job on this node or manually pull the image.

awx-manage inventory_import --source /tmp/hosts --inventory-id=1 -v 3
    0.837 INFO     Updating inventory 1: Demo Inventory
    0.910 WARNING  The default execution environment (id=3, name=Default execution environment, image=registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest) is not available on this node. The image needs to be available locally before using this command, due to registry authentication. To pull this image, either run a job on this node or manually pull the image.
    0.910 DEBUG    Error occurred while running ansible-inventory
```

<img width="1408" alt="image" src="https://user-images.githubusercontent.com/18033113/222838001-fbaba187-f789-4583-9aaf-37e91702205e.png">

