### PR TITLE
Add missing comma in host_status_counts list

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -284,7 +284,7 @@ class JobNotificationMixin(object):
         'workflow_url',
         'scm_branch',
         'artifacts',
-        {'host_status_counts': ['skipped', 'ok', 'changed', 'failed', 'failures', 'dark' 'processed', 'rescued', 'ignored']},
+        {'host_status_counts': ['skipped', 'ok', 'changed', 'failed', 'failures', 'dark', 'processed', 'rescued', 'ignored']},
         {
             'summary_fields': [
                 {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Noticed this when doing some other zen gardening.

According to the code in ansible, it looks like `dark` is the behind-the-scenes name for `unreachable`:

https://github.com/ansible/ansible/blob/f68c66a3ef2390d21f5eeb10bb6b151058570206/lib/ansible/executor/stats.py#L67

It would be good to know why this didnt seem to matter. Are we missing test coverage? Is this dead code?

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API