### PR TITLE
Adding import of centos repo key for dnf

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -15,6 +15,9 @@ ENV AWX_LOGGING_MODE stdout
 
 USER root
 
+# Import the gpg key for DNF to work
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
 # Install build dependencies
 RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
@@ -98,6 +101,9 @@ ENV LC_ALL en_US.UTF-8
 ENV AWX_LOGGING_MODE stdout
 
 USER root
+
+# Import the gpg key for DNF to work
+RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 # Install runtime requirements
 RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \


### PR DESCRIPTION
##### SUMMARY
PRs were failing several checks starting yesterday. In the logs of the errors we were seeing:
```
CentOS Stream 9 - BaseOS                                                                                                                                                                       1.6 MB/s | 1.6 kB     00:00    
The GPG keys listed for the "CentOS Stream 9 - BaseOS" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.. Failing package is: dbus-libs-1:1.12.20-7.el9.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Public key for dnf-plugins-core-4.3.0-4.el9.noarch.rpm is not installed. Failing package is: dnf-plugins-core-4.3.0-4.el9.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Public key for python3-dateutil-2.8.1-6.el9.noarch.rpm is not installed. Failing package is: python3-dateutil-1:2.8.1-6.el9.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Public key for python3-dbus-1.2.18-2.el9.x86_64.rpm is not installed. Failing package is: python3-dbus-1.2.18-2.el9.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Public key for python3-dnf-plugins-core-4.3.0-4.el9.noarch.rpm is not installed. Failing package is: python3-dnf-plugins-core-4.3.0-4.el9.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Public key for python3-six-1.15.0-9.el9.noarch.rpm is not installed. Failing package is: python3-six-1.15.0-9.el9.noarch
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Public key for python3-systemd-234-18.el9.x86_64.rpm is not installed. Failing package is: python3-systemd-234-18.el9.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
Public key for systemd-libs-252-8.el9.x86_64.rpm is not installed. Failing package is: systemd-libs-252-8.el9.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'dnf clean packages'.
Error: GPG check FAILED
```

This PR adds a run step to the Dockerfile to ensure the `centosofficial` GPG is installed and used properly.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
