### PR TITLE
[constructed-inventory] Point constructed inventory URL to special view

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -206,6 +206,8 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
     )
 
     def get_absolute_url(self, request=None):
+        if self.kind == 'constructed':
+            return reverse('api:constructed_inventory_detail', kwargs={'pk': self.pk}, request=request)
         return reverse('api:inventory_detail', kwargs={'pk': self.pk}, request=request)
 
     variables_dict = VarsDictProperty('variables')


### PR DESCRIPTION
##### SUMMARY
We started hitting a lot of test failures because of awxkit `inventory.get()` done on a constructed inventory created via the `/api/v2/constructed_inventories/`, which sent it back to `/api/v2/inventories/42/`.

At _absolute minimum_ we should point the URL link to the constructed inventory detail (`/api/v2/constructed_inventories/42/`) if you start from one of the constructed inventory URLs. Implementation-wise, that would be a little trickier of a conditional to implement, so this just says "whatever" and always points it to the constructed inventory view if the kind of inventory is "constructed".

Could have fallout, but for my purposes this seems to be clearly preferable, and will fix the testing problems we're having.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

