### PR TITLE
Allow running AWX checks on forks with capital letters in them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
   CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  DEV_DOCKER_TAG_BASE: ghcr.io/${{ github.repository_owner }}
+  DEV_DOCKER_OWNER: ${{ github.repository_owner }}
   COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
 on:
   pull_request:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,10 @@ TACACS ?= false
 
 VENV_BASE ?= /var/lib/awx/venv
 
-DEV_DOCKER_TAG_BASE ?= ghcr.io/ansible
+DEV_DOCKER_OWNER ?= ansible
+# Docker will only accept lowercase, so github names like Paul need to be paul
+DEV_DOCKER_OWNER_LOWER = $(shell echo $(DEV_DOCKER_OWNER) | tr A-Z a-z)
+DEV_DOCKER_TAG_BASE ?= ghcr.io/$(DEV_DOCKER_OWNER_LOWER)
 DEVEL_IMAGE_NAME ?= $(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG)
 
 RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel


### PR DESCRIPTION
##### SUMMARY
This should allow checks to run on forks like my own (see this PR)

To see the problem this solves, see a counter-example here https://github.com/AlanCoding/awx/pull/82, which fails because "AlanCoding" cannot be used in the standard docker reference format.

This change converts the username given into lowercase, so AlanCoding -> alancoding for use in docker image names.

See fix tested on my fork with checks passing https://github.com/AlanCoding/awx/pull/83

EDIT: I had some of the links wrong, they should be updated to link to AlanCoding fork PRs now.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

