### PR TITLE
[#13711] git depth set to 1

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -47,6 +47,7 @@
             force: "{{ scm_clean }}"
             track_submodules: "{{ scm_track_submodules | default(omit) }}"
             accept_hostkey: "{{ scm_accept_hostkey | default(omit) }}"
+            depth: 1
           register: git_result
 
         - name: Set the git repository version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #13711.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Using depth attirbute will create a shallow clone with a history truncated. Cloning the project will be a lot faster and it won't hurt current setup, because we are deleting the project folder before and there is no need for walking down the history line in git repository. User only wants to checkout to a specific commit/branch and that is it. Ansible documentation also states this: Needs git>=1.9.1 to work correctly. but if git version is lower than the requested one, Ansible will print a warning that depth attribute will not be used so it also won't break older instances.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
