### PR TITLE
Fix screen crash when changing credential type in launch prompt dropdown 

### DIFF
--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -43,6 +43,7 @@ function LaunchButton({ resource, children }) {
   const [surveyConfig, setSurveyConfig] = useState(null);
   const [labels, setLabels] = useState([]);
   const [isLaunching, setIsLaunching] = useState(false);
+  const [resourceCredentials, setResourceCredentials] = useState([]);
   const [error, setError] = useState(null);
 
   const handleLaunch = async () => {
@@ -81,6 +82,13 @@ function LaunchButton({ resource, children }) {
         }));
 
         setLabels(allLabels);
+      }
+
+      if (launch.ask_credential_on_launch) {
+        const {
+          data: { results: templateCredentials },
+        } = await JobTemplatesAPI.readCredentials(resource.id);
+        setResourceCredentials(templateCredentials);
       }
 
       if (canLaunchWithoutPrompt(launch)) {
@@ -208,6 +216,7 @@ function LaunchButton({ resource, children }) {
           labels={labels}
           onLaunch={launchWithParams}
           onCancel={() => setShowLaunchPrompt(false)}
+          resourceDefaultCredentials={resourceCredentials}
         />
       )}
     </>

--- a/awx/ui/src/components/LaunchButton/LaunchButton.test.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.test.js
@@ -47,6 +47,12 @@ describe('LaunchButton', () => {
         variables_needed_to_start: [],
       },
     });
+    JobTemplatesAPI.readCredentials.mockResolvedValue({
+      data: {
+        count: 0,
+        results: [],
+      },
+    });
   });
 
   afterEach(() => jest.clearAllMocks());

--- a/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
+++ b/awx/ui/src/components/LaunchPrompt/LaunchPrompt.js
@@ -19,6 +19,7 @@ function PromptModalForm({
   labels,
   surveyConfig,
   instanceGroups,
+  resourceDefaultCredentials,
 }) {
   const { setFieldTouched, values } = useFormikContext();
   const [showDescription, setShowDescription] = useState(false);
@@ -35,9 +36,9 @@ function PromptModalForm({
     surveyConfig,
     resource,
     labels,
-    instanceGroups
+    instanceGroups,
+    resourceDefaultCredentials
   );
-
   const handleSubmit = async () => {
     const postValues = {};
     const setValue = (key, value) => {

--- a/awx/ui/src/components/LaunchPrompt/LaunchPrompt.test.js
+++ b/awx/ui/src/components/LaunchPrompt/LaunchPrompt.test.js
@@ -69,6 +69,20 @@ describe('LaunchPrompt', () => {
         spec: [{ type: 'text', variable: 'foo' }],
       },
     });
+    JobTemplatesAPI.readCredentials.mockResolvedValue({
+      data: {
+        results: [
+          {
+            id: 5,
+            name: 'cred that prompts',
+            credential_type: 1,
+            inputs: {
+              password: 'ASK',
+            },
+          },
+        ],
+      },
+    });
     InstanceGroupsAPI.read.mockResolvedValue({
       data: {
         results: [
@@ -212,6 +226,16 @@ describe('LaunchPrompt', () => {
               ],
             },
           }}
+          resourceDefaultCredentials={[
+            {
+              id: 5,
+              name: 'cred that prompts',
+              credential_type: 1,
+              inputs: {
+                password: 'ASK',
+              },
+            },
+          ]}
           onLaunch={noop}
           onCancel={noop}
           surveyConfig={{
@@ -289,6 +313,16 @@ describe('LaunchPrompt', () => {
           resource={resource}
           onLaunch={noop}
           onCancel={noop}
+          resourceDefaultCredentials={[
+            {
+              id: 5,
+              name: 'cred that prompts',
+              credential_type: 1,
+              inputs: {
+                password: 'ASK',
+              },
+            },
+          ]}
         />
       );
     });

--- a/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
+++ b/awx/ui/src/components/LaunchPrompt/steps/CredentialsStep.test.js
@@ -168,7 +168,9 @@ describe('CredentialsStep', () => {
   test('should reset query params (credential.page) when selected credential type is changed', async () => {
     let wrapper;
     const history = createMemoryHistory({
-      initialEntries: ['?credential.page=2'],
+      initialEntries: [
+        '?credential.page=2&credential.page_size=5&credential.order_by=name',
+      ],
     });
     await act(async () => {
       wrapper = mountWithContexts(

--- a/awx/ui/src/components/LaunchPrompt/useLaunchSteps.js
+++ b/awx/ui/src/components/LaunchPrompt/useLaunchSteps.js
@@ -46,7 +46,8 @@ export default function useLaunchSteps(
   surveyConfig,
   resource,
   labels,
-  instanceGroups
+  instanceGroups,
+  resourceDefaultCredentials
 ) {
   const [visited, setVisited] = useState({});
   const [isReady, setIsReady] = useState(false);
@@ -56,7 +57,7 @@ export default function useLaunchSteps(
     useCredentialsStep(
       launchConfig,
       resource,
-      resource.summary_fields.credentials || [],
+      resourceDefaultCredentials,
       true
     ),
     useCredentialPasswordsStep(


### PR DESCRIPTION
##### SUMMARY
* On credential type change, reset credential namespace query params to default values 
* Fix credential_type undefined error by fetching the credentials and passing it to `resourceDefaultCredentials`  
<img width="945" alt="Screenshot 2023-04-17 at 10 05 16 PM" src="https://user-images.githubusercontent.com/15881645/232818078-184cb4e5-9ff7-4882-bf2c-70800189b299.png">


_Fix Demo_
![launch](https://user-images.githubusercontent.com/15881645/232817877-825e68fb-3b45-400d-9ad1-1ccf839a721f.gif)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

