### PR TITLE
Fix bug with manual type alias

### DIFF
--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -284,13 +284,15 @@ def main():
         argument_spec=argument_spec,
     )
 
+    # Alias for manual projects
+    if module.params.get('scm_type') == "manual":
+        module.params['scm_type'] = ''
+
     # Extract our parameters
     name = module.params.get('name')
     new_name = module.params.get("new_name")
     copy_from = module.params.get('copy_from')
     scm_type = module.params.get('scm_type')
-    if scm_type == "manual":
-        scm_type = ""
     local_path = module.params.get('local_path')
     credential = module.params.get('credential')
     scm_update_on_launch = module.params.get('scm_update_on_launch')
@@ -387,7 +389,8 @@ def main():
         # this is resolved earlier, so save an API call and don't do it again in the loop above
         project_fields['organization'] = org_id
 
-    if scm_type == '' and local_path is not None:
+    # Respect local_path if scm_type is manual type or not specified
+    if scm_type in ('', None) and local_path is not None:
         project_fields['local_path'] = local_path
 
     if scm_update_cache_timeout not in (0, None) and scm_update_on_launch is not True:

--- a/awx_collection/test/awx/test_project.py
+++ b/awx_collection/test/awx/test_project.py
@@ -27,6 +27,24 @@ def test_create_project(run_module, admin_user, organization, silence_warning):
 
 
 @pytest.mark.django_db
+def test_create_manual_project(run_module, admin_user, organization, mocker):
+    mocker.patch('awx.main.models.projects.Project.get_local_path_choices', return_value=['foo_folder/'])
+    result = run_module(
+        'project',
+        dict(name='foo', organization=organization.name, scm_type='manual', local_path='foo_folder/', wait=False),
+        admin_user,
+    )
+    assert result.pop('changed', None), result
+
+    proj = Project.objects.get(name='foo')
+    assert proj.local_path == 'foo_folder/'
+    assert proj.organization == organization
+
+    result.pop('invocation')
+    assert result == {'name': 'foo', 'id': proj.id}
+
+
+@pytest.mark.django_db
 def test_create_project_copy_from(run_module, admin_user, organization, silence_warning):
     '''Test the copy_from functionality'''
     result = run_module(


### PR DESCRIPTION
##### SUMMARY
While `scm_type` local variable is changed to `''` when it gets "manual", it later on gets it from `module.params` which is obviously not aliased. To avoid, we alias earlier. Also, we can't say `scm_type` is not manual when it's not provided (`None`), so act accordingly.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

