### PR TITLE
Fixes bug where attempting to edit a schedule with stringified extra_data threw error

### DIFF
--- a/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
+++ b/awx/ui/src/components/Schedule/ScheduleEdit/ScheduleEdit.js
@@ -113,6 +113,9 @@ function ScheduleEdit({
             days: values.daysToKeep,
           });
         } else {
+          if (typeof requestData.extra_data === 'string') {
+            requestData.extra_data = JSON.parse(requestData.extra_data);
+          }
           requestData.extra_data.days = values.daysToKeep;
         }
       }


### PR DESCRIPTION
##### SUMMARY
Addresses https://github.com/ansible/awx/issues/10153.  extra_data can be stored as either a string or a json blob but the UI was not handling the stringified format properly resulting in an error on the screen.  This bit of code detects the stringified extra_data and converts it to json before resetting the `days` attribute.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
