### PR TITLE
Remove Ansible config override to validate group names

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1479,8 +1479,6 @@ class PluginFileInjector(object):
     def build_env(self, inventory_update, env, private_data_dir, private_data_files):
         injector_env = self.get_plugin_env(inventory_update, private_data_dir, private_data_files)
         env.update(injector_env)
-        # Preserves current behavior for Ansible change in default planned for 2.10
-        env['ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS'] = 'never'
         # All CLOUD_PROVIDERS sources implement as inventory plugin from collection
         env['ANSIBLE_INVENTORY_ENABLED'] = 'auto'
         return env

--- a/awx/main/tests/data/inventory/plugins/azure_rm/env.json
+++ b/awx/main/tests/data/inventory/plugins/azure_rm/env.json
@@ -1,6 +1,5 @@
 {
     "ANSIBLE_JINJA2_NATIVE": "True",
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "AZURE_CLIENT_ID": "fooo",
     "AZURE_CLOUD_ENVIRONMENT": "fooo",
     "AZURE_SECRET": "fooo",

--- a/awx/main/tests/data/inventory/plugins/controller/env.json
+++ b/awx/main/tests/data/inventory/plugins/controller/env.json
@@ -1,5 +1,4 @@
 {
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "TOWER_HOST": "https://foo.invalid",
     "TOWER_PASSWORD": "fooo",
     "TOWER_USERNAME": "fooo",

--- a/awx/main/tests/data/inventory/plugins/ec2/env.json
+++ b/awx/main/tests/data/inventory/plugins/ec2/env.json
@@ -1,6 +1,5 @@
 {
     "ANSIBLE_JINJA2_NATIVE": "True",
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "AWS_ACCESS_KEY_ID": "fooo",
     "AWS_SECRET_ACCESS_KEY": "fooo",
     "AWS_SECURITY_TOKEN": "fooo",

--- a/awx/main/tests/data/inventory/plugins/gce/env.json
+++ b/awx/main/tests/data/inventory/plugins/gce/env.json
@@ -1,6 +1,5 @@
 {
     "ANSIBLE_JINJA2_NATIVE": "True",
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "GCE_CREDENTIALS_FILE_PATH": "{{ file_reference }}",
     "GOOGLE_APPLICATION_CREDENTIALS": "{{ file_reference }}",
     "GCP_AUTH_KIND": "serviceaccount",

--- a/awx/main/tests/data/inventory/plugins/insights/env.json
+++ b/awx/main/tests/data/inventory/plugins/insights/env.json
@@ -1,5 +1,4 @@
 {
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "INSIGHTS_USER": "fooo",
     "INSIGHTS_PASSWORD": "fooo"
 }

--- a/awx/main/tests/data/inventory/plugins/openstack/env.json
+++ b/awx/main/tests/data/inventory/plugins/openstack/env.json
@@ -1,4 +1,3 @@
 {
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "OS_CLIENT_CONFIG_FILE": "{{ file_reference }}"
 }

--- a/awx/main/tests/data/inventory/plugins/rhv/env.json
+++ b/awx/main/tests/data/inventory/plugins/rhv/env.json
@@ -1,5 +1,4 @@
 {
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "OVIRT_INI_PATH": "{{ file_reference }}",
     "OVIRT_PASSWORD": "fooo",
     "OVIRT_URL": "https://foo.invalid",

--- a/awx/main/tests/data/inventory/plugins/satellite6/env.json
+++ b/awx/main/tests/data/inventory/plugins/satellite6/env.json
@@ -1,5 +1,4 @@
 {
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "FOREMAN_PASSWORD": "fooo",
     "FOREMAN_SERVER": "https://foo.invalid",
     "FOREMAN_USER": "fooo"

--- a/awx/main/tests/data/inventory/plugins/vmware/env.json
+++ b/awx/main/tests/data/inventory/plugins/vmware/env.json
@@ -1,5 +1,4 @@
 {
-    "ANSIBLE_TRANSFORM_INVALID_GROUP_CHARS": "never",
     "VMWARE_HOST": "https://foo.invalid",
     "VMWARE_PASSWORD": "fooo",
     "VMWARE_USER": "fooo",


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/3513

The idea is that there is has been enough time for the Ansible content producers to update their inventory plugins to no longer produce group names with the "invalid" characters in them. For a time, we would add these old (now invalid) names via the inventory files that we produced for inventory updates, but we also stopped doing that at some point.

This should be put as a release note.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API


