### PR TITLE
[constructed-inventory] Fix misplaced `not`, make constructed always overwrite vars

### DIFF
--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -460,7 +460,7 @@ class Command(BaseCommand):
         # update variables mixing with each other.
         # issue for this: https://github.com/ansible/awx/issues/11623
 
-        if not (self.inventory.kind == 'constructed' and self.inventory_source.overwrite_vars):
+        if self.inventory.kind == 'constructed' and self.inventory_source.overwrite_vars:
             # NOTE: we had to add a exception case to not merge variables
             # to make constructed inventory coherent
             db_variables = self.all_group.variables
@@ -529,16 +529,32 @@ class Command(BaseCommand):
     def _update_db_host_from_mem_host(self, db_host, mem_host):
         # Update host variables.
         db_variables = db_host.variables_dict
-        if self.overwrite_vars:
-            db_variables = mem_host.variables
-        else:
-            db_variables.update(mem_host.variables)
+        mem_variables = mem_host.variables
         update_fields = []
+
+        # Update host instance_id.
+        instance_id = self._get_instance_id(mem_variables)
+        if instance_id != db_host.instance_id:
+            old_instance_id = db_host.instance_id
+            db_host.instance_id = instance_id
+            update_fields.append('instance_id')
+
+        if self.inventory.kind == 'constructed':
+            # remote towervars so the constructed hosts do not have extra variables
+            for prefix in ('host', 'tower'):
+                for var in ('remote_{}_enabled', 'remote_{}_id'):
+                    mem_variables.pop(var.format(prefix), None)
+
+        if self.overwrite_vars:
+            db_variables = mem_variables
+        else:
+            db_variables.update(mem_variables)
+
         if db_variables != db_host.variables_dict:
             db_host.variables = json.dumps(db_variables)
             update_fields.append('variables')
         # Update host enabled flag.
-        enabled = self._get_enabled(mem_host.variables)
+        enabled = self._get_enabled(mem_variables)
         if enabled is not None and db_host.enabled != enabled:
             db_host.enabled = enabled
             update_fields.append('enabled')
@@ -547,12 +563,6 @@ class Command(BaseCommand):
             old_name = db_host.name
             db_host.name = mem_host.name
             update_fields.append('name')
-        # Update host instance_id.
-        instance_id = self._get_instance_id(mem_host.variables)
-        if instance_id != db_host.instance_id:
-            old_instance_id = db_host.instance_id
-            db_host.instance_id = instance_id
-            update_fields.append('instance_id')
         # Update host and display message(s) on what changed.
         if update_fields:
             db_host.save(update_fields=update_fields)

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -458,7 +458,9 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
         """
         if self.kind == 'constructed':
             if not self.inventory_sources.exists():
-                self.inventory_sources.create(source='constructed', name=f'Auto-created source for: {self.name}'[:512], overwrite=True, update_on_launch=True)
+                self.inventory_sources.create(
+                    source='constructed', name=f'Auto-created source for: {self.name}'[:512], overwrite=True, overwrite_vars=True, update_on_launch=True
+                )
 
     def save(self, *args, **kwargs):
         self._update_host_smart_inventory_memeberships()


### PR DESCRIPTION
##### SUMMARY
The big story here is that I had a `not` where I should not have. This had appeared to be working before because I was working under the assumption that `overwrite_vars` was set to true, where it had not been. So there are 2 sign switches here to make things work as actually intended.

Also, we had a problem where "metavars" were still picked up on updates of hosts in constructed inventory imports, like `remote_tower_id`. We already had logic to remove these for initial host saves, and this replicates it for host updates.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

