### PR TITLE
Fix incorrect parent_key ref from label to job

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3333,7 +3333,6 @@ class JobLabelList(SubListAPIView):
     serializer_class = serializers.LabelSerializer
     parent_model = models.Job
     relationship = 'labels'
-    parent_key = 'job'
 
 
 class WorkflowJobLabelList(JobLabelList):

--- a/awx/main/tests/functional/api/test_job.py
+++ b/awx/main/tests/functional/api/test_job.py
@@ -52,6 +52,16 @@ def test_job_relaunch_permission_denied_response(post, get, inventory, project, 
 
 
 @pytest.mark.django_db
+def test_label_sublist(get, admin_user, organization):
+    job = Job.objects.create()
+    label = Label.objects.create(organization=organization, name='Steve')
+    job.labels.add(label)
+    r = get(url=reverse('api:job_label_list', kwargs={'pk': job.pk}), user=admin_user, expect=200)
+    assert r.data['count'] == 1
+    assert r.data['results'].pop()['id'] == label.id
+
+
+@pytest.mark.django_db
 def test_job_relaunch_prompts_not_accepted_response(post, get, inventory, project, credential, net_credential, machine_credential):
     jt = JobTemplate.objects.create(name='testjt', inventory=inventory, project=project)
     jt.credentials.add(machine_credential)


### PR DESCRIPTION
##### SUMMARY
This was causing the `/api/v2/jobs/N/labels/` endpoint to give a 400 error with a confusing error text.

It was introduced in https://github.com/ansible/awx/pull/13957, however the `parent_key` here is not a valid field name.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

