### PR TITLE
Changing check for all in awx.awx.export

### DIFF
--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -159,7 +159,7 @@ def main():
     # Here we are going to setup a dict of values to export
     export_args = {}
     for resource in EXPORTABLE_RESOURCES:
-        if module.params.get('all') or module.params.get(resource) == 'all':
+        if module.params.get('all') or module.params.get(resource) == ['all']:
             # If we are exporting everything or we got the keyword "all" we pass in an empty string for this asset type
             export_args[resource] = ''
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #13853

The fields used to be strings but at some point converted to arrays. The check for `== 'all'` never matched `== ['all']` so exporting everything of a type would never work.

To test, run a playbook like:
```
---
- name: Export the inventory
  hosts: localhost
  connection: local
  gather_facts: False
  tasks:
    - awx.awx.export:
        inventory: ['something', 'all']
        controller_host: https://localhost:8043
        controller_username: admin
        controller_password: admin
        validate_certs: False
      register: inventory

    - debug:
        var: inventory
``` 

The exported inventories would be `[]` (because it was looking for an inventory named all). After the fix the exported inventories should match your instance.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
