### PR TITLE
Fixing issue were we assumed DATABASES would be defined

### DIFF
--- a/awx/main/tests/functional/api/test_application_name.py
+++ b/awx/main/tests/functional/api/test_application_name.py
@@ -1,0 +1,23 @@
+import pytest
+from awx.settings.application_name import get_service_name, set_application_name
+
+
+@pytest.mark.parametrize(
+    'argv,result',
+    (
+        ([], None),
+        (['-m'], None),
+        (['-m', 'python'], None),
+        (['-m', 'python', 'manage'], None),
+        (['-m', 'python', 'manage', 'a'], 'a'),
+        (['-m', 'python', 'manage', 'b', 'a'], 'b'),
+        (['-m', 'python', 'manage', 'run_something', 'b', 'a'], 'something'),
+    ),
+)
+def test_get_service_name(argv, result):
+    assert get_service_name(argv) == result
+
+
+@pytest.mark.parametrize('DATABASES,CLUSTER_ID,function', (({}, 12, ''), ({'default': {'ENGINE': 'sqllite3'}}, 12, '')))
+def test_set_application_name(DATABASES, CLUSTER_ID, function):
+    set_application_name(DATABASES, CLUSTER_ID, function)

--- a/awx/settings/application_name.py
+++ b/awx/settings/application_name.py
@@ -25,6 +25,10 @@ def get_application_name(CLUSTER_HOST_ID, function=''):
 
 
 def set_application_name(DATABASES, CLUSTER_HOST_ID, function=''):
+    # If settings files were not properly passed DATABASES could be {} at which point we don't need to set the app name.
+    if not DATABASES or 'default' not in DATABASES:
+        return
+
     if 'sqlite3' in DATABASES['default']['ENGINE']:
         return
     options_dict = DATABASES['default'].setdefault('OPTIONS', dict())


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In #13074 we added a feature which would include an application name in a database connection to allow for better troubleshooting. However, in some cases DATABASES may not be defined. For example, when we `collectstatic` in the build process we run:
```
AWX_SETTINGS_FILE=/dev/null SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear
```

In this scenario, since `AWX_SETTINGS_FILE` is `/dev/null` we never load the `/etc/tower/conf.d/database.py` file so DATABASES is the default defined as `{}`. In this scenario we hit this exception:
```
2023-04-18T14:43:42.5475947Z #20 [builder 13/13] RUN AWX_SETTINGS_FILE=/dev/null SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear
2023-04-18T14:43:42.5476472Z #20 sha256:b9a15a6b739c59345db1fea6b5b607c19ca9e19431b9664643f30c3ebd1a7adc
2023-04-18T14:43:43.2785319Z #20 0.732 Traceback (most recent call last):
2023-04-18T14:43:43.2786107Z #20 0.732   File "/var/lib/awx/venv/awx/bin/awx-manage", line 8, in <module>
2023-04-18T14:43:43.3465846Z #20 0.733     sys.exit(manage())
2023-04-18T14:43:43.3466630Z #20 0.733   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/__init__.py", line 177, in manage
2023-04-18T14:43:43.3466952Z #20 0.733     prepare_env()
2023-04-18T14:43:43.3467396Z #20 0.733   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/__init__.py", line 132, in prepare_env
2023-04-18T14:43:43.3467767Z #20 0.733     if not settings.DEBUG:  # pragma: no cover
2023-04-18T14:43:43.3468262Z #20 0.733   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/conf/__init__.py", line 82, in __getattr__
2023-04-18T14:43:43.3468595Z #20 0.733     self._setup(name)
2023-04-18T14:43:43.3469042Z #20 0.733   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/conf/__init__.py", line 69, in _setup
2023-04-18T14:43:43.3469402Z #20 0.733     self._wrapped = Settings(settings_module)
2023-04-18T14:43:43.3469886Z #20 0.733   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/conf/__init__.py", line 170, in __init__
2023-04-18T14:43:43.3470266Z #20 0.733     mod = importlib.import_module(self.SETTINGS_MODULE)
2023-04-18T14:43:43.3470615Z #20 0.733   File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
2023-04-18T14:43:43.3470964Z #20 0.733     return _bootstrap._gcd_import(name[level:], package, level)
2023-04-18T14:43:43.3471289Z #20 0.733   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
2023-04-18T14:43:43.3471629Z #20 0.733   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
2023-04-18T14:43:43.3471979Z #20 0.733   File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
2023-04-18T14:43:43.3472649Z #20 0.733   File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
2023-04-18T14:43:43.3472980Z #20 0.733   File "<frozen importlib._bootstrap_external>", line 850, in exec_module
2023-04-18T14:43:43.3473343Z #20 0.733   File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
2023-04-18T14:43:43.3473886Z #20 0.733   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/settings/production.py", line 105, in <module>
2023-04-18T14:43:43.3474286Z #20 0.733     set_application_name(DATABASES, CLUSTER_HOST_ID)  # NOQA
2023-04-18T14:43:43.3474828Z #20 0.733   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/settings/application_name.py", line 28, in set_application_name
2023-04-18T14:43:43.3475296Z #20 0.733     if 'sqlite3' in DATABASES['default']['ENGINE']:
2023-04-18T14:43:43.3475609Z #20 0.733 KeyError: 'default'
2023-04-18T14:43:43.3476265Z #20 ERROR: executor failed running [/bin/sh -c AWX_SETTINGS_FILE=/dev/null SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear]: exit code: 1
```

This PR should prevent catch an empty DATABASE hash or a hash that is missing the `default` database and not attempt to include an application name in its settings. 

In the future, if we decided to have >1 database defined, we might want to change this to a for loop over the `DATABASES` object. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
