### PR TITLE
Adds missing language fallback when no translations are present

### DIFF
--- a/awx/ui/src/App.js
+++ b/awx/ui/src/App.js
@@ -28,7 +28,7 @@ import { getLanguageWithoutRegionCode } from 'util/language';
 import Metrics from 'screens/Metrics';
 import SubscriptionEdit from 'screens/Setting/Subscription/SubscriptionEdit';
 import useTitle from 'hooks/useTitle';
-import { dynamicActivate } from './i18nLoader';
+import { dynamicActivate, locales } from './i18nLoader';
 import getRouteConfig from './routeConfig';
 import { SESSION_REDIRECT_URL } from './constants';
 
@@ -142,8 +142,13 @@ function App() {
   const searchParams = Object.fromEntries(new URLSearchParams(search));
   const pseudolocalization =
     searchParams.pseudolocalization === 'true' || false;
-  const language =
-    searchParams.lang || getLanguageWithoutRegionCode(navigator) || 'en';
+  let language = searchParams.lang || getLanguageWithoutRegionCode(navigator);
+
+  if (!Object.keys(locales).includes(language)) {
+    // If there isn't a string catalog available for the browser's
+    // preferred language, default to one that has strings.
+    language = 'en';
+  }
 
   useEffect(() => {
     dynamicActivate(language, pseudolocalization);


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/13756

When I added pseudolocalization support I broke the fallback that handled setting the language to `en` if the browser language didn't match one of the supported locales.  This change adds that logic back.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
