### PR TITLE
[constructed-inventory] Fail constructed inventory if ANY source is unparsed

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1600,8 +1600,9 @@ class constructed(PluginFileInjector):
 
     def build_env(self, *args, **kwargs):
         env = super().build_env(*args, **kwargs)
-        # Enable all types of inventory plugins so we pick up the script files from source inventories
-        del env['ANSIBLE_INVENTORY_ENABLED']
+        # Enable script inventory plugin so we pick up the script files from source inventories
+        env['ANSIBLE_INVENTORY_ENABLED'] += ',script'
+        env['ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED'] = 'True'
         return env
 
 


### PR DESCRIPTION
##### SUMMARY
We had a reported problem, @akus062381 and others, that even if the constructed inventory template was malformed, the inventory update wouldn't fail.

"funny" I thought, I was sure we had used a setting for this, and of course we did - that is `ANSIBLE_INVENTORY_UNPARSED_FAILED`

But then I checked the global menu of Ansible settings, looking for this, and I see right there - `ANSIBLE_INVENTORY_ANY_UNPARSED_IS_FAILED` which was a big OH! moment. In our case we list script sources (sources as in `-i`) from the input inventories and then put the constructed inventory at the end. The scripts should never give a parsing failure, but the constructed inventory is expected to fail depending on user content.

Output in this case:

```
Resource limits are not supported and ignored on cgroups V1 rootless systems
[WARNING]: You are running the development version of Ansible. You should only
run Ansible from "devel" if you are modifying the Ansible engine, or trying out
features under development. This is a rapidly changing source of code and can
become unstable at any point.
ansible-inventory [core 2.15.0.dev0]
  config file = None
  configured module search path = ['/home/runner/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.9/site-packages/ansible
  ansible collection location = /home/runner/.ansible/collections:/usr/share/ansible/collections:/usr/share/automation-controller/collections
  executable location = /usr/local/bin/ansible-inventory
  python version = 3.9.16 (main, Dec  8 2022, 00:00:00) [GCC 11.3.1 20221121 (Red Hat 11.3.1-4)] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
No config file found; using defaults
setting up inventory plugins
Loading collection ansible.builtin from 
auto declined parsing /runner/inventory/hosts_27 as it did not pass its verify_file() method
Parsed /runner/inventory/hosts_27 inventory source with script plugin
setting up inventory plugins
Using inventory plugin 'constructed' to process inventory source '/runner/inventory/constructed.yml'
[WARNING]:  * Failed to parse /runner/inventory/constructed.yml with auto
plugin: failed to parse /runner/inventory/constructed.yml: Could not add host
HostOptionProcess809813407072249664674464522324249825585637672619686549901 to
group will_not_work: 'variable_that_does_not_exist' is undefined.
'variable_that_does_not_exist' is undefined . Could not add host
HostOptionProcess809813407072249664674464522324249825585637672619686549901 to
group will_not_work: 'variable_that_does_not_exist' is undefined.
'variable_that_does_not_exist' is undefined
  File "/usr/local/lib/python3.9/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/local/lib/python3.9/site-packages/ansible/plugins/inventory/auto.py", line 59, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/usr/local/lib/python3.9/site-packages/ansible/plugins/inventory/constructed.py", line 177, in parse
    raise AnsibleParserError("failed to parse %s: %s " % (to_native(path), to_native(e)), orig_exc=e)
[WARNING]:  * Failed to parse /runner/inventory/constructed.yml with script
plugin: problem running /runner/inventory/constructed.yml --list ([Errno 8]
Exec format error: '/runner/inventory/constructed.yml')
  File "/usr/local/lib/python3.9/site-packages/ansible/inventory/manager.py", line 293, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/usr/local/lib/python3.9/site-packages/ansible/plugins/inventory/script.py", line 150, in parse
    raise AnsibleParserError(to_native(e))
ERROR! Completely failed to parse inventory source /runner/inventory/constructed.yml
```

You can see in this text

> Parsed /runner/inventory/hosts_27 inventory source with script plugin

So that is a first inventory parsed correctly, then the second (constructed) not parsed.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

