### PR TITLE
Only select task instance that are ready and enabled

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -19,7 +19,18 @@ def get_task_queuename():
     if os.getenv('AWX_COMPONENT') == 'web':
         from awx.main.models.ha import Instance
 
-        return Instance.objects.filter(node_type__in=['control', 'hybrid']).order_by('?').first().hostname
+        return (
+            Instance.objects.filter(
+                node_type__in=[Instance.Types.CONTROL, Instance.Types.HYBRID],
+                node_state=Instance.States.READY,
+                enabled=True,
+            )
+            .only('hostname')
+            .order_by('?')
+            .first()
+            .hostname
+        )
+
     else:
         return settings.CLUSTER_HOST_ID
 


### PR DESCRIPTION
When select a queue for task instance to run task only select task instance that are ready and enabled

##### SUMMARY
When select a queue for task instance to run task only select task instance that are ready and enabled

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.13.1.dev185+g58ae461e1a.d20230327
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
