### PR TITLE
[troubleshooting] Make dispatcher --status accurate real-time

### DIFF
--- a/awx/main/dispatch/control.py
+++ b/awx/main/dispatch/control.py
@@ -24,12 +24,11 @@ class Control(object):
         self.queuename = host or get_task_queuename()
 
     def status(self, *args, **kwargs):
-        r = redis.Redis.from_url(settings.BROKER_URL)
         if self.service == 'dispatcher':
-            stats = r.get(f'awx_{self.service}_statistics') or b''
-            return stats.decode('utf-8')
+            return self.control_with_reply('status', *args, **kwargs)
         else:
             workers = []
+            r = redis.Redis.from_url(settings.BROKER_URL)
             for key in r.keys('awx_callback_receiver_statistics_*'):
                 workers.append(r.get(key).decode('utf-8'))
             return '\n'.join(workers)

--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -123,6 +123,9 @@ class PoolWorker(object):
     def calculate_managed_tasks(self):
         if not self.track_managed_tasks:
             return
+        # optimization: if there are no active tasks then do not bother checking the queue
+        if not self.managed_tasks:
+            return
         # look to see if any tasks were finished
         finished = []
         for _ in range(self.finished.qsize()):
@@ -253,6 +256,8 @@ class WorkerPool(object):
         return idx, worker
 
     def debug(self, *args, **kwargs):
+        for worker in self.workers:
+            worker.calculate_managed_tasks()
         tmpl = Template(
             'Recorded at: {{ dt }} \n'
             '{{ pool.name }}[pid:{{ pool.pid }}] workers total={{ workers|length }} {{ meta }} \n'


### PR DESCRIPTION
##### SUMMARY
With this change:

```
bash-5.1$ awx-manage run_dispatcher --status
2023-05-10 13:29:07,138 WARNING  [-] awx.main.dispatch checking dispatcher status for awx_1
listening on ['tower_broadcast_all', 'tower_settings_change', 'awx_1']
Recorded at: 2023-05-10 13:29:07 UTC 
awx_1[pid:78909] workers total=4 min=4 max=314 
.  worker[pid:79000] sent=1 finished=1 qsize=0 rss=125.996MB [IDLE]
.  worker[pid:79001] sent=2 finished=2 qsize=0 rss=129.141MB [IDLE]
.  worker[pid:79002] sent=1 finished=1 qsize=0 rss=127.152MB [IDLE]
.  worker[pid:79003] sent=3 finished=3 qsize=0 rss=126.535MB [IDLE]
```

You can run this _over and over_ again and it almost never shows a scheduled task running. These tasks take on the order of `0.02` seconds, which the task manager being the longest at around `0.1` seconds on a quiet system. Given that these run on periods of 20 seconds to 60 seconds, we actually _expect_ to (almost) never see such tasks. We're looking at a 1 in 200 chance.

But right now, the dispatcher regularly shows workers with active tasks. This is because those workers are not actually active. They are only shown in-memory to be active because their finished queue has not been checked.

This _does_ make it more likely that the `--status` command will hang, and while we might want some kind of balancing fix for that, I would like to look elsewhere instead of what this is removing.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

