### PR TITLE
Allow TLS 1.2 for Receptor connections

### DIFF
--- a/awx/api/templates/instance_install_bundle/group_vars/all.yml
+++ b/awx/api/templates/instance_install_bundle/group_vars/all.yml
@@ -2,6 +2,7 @@ receptor_user: awx
 receptor_group: awx
 receptor_verify: true
 receptor_tls: true
+receptor_mintls13: false
 receptor_work_commands:
   ansible-runner:
     command: ansible-runner

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -668,6 +668,7 @@ RECEPTOR_CONFIG_STARTER = (
             'rootcas': '/etc/receptor/tls/ca/receptor-ca.crt',
             'cert': '/etc/receptor/tls/receptor.crt',
             'key': '/etc/receptor/tls/receptor.key',
+            'mintls13': False,
         }
     },
 )


### PR DESCRIPTION
goes with this operator change https://github.com/ansible/awx-operator/pull/1300
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Required for FIPS environment where TLS 1.3 is not supported
- TLS 1.3 can still be used if the nodes both agree to use during handshake.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.13.1.dev108+gdb2253601d
```
