### PR TITLE
[constructed-inventory] Save facts on model for original host

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1881,6 +1881,7 @@ class HostSerializer(BaseSerializerWithVariables):
         )
         if obj.inventory.kind == 'constructed':
             res['original_host'] = self.reverse('api:host_detail', kwargs={'pk': obj.instance_id})
+            res['ansible_facts'] = self.reverse('api:host_ansible_facts_detail', kwargs={'pk': obj.instance_id})
         if obj.inventory:
             res['inventory'] = self.reverse('api:inventory_detail', kwargs={'pk': obj.inventory.pk})
         if obj.last_job:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -30,7 +30,7 @@ from django.utils.safestring import mark_safe
 from django.utils.timezone import now
 from django.views.decorators.csrf import csrf_exempt
 from django.template.loader import render_to_string
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 
@@ -1584,6 +1584,14 @@ class HostDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAPIView):
 class HostAnsibleFactsDetail(RetrieveAPIView):
     model = models.Host
     serializer_class = serializers.AnsibleFactsSerializer
+
+    def get(self, request, *args, **kwargs):
+        obj = self.get_object()
+        if obj.inventory.kind == 'constructed':
+            # If this is a constructed inventory host, it is not the source of truth about facts
+            # redirect to the original input inventory host instead
+            return HttpResponseRedirect(reverse('api:host_ansible_facts_detail', kwargs={'pk': obj.instance_id}, request=self.request))
+        return super().get(request, *args, **kwargs)
 
 
 class InventoryHostsList(HostRelatedSearchMixin, SubListCreateAttachDetachAPIView):

--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -108,3 +108,6 @@ JOB_VARIABLE_PREFIXES = [
 ANSIBLE_RUNNER_NEEDS_UPDATE_MESSAGE = (
     '\u001b[31m \u001b[1m This can be caused if the version of ansible-runner in your execution environment is out of date.\u001b[0m'
 )
+
+# Shared prefetch to use for creating a queryset for the purpose of writing or saving facts
+HOST_FACTS_FIELDS = ('name', 'ansible_facts', 'ansible_facts_modified', 'modified', 'inventory_id')

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -838,7 +838,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
 
     def get_hosts_for_fact_cache(self):
         """
-        Builds the querset to use for writing or finalizing the fact cache
+        Builds the queryset to use for writing or finalizing the fact cache
         these need to be the 'real' hosts associated with the job.
         For constructed inventories, that means the original (input inventory) hosts
         when slicing, that means only returning hosts in that slice

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -11,6 +11,7 @@ from urllib.parse import urljoin
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models.functions import Cast
 
 # from django.core.cache import cache
 from django.utils.translation import gettext_lazy as _
@@ -21,6 +22,7 @@ from rest_framework.exceptions import ParseError
 
 # AWX
 from awx.api.versioning import reverse
+from awx.main.constants import HOST_FACTS_FIELDS
 from awx.main.models.base import (
     BaseModel,
     CreatedModifiedModel,
@@ -833,6 +835,27 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
 
     def get_notification_friendly_name(self):
         return "Job"
+
+    def get_hosts_for_fact_cache(self):
+        """
+        Builds the querset to use for writing or finalizing the fact cache
+        these need to be the 'real' hosts associated with the job.
+        For constructed inventories, that means the original (input inventory) hosts
+        when slicing, that means only returning hosts in that slice
+        """
+        Host = JobHostSummary._meta.get_field('host').related_model
+        if not self.inventory_id:
+            return Host.objects.none()
+
+        if self.inventory.kind == 'constructed':
+            id_field = Host._meta.get_field('id')
+            host_qs = Host.objects.filter(id__in=self.inventory.hosts.exclude(instance_id='').values_list(Cast('instance_id', output_field=id_field)))
+        else:
+            host_qs = self.inventory.hosts
+
+        host_qs = host_qs.only(*HOST_FACTS_FIELDS)
+        host_qs = self.inventory.get_sliced_hosts(host_qs, self.job_slice_number, self.job_slice_count)
+        return host_qs
 
 
 class LaunchTimeConfigBase(BaseModel):

--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -12,28 +12,16 @@ from django.utils.timezone import now
 
 # AWX
 from awx.main.utils.common import log_excess_runtime
+from awx.main.models.inventory import Host
 
 
 logger = logging.getLogger('awx.main.tasks.facts')
 system_tracking_logger = logging.getLogger('awx.analytics.system_tracking')
 
 
-def _get_inventory_hosts(inventory, slice_number, slice_count, only=('name', 'ansible_facts', 'ansible_facts_modified', 'modified', 'inventory_id'), **filters):
-    """Return value is an iterable for the relevant hosts for this job"""
-    if not inventory:
-        return []
-    host_queryset = inventory.hosts.only(*only)
-    if filters:
-        host_queryset = host_queryset.filter(**filters)
-    host_queryset = inventory.get_sliced_hosts(host_queryset, slice_number, slice_count)
-    if isinstance(host_queryset, QuerySet):
-        return host_queryset.iterator()
-    return host_queryset
-
-
 @log_excess_runtime(logger, debug_cutoff=0.01, msg='Inventory {inventory_id} host facts prepared for {written_ct} hosts, took {delta:.3f} s', add_log_data=True)
-def start_fact_cache(inventory, destination, log_data, timeout=None, slice_number=0, slice_count=1):
-    log_data['inventory_id'] = inventory.id
+def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=None):
+    log_data['inventory_id'] = inventory_id
     log_data['written_ct'] = 0
     try:
         os.makedirs(destination, mode=0o700)
@@ -42,15 +30,14 @@ def start_fact_cache(inventory, destination, log_data, timeout=None, slice_numbe
 
     if timeout is None:
         timeout = settings.ANSIBLE_FACT_CACHE_TIMEOUT
-    if timeout > 0:
-        # exclude hosts with fact data older than `settings.ANSIBLE_FACT_CACHE_TIMEOUT seconds`
-        timeout = now() - datetime.timedelta(seconds=timeout)
-        hosts = _get_inventory_hosts(inventory, slice_number, slice_count, ansible_facts_modified__gte=timeout)
-    else:
-        hosts = _get_inventory_hosts(inventory, slice_number, slice_count)
+
+    if isinstance(hosts, QuerySet):
+        hosts = hosts.iterator()
 
     last_filepath_written = None
     for host in hosts:
+        if host.ansible_facts_modified and (host.ansible_facts_modified >= now() - datetime.timedelta(seconds=timeout)):
+            continue  # facts are expired - do not write them
         filepath = os.sep.join(map(str, [destination, host.name]))
         if not os.path.realpath(filepath).startswith(destination):
             system_tracking_logger.error('facts for host {} could not be cached'.format(smart_str(host.name)))
@@ -76,13 +63,17 @@ def start_fact_cache(inventory, destination, log_data, timeout=None, slice_numbe
     msg='Inventory {inventory_id} host facts: updated {updated_ct}, cleared {cleared_ct}, unchanged {unmodified_ct}, took {delta:.3f} s',
     add_log_data=True,
 )
-def finish_fact_cache(inventory, destination, facts_write_time, log_data, slice_number=0, slice_count=1, job_id=None):
-    log_data['inventory_id'] = inventory.id
+def finish_fact_cache(hosts, destination, facts_write_time, log_data, job_id=None, inventory_id=None):
+    log_data['inventory_id'] = inventory_id
     log_data['updated_ct'] = 0
     log_data['unmodified_ct'] = 0
     log_data['cleared_ct'] = 0
+
+    if isinstance(hosts, QuerySet):
+        hosts = hosts.iterator()
+
     hosts_to_update = []
-    for host in _get_inventory_hosts(inventory, slice_number, slice_count):
+    for host in hosts:
         filepath = os.sep.join(map(str, [destination, host.name]))
         if not os.path.realpath(filepath).startswith(destination):
             system_tracking_logger.error('facts for host {} could not be cached'.format(smart_str(host.name)))
@@ -120,7 +111,7 @@ def finish_fact_cache(inventory, destination, facts_write_time, log_data, slice_
             system_tracking_logger.info('Facts cleared for inventory {} host {}'.format(smart_str(host.inventory.name), smart_str(host.name)))
             log_data['cleared_ct'] += 1
         if len(hosts_to_update) > 100:
-            inventory.hosts.bulk_update(hosts_to_update, ['ansible_facts', 'ansible_facts_modified'])
+            Host.objects.bulk_update(hosts_to_update, ['ansible_facts', 'ansible_facts_modified'])
             hosts_to_update = []
     if hosts_to_update:
-        inventory.hosts.bulk_update(hosts_to_update, ['ansible_facts', 'ansible_facts_modified'])
+        Host.objects.bulk_update(hosts_to_update, ['ansible_facts', 'ansible_facts_modified'])

--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -36,7 +36,7 @@ def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=No
 
     last_filepath_written = None
     for host in hosts:
-        if host.ansible_facts_modified and (host.ansible_facts_modified >= now() - datetime.timedelta(seconds=timeout)):
+        if (not host.ansible_facts_modified) or (timeout and host.ansible_facts_modified < now() - datetime.timedelta(seconds=timeout)):
             continue  # facts are expired - do not write them
         filepath = os.sep.join(map(str, [destination, host.name]))
         if not os.path.realpath(filepath).startswith(destination):

--- a/awx/main/tests/unit/models/test_jobs.py
+++ b/awx/main/tests/unit/models/test_jobs.py
@@ -6,7 +6,6 @@ import time
 import pytest
 
 from awx.main.models import (
-    Job,
     Inventory,
     Host,
 )
@@ -24,22 +23,9 @@ def hosts():
     ]
 
 
-@pytest.fixture
-def inventory(mocker, hosts):
-    mocker.patch('awx.main.tasks.facts._get_inventory_hosts', return_value=hosts)
-    return Inventory(id=5)
-
-
-@pytest.fixture
-def job(mocker, inventory):
-    j = Job(inventory=inventory, id=2)
-    # j._get_inventory_hosts = mocker.Mock(return_value=hosts)
-    return j
-
-
-def test_start_job_fact_cache(hosts, job, inventory, tmpdir):
+def test_start_job_fact_cache(hosts, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified = start_fact_cache(inventory, fact_cache, timeout=0)
+    last_modified = start_fact_cache(hosts, fact_cache, timeout=0)
 
     for host in hosts:
         filepath = os.path.join(fact_cache, host.name)
@@ -49,26 +35,23 @@ def test_start_job_fact_cache(hosts, job, inventory, tmpdir):
         assert os.path.getmtime(filepath) <= last_modified
 
 
-def test_fact_cache_with_invalid_path_traversal(job, inventory, tmpdir, mocker):
-    mocker.patch(
-        'awx.main.tasks.facts._get_inventory_hosts',
-        return_value=[
-            Host(
-                name='../foo',
-                ansible_facts={"a": 1, "b": 2},
-            ),
-        ],
-    )
+def test_fact_cache_with_invalid_path_traversal(tmpdir):
+    hosts = [
+        Host(
+            name='../foo',
+            ansible_facts={"a": 1, "b": 2},
+        ),
+    ]
 
     fact_cache = os.path.join(tmpdir, 'facts')
-    start_fact_cache(inventory, fact_cache, timeout=0)
+    start_fact_cache(hosts, fact_cache, timeout=0)
     # a file called "foo" should _not_ be written outside the facts dir
     assert os.listdir(os.path.join(fact_cache, '..')) == ['facts']
 
 
-def test_finish_job_fact_cache_with_existing_data(job, hosts, inventory, mocker, tmpdir):
+def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified = start_fact_cache(inventory, fact_cache, timeout=0)
+    last_modified = start_fact_cache(hosts, fact_cache, timeout=0)
 
     bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
 
@@ -84,7 +67,7 @@ def test_finish_job_fact_cache_with_existing_data(job, hosts, inventory, mocker,
         new_modification_time = time.time() + 3600
         os.utime(filepath, (new_modification_time, new_modification_time))
 
-    finish_fact_cache(inventory, fact_cache, last_modified)
+    finish_fact_cache(hosts, fact_cache, last_modified)
 
     for host in (hosts[0], hosts[2], hosts[3]):
         assert host.ansible_facts == {"a": 1, "b": 2}
@@ -93,9 +76,9 @@ def test_finish_job_fact_cache_with_existing_data(job, hosts, inventory, mocker,
     bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'])
 
 
-def test_finish_job_fact_cache_with_bad_data(job, hosts, inventory, mocker, tmpdir):
+def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified = start_fact_cache(inventory, fact_cache, timeout=0)
+    last_modified = start_fact_cache(hosts, fact_cache, timeout=0)
 
     bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
 
@@ -107,19 +90,19 @@ def test_finish_job_fact_cache_with_bad_data(job, hosts, inventory, mocker, tmpd
             new_modification_time = time.time() + 3600
             os.utime(filepath, (new_modification_time, new_modification_time))
 
-    finish_fact_cache(inventory, fact_cache, last_modified)
+    finish_fact_cache(hosts, fact_cache, last_modified)
 
     bulk_update.assert_not_called()
 
 
-def test_finish_job_fact_cache_clear(job, hosts, inventory, mocker, tmpdir):
+def test_finish_job_fact_cache_clear(hosts, mocker, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified = start_fact_cache(inventory, fact_cache, timeout=0)
+    last_modified = start_fact_cache(hosts, fact_cache, timeout=0)
 
     bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
 
     os.remove(os.path.join(fact_cache, hosts[1].name))
-    finish_fact_cache(inventory, fact_cache, last_modified)
+    finish_fact_cache(hosts, fact_cache, last_modified)
 
     for host in (hosts[0], hosts[2], hosts[3]):
         assert host.ansible_facts == {"a": 1, "b": 2}


### PR DESCRIPTION
##### SUMMARY
This change makes the "real" host the source of truth about Ansible facts when a job runs against constructed inventory.

These two diagrams were made to articulate the goal of this:

**Saving**

![Screenshot from 2023-03-15 14-09-19](https://user-images.githubusercontent.com/1385596/225403447-56bb833c-b2d0-4509-9234-328ec8b4eb81.png)

**Loading**

![Screenshot from 2023-03-15 14-09-01](https://user-images.githubusercontent.com/1385596/225403449-3d8be575-9ecf-4a4d-8ec5-bf571f766e9d.png)

The idea is that we keep the original host (that which exists inside the input inventory) as the source of truth about Ansible facts. This is so that we can persist facts across jobs that use normal inventories and constructed inventories, both of which may touch the same host.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

