### PR TITLE
[collection] Hack around constructed inventory url

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -965,13 +965,35 @@ class ControllerAPIModule(ControllerModule):
             return last_data
 
     def create_or_update_if_needed(
-            self, existing_item, new_item, endpoint=None, item_type='unknown', on_create=None, on_update=None, auto_exit=True, associations=None, modify_item_url=None
+            self,
+            existing_item,
+            new_item,
+            endpoint=None,
+            item_type='unknown',
+            on_create=None,
+            on_update=None,
+            auto_exit=True,
+            associations=None,
+            modify_item_url=None
     ):
         if existing_item:
-            return self.update_if_needed(existing_item, new_item, on_update=on_update, auto_exit=auto_exit, associations=associations, modify_item_url=modify_item_url)
+            return self.update_if_needed(
+                existing_item,
+                new_item,
+                on_update=on_update,
+                auto_exit=auto_exit,
+                associations=associations,
+                modify_item_url=modify_item_url)
         else:
             return self.create_if_needed(
-                existing_item, new_item, endpoint, on_create=on_create, item_type=item_type, auto_exit=auto_exit, associations=associations, modify_item_url=modify_item_url)
+                existing_item,
+                new_item,
+                endpoint,
+                on_create=on_create,
+                item_type=item_type,
+                auto_exit=auto_exit,
+                associations=associations,
+                modify_item_url=modify_item_url)
 
     def logout(self):
         if self.authenticated and self.oauth_token_id:

--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -230,6 +230,7 @@ def main():
         endpoint='inventories',
         item_type='inventory',
         associations=association_fields,
+        modify_item_url=lambda url: url.replace('/constructed_inventories/', '/inventories/') if kind == 'constructed' else None,
     )
 
 


### PR DESCRIPTION
# NOTE
This is incredibly hacky and I don't think we should do it this way.


# Description

Constructed inventories identify themselves in the API as /constructed_inventories/ after #13730. This breaks the collection, which relies on the URL (as given by the API) to construct other endpoints for assocations (for example, input_inventories).

This results in a request to
/api/v2/constructed_inventories/<id>/input_inventories which is not valid.

This commit introduces a way to hack the item URL before creating/updating it by passing along a lambda.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Collection
