### PR TITLE
Fix credentials search in adhoc prompt modal

### DIFF
--- a/awx/ui/src/components/AdHocCommands/AdHocCredentialStep.js
+++ b/awx/ui/src/components/AdHocCommands/AdHocCredentialStep.js
@@ -115,16 +115,16 @@ function AdHocCredentialStep({ credentialTypeId }) {
             searchColumns={[
               {
                 name: t`Name`,
-                key: 'name',
+                key: 'name__icontains',
                 isDefault: true,
               },
               {
                 name: t`Created By (Username)`,
-                key: 'created_by__username',
+                key: 'created_by__username__icontains',
               },
               {
                 name: t`Modified By (Username)`,
-                key: 'modified_by__username',
+                key: 'modified_by__username__icontains',
               },
             ]}
             sortColumns={[


### PR DESCRIPTION
##### SUMMARY
* Fix broken `name` search in the credentials step of ad-hoc commands
* Update adhoc credentials search queries to include `icontains`

![adhoc_cred](https://user-images.githubusercontent.com/15881645/232841551-193a411c-664f-4811-9b77-31bbb56ae3d4.gif)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
