### PR TITLE
Remove --until option from the `host_metric` CLI

### DIFF
--- a/awx/main/management/commands/host_metric.py
+++ b/awx/main/management/commands/host_metric.py
@@ -185,7 +185,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--since', type=datetime.datetime.fromisoformat, help='Start Date in ISO format YYYY-MM-DD')
-        parser.add_argument('--until', type=datetime.datetime.fromisoformat, help='End Date in ISO format YYYY-MM-DD')
         parser.add_argument('--json', type=str, const='host_metric', nargs='?', help='Select output as JSON for host_metric or host_metric_summary_monthly')
         parser.add_argument('--csv', type=str, const='host_metric', nargs='?', help='Select output as CSV for host_metric or host_metric_summary_monthly')
         parser.add_argument('--tarball', action='store_true', help=f'Package CSV files into a tar with upto {CSV_PREFERRED_ROW_COUNT} rows')
@@ -193,25 +192,17 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         since = options.get('since')
-        until = options.get('until')
 
         if since is not None and since.tzinfo is None:
             since = since.replace(tzinfo=datetime.timezone.utc)
 
-        if until is not None and until.tzinfo is None:
-            until = until.replace(tzinfo=datetime.timezone.utc)
-
         filter_kwargs = {}
         if since is not None:
             filter_kwargs['last_automation__gte'] = since
-        if until is not None:
-            filter_kwargs['last_automation__lte'] = until
 
         filter_kwargs_host_metrics_summary = {}
         if since is not None:
             filter_kwargs_host_metrics_summary['date__gte'] = since
-        if until is not None:
-            filter_kwargs_host_metrics_summary['date__lte'] = until
 
         if options['rows_per_file'] and options.get('rows_per_file') > CSV_PREFERRED_ROW_COUNT:
             print(f"rows_per_file exceeds the allowable limit of {CSV_PREFERRED_ROW_COUNT}.")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Remove the `--until` option from the CLI

The ADR was recently updated where it now states that the `--until` option should be removed from the CLI utility. 
The rationale being - if a host is managed in July and then in August, the last managed date would move to August. If we now run the CLI with `–since=2022-07-01 –until=2022-07-31`, then the CLI will not output this host, which is not desirable


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI



##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.13.1.dev132+g790bbeb62d
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
--until option was supported 

After:
If  --until is used, the user would see the below message

usage: awx-manage host_metric [-h] [--since SINCE] [--json [JSON]] [--csv [CSV]] [--tarball] [--rows_per_file ROWS_PER_FILE] [--version] [-v {0,1,2,3}] [--settings SETTINGS]
                              [--pythonpath PYTHONPATH] [--traceback] [--no-color] [--force-color] [--skip-checks]
awx-manage host_metric: error: unrecognized arguments: --until 2023-03-22

```
