### PR TITLE
HostMetrics cleanup task and more Subscription info

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -822,6 +822,15 @@ register(
     category_slug='system',
 )
 
+register(
+    'CLEANUP_HOST_METRICS_LAST_TS',
+    field_class=fields.DateTimeField,
+    label=_('Last cleanup date for HostMetrics'),
+    allow_null=True,
+    category=_('System'),
+    category_slug='system',
+)
+
 
 def logging_validate(serializer, attrs):
     if not serializer.instance or not hasattr(serializer.instance, 'LOG_AGGREGATOR_HOST') or not hasattr(serializer.instance, 'LOG_AGGREGATOR_TYPE'):

--- a/awx/main/management/commands/cleanup_host_metrics.py
+++ b/awx/main/management/commands/cleanup_host_metrics.py
@@ -1,0 +1,22 @@
+from awx.main.models import HostMetric
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    """
+    Run soft-deleting of HostMetrics
+    """
+
+    help = 'Run soft-deleting of HostMetrics'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--months-ago', type=int, dest='months-ago', action='store', help='Threshold in months for soft-deleting')
+
+    def handle(self, *args, **options):
+        months_ago = options.get('months-ago') or None
+
+        if not months_ago:
+            months_ago = getattr(settings, 'CLEANUP_HOST_METRICS_THRESHOLD', 12)
+
+        HostMetric.cleanup_task(months_ago)

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -892,13 +892,20 @@ class HostMetric(models.Model):
 
     @classmethod
     def cleanup_task(cls, months_ago):
-        last_automation_before = now() - dateutil.relativedelta.relativedelta(months=months_ago)
+        try:
+            months_ago = int(months_ago)
+            if months_ago <= 0:
+                raise ValueError()
 
-        logger.info(f'Cleanup [HostMetric]: soft-deleting records last automated before {last_automation_before}')
-        HostMetric.objects.filter(last_automation__lt=last_automation_before).update(
-            deleted=True, deleted_counter=models.F('deleted_counter') + 1, last_deleted=now()
-        )
-        settings.CLEANUP_HOST_METRICS_LAST_TS = now()
+            last_automation_before = now() - dateutil.relativedelta.relativedelta(months=months_ago)
+
+            logger.info(f'Cleanup [HostMetric]: soft-deleting records last automated before {last_automation_before}')
+            HostMetric.active_objects.filter(last_automation__lt=last_automation_before).update(
+                deleted=True, deleted_counter=models.F('deleted_counter') + 1, last_deleted=now()
+            )
+            settings.CLEANUP_HOST_METRICS_LAST_TS = now()
+        except (TypeError, ValueError):
+            logger.error(f"Cleanup [HostMetric]: months_ago({months_ago}) has to be a positive integer value")
 
 
 class HostMetricSummaryMonthly(models.Model):

--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -388,9 +388,13 @@ class Licenser(object):
         if subscription_model == SUBSCRIPTION_USAGE_MODEL_UNIQUE_HOSTS:
             automated_instances = HostMetric.active_objects.count()
             first_host = HostMetric.active_objects.only('first_automation').order_by('first_automation').first()
+            attrs['deleted_instances'] = HostMetric.objects.filter(deleted=True).count()
+            attrs['reactivated_instances'] = HostMetric.active_objects.filter(deleted_counter__gte=1).count()
         else:
-            automated_instances = HostMetric.objects.count()
+            automated_instances = 0
             first_host = HostMetric.objects.only('first_automation').order_by('first_automation').first()
+            attrs['deleted_instances'] = 0
+            attrs['reactivated_instances'] = 0
 
         if first_host:
             automated_since = int(first_host.first_automation.timestamp())

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -475,6 +475,7 @@ CELERYBEAT_SCHEDULE = {
     'receptor_reaper': {'task': 'awx.main.tasks.system.awx_receptor_workunit_reaper', 'schedule': timedelta(seconds=60)},
     'send_subsystem_metrics': {'task': 'awx.main.analytics.analytics_tasks.send_subsystem_metrics', 'schedule': timedelta(seconds=20)},
     'cleanup_images': {'task': 'awx.main.tasks.system.cleanup_images_and_files', 'schedule': timedelta(hours=3)},
+    'cleanup_host_metrics': {'task': 'awx.main.tasks.system.cleanup_host_metrics', 'schedule': timedelta(days=1)},
 }
 
 # Django Caching Configuration
@@ -1050,3 +1051,10 @@ UI_NEXT = True
 # - '': No model - Subscription not counted from Host Metrics
 # - 'unique_managed_hosts': Compliant = automated - deleted hosts (using /api/v2/host_metrics/)
 SUBSCRIPTION_USAGE_MODEL = ''
+
+# Host metrics cleanup - last time of the cleanup run (soft-deleting records)
+CLEANUP_HOST_METRICS_LAST_TS = None
+# Host metrics cleanup - minimal interval between two cleanups in days
+CLEANUP_HOST_METRICS_INTERVAL = 30  # days
+# Host metrics cleanup - soft-delete HostMetric records with last_automation < [threshold] (in months)
+CLEANUP_HOST_METRICS_THRESHOLD = 12  # months

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
@@ -56,7 +56,8 @@ function SubscriptionDetail() {
       <RoutedTabs tabsArray={tabsArray} />
       <CardBody>
         <DetailList>
-          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL ===
+            'unique_managed_hosts' && (
             <Detail
               dataCy="subscription-status"
               label={t`Status`}
@@ -109,21 +110,24 @@ function SubscriptionDetail() {
             label={t`Hosts imported`}
             value={license_info.current_instances}
           />
-          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL ===
+            'unique_managed_hosts' && (
             <Detail
               dataCy="subscription-hosts-remaining"
               label={t`Hosts remaining`}
               value={license_info.free_instances}
             />
           )}
-          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL ===
+            'unique_managed_hosts' && (
             <Detail
               dataCy="subscription-hosts-deleted"
               label={t`Hosts deleted`}
               value={license_info.deleted_instances}
             />
           )}
-          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL ===
+            'unique_managed_hosts' && (
             <Detail
               dataCy="subscription-hosts-reactivated"
               label={t`Active hosts previously deleted`}

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
@@ -24,7 +24,7 @@ const HelperText = styled(PFHelperText)`
 `;
 
 function SubscriptionDetail() {
-  const { me = {}, license_info, version } = useConfig();
+  const { me = {}, license_info, version, systemConfig } = useConfig();
   const baseURL = '/settings/subscription';
   const tabsArray = [
     {
@@ -56,35 +56,37 @@ function SubscriptionDetail() {
       <RoutedTabs tabsArray={tabsArray} />
       <CardBody>
         <DetailList>
-          <Detail
-            dataCy="subscription-status"
-            label={t`Status`}
-            value={
-              license_info.compliant ? (
-                <>
-                  <Label variant="outline" color="green" icon={<CheckIcon />}>
-                    {t`Compliant`}
-                  </Label>
-                  <HelperText>
-                    <HelperTextItem>{t`The number of hosts you have automated against is below your subscription count.`}</HelperTextItem>
-                  </HelperText>
-                </>
-              ) : (
-                <>
-                  <Label
-                    variant="outline"
-                    color="red"
-                    icon={<ExclamationCircleIcon />}
-                  >
-                    {t`Out of compliance`}
-                  </Label>
-                  <HelperText>
-                    <HelperTextItem>{t`You have automated against more hosts than your subscription allows.`}</HelperTextItem>
-                  </HelperText>
-                </>
-              )
-            }
-          />
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+            <Detail
+              dataCy="subscription-status"
+              label={t`Status`}
+              value={
+                license_info.compliant ? (
+                  <>
+                    <Label variant="outline" color="green" icon={<CheckIcon />}>
+                      {t`Compliant`}
+                    </Label>
+                    <HelperText>
+                      <HelperTextItem>{t`The number of hosts you have automated against is below your subscription count.`}</HelperTextItem>
+                    </HelperText>
+                  </>
+                ) : (
+                  <>
+                    <Label
+                      variant="outline"
+                      color="red"
+                      icon={<ExclamationCircleIcon />}
+                    >
+                      {t`Out of compliance`}
+                    </Label>
+                    <HelperText>
+                      <HelperTextItem>{t`You have automated against more hosts than your subscription allows.`}</HelperTextItem>
+                    </HelperText>
+                  </>
+                )
+              }
+            />
+          )}
           {typeof automatedInstancesCount !== 'undefined' &&
             automatedInstancesCount !== null && (
               <Detail
@@ -107,21 +109,27 @@ function SubscriptionDetail() {
             label={t`Hosts imported`}
             value={license_info.current_instances}
           />
-          <Detail
-            dataCy="subscription-hosts-remaining"
-            label={t`Hosts remaining`}
-            value={license_info.free_instances}
-          />
-          <Detail
-            dataCy="subscription-hosts-deleted"
-            label={t`Hosts deleted`}
-            value={license_info.deleted_instances}
-          />
-          <Detail
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+            <Detail
+              dataCy="subscription-hosts-remaining"
+              label={t`Hosts remaining`}
+              value={license_info.free_instances}
+            />
+          )}
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+            <Detail
+              dataCy="subscription-hosts-deleted"
+              label={t`Hosts deleted`}
+              value={license_info.deleted_instances}
+            />
+          )}
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL === 'unique_managed_hosts' && (
+            <Detail
               dataCy="subscription-hosts-reactivated"
               label={t`Active hosts previously deleted`}
               value={license_info.reactivated_instances}
-          />
+            />
+          )}
           {license_info.instance_count < 9999999 && (
             <Detail
               dataCy="subscription-hosts-available"

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
@@ -112,6 +112,16 @@ function SubscriptionDetail() {
             label={t`Hosts remaining`}
             value={license_info.free_instances}
           />
+          <Detail
+            dataCy="subscription-hosts-deleted"
+            label={t`Hosts deleted`}
+            value={license_info.deleted_instances}
+          />
+          <Detail
+              dataCy="subscription-hosts-reactivated"
+              label={t`Active hosts previously deleted`}
+              value={license_info.reactivated_instances}
+          />
           {license_info.instance_count < 9999999 && (
             <Detail
               dataCy="subscription-hosts-available"

--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.test.js
@@ -31,6 +31,9 @@ const config = {
     trial: false,
     valid_key: true,
   },
+  systemConfig: {
+    SUBSCRIPTION_USAGE_MODEL: 'unique_managed_hosts',
+  },
 };
 
 describe('<SubscriptionDetail />', () => {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
- Subscription Settings page: Deleted host metrics and Active previously deleted info. Visible when `SUBSCRIPTION_USAGE_MODEL == 'unique-managed_hosts'`
  - https://issues.redhat.com/browse/AA-1642
  - https://issues.redhat.com/browse/AA-1634
- Host Metric cleanup task - soft deletes HostMetric records which were automated more than 12 months ago
  - https://issues.redhat.com/browse/AA-1593


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.14.1.dev34+gba108660af
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
