### PR TITLE
Add missing filtering mechanism for the Thycotic Devops Vault credential lookup

### DIFF
--- a/awx/main/credential_plugins/dsv.py
+++ b/awx/main/credential_plugins/dsv.py
@@ -35,8 +35,14 @@ dsv_inputs = {
             'type': 'string',
             'help_text': _('The secret path e.g. /test/secret1'),
         },
+        {
+            'id': 'secret_field',
+            'label': _('Secret Field'),
+            'help_text': _('The field to extract from the secret'),
+            'type': 'string',
+        },
     ],
-    'required': ['tenant', 'client_id', 'client_secret', 'path'],
+    'required': ['tenant', 'client_id', 'client_secret', 'path', 'secret_field'],
 }
 
 if settings.DEBUG:
@@ -52,5 +58,5 @@ if settings.DEBUG:
 dsv_plugin = CredentialPlugin(
     'Thycotic DevOps Secrets Vault',
     dsv_inputs,
-    lambda **kwargs: SecretsVault(**{k: v for (k, v) in kwargs.items() if k in [field['id'] for field in dsv_inputs['fields']]}).get_secret(kwargs['path']),
+    lambda **kwargs: SecretsVault(**{k: v for (k, v) in kwargs.items() if k in [field['id'] for field in dsv_inputs['fields']]}).get_secret(kwargs['path'])['data'][kwargs['secret_field']],
 )

--- a/awx/main/credential_plugins/dsv.py
+++ b/awx/main/credential_plugins/dsv.py
@@ -58,5 +58,5 @@ if settings.DEBUG:
 dsv_plugin = CredentialPlugin(
     'Thycotic DevOps Secrets Vault',
     dsv_inputs,
-    lambda **kwargs: SecretsVault(**{k: v for (k, v) in kwargs.items() if k in [field['id'] for field in dsv_inputs['fields']]}).get_secret(kwargs['path'])['data'][kwargs['secret_field']],
+    lambda **kwargs: SecretsVault(**{k: v for (k, v) in kwargs.items() if k in [field['id'] for field in dsv_inputs['fields']]}).get_secret(kwargs['path'])['data'][kwargs['secret_field']],  # fmt: skip
 )


### PR DESCRIPTION
##### SUMMARY
Thycotic's DevOps Vault returns a JSON-encoded string with all sorts of metadata, etc., in it, which is not useful as a credential lookup plugin, as one would typically require a specific field of the secret (such as username or password).
This PR introduces a new field ('secret_field') which allows filtering the returned JSON encoded string on a specific field.
The implementation is in accordance with Thycotic's other product: Thycotic Secret Server, which provides this filtering mechanism as well. It is implemented as `tss.py`

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
 - Other

##### AWX VERSION
```
awx: 0.1.dev32960+g4f6e7eb
```
