### PR TITLE
Add instance groups role to awxkit and awx collection

### DIFF
--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -116,6 +116,11 @@ options:
         - Project the role acts on.
       type: list
       elements: str
+    instance_groups:
+      description:
+        - Instance Group the role acts on.
+      type: list
+      elements: str
     state:
       description:
         - Desired state.
@@ -193,6 +198,7 @@ def main():
         lookup_organization=dict(),
         project=dict(),
         projects=dict(type='list', elements='str'),
+        instance_groups=dict(type='list', elements='str'),
         state=dict(choices=['present', 'absent'], default='present'),
     )
 

--- a/awxkit/awxkit/cli/custom.py
+++ b/awxkit/awxkit/cli/custom.py
@@ -396,6 +396,7 @@ class RoleMixin(object):
         ['credentials', 'credential'],
         ['job_templates', 'job_template'],
         ['workflow_job_templates', 'workflow_job_template'],
+        ['instance_groups', 'instance_group'],
     ]
     roles = {}  # this is calculated once
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This pull request will enable instance_groups role to awxkit and awx collection.
Moreover will close https://github.com/ansible/awx/issues/13783

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
 - CLI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
21.14.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
