### PR TITLE
Fallback on PYTHON path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include awx/ui_next/Makefile
 
-PYTHON ?= python3.9
+PYTHON := $(notdir $(shell for i in python3.9 python3; do command -v $$i; done|sed 1q))
 DOCKER_COMPOSE ?= docker-compose
 OFFICIAL ?= no
 NODE ?= node
@@ -606,7 +606,18 @@ VERSION:
 	@echo "awx: $(VERSION)"
 
 PYTHON_VERSION:
-	@echo "$(PYTHON)" | sed 's:python::'
+	@echo "$(subst python,,$(PYTHON))"
+
+.PHONY: version-for-buildyml
+version-for-buildyml:
+	@echo $(firstword $(subst +, ,$(VERSION)))
+# version-for-buildyml prints a special version string for build.yml,
+# chopping off the sha after the '+' sign.
+# tools/ansible/build.yml was doing this: make print-VERSION | cut -d + -f -1
+# This does the same thing in native make without
+# the pipe or the extra processes, and now the pb does `make version-for-buildyml`
+# Example:
+# 	22.1.1.dev38+g523c0d9781 becomes 22.1.1.dev38
 
 .PHONY: Dockerfile
 ## Generate Dockerfile for awx image
@@ -658,6 +669,7 @@ messages:
 	fi; \
 	$(PYTHON) manage.py makemessages -l en_us --keep-pot
 
+.PHONY: print-%
 print-%:
 	@echo $($*)
 

--- a/tools/ansible/build.yml
+++ b/tools/ansible/build.yml
@@ -4,8 +4,7 @@
   gather_facts: true
   tasks:
     - name: Get version from SCM if not explicitly provided
-      shell: |
-        make print-VERSION | cut -d + -f -1
+      command: make version-for-buildyml
       args:
         chdir: '../../'
       register: scm_version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If I understand correctly, this change should make '$(PYTHON)' work how we want it to everywhere. Before this change, on develpers' machines that don't have a 'python3.9' in their path, make would fail. With this change, we will prefer python3.9 if it's available, but we'll take python3 or python otherwise.

I think setting this might be an artifact from having several minor versions of Python 3 available. It may not even still be relevant. Let me know if I'm misunderstanding this or if there's somewhere where this will fail. My main goal is to avoid `make` failing because a developer does not have a bin named `python3.9` in their path (or the equiv symlink or w/e). Like, maybe I have `python3` and `python3.11` and then I have to set `PYTHON` myself for running `make`. I think we can find something that works for these cases.

I really think this does what we mean for all cases: make from dev machine, make from container, make from scripts. It will even run the venv path one if started from venv.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Collection
 - CLI
 - Docs
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
