### PR TITLE
Remove Inventories column

### DIFF
--- a/awx/ui/src/screens/HostMetrics/HostMetrics.js
+++ b/awx/ui/src/screens/HostMetrics/HostMetrics.js
@@ -132,12 +132,6 @@ function HostMetrics() {
                   {t`Automation`}
                 </HeaderCell>
                 <HeaderCell
-                  sortKey="used_in_inventories"
-                  tooltip={t`How many inventories is the host in, recomputed on a weekly schedule`}
-                >
-                  {t`Inventories`}
-                </HeaderCell>
-                <HeaderCell
                   sortKey="deleted_counter"
                   tooltip={t`How many times was the host deleted`}
                 >

--- a/awx/ui/src/screens/HostMetrics/HostMetricsListItem.js
+++ b/awx/ui/src/screens/HostMetrics/HostMetricsListItem.js
@@ -21,7 +21,6 @@ function HostMetricsListItem({ item, isSelected, onSelect, rowIndex }) {
         {formatDateString(item.last_automation)}
       </Td>
       <Td dataLabel={t`Automation`}>{item.automated_counter}</Td>
-      <Td dataLabel={t`Inventories`}>{item.used_in_inventories || 0}</Td>
       <Td dataLabel={t`Deleted`}>{item.deleted_counter}</Td>
     </Tr>
   );


### PR DESCRIPTION
There's no backend for `Inventories` column right now. This will be reverted once there is.

New or Enhanced Feature - related to https://github.com/ansible/awx/pull/13582

TODO: move this against new feature branch

