### PR TITLE
Fix for incorrect value for 'Run on' field in frequency details

### DIFF
--- a/awx/ui/src/components/Schedule/ScheduleDetail/FrequencyDetails.js
+++ b/awx/ui/src/components/Schedule/ScheduleDetail/FrequencyDetails.js
@@ -122,6 +122,18 @@ function sortWeekday(a, b) {
 }
 
 function RunOnDetail({ type, options, prefix }) {
+  const weekdays = {
+    sunday: t`Sunday`,
+    monday: t`Monday`,
+    tuesday: t`Tuesday`,
+    wednesday: t`Wednesday`,
+    thursday: t`Thursday`,
+    friday: t`Friday`,
+    saturday: t`Saturday`,
+    day: t`day`,
+    weekday: t`weekday`,
+    weekendDay: t`weekend day`,
+  };
   if (type === 'month') {
     if (options.runOn === 'day') {
       return (
@@ -132,16 +144,16 @@ function RunOnDetail({ type, options, prefix }) {
         />
       );
     }
-    const dayOfWeek = options.runOnTheDay;
+    const dayOfWeek = weekdays[options.runOnTheDay];
     return (
       <Detail
         label={t`Run on`}
         value={
-          options.runOnDayNumber === -1 ? (
+          options.runOnTheOccurrence === -1 ? (
             t`The last ${dayOfWeek}`
           ) : (
             <SelectOrdinal
-              value={options.runOnDayNumber}
+              value={options.runOnTheOccurrence}
               one={`The first ${dayOfWeek}`}
               two={`The second ${dayOfWeek}`}
               _3={`The third ${dayOfWeek}`}
@@ -178,18 +190,6 @@ function RunOnDetail({ type, options, prefix }) {
         />
       );
     }
-    const weekdays = {
-      sunday: t`Sunday`,
-      monday: t`Monday`,
-      tuesday: t`Tuesday`,
-      wednesday: t`Wednesday`,
-      thursday: t`Thursday`,
-      friday: t`Friday`,
-      saturday: t`Saturday`,
-      day: t`day`,
-      weekday: t`weekday`,
-      weekendDay: t`weekend day`,
-    };
     const weekday = weekdays[options.runOnTheDay];
     const month = months[options.runOnTheMonth];
     return (


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
**Bug**: If a schedule is saved with a monthly frequency and with `Run on` specified as (for eg.) `The Fourth Wednesday`, the schedule details incorrectly display `Run on` as `The first wednesday`.

![Screenshot 2023-05-01 at 5 16 57 PM](https://user-images.githubusercontent.com/43621546/235533717-69212b95-c4fc-4235-b2a4-99d2e92eb74c.png)
![Screenshot 2023-05-01 at 5 17 21 PM](https://user-images.githubusercontent.com/43621546/235533727-948edc0f-e028-4300-8e76-586eff30f35e.png)


### With fix:
<img width="752" alt="Screenshot 2023-05-01 at 5 23 21 PM" src="https://user-images.githubusercontent.com/43621546/235534232-0dc51e24-e6cb-4891-999c-b79f8a8b385f.png">

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

