### PR TITLE
Fixes bug where editing a node always defaulted to all convergence

### DIFF
--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/useWorkflowNodeSteps.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/useWorkflowNodeSteps.js
@@ -66,7 +66,13 @@ const getNodeToEditDefaultValues = (
     // There is a case where the nodeToEdit convergence value will not align with the
     // original node object value.  This allows the nodeToEdit value to take precedence over the
     // original node object.
-    if (nodeToEdit) {
+    if (
+      nodeToEdit &&
+      Object.prototype.hasOwnProperty.call(
+        nodeToEdit,
+        'all_parents_must_converge'
+      )
+    ) {
       return nodeToEdit.all_parents_must_converge ? 'all' : 'any';
     }
     return nodeToEdit?.originalNodeObject?.all_parents_must_converge


### PR DESCRIPTION
##### SUMMARY
link #12651 

When editing a node the form was always defaulting to `All` even if the value we got back was `Any`.  This PR addresses that bug.  Here's a gif of the fix in action:

![workflow_any_all](https://user-images.githubusercontent.com/9889020/225329155-97ecdac9-ec6a-4f22-83c5-7342f5d49344.gif)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
