### PR TITLE
Fix enable local authentication

### DIFF
--- a/awx/main/management/commands/enable_local_authentication.py
+++ b/awx/main/management/commands/enable_local_authentication.py
@@ -1,5 +1,6 @@
-from django.core.management.base import BaseCommand, CommandError
+from awx.main.tasks.system import clear_setting_cache
 from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
@@ -30,6 +31,8 @@ class Command(BaseCommand):
 
         else:
             raise CommandError('Please pass --enable flag to allow local auth or --disable flag to disable local auth')
+
+        clear_setting_cache.delay(['DISABLE_LOCAL_AUTH'])
 
     def handle(self, **options):
         self._enable_disable_auth(options.get('enable'), options.get('disable'))


### PR DESCRIPTION
##### SUMMARY
flush redis cache after DISABLE_LOCAL_AUTH changed in `awx-manage enable_local_authentication`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 21.13.1.dev63+ge162490ab8
```
