### PR TITLE
Stop using make to start awx processes part 1

### DIFF
--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -4,7 +4,7 @@ minfds = 4096
 nodaemon=true
 
 [program:awx-dispatcher]
-command = make dispatcher
+command = awx-manage run_dispatcher
 autorestart = true
 stopasgroup=true
 killasgroup=true
@@ -12,7 +12,7 @@ stdout_events_enabled = true
 stderr_events_enabled = true
 
 [program:awx-receiver]
-command = make receiver
+command = awx-manage run_callback_receiver
 autorestart = true
 stopasgroup=true
 killasgroup=true
@@ -20,7 +20,7 @@ stdout_events_enabled = true
 stderr_events_enabled = true
 
 [program:awx-wsrelay]
-command = make run-wsrelay
+command = awx-manage run_wsrelay
 autorestart = true
 autorestart = true
 stopasgroup=true
@@ -29,7 +29,7 @@ stdout_events_enabled = true
 stderr_events_enabled = true
 
 [program:awx-heartbeet]
-command = make run-heartbeet
+command = awx-manage run_heartbeet
 autorestart = true
 autorestart = true
 stopasgroup=true
@@ -38,7 +38,7 @@ stdout_events_enabled = true
 stderr_events_enabled = true
 
 [program:awx-rsyslog-configurer]
-command = make run-rsyslog-configurer
+command = awx-manage run_rsyslog_configurer
 autorestart = true
 stopasgroup=true
 killasgroup=true
@@ -48,7 +48,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:awx-cache-clear]
-command = make run-cache-clear
+command = awx-manage run_cache_clear
 autorestart = true
 stopasgroup=true
 killasgroup=true


### PR DESCRIPTION
##### SUMMARY
part 1...

we dont need to run awx processes through make
because awx-manage uses awx-python which is already activating the correct venv

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.1.1.dev21+g177f8cb7b2.d20230419
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
