### PR TITLE
Fix: Misconfigured LOG_AGGREGATOR_URL can cause dispatcher to go into a crash loop. #13823 

### DIFF
--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -69,6 +69,9 @@ def construct_rsyslog_conf_template(settings=settings):
             host = 'https://%s' % (host)
         parsed = urlparse.urlsplit(host)
 
+        if 's' in str(parsed.port):  # Check if the port contains an 's'
+            raise ValueError(f"Invalid URL for logging: {host}. Please check the LOG_AGGREGATOR_HOST setting.")
+
         host = escape_quotes(parsed.hostname)
         try:
             if parsed.port:

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -73,7 +73,6 @@ def construct_rsyslog_conf_template(settings=settings):
         if parsed.port and not str(parsed.port).isdigit():
             raise ValueError(f"Invalid port in URL for logging: {host}. Please check the LOG_AGGREGATOR_HOST setting.")
 
-
         host = escape_quotes(parsed.hostname)
         try:
             if parsed.port:

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -68,9 +68,11 @@ def construct_rsyslog_conf_template(settings=settings):
         if (not original_parsed.scheme and not host.startswith('//')) or original_parsed.hostname is None:
             host = 'https://%s' % (host)
         parsed = urlparse.urlsplit(host)
-
-        if 's' in str(parsed.port):  # Check if the port contains an 's'
+        if not parsed.scheme or not parsed.hostname:
             raise ValueError(f"Invalid URL for logging: {host}. Please check the LOG_AGGREGATOR_HOST setting.")
+        if parsed.port and not str(parsed.port).isdigit():
+            raise ValueError(f"Invalid port in URL for logging: {host}. Please check the LOG_AGGREGATOR_HOST setting.")
+
 
         host = escape_quotes(parsed.hostname)
         try:


### PR DESCRIPTION
##### SUMMARY
- Integrate URL validation within the construct_rsyslog_conf_template function
- Check for proper scheme, hostname, and port in the URL
- Raise a ValueError for invalid URLs with appropriate messages

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
```
awx: 22.0.1.dev33+gf4a6301057
```


##### ADDITIONAL INFORMATION
Before the change, the construct_rsyslog_conf_template function did not validate the URL, which could lead to misconfigurations and errors. The issue occurred when the URL contained a misconfigured scheme or port, such as "http:s//test.com" or "ht:tps//test.com".

After the change, the function validates the URL by checking for the proper scheme, hostname, and port. If an invalid URL is found, it raises a ValueError with an appropriate error message. This helps prevent misconfigurations and ensures that the logging feature works as intended.


```
Before change example output:
- Misconfigured URLs were accepted without validation

After change example output:
- ValueError: Invalid URL for logging: http:s//test.com. Please check the LOG_AGGREGATOR_HOST setting.
- ValueError: Invalid port in URL for logging: ht:tps//test.com. Please check the LOG_AGGREGATOR_HOST setting.
```
