### PR TITLE
expose task settings in api

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -795,6 +795,106 @@ register(
     category_slug='bulk',
 )
 
+register(
+    'SYSTEM_TASK_ABS_CPU',
+    field_class=fields.CharField,
+    default='',
+    allow_blank=True,
+    label=_('Override CPU for capacity calculations for all instances.'),
+    help_text=_(
+        'Override CPU for capacity calculations for all instances.'
+        ' When not set, the heartbeat task will dynamically detect CPU available.'
+        ' Accepts formats equivalent to kubernetes resource requests like 4 or 4000m.'
+        ' For operator based deployments, this is managed by the operator based on resource limits.'
+    ),
+    category=_('Task'),
+    category_slug='task',
+)
+
+register(
+    'SYSTEM_TASK_ABS_MEM',
+    field_class=fields.CharField,
+    default='',
+    allow_blank=True,
+    label=_('Override Memory for capacity calculations for all instances.'),
+    help_text=_(
+        'Override Memory for capacity calculations for all instances.'
+        ' When not set, the heartbeat task will dynamically detect memory available.'
+        ' Accepts formats equivalent to kubernetes resource requests like 4Gi or 4000Mi.'
+        ' For operator based deployments, this is managed by the operator based on resource limits.'
+    ),
+    category=_('Task'),
+    category_slug='task',
+)
+
+register(
+    'SYSTEM_TASK_FORKS_MEM',
+    field_class=fields.IntegerField,
+    default=100,
+    label=_('Amount of memory needed per-fork.'),
+    help_text=_('Amount of memory needed per-fork, used when calculating memory based capacity of an instance.'),
+    category=_('Task'),
+    category_slug='task',
+)
+
+register(
+    'SYSTEM_TASK_FORKS_CPU',
+    field_class=fields.IntegerField,
+    default=4,
+    label=_('Number of forks able to run per CPU.'),
+    help_text=_('Number of forks able to run per CPU, used when calculating CPU based capacity of an instance.'),
+    category=_('Task'),
+    category_slug='task',
+)
+
+register(
+    'TASK_MANAGER_TIMEOUT',
+    field_class=fields.IntegerField,
+    default=300,
+    label=_('Timeout limit in seconds for the task managers.'),
+    help_text=_('Timeout limit in seconds for the task managers.' ' After this timeout, task managers will attempt to exit and commit progress.'),
+    category=_('Task'),
+    category_slug='task',
+)
+
+register(
+    'TASK_MANAGER_TIMEOUT_GRACE_PERIOD',
+    field_class=fields.IntegerField,
+    default=60,
+    label=_('After TASK_MANAGER_TIMEOUT seconds, allow an additoinal TASK_MANAGER_TIMEOUT_GRACE_PERIOD.'),
+    help_text=_(
+        'After TASK_MANAGER_TIMEOUT seconds, allow an additoinal TASK_MANAGER_TIMEOUT_GRACE_PERIOD'
+        ' during which the task manager will attempt to exit gracefully before receiving SIGKILL.'
+    ),
+    category=_('Task'),
+    category_slug='task',
+)
+
+register(
+    'START_TASK_LIMIT',
+    field_class=fields.IntegerField,
+    default=100,
+    label=_('Max number of tasks to start in an individual task manager run.'),
+    help_text=_('Max number of tasks to start in an individual task manager run.'),
+    category=_('Task'),
+    category_slug='task',
+)
+
+register(
+    'AWX_CONTROL_NODE_TASK_IMPACT',
+    field_class=fields.IntegerField,
+    default=1,
+    label=_('Impact on the capacity of a control node when it controls a job.'),
+    help_text=_(
+        'Number of capacity units to consume on a control node when it is selected'
+        ' to run control processes for a task. For example, a control node with 100 capacity'
+        ' and AWX_CONTROL_NODE_TASK_IMPACT set to 5 will be able to control at most 20 jobs.'
+        ' Note some capacity may be reserved for other background tasks.'
+    ),
+    category=_('Task'),
+    category_slug='task',
+)
+
 
 def logging_validate(serializer, attrs):
     if not serializer.instance or not hasattr(serializer.instance, 'LOG_AGGREGATOR_HOST') or not hasattr(serializer.instance, 'LOG_AGGREGATOR_TYPE'):

--- a/awx/main/tests/functional/task_management/test_capacity.py
+++ b/awx/main/tests/functional/task_management/test_capacity.py
@@ -22,7 +22,7 @@ class TestInstanceGroupInstanceMapping(TransactionTestCase):
 
     def test_mapping(self):
         self.sample_cluster()
-        with self.assertNumQueries(3):
+        with self.assertNumQueries(4):
             instance_groups = TaskManagerInstanceGroups()
 
         ig_instance_map = instance_groups.instance_groups

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -761,7 +761,7 @@ def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
 
     if env_abscpu is not None:
         return convert_cpu_str_to_decimal_cpu(env_abscpu)
-    elif settings_abscpu is not None:
+    elif settings_abscpu is not None and settings_abscpu != '':  # user for some reason may one to set to a falsy 0
         return convert_cpu_str_to_decimal_cpu(settings_abscpu)
 
     return cpu_count  # no correction
@@ -835,7 +835,7 @@ def get_corrected_memory(memory):
     # so we convert memory from settings to bytes as well.
     if env_absmem is not None:
         return convert_mem_str_to_bytes(env_absmem)
-    elif settings_absmem is not None:
+    elif settings_absmem is not None and settings_absmem != '':  # user for some reason may want to set to falsy 0
         return convert_mem_str_to_bytes(settings_absmem)
 
     return memory


### PR DESCRIPTION
This will surface these settings that play key role in the task management system that are especially crucial for k8s deployements where relying on system detected capacity is generally dangerous because it will lead to control instances that appear to have the capacity of the entire underlying node.

We already did some magic to set these settings if resource limits are set...but I think its good to expose them and allow them to be set via API as 1) a way to verify it worked or 2) have an easy way to set them through API instead of by setting limits

Because in k8s all the replicas are the same, setting the capacity related settings in the API is safe. For other deployments where services are deployed directly on nodes, leaving these settings unset does not change behavior and capacity will still be detected from the filesystem.

No default behavior is changed by this PR, just allows the ability to view and set these settings from the API.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
some of these settings we have kept quite well hidden and not documented. This is an attempt to help make transparent that they exist and provide some minimal documentation via the help text.

![image](https://user-images.githubusercontent.com/29239279/224365426-663e72ff-61ef-4ce2-b4ac-a2b98c252650.png)
