### PR TITLE
Prevent manual peering of control plane nodes to hop node

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5490,6 +5490,13 @@ class InstanceSerializer(BaseSerializer):
 
         if peers_from_control_nodes and node_type not in (Instance.Types.EXECUTION, Instance.Types.HOP):
             raise serializers.ValidationError("peers_from_control_nodes can only be enabled for execution or hop nodes.")
+
+        if node_type in (Instance.Types.CONTROL):
+            if self.instance and 'peers' in attrs and set(self.instance.peers.all()) != set(attrs['peers']):
+                raise serializers.ValidationError(
+                    "Setting peers manually for control nodes is not allowed. Enable peers_from_control_nodes on the hop and execution nodes instead."
+                )
+
         return super().validate(attrs)
 
     def validate_node_type(self, value):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Prevent manual peering of control plane nodes to hop node
- related #13910
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.1.1
```

##### Test Scenarios:
- Ensure that if `peers` has been set, it cannot be changed to a different node
- Esnure that `peers` cannot be set manually, must be set via `peers_from_control_nodes`