### PR TITLE
Use psycopg2 instead of psycopg3 for wsrelay

### DIFF
--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import asyncio
-import select
 from typing import Dict
 
 import aiohttp
@@ -12,7 +11,6 @@ from channels.layers import get_channel_layer
 from django.conf import settings
 from django.apps import apps
 
-import psycopg2
 import asyncpg
 
 from awx.main.analytics.broadcast_websocket import (

--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -11,7 +11,7 @@ from channels.layers import get_channel_layer
 from django.conf import settings
 from django.apps import apps
 
-import psycopg
+import psycopg2
 
 from awx.main.analytics.broadcast_websocket import (
     RelayWebsocketStats,
@@ -207,35 +207,43 @@ class WebSocketRelayManager(object):
 
     async def pg_consumer(self, conn):
         try:
-            await conn.execute("LISTEN web_heartbeet")
-            async for notif in conn.notifies():
-                if notif is not None and notif.channel == "web_heartbeet":
-                    try:
-                        payload = json.loads(notif.payload)
-                    except json.JSONDecodeError:
-                        logmsg = "Failed to decode message from pg_notify channel `web_heartbeet`"
-                        if logger.isEnabledFor(logging.DEBUG):
-                            logmsg = "{} {}".format(logmsg, payload)
-                        logger.warning(logmsg)
-                        continue
+            conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+            curs = conn.cursor()
+            curs.execute("LISTEN web_heartbeet")
+            conn.poll()
 
-                    # Skip if the message comes from the same host we are running on
-                    # In this case, we'll be sharing a redis, no need to relay.
-                    if payload.get("hostname") == self.local_hostname:
-                        continue
+            while True:
+                if conn.notifies:
+                    notif = conn.notifies.pop()
+                    if notif is not None and notif.channel == "web_heartbeet":
+                        try:
+                            payload = json.loads(notif.payload)
+                        except json.JSONDecodeError:
+                            logmsg = "Failed to decode message from pg_notify channel `web_heartbeet`"
+                            if logger.isEnabledFor(logging.DEBUG):
+                                logmsg = "{} {}".format(logmsg, payload)
+                            logger.warning(logmsg)
+                            continue
 
-                    if payload.get("action") == "online":
-                        hostname = payload["hostname"]
-                        ip = payload["ip"]
-                        if ip is None:
-                            # If we don't get an IP, just try the hostname, maybe it resolves
-                            ip = hostname
-                        self.known_hosts[hostname] = ip
-                        logger.debug(f"Web host {hostname} ({ip}) online heartbeat received.")
-                    elif payload.get("action") == "offline":
-                        hostname = payload["hostname"]
-                        del self.known_hosts[hostname]
-                        logger.debug(f"Web host {hostname} ({ip}) offline heartbeat received.")
+                        # Skip if the message comes from the same host we are running on
+                        # In this case, we'll be sharing a redis, no need to relay.
+                        if payload.get("hostname") == self.local_hostname:
+                            continue
+
+                        if payload.get("action") == "online":
+                            hostname = payload["hostname"]
+                            ip = payload["ip"]
+                            if ip is None:
+                                # If we don't get an IP, just try the hostname, maybe it resolves
+                                ip = hostname
+                            self.known_hosts[hostname] = ip
+                            logger.debug(f"Web host {hostname} ({ip}) online heartbeat received.")
+                        elif payload.get("action") == "offline":
+                            hostname = payload["hostname"]
+                            del self.known_hosts[hostname]
+                            logger.debug(f"Web host {hostname} ({ip}) offline heartbeat received.")
+                await asyncio.sleep(1)
+
         except Exception as e:
             # This catch-all is the same as the one above. asyncio will eat the exception
             # but we want to know about it.
@@ -249,7 +257,7 @@ class WebSocketRelayManager(object):
 
         # Set up a pg_notify consumer for allowing web nodes to "provision" and "deprovision" themselves gracefully.
         database_conf = settings.DATABASES['default']
-        async_conn = await psycopg.AsyncConnection.connect(
+        async_conn = psycopg2.connect(
             dbname=database_conf['NAME'],
             host=database_conf['HOST'],
             user=database_conf['USER'],
@@ -257,7 +265,7 @@ class WebSocketRelayManager(object):
             port=database_conf['PORT'],
             **database_conf.get("OPTIONS", {}),
         )
-        await async_conn.set_autocommit(True)
+        # await async_conn.set_autocommit(True)
         event_loop.create_task(self.pg_consumer(async_conn))
 
         # Establishes a websocket connection to /websocket/relay on all API servers

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -36,7 +36,7 @@ openshift
 pexpect==4.7.0 # see library notes
 prometheus_client
 psycopg2
-psycopg  # psycopg3 is used to listen for pg_notify messages from web servers in awx.main.wsrelay where asyncio is used
+asyncpg
 psutil
 pygerduty
 pyparsing==2.4.6  # Upgrading to v3 of pyparsing introduce errors on smart host filtering: Expected 'or' term, found 'or'  (at char 15), (line:1, col:16)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -24,6 +24,8 @@ async-timeout==4.0.2
     #   aiohttp
     #   aioredis
     #   redis
+asyncpg==0.27.0
+    # via -r /awx_devel/requirements/requirements.in
 attrs==22.1.0
     # via
     #   aiohttp
@@ -266,8 +268,6 @@ prometheus-client==0.15.0
     # via -r /awx_devel/requirements/requirements.in
 psutil==5.9.4
     # via -r /awx_devel/requirements/requirements.in
-psycopg==3.1.4
-    # via -r /awx_devel/requirements/requirements.in
 psycopg2==2.9.5
     # via -r /awx_devel/requirements/requirements.in
 ptyprocess==0.7.0
@@ -428,7 +428,7 @@ txaio==22.2.1
 typing-extensions==4.4.0
     # via
     #   azure-core
-    #   psycopg
+    #   pydantic
     #   setuptools-rust
     #   setuptools-scm
     #   twisted


### PR DESCRIPTION
##### SUMMARY
Django 4.2 will default to psycopg3 if it's present

We do not want to deal with upgrading Django and have all of our code be compatible with psycopg3 at the same time 

Removing psycopg3 for now and will deal with this after we finish upgrading to Django 4.2

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.1.1.dev70+g0b52514811
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
