### PR TITLE
[wip] Allow switching DB in dev env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,6 +498,7 @@ EXECUTION_NODE_COUNT ?= 0
 MINIKUBE_CONTAINER_GROUP ?= false
 MINIKUBE_SETUP ?= false # if false, run minikube separately
 EXTRA_SOURCES_ANSIBLE_OPTS ?=
+DBNAME ?= tools_awx_db
 
 ifneq ($(ADMIN_PASSWORD),)
 	EXTRA_SOURCES_ANSIBLE_OPTS := -e admin_password=$(ADMIN_PASSWORD) $(EXTRA_SOURCES_ANSIBLE_OPTS)
@@ -519,9 +520,11 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e enable_ldap=$(LDAP) \
 	    -e enable_splunk=$(SPLUNK) \
 	    -e enable_prometheus=$(PROMETHEUS) \
-	    -e enable_grafana=$(GRAFANA) $(EXTRA_SOURCES_ANSIBLE_OPTS)
+	    -e enable_grafana=$(GRAFANA) $(EXTRA_SOURCES_ANSIBLE_OPTS) \
+	    -e dbname=$(DBNAME) \
 
 docker-compose: awx/projects docker-compose-sources
+	-docker rm tools_postgres_1
 	$(DOCKER_COMPOSE) -f tools/docker-compose/_sources/docker-compose.yml $(COMPOSE_OPTS) up $(COMPOSE_UP_OPTS) --remove-orphans
 
 docker-compose-credential-plugins: awx/projects docker-compose-sources

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -228,7 +228,7 @@ services:
 
 volumes:
   awx_db:
-    name: tools_awx_db
+    name: {{ dbname }}
 {% for i in range(control_plane_node_count|int) -%}
   {% set container_postfix = loop.index %}
   redis_socket_{{ container_postfix }}:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows you to name your own db volume so that you can switch between branches more easily.

Usage:

`DBNAME=sbf make docker-compose`

this will create a docker volume called "sbf" that will persist on disk.

You can then switch back to devel or some other branch, which will use a different branch.

not setting DBNAME defaults to `tools_awx_db`

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
