### PR TITLE
Fix docker-clean target, accounting for slashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ docker-compose-build:
 
 docker-clean:
 	-$(foreach container_id,$(shell docker ps -f name=tools_awx -aq && docker ps -f name=tools_receptor -aq),docker stop $(container_id); docker rm -f $(container_id);)
-	-$(foreach image_id,$(shell docker images --filter=reference='*awx_devel*' -aq),docker rmi --force $(image_id);)
+	-$(foreach image_id,$(shell docker images --filter=reference='*/*/*awx_devel*' --filter=reference='*/*awx_devel*' --filter=reference='*awx_devel*' -aq),docker rmi --force $(image_id);)
 
 docker-clean-volumes: docker-compose-clean docker-compose-container-group-clean
 	docker volume rm -f tools_awx_db tools_grafana_storage tools_prometheus_storage $(docker volume ls --filter name=tools_redis_socket_ -q)
@@ -680,4 +680,3 @@ help/generate:
 ## Display help for ui-next targets
 help/ui-next:
 	@make -s help MAKEFILE_LIST="awx/ui_next/Makefile"
-


### PR DESCRIPTION
##### SUMMARY
As documented in https://github.com/moby/moby/issues/36196, the docker `reference=` notion does not support `/`. This is a problem, as it makes the prior filter completely non-functional:

```
docker images --filter=reference='*awx_devel*' -aq
```

This returns no images because `*` does not match `ghcr.io/ansible`, as per the file glob philosophy - and requests for an expansion pattern `**` that include slashes (as per file globs) have been denied.

Multiple `--filter` arguments will OR the criteria together, so we are safe to allow fewer slashes by being slightly redundant, as I am doing here. This is essentially a poor person's version of `**`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
Because web/task split just merged, it goes without saying that many people will need an image refresh.
