### PR TITLE
AAP-18284 Added a new logger configuration for activity_stream

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -744,6 +744,9 @@ LOGGING = {
         'json': {'()': 'awx.main.utils.formatters.LogstashFormatter'},
         'timed_import': {'()': 'awx.main.utils.formatters.TimeFormatter', 'format': '%(relativeSeconds)9.3f %(levelname)-8s %(message)s'},
         'dispatcher': {'format': '%(asctime)s %(levelname)-8s [%(guid)s] %(name)s PID:%(process)d %(message)s'},
+        'activity_stream': {
+            'format': '%(asctime)s %(levelname)-8s [%(guid)s] %(name)s %(message)s, Operation: %(operation)s, Actor: %(actor)s, Changes: %(changes)s'
+        },
     },
     # Extended below based on install scenario. You probably don't want to add something directly here.
     # See 'handler_config' below.
@@ -791,7 +794,8 @@ LOGGING = {
         'awx.main.access': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs
-        'awx.analytics': {'handlers': ['external_logger', 'activity_stream'], 'level': 'INFO', 'propagate': False},
+        'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
+        'awx.analytics.activity_stream': {'handlers': ['activity_stream']},
         'awx.analytics.broadcast_websocket': {'handlers': ['console', 'file', 'wsrelay', 'external_logger'], 'level': 'INFO', 'propagate': False},
         'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
         'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
@@ -816,7 +820,7 @@ handler_config = {
     'rsyslog_configurer': {'filename': 'rsyslog_configurer.log'},
     'cache_clear': {'filename': 'cache_clear.log'},
     'ws_heartbeat': {'filename': 'ws_heartbeat.log'},
-    'activity_stream': {'filename': 'activity_stream.log', 'formatter': 'json'},
+    'activity_stream': {'filename': 'activity_stream.log', 'formatter': 'activity_stream'},
 }
 
 # If running on a VM, we log to files. When running in a container, we log to stdout.

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -791,7 +791,7 @@ LOGGING = {
         'awx.main.access': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs
-        'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
+        'awx.analytics': {'handlers': ['external_logger', 'activity_stream'], 'level': 'INFO', 'propagate': False},
         'awx.analytics.broadcast_websocket': {'handlers': ['console', 'file', 'wsrelay', 'external_logger'], 'level': 'INFO', 'propagate': False},
         'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
         'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
@@ -816,6 +816,7 @@ handler_config = {
     'rsyslog_configurer': {'filename': 'rsyslog_configurer.log'},
     'cache_clear': {'filename': 'cache_clear.log'},
     'ws_heartbeat': {'filename': 'ws_heartbeat.log'},
+    'activity_stream': {'filename': 'activity_stream.log', 'formatter': 'json'},
 }
 
 # If running on a VM, we log to files. When running in a container, we log to stdout.


### PR DESCRIPTION
##### SUMMARY
- Added a new handler for activity_stream with formatter type json
- Added the new handler at the awx.analytics logger

The activity stream is a critical security log that can only be used from UI or when using an external logging aggregation.
Creating an activity_stream.log allows for easier and more effective analysis without relying only on the API endpoint.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other
