### PR TITLE
Remove unnecessary egg-link linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,9 +300,9 @@ api-lint:
 	flake8 awx
 	yamllint -s .
 
+## Run egg_info_dev to generate awx.egg-info for development.
 awx-link:
 	[ -d "/awx_devel/awx.egg-info" ] || $(PYTHON) /awx_devel/tools/scripts/egg_info_dev
-	cp -f /tmp/awx.egg-link /var/lib/awx/venv/awx/lib/$(PYTHON)/site-packages/awx.egg-link
 
 TEST_DIRS ?= awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests
 PYTEST_ARGS ?= -n auto

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -232,7 +232,7 @@ ADD {{ template_dest }}/supervisor_rsyslog.conf /etc/supervisord_rsyslog.conf
 {% endif %}
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
-ADD tools/docker-compose/awx.egg-link /tmp/awx.egg-link
+RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.9/site-packages/awx.egg-link
 ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
 ADD tools/scripts/awx-python /usr/bin/awx-python
 {% endif %}
@@ -285,8 +285,7 @@ RUN for dir in \
       /var/lib/shared/overlay-layers/layers.lock \
       /var/lib/shared/vfs-images/images.lock \
       /var/lib/shared/vfs-layers/layers.lock \
-      /var/run/nginx.pid \
-      /var/lib/awx/venv/awx/lib/python3.9/site-packages/awx.egg-link ; \
+      /var/run/nginx.pid; \
     do touch $file ; chmod g+rw $file ; done && \
     echo "\setenv PAGER 'less -SXF'" > /var/lib/awx/.psqlrc
 {% endif %}

--- a/tools/docker-compose/awx.egg-link
+++ b/tools/docker-compose/awx.egg-link
@@ -1,1 +1,0 @@
-/awx_devel


### PR DESCRIPTION
##### SUMMARY
we link awx.egg-link from `tools/docker-compose/awx.egg-link` to `/tmp/awx.egg-link` than we move `/tmp/awx.egg-link` to `/var/lib/awx/venv/awx/lib/python3.9/site-packages/awx.egg-link`

bonus... now we dont have to set PYTHON=python3.9

https://github.com/ansible/awx/issues/13737

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.1.1.dev27+gadb89cd48f
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
