### PR TITLE
Use different dockerfile for docker-compose-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,9 +157,10 @@ use_dev_supervisor.txt
 *.unison.tmp
 *.#
 /awx/ui/.ui-built
-/Dockerfile
 /_build/
 /_build_kube_dev/
+/Dockerfile
+/Dockerfile.dev
 /Dockerfile.kube-dev
 
 awx/ui_next/src


### PR DESCRIPTION
##### SUMMARY
one of my previous commit turn Dockerfile to a PHONY make target, to avoid collision between `make docker-compose-build` and `make awx-kube-build` this is a better approach

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.13.1.dev13+ga9b60cc3e4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
