### PR TITLE
Make ui-devel run-able outside docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,12 +411,6 @@ ui-release: $(UI_BUILD_FLAG_FILE)
 
 ui-devel: awx/ui/node_modules
 	@$(MAKE) -B $(UI_BUILD_FLAG_FILE)
-	mkdir -p /var/lib/awx/public/static/css
-	mkdir -p /var/lib/awx/public/static/js
-	mkdir -p /var/lib/awx/public/static/media
-	cp -r awx/ui/build/static/css/* /var/lib/awx/public/static/css
-	cp -r awx/ui/build/static/js/* /var/lib/awx/public/static/js
-	cp -r awx/ui/build/static/media/* /var/lib/awx/public/static/media
 
 ui-devel-instrumented: awx/ui/node_modules
 	$(NPM_BIN) --prefix awx/ui --loglevel warn run start-instrumented


### PR DESCRIPTION
##### SUMMARY
remove unnecessary bits from the make ui-devel target that to allow `make ui-devel` to be run-able outside of docker-compose

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.13.1.dev37+g3b39bdf1f0
```


##### ADDITIONAL INFORMATION
tests
- `make ui-devel` outside of container is successful
- `make docker-compose` without `make ui-devel` is successful and is able to access /api/v2
- `make docker-compose` after `make ui-devel` is successful and the UI come up 
- `make docker-compose` after `make ui-clean` is successful and able to access /api/v2