### PR TITLE
Fix importlib-metadata dependency conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 MANAGEMENT_COMMAND ?= awx-manage
 VERSION := $(shell $(PYTHON) tools/scripts/scm_version.py)
 
-# temparary workaround for pip resolver issues
-PIP_OPTIONS="--use-deprecated=legacy-resolver"
-
 # ansible-test requires semver compatable version, so we allow overrides to hack it
 COLLECTION_VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py | cut -d . -f 1-3)
 # args for the ansible-test sanity command

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -172,8 +172,10 @@ idna==3.4
     #   requests
     #   twisted
     #   yarl
-importlib-metadata==5.1.0
-    # via markdown
+importlib-metadata==4.6.4
+    # via
+    #   ansible-runner
+    #   markdown
 incremental==22.10.0
     # via twisted
 inflect==6.0.2


### PR DESCRIPTION
##### SUMMARY
rerun requirements/updator.sh to regenerate requirements.txt fix conflict introduced by https://github.com/ansible/ansible-runner/pull/1224



##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.0.1.dev21+g328880609b
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
