### PR TITLE
Do not use local_settings.py in test running, because reference no longer exists

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/local_settings.py.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/local_settings.py.j2
@@ -1,8 +1,7 @@
 # Copyright (c) 2015 Ansible, Inc. (formerly AnsibleWorks, Inc.)
 # All Rights Reserved.
 
-# Local Django settings for AWX project.  Rename to "local_settings.py" and
-# edit as needed for your development environment.
+# Local Django settings for AWX project.
 
 # All variables defined in awx/settings/development.py will already be loaded
 # into the global namespace before this file is loaded, to allow for reading

--- a/tools/docker-compose/start_tests.sh
+++ b/tools/docker-compose/start_tests.sh
@@ -5,7 +5,7 @@ cd /awx_devel
 make clean
 make awx-link
 
-cp tools/docker-compose/ansible/roles/sources/files/local_settings.py awx/settings/local_settings.py
+cp tools/docker-compose/_sources/local_settings.py awx/settings/local_settings.py
 
 if [[ ! $@ ]]; then
     make test

--- a/tools/docker-compose/start_tests.sh
+++ b/tools/docker-compose/start_tests.sh
@@ -5,8 +5,6 @@ cd /awx_devel
 make clean
 make awx-link
 
-cp tools/docker-compose/_sources/local_settings.py awx/settings/local_settings.py
-
 if [[ ! $@ ]]; then
     make test
 else


### PR DESCRIPTION
##### SUMMARY
The file `tools/docker-compose/ansible/roles/sources/files/local_settings.py` doesn't exist anymore.

It was moved from files to templates folder in https://github.com/ansible/awx/pull/13619, and this copy was giving an error message in checks.

I considered adding back the copy from the correct location... but it is not entirely clear to me that the test runner commands run `make docker-compose-sources`, because it builds the _Dockerfile_ which is a different playbook from running docker-compose. If this is so hard to reason out, and we were effectively not using it before, then we should get rid of it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

