### PR TITLE
RFE - Adding selinux level to default options

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1045,7 +1045,7 @@ DEFAULT_CONTROL_PLANE_QUEUE_NAME = 'controlplane'
 # Extend container runtime attributes.
 # For example, to disable SELinux in containers for podman
 # DEFAULT_CONTAINER_RUN_OPTIONS = ['--security-opt', 'label=disable']
-DEFAULT_CONTAINER_RUN_OPTIONS = ['--network', 'slirp4netns:enable_ipv6=true']
+DEFAULT_CONTAINER_RUN_OPTIONS = ['--network', 'slirp4netns:enable_ipv6=true', '--security-opt', 'label=level:s0']
 
 # Mount exposed paths as hostPath resource in k8s/ocp
 AWX_MOUNT_ISOLATED_PATHS_ON_K8S = False


### PR DESCRIPTION
##### SUMMARY
Adding the selinux level s0 to avoid issues due to MLS
MLS results in failures for multiple executions for the same playbook or workflows handling the same files created by a previous playbook

Changes: Enforcing s0 level as a default podman option in defaults.py

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other

##### ADDITIONAL INFORMATION
[Multi Level Security](https://www.redhat.com/en/blog/how-selinux-separates-containers-using-multi-level-security)
