### PR TITLE
Auto reload services in kube dev env

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
@@ -33,6 +33,19 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
+{% if kube_dev | bool %}
+[program:awx-autoreload]
+command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx 'supervisorctl -c /etc/supervisord_rsyslog.conf restart tower-processes:*'
+autostart = true
+autorestart = true
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+{% endif %}
+
 [group:tower-processes]
 programs=awx-rsyslog-configurer,awx-rsyslogd
 priority=5

--- a/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
@@ -56,6 +56,19 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
+{% if kube_dev | bool %}
+[program:awx-autoreload]
+command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx 'supervisorctl -c /etc/supervisord_task.conf restart tower-processes:*'
+autostart = true
+autorestart = true
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+{% endif %}
+
 [group:tower-processes]
 programs=dispatcher,callback-receiver,wsrelay
 priority=5

--- a/tools/ansible/roles/dockerfile/templates/supervisor_web.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_web.conf.j2
@@ -25,8 +25,6 @@ stderr_logfile_maxbytes=0
 {% if kube_dev | bool %}
 command = make uwsgi
 directory = /awx_devel
-environment =
-    DEV_RELOAD_COMMAND='supervisorctl -c /etc/supervisord_task.conf restart all; supervisorctl restart tower-processes:daphne'
 {% else %}
 command = /var/lib/awx/venv/awx/bin/uwsgi /etc/tower/uwsgi.ini
 directory = /var/lib/awx
@@ -90,6 +88,19 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+{% if kube_dev | bool %}
+[program:awx-autoreload]
+command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx 'supervisorctl -c /etc/supervisord_web.conf restart tower-processes:*'
+autostart = true
+autorestart = true
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+{% endif %}
 
 [group:tower-processes]
 programs=nginx,uwsgi,daphne,awx-cache-clear,heartbeet


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix awx-autoreload in kube development environment

NOTE: for some reason it takes a while after the pod started for auto reload to start working?
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.1.1.dev12+gcfbbc4cb92
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
