### PR TITLE
Fix missing rsyslog conf

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -194,6 +194,7 @@ ENV _CONTAINERS_USERNS_CONFIGURED=""
 RUN mkdir -p /etc/containers/registries.conf.d/ && echo "unqualified-search-registries = []" >> /etc/containers/registries.conf.d/force-fully-qualified-images.conf && chmod 644 /etc/containers/registries.conf.d/force-fully-qualified-images.conf
 {% endif %}
 
+ADD tools/ansible/roles/dockerfile/files/rsyslog.conf /var/lib/awx/rsyslog/rsyslog.conf
 ADD tools/ansible/roles/dockerfile/files/wait-for-migrations /usr/local/bin/wait-for-migrations
 ADD tools/ansible/roles/dockerfile/files/stop-supervisor /usr/local/bin/stop-supervisor
 


### PR DESCRIPTION
##### SUMMARY
fix 
```
________________ test_logging_aggregator_connection_test_valid _________________
[gw0] linux -- Python 3.9.16 /var/lib/awx/venv/awx/bin/python3.9
Traceback (most recent call last):
  File "/awx_devel/awx/main/tests/functional/api/test_settings.py", line 320, in test_logging_aggregator_connection_test_valid
    post(url, {}, user=admin, expect=202)
  File "/awx_devel/awx/main/tests/functional/conftest.py", line 625, in rf
    assert response.status_code == expect, 'Response data: {}'.format(getattr(response, 'data', None))
AssertionError: Response data: {'error': "b'rsyslogd: version 8.2102.0-106.el9, config validation run (level 1), master config /var/lib/awx/rsyslog/rsyslog.conf\\nrsyslogd: there are no active actions configured. Inputs would run, but no output whatsoever were created. [v8.2102.0-106.el9 try https://www.rsyslog.com/e/2103 ]\\nrsyslogd: run failed with error -2103 (see rsyslog.h or try https://www.rsyslog.com/e/2103 to learn what that number means)\\n'"}
assert 400 == 202
 +  where 400 = <Response status_code=400, "text/html; charset=utf-8">.status_code
----------------------------- Captured stderr call -----------------------------
2023-03-27 20:34:06,169 ERROR    [-] awx AWX Connection Test Message
2023-03-27 20:34:06 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
AWX Connection Test Message
2023-03-27 20:34:06,187 WARNING  [-] awx.api.generics status 400 received by user admin attempting to access /api/v2/settings/logging/test/ from 127.0.0.1
2023-03-27 20:34:06 ERROR rsyslogd was unresponsive: FileNotFoundError: [Errno 2] No such file or directory
status 400 received by user admin attempting to access /api/v2/settings/logging/test/ from 127.0.0.1
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 21.13.1.dev187+g676d3a5f65
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
