### PR TITLE
In collection, allow roles to be added to multiple teams and users

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -331,11 +331,6 @@ class ControllerAPIModule(ControllerModule):
             self.update_secrets = True
 
     @staticmethod
-    def param_to_endpoint(name):
-        exceptions = {'inventory': 'inventories', 'target_team': 'teams', 'workflow': 'workflow_job_templates'}
-        return exceptions.get(name, '{0}s'.format(name))
-
-    @staticmethod
     def get_name_field_from_endpoint(endpoint):
         return ControllerAPIModule.IDENTITY_FIELDS.get(endpoint, 'name')
 

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -11,6 +11,8 @@
     jt1: "AWX-Collection-tests-role-jt1-{{ test_id }}"
     jt2: "AWX-Collection-tests-role-jt2-{{ test_id }}"
     wfjt_name: "AWX-Collection-tests-role-project-wfjt-{{ test_id }}"
+    team_name: "AWX-Collection-tests-team-team-{{ test_id }}"
+    team2_name: "AWX-Collection-tests-team-team-{{ test_id }}2"
 
 - block:
     - name: Create a User
@@ -23,6 +25,32 @@
         state: present
       register: result
 
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a 2nd User
+      user:
+        first_name: Joe
+        last_name: User
+        username: "{{ username }}2"
+        password: "{{ 65535 | random | to_uuid }}"
+        email: joe@example.org
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create teams
+      team:
+        name: "{{ item }}"
+        organization: Default
+      register: result
+      loop:
+        - "{{ team_name }}"
+        - "{{ team2_name }}"
     - assert:
         that:
           - "result is changed"
@@ -55,9 +83,14 @@
         that:
           - "result is changed"
 
-    - name: Add Joe to the update role of the default Project with lookup Organization
+    - name: Add Joe and teams to the update role of the default Project with lookup Organization
       role:
         user: "{{ username }}"
+        users:
+          - "{{ username }}2"
+        teams:
+          - "{{ team_name }}"
+          - "{{ team2_name }}"
         role: update
         lookup_organization: Default
         project: "Demo Project"
@@ -74,6 +107,11 @@
     - name: Add Joe to the new project by ID
       role:
         user: "{{ username }}"
+        users:
+          - "{{ username }}2"
+        teams:
+          - "{{ team_name }}"
+          - "{{ team2_name }}"
         role: update
         project: "{{ project_info['id'] }}"
         state: "{{ item }}"
@@ -89,6 +127,8 @@
     - name: Add Joe as execution admin to Default Org.
       role:
         user: "{{ username }}"
+        users:
+          - "{{ username }}2"
         role: execution_environment_admin
         organizations: Default
         state: "{{ item }}"
@@ -110,6 +150,8 @@
     - name: Add Joe to workflow execute role
       role:
         user: "{{ username }}"
+        users:
+          - "{{ username }}2"
         role: execute
         workflow: test-role-workflow
         job_templates:
@@ -125,6 +167,8 @@
     - name: Add Joe to nonexistant job template execute role
       role:
         user: "{{ username }}"
+        users:
+          - "{{ username }}2"
         role: execute
         workflow: test-role-workflow
         job_templates:
@@ -141,6 +185,8 @@
     - name: Add Joe to workflow execute role, no-op
       role:
         user: "{{ username }}"
+        users:
+          - "{{ username }}2"
         role: execute
         workflow: test-role-workflow
         state: present
@@ -153,6 +199,8 @@
     - name: Add Joe to workflow approve role
       role:
         user: "{{ username }}"
+        users:
+          - "{{ username }}2"
         role: approval
         workflow: test-role-workflow
         state: present
@@ -169,6 +217,23 @@
         email: joe@example.org
         state: absent
       register: result
+
+    - name: Delete a 2nd User
+      user:
+        username: "{{ username }}2"
+        email: joe@example.org
+        state: absent
+      register: result
+
+    - name: Delete teams
+      team:
+        name: "{{ item }}"
+        organization: Default
+        state: absent
+      register: result
+      loop:
+        - "{{ team_name }}"
+        - "{{ team2_name }}"
 
     - name: Delete job templates
       job_template:


### PR DESCRIPTION
##### SUMMARY
collection, allow roles to be added to multiple teams and users

Have had multiple people saw when assigning roles to teams and users they have to have the same long list of JT/WFT declared multiple times one for each team and user to receive that permission. This is a way to do that in bulk. 

This also simplifies the code a bit as well removing an entire block, I also searched and after the changes the function param_to_endpoint, was no longer needed as well.

Also should we retire the other singular parameters now, they've been depreciated for a while, or create another issue around that.

##### ISSUE TYPE
 - New or Enhanced Feature


##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
22.1.0
```