### PR TITLE
Show related dependent_jobs list in the API

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -812,8 +812,10 @@ class UnifiedJobSerializer(BaseSerializer):
             res['stdout'] = self.reverse('api:project_update_stdout', kwargs={'pk': obj.pk})
         elif isinstance(obj, InventoryUpdate):
             res['stdout'] = self.reverse('api:inventory_update_stdout', kwargs={'pk': obj.pk})
+            res['dependent_jobs'] = self.reverse('api:inventory_update_dependent_jobs_list', kwargs={'pk': obj.pk})
         elif isinstance(obj, Job):
             res['stdout'] = self.reverse('api:job_stdout', kwargs={'pk': obj.pk})
+            res['dependent_jobs'] = self.reverse('api:job_dependent_jobs_list', kwargs={'pk': obj.pk})
         elif isinstance(obj, AdHocCommand):
             res['stdout'] = self.reverse('api:ad_hoc_command_stdout', kwargs={'pk': obj.pk})
         if obj.workflow_job_id:

--- a/awx/api/urls/inventory_update.py
+++ b/awx/api/urls/inventory_update.py
@@ -13,6 +13,7 @@ from awx.api.views import (
     InventoryUpdateStdout,
     InventoryUpdateNotificationsList,
     InventoryUpdateCredentialsList,
+    DependentJobsList,
 )
 
 
@@ -24,6 +25,7 @@ urls = [
     re_path(r'^(?P<pk>[0-9]+)/notifications/$', InventoryUpdateNotificationsList.as_view(), name='inventory_update_notifications_list'),
     re_path(r'^(?P<pk>[0-9]+)/credentials/$', InventoryUpdateCredentialsList.as_view(), name='inventory_update_credentials_list'),
     re_path(r'^(?P<pk>[0-9]+)/events/$', InventoryUpdateEventsList.as_view(), name='inventory_update_events_list'),
+    re_path(r'^(?P<pk>[0-9]+)/dependent_jobs/$', DependentJobsList.as_view(), name='inventory_update_dependent_jobs_list'),
 ]
 
 __all__ = ['urls']

--- a/awx/api/urls/job.py
+++ b/awx/api/urls/job.py
@@ -17,6 +17,7 @@ from awx.api.views import (
     JobNotificationsList,
     JobLabelList,
     JobHostSummaryDetail,
+    DependentJobsList,
 )
 
 
@@ -33,6 +34,7 @@ urls = [
     re_path(r'^(?P<pk>[0-9]+)/stdout/$', JobStdout.as_view(), name='job_stdout'),
     re_path(r'^(?P<pk>[0-9]+)/notifications/$', JobNotificationsList.as_view(), name='job_notifications_list'),
     re_path(r'^(?P<pk>[0-9]+)/labels/$', JobLabelList.as_view(), name='job_label_list'),
+    re_path(r'^(?P<pk>[0-9]+)/dependent_jobs/$', DependentJobsList.as_view(), name='job_dependent_jobs_list'),
     re_path(r'^(?P<pk>[0-9]+)/$', JobHostSummaryDetail.as_view(), name='job_host_summary_detail'),
 ]
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3647,7 +3647,7 @@ class DependentJobsList(SubListAPIView):
     parent_model = models.UnifiedJob
     model = models.UnifiedJob
     relationship = 'dependent_jobs'
-    serializer_class = serializers.UnifiedJobSerializer
+    serializer_class = serializers.UnifiedJobListSerializer
     name = _('Unified Job Dependent Jobs List')
 
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3643,6 +3643,14 @@ class GroupJobEventsList(BaseJobEventsList):
     parent_model = models.Group
 
 
+class DependentJobsList(SubListAPIView):
+    parent_model = models.UnifiedJob
+    model = models.UnifiedJob
+    relationship = 'dependent_jobs'
+    serializer_class = serializers.UnifiedJobSerializer
+    name = _('Unified Job Dependent Jobs List')
+
+
 class JobJobEventsList(BaseJobEventsList):
     parent_model = models.Job
     pagination_class = UnifiedJobEventPagination


### PR DESCRIPTION
##### SUMMARY
This is populated by the `DependencyManager` but users cannot see it. I feel that the UI should surface this in some way.

For now, this is just a discussion piece.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

