### PR TITLE
Temporary workaround for make requirements_awx failure and fix license test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 MANAGEMENT_COMMAND ?= awx-manage
 VERSION := $(shell $(PYTHON) tools/scripts/scm_version.py)
 
+# temparary workaround for pip resolver issues
+PIP_OPTIONS="--use-deprecated=legacy-resolver"
+
 # ansible-test requires semver compatable version, so we allow overrides to hack it
 COLLECTION_VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py | cut -d . -f 1-3)
 # args for the ansible-test sanity command

--- a/awx/main/tests/functional/test_licenses.py
+++ b/awx/main/tests/functional/test_licenses.py
@@ -26,12 +26,12 @@ def test_python_and_js_licenses():
                 return (is_gpl, is_lgpl)
 
         def find_embedded_source_version(path, name):
-            for entry in os.listdir(path):
-                # Check variations of '-' and '_' in filenames due to python
-                for fname in [name, name.replace('-', '_')]:
-                    if entry.startswith(fname) and entry.endswith('.tar.gz'):
-                        v = entry.split(name + '-')[1].split('.tar.gz')[0]
-                        return v
+            files = os.listdir(path)
+            tgz_files = [f for f in files if f.endswith('.tar.gz')]
+            for tgz in tgz_files:
+                pkg_name = tgz.split('-')[0].split('_')[0]
+                if pkg_name == name:
+                    return tgz.split('-')[1].split('.tar.gz')[0]
             return None
 
         list = {}


### PR DESCRIPTION
##### SUMMARY
`make docker-compose-build` has been failing due to 

```
#17 51.29 ERROR: Cannot install -r /dev/stdin (line 220), -r /dev/stdin (line 470) and importlib-metadata==5.1.0 because these package versions have conflicting dependencies.
#17 51.29 
#17 51.29 The conflict is caused by:
#17 51.29     The user requested importlib-metadata==5.1.0
#17 51.29     markdown 3.4.1 depends on importlib-metadata>=4.4; python_version < "3.10"
#17 51.29     ansible-runner 2.3.1.dev16 depends on importlib-metadata<4.7 and >=4.6
#17 51.29 
#17 51.29 To fix this you could try to:
#17 51.29 1. loosen the range of package versions you've specified
#17 51.29 2. remove package versions to allow pip attempt to solve the dependency conflict
#17 51.29 
#17 51.29 ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/user_guide/#fixing-conflicting-dependencies
#17 51.30 WARNING: You are using pip version 21.2.4; however, version 23.0.1 is available.
#17 51.30 You should consider upgrading via the '/var/lib/awx/venv/awx/bin/python3.9 -m pip install --upgrade pip' command.
#17 51.90 make: *** [Makefile:140: requirements_awx] Error 1
#17 ERROR: executor failed running [/bin/sh -c cd /tmp && make requirements_awx]: exit code: 2
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.0.1.dev11+g98e37383c2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
