### PR TITLE
[constructed-inventory] Remove towervars from constructed inventory hosts

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -357,13 +357,12 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
             for host in hosts:
                 data['_meta']['hostvars'][host.name] = host.variables_dict
                 if towervars:
-                    tower_dict = dict(
-                        remote_tower_enabled=str(host.enabled).lower(),
-                        remote_tower_id=host.id,
-                        remote_host_enabled=str(host.enabled).lower(),
-                        remote_host_id=host.id,
-                    )
-                    data['_meta']['hostvars'][host.name].update(tower_dict)
+                    for prefix in ('host', 'tower'):
+                        tower_dict = {
+                            f'remote_{prefix}_enabled': str(host.enabled).lower(),
+                            f'remote_{prefix}_id': host.id,
+                        }
+                        data['_meta']['hostvars'][host.name].update(tower_dict)
 
         return data
 


### PR DESCRIPTION
##### SUMMARY
This addresses an aesthetic problem with constructed inventory, that all 4 of these variables would be present in all constructed hosts. The data doesn't actually offer any value to the user, but it is necessary as an intermediary step in order to fill in `instance_id` with the id of the original host that it came from.

This addresses the test case `test_metavars_not_in_constructed_hosts` which checks that the constructed inventory host has the same variables as the original host.

Just realized this needs to be done for groups too!

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

