### PR TITLE
Analytics API: Permissions for System Auditor

### DIFF
--- a/awx/api/permissions.py
+++ b/awx/api/permissions.py
@@ -25,6 +25,7 @@ __all__ = [
     'UserPermission',
     'IsSystemAdminOrAuditor',
     'WorkflowApprovalPermission',
+    'AnalyticsPermission',
 ]
 
 
@@ -250,3 +251,16 @@ class IsSystemAdminOrAuditor(permissions.BasePermission):
 class WebhookKeyPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         return request.user.can_access(view.model, 'admin', obj, request.data)
+
+
+class AnalyticsPermission(permissions.BasePermission):
+    """
+    Allows GET/POST/OPTIONS to system admins and system auditors.
+    """
+
+    def has_permission(self, request, view):
+        if not (request.user and request.user.is_authenticated):
+            return False
+        if request.method in ["GET", "POST", "OPTIONS"]:
+            return request.user.is_superuser or request.user.is_system_auditor
+        return request.user.is_superuser

--- a/awx/api/views/analytics.py
+++ b/awx/api/views/analytics.py
@@ -7,10 +7,9 @@ from django.utils.translation import gettext_lazy as _
 from django.utils import translation
 
 from awx.api.generics import APIView, Response
-from awx.api.permissions import IsSystemAdminOrAuditor
+from awx.api.permissions import AnalyticsPermission
 from awx.api.versioning import reverse
 from awx.main.utils import get_awx_version
-from rest_framework.permissions import AllowAny
 from rest_framework import status
 
 from collections import OrderedDict
@@ -43,7 +42,7 @@ class GetNotAllowedMixin(object):
 
 
 class AnalyticsRootView(APIView):
-    permission_classes = (AllowAny,)
+    permission_classes = (AnalyticsPermission,)
     name = _('Automation Analytics')
     swagger_topic = 'Automation Analytics'
 
@@ -99,7 +98,7 @@ class AnalyticsGenericView(APIView):
         return Response(response.json(), status=response.status_code)
     """
 
-    permission_classes = (IsSystemAdminOrAuditor,)
+    permission_classes = (AnalyticsPermission,)
 
     @staticmethod
     def _request_headers(request):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Adds permissions for System Auditor for POST/OPTIONS requests to Analytics API.
Required because cloud's API is based on POST requests even for lists

- https://issues.redhat.com/browse/AA-1650

Also changes permissions for `/api/v2/analytics/` from everyone to the same like other analytics URLs (admins/auditors)

- https://issues.redhat.com/browse/AAP-11166

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.0.1.dev32+g805c55bee2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
