### PR TITLE
Add host_metrics page to the awxkit

### DIFF
--- a/awxkit/awxkit/api/pages/__init__.py
+++ b/awxkit/awxkit/api/pages/__init__.py
@@ -42,3 +42,4 @@ from .credential_input_sources import *  # NOQA
 from .metrics import *  # NOQA
 from .subscriptions import *  # NOQA
 from .workflow_approval_templates import *  # NOQA
+from .host_metrics import *  # NOQA

--- a/awxkit/awxkit/api/pages/host_metrics.py
+++ b/awxkit/awxkit/api/pages/host_metrics.py
@@ -1,0 +1,18 @@
+from awxkit.api.resources import resources
+from . import base
+from . import page
+
+
+class HostMetric(base.Base):
+    def get(self, **query_parameters):
+        request = self.connection.get(self.endpoint, query_parameters, headers={'Accept': 'application/json'})
+        return self.page_identity(request)
+
+
+class HostMetrics(page.PageList, HostMetric):
+    pass
+
+
+page.register_page([resources.host_metric], HostMetric)
+
+page.register_page([resources.host_metrics], HostMetrics)

--- a/awxkit/awxkit/api/resources.py
+++ b/awxkit/awxkit/api/resources.py
@@ -44,6 +44,8 @@ class Resources(object):
     _groups = 'groups/'
     _host = r'hosts/\d+/'
     _host_groups = r'hosts/\d+/groups/'
+    _host_metrics = 'host_metrics/'
+    _host_metric = r'host_metrics/\d+/'
     _host_insights = r'hosts/\d+/insights/'
     _host_related_ad_hoc_commands = r'hosts/\d+/ad_hoc_commands/'
     _host_related_fact_version = r'hosts/\d+/fact_versions/\d+/'


### PR DESCRIPTION
Added awxkit changes  so we can test host_metrics. We need to have appropriate pages so we can, for example, delete host metrics in our test scenarios.

Bug, Docs Fix or other nominal change
