### PR TITLE
Fix job template admin permission

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1629,18 +1629,18 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
             return True
 
         data = dict(data)
-
         if self.changes_are_non_sensitive(obj, data):
             return True
-
         if not self.check_related('execution_environment', ExecutionEnvironment, data, obj=obj, role_field='read_role'):
             return False
-
         for required_field, cls in (('inventory', Inventory), ('project', Project)):
             is_mandatory = True
             if not getattr(obj, '{}_id'.format(required_field)):
                 is_mandatory = False
             if not self.check_related(required_field, cls, data, obj=obj, role_field='use_role', mandatory=is_mandatory):
+                if required_field in data:
+                    new_obj = get_object_from_data(required_field, cls, data)
+                    return self.user in new_obj.use_role and (self.user in obj.inventory.use_role or self.user in obj.project.use_role)
                 return False
         return True
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There are a few edge cases with regards to job template admin and object permissions. This tries to fix them by adding another check for the incoming object.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.0.1.dev10+g9e336d55e4.d20230407

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
