### PR TITLE
Fix bug with parent_key filtering

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -522,14 +522,13 @@ class SubListAPIView(ParentMixin, ListAPIView):
     def get_queryset(self):
         parent = self.get_parent_object()
         self.check_parent_access(parent)
-        sublist_qs = self.get_sublist_queryset(parent)
         if not self.filter_read_permission:
-            return optimize_queryset(sublist_qs)
+            return optimize_queryset(self.get_sublist_queryset(parent))
         qs = self.request.user.get_queryset(self.model)
         if hasattr(self, 'parent_key'):
             # This is vastly preferable for ReverseForeignKey relationships
             return qs.filter(**{self.parent_key: parent})
-        return qs.distinct() & sublist_qs.distinct()
+        return qs.distinct() & self.get_sublist_queryset(parent).distinct()
 
     def get_sublist_queryset(self, parent):
         return getattrd(parent, self.relationship)

--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -525,11 +525,14 @@ class SubListAPIView(ParentMixin, ListAPIView):
         sublist_qs = self.get_sublist_queryset(parent)
         if not self.filter_read_permission:
             return optimize_queryset(sublist_qs)
-        qs = self.request.user.get_queryset(self.model).distinct()
-        return qs & sublist_qs
+        qs = self.request.user.get_queryset(self.model)
+        if hasattr(self, 'parent_key'):
+            # This is vastly preferable for ReverseForeignKey relationships
+            return qs.filter(**{self.parent_key: parent})
+        return qs.distinct() & sublist_qs.distinct()
 
     def get_sublist_queryset(self, parent):
-        return getattrd(parent, self.relationship).distinct()
+        return getattrd(parent, self.relationship)
 
 
 class DestroyAPIView(generics.DestroyAPIView):
@@ -577,15 +580,6 @@ class SubListCreateAPIView(SubListAPIView, ListCreateAPIView):
         d = super(SubListCreateAPIView, self).get_description_context()
         d.update({'parent_key': getattr(self, 'parent_key', None)})
         return d
-
-    def get_queryset(self):
-        if hasattr(self, 'parent_key'):
-            # Prefer this filtering because ForeignKey allows us more assumptions
-            parent = self.get_parent_object()
-            self.check_parent_access(parent)
-            qs = self.request.user.get_queryset(self.model)
-            return qs.filter(**{self.parent_key: parent})
-        return super(SubListCreateAPIView, self).get_queryset()
 
     def create(self, request, *args, **kwargs):
         # If the object ID was not specified, it probably doesn't exist in the


### PR DESCRIPTION
##### SUMMARY
I introduced this bug with the merge of https://github.com/ansible/awx/pull/13906, and it was unfortunately fairly high-consequence.

The "new" logic was just fine, but the problem is that the `parent_key` specification dropped us into the `get_queryset` of a subclass, which I... didn't expect.

This doubles-down on the refactor, and merges those two methods together. So far, it addresses the test case that was found to be failing.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

