### PR TITLE
Adds support for a pseudolocalization and lang query params

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -142,13 +142,8 @@ function App() {
   const searchParams = Object.fromEntries(new URLSearchParams(search));
   const pseudolocalization =
     searchParams.pseudolocalization === 'true' || false;
-  let language = getLanguageWithoutRegionCode(navigator);
-
-  if (!Object.keys(locales).includes(language)) {
-    // If there isn't a string catalog available for the browser's
-    // preferred language, default to one that has strings.
-    language = 'en';
-  }
+  const language =
+    searchParams.lang || getLanguageWithoutRegionCode(navigator) || 'en';
 
   useEffect(() => {
     dynamicActivate(language, pseudolocalization);

--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -28,7 +28,7 @@ import { getLanguageWithoutRegionCode } from 'util/language';
 import Metrics from 'screens/Metrics';
 import SubscriptionEdit from 'screens/Setting/Subscription/SubscriptionEdit';
 import useTitle from 'hooks/useTitle';
-import { dynamicActivate, locales } from './i18nLoader';
+import { dynamicActivate } from './i18nLoader';
 import getRouteConfig from './routeConfig';
 import { SESSION_REDIRECT_URL } from './constants';
 

--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -139,7 +139,11 @@ export function ProtectedRoute({ children, ...rest }) {
 function App() {
   const history = useHistory();
   const { hash, search, pathname } = useLocation();
+  const searchParams = Object.fromEntries(new URLSearchParams(search));
+  const pseudolocalization =
+    searchParams.pseudolocalization === 'true' || false;
   let language = getLanguageWithoutRegionCode(navigator);
+
   if (!Object.keys(locales).includes(language)) {
     // If there isn't a string catalog available for the browser's
     // preferred language, default to one that has strings.
@@ -147,8 +151,8 @@ function App() {
   }
 
   useEffect(() => {
-    dynamicActivate(language);
-  }, [language]);
+    dynamicActivate(language, pseudolocalization);
+  }, [language, pseudolocalization]);
 
   useTitle();
 

--- a/awx/ui/src/i18nLoader.js
+++ b/awx/ui/src/i18nLoader.js
@@ -27,8 +27,21 @@ i18n.loadLocaleData({
  * We do a dynamic import of just the catalog that we need
  * @param locale any locale string
  */
-export async function dynamicActivate(locale) {
+export async function dynamicActivate(locale, pseudolocalization = false) {
   const { messages } = await import(`./locales/${locale}/messages`);
+
+  if (pseudolocalization) {
+    Object.keys(messages).forEach((key) => {
+      if (Array.isArray(messages[key])) {
+        // t`Foo ${param}` -> ["Foo ", ['param']] => [">>", "Foo ", ['param'], "<<"]
+        messages[key] = ['»', ...messages[key], '«'];
+      } else {
+        // simple string
+        messages[key] = `»${messages[key]}«`;
+      }
+    });
+  }
+
   i18n.load(locale, messages);
   i18n.activate(locale);
 }


### PR DESCRIPTION
##### SUMMARY
This work follows https://github.com/ansible/awx/pull/9537.  The changes here allow a developer to add ?pseudolocalization=true to the query parameters in the URL to check to see if a rendered string has been marked for translation.  All strings marked for translation will be wrapped in carats like so: `>>string<<`.  Unmarked strings will render without the carats.  Note that a hard reload is required for the changes to take effect.  Also note that this only works for strings _defined in the UI_.  Strings that get rendered in the interface that come from API call responses will not be wrapped in carats.

![pseudolocalization](https://user-images.githubusercontent.com/9889020/223763894-7591e492-5df6-4268-9c37-b8354c6169e4.gif)

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - UI
