### PR TITLE
Show schedule details warning when RRule is unsupported

### DIFF
--- a/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.test.js
+++ b/awx/ui/src/components/Schedule/ScheduleDetail/ScheduleDetail.test.js
@@ -587,4 +587,31 @@ describe('<ScheduleDetail />', () => {
       (el) => el.prop('isDisabled') === true
     );
   });
+  test('should display warning for unsupported recurrence rules ', async () => {
+    const unsupportedSchedule = {
+      ...schedule,
+      rrule:
+        'DTSTART:20221220T161500Z RRULE:FREQ=HOURLY;INTERVAL=1 EXRULE:FREQ=HOURLY;INTERVAL=1;BYDAY=TU;BYMONTHDAY=1,2,3,4,5,6,7 EXRULE:FREQ=HOURLY;INTERVAL=1;BYDAY=WE;BYMONTHDAY=2,3,4,5,6,7,8',
+    };
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <Route
+          path="/templates/job_template/:id/schedules/:scheduleId"
+          component={() => <ScheduleDetail schedule={unsupportedSchedule} />}
+        />,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: history.location,
+                match: { params: { id: 1 } },
+              },
+            },
+          },
+        }
+      );
+    });
+    expect(wrapper.find('UnsupportedRRuleAlert').length).toBe(1);
+  });
 });

--- a/awx/ui/src/components/Schedule/shared/UnsupportedRRuleAlert.js
+++ b/awx/ui/src/components/Schedule/shared/UnsupportedRRuleAlert.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import styled from 'styled-components';
+import { t } from '@lingui/macro';
+import { Alert } from '@patternfly/react-core';
+
+const AlertWrapper = styled.div`
+  margin-top: var(--pf-global--spacer--lg);
+  margin-bottom: var(--pf-global--spacer--lg);
+`;
+const RulesTitle = styled.p`
+  margin-top: var(--pf-global--spacer--lg);
+  margin-bottom: var(--pf-global--spacer--lg);
+  font-weight: var(--pf-global--FontWeight--bold);
+`;
+
+export default function UnsupportedRRuleAlert({ schedule }) {
+  return (
+    <AlertWrapper>
+      <Alert
+        isInline
+        variant="danger"
+        ouiaId="schedule-warning"
+        title={t`This schedule uses complex rules that are not supported in the
+        UI.  Please use the API to manage this schedule.`}
+      />
+      <RulesTitle>{t`Schedule Rules`}:</RulesTitle>
+      <pre css="white-space: pre; font-family: var(--pf-global--FontFamily--monospace)">
+        {schedule.rrule.split(' ').join('\n')}
+      </pre>
+    </AlertWrapper>
+  );
+}

--- a/awx/ui/src/components/Schedule/shared/parseRuleObj.js
+++ b/awx/ui/src/components/Schedule/shared/parseRuleObj.js
@@ -82,11 +82,7 @@ const frequencyTypes = {
 };
 
 function parseRrule(rruleString, schedule, values) {
-  const { frequency, options } = parseRule(
-    rruleString,
-    schedule,
-    values.exceptionFrequency
-  );
+  const { frequency, options } = parseRule(rruleString, schedule);
 
   if (values.frequencyOptions[frequency]) {
     throw new UnsupportedRRuleError(
@@ -105,11 +101,7 @@ function parseRrule(rruleString, schedule, values) {
 }
 
 function parseExRule(exruleString, schedule, values) {
-  const { frequency, options } = parseRule(
-    exruleString,
-    schedule,
-    values.exceptionFrequency
-  );
+  const { frequency, options } = parseRule(exruleString, schedule);
 
   if (values.exceptionOptions[frequency]) {
     throw new UnsupportedRRuleError(
@@ -129,7 +121,7 @@ function parseExRule(exruleString, schedule, values) {
   };
 }
 
-function parseRule(ruleString, schedule, frequencies) {
+function parseRule(ruleString, schedule) {
   const {
     origOptions: {
       bymonth,
@@ -178,9 +170,6 @@ function parseRule(ruleString, schedule, frequencies) {
     throw new Error(`Unexpected rrule frequency: ${freq}`);
   }
   const frequency = frequencyTypes[freq];
-  if (frequencies.includes(frequency)) {
-    throw new Error(`Duplicate frequency types not supported (${frequency})`);
-  }
 
   if (freq === RRule.WEEKLY && byweekday) {
     options.daysOfWeek = byweekday;


### PR DESCRIPTION
##### SUMMARY
Replace error stack trace with inline warning message when the schedule has an unsupported rrule. 
![Screenshot 2023-04-26 at 2 15 40 PM](https://user-images.githubusercontent.com/15881645/234674941-324adcef-ef37-4ee8-9dec-55cd94973b6a.png)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
