### PR TITLE
isolate parallel tests to file by file in awx PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ awx-link:
 	cp -f /tmp/awx.egg-link /var/lib/awx/venv/awx/lib/$(PYTHON)/site-packages/awx.egg-link
 
 TEST_DIRS ?= awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests
-PYTEST_ARGS ?= -n auto
+PYTEST_ARGS ?= -n auto --dist=loadfile
 ## Run all API unit tests.
 test:
 	if [ "$(VENV_BASE)" ]; then \


### PR DESCRIPTION
we've  noticed some flake, specifically around "test_lost_worker_autoscale" that could be sensitive race conditions caused by test running along side it that consumes too many resources.

Trying out this config for pytest that loads tests file-by-file so at least we have better idea what tests its running along side of.

### ISSUE TYPE
Bug, Docs Fix or other nominal change

### COMPONENT NAME
Other