### PR TITLE
[do not merge] Fix whitespace from black conversions

### DIFF
--- a/awx/main/management/commands/custom_venv_associations.py
+++ b/awx/main/management/commands/custom_venv_associations.py
@@ -44,7 +44,7 @@ class Command(BaseCommand):
                         '- To list all (now deprecated) custom virtual environments run:',
                         'awx-manage list_custom_venvs',
                         '',
-                        '- To export the contents of a (deprecated) virtual environment, ' 'run the following command while supplying the path as an argument:',
+                        '- To export the contents of a (deprecated) virtual environment, run the following command while supplying the path as an argument:',
                         'awx-manage export_custom_venv /path/to/venv',
                         '',
                         '- Run these commands with `-q` to remove tool tips.',


### PR DESCRIPTION
##### SUMMARY
Counter-example showing checks failing because "AlanCoding" uses capital letters

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
