### PR TITLE
[WIP] fix headless awx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,10 +447,18 @@ ui-test-general:
 	$(NPM_BIN) run --prefix awx/ui pretest
 	$(NPM_BIN) run --prefix awx/ui/ test-general --runInBand
 
+## Create empty ui/build for headless builds
+ui-headless:
+	@echo "=== Creating empty awx/ui/build ==="
+	@rm -rf awx/ui/build/static
+	@mkdir -p awx/ui/build/static
+	@touch awx/ui/build/static/HEADLESS
+	@echo "=== Done creating empty awx/ui/build ==="
+
 # NOTE: The make target ui-next is imported from awx/ui_next/Makefile
 HEADLESS ?= no
 ifeq ($(HEADLESS), yes)
-dist/$(SDIST_TAR_FILE):
+dist/$(SDIST_TAR_FILE): ui-headless ui-next/headless
 else
 dist/$(SDIST_TAR_FILE): $(UI_BUILD_FLAG_FILE) ui-next
 endif

--- a/awx/ui_next/Makefile
+++ b/awx/ui_next/Makefile
@@ -13,6 +13,15 @@ UI_NEXT_GIT_BRANCH ?= main
 ## Default build target of ui-next Makefile, builds ui-next/build
 ui-next: ui-next/build
 
+.PHONY: ui-next/headless
+## Create fake ui-next/build/awx for headless builds
+ui-next/headless:
+	@echo "=== Creating fake $(UI_NEXT_DIR)/build/awx ==="
+	@rm -rf $(UI_NEXT_DIR)/build/awx
+	@mkdir -p $(UI_NEXT_DIR)/build/awx
+	@touch $(UI_NEXT_DIR)/build/awx/HEADLESS
+	@echo "=== Done creating fake $(UI_NEXT_DIR)/build/awx ==="
+
 .PHONY: ui-next/build
 ## Build ui-next/build
 ui-next/build: $(UI_NEXT_DIR)/build


### PR DESCRIPTION
##### SUMMARY
headless build of awx end in following error 
```
 => ERROR [builder 12/12] RUN AWX_SETTINGS_FILE=/dev/null SKIP_SECRET_KEY_CHEC  2.1s
------
 > [builder 12/12] RUN AWX_SETTINGS_FILE=/dev/null SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear:
#19 1.839 Traceback (most recent call last):
#19 1.839   File "/var/lib/awx/venv/awx/bin/awx-manage", line 8, in <module>
#19 1.839     sys.exit(manage())
#19 1.839   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/__init__.py", line 200, in manage
#19 1.840     execute_from_command_line(sys.argv)
#19 1.840   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
#19 1.840     utility.execute()
#19 1.840   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 413, in execute
#19 1.840     self.fetch_command(subcommand).run_from_argv(self.argv)
#19 1.840   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/base.py", line 354, in run_from_argv
#19 1.840     self.execute(*args, **cmd_options)
#19 1.840   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/base.py", line 398, in execute
#19 1.840     output = self.handle(*args, **options)
#19 1.840   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 187, in handle
#19 1.841     collected = self.collect()
#19 1.841   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 105, in collect
#19 1.841     for path, storage in finder.list(self.ignore_patterns):
#19 1.841   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/contrib/staticfiles/finders.py", line 130, in list
#19 1.841     for path in utils.get_files(storage, ignore_patterns):
#19 1.841   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/contrib/staticfiles/utils.py", line 23, in get_files
#19 1.841     directories, files = storage.listdir(location)
#19 1.841   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/files/storage.py", line 330, in listdir
#19 1.841     for entry in os.scandir(path):
#19 1.841 FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/ui/build/static'
------
executor failed running [/bin/sh -c AWX_SETTINGS_FILE=/dev/null SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear]: exit code: 1
make: *** [awx-kube-build] Error 1
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.13.1.dev105+g0e6f49288a
```


##### ADDITIONAL INFORMATION
test:
```
make clean
HEADLESS=yes make awx-kube-build
```

🟢 IS able to access `/api/v2/`
🟡 `/` will show `Server Error` (we can improve this by placing a dummy index.htlm in the static dir but out of scope of this PR)

