### PR TITLE
Add run-clear-cache to tower-processes for auto-reload

### DIFF
--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -101,7 +101,7 @@ stdout_events_enabled = true
 stderr_events_enabled = true
 
 [group:tower-processes]
-programs=awx-dispatcher,awx-receiver,awx-uwsgi,awx-daphne,awx-nginx,awx-wsrelay,awx-rsyslogd,awx-heartbeet, awx-rsyslog-configurer
+programs=awx-dispatcher,awx-receiver,awx-uwsgi,awx-daphne,awx-nginx,awx-wsrelay,awx-rsyslogd,awx-heartbeet,awx-rsyslog-configurer,awx-cache-clear
 priority=5
 
 [program:awx-autoreload]


### PR DESCRIPTION
##### SUMMARY
Hopefully a self-obvious change. This service wasn't in the process group, so it wouldn't get restarted if a code change happens. It's not a huge deal, but want for general coherency.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

