### PR TITLE
Change the job_wait integration test

### DIFF
--- a/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
@@ -9,154 +9,156 @@
     jt_name: "AWX-Collection-tests-job_wait-long_running-{{ test_id }}"
     proj_name: "AWX-Collection-tests-job_wait-long_running-{{ test_id }}"
 
-- name: Assure that the demo project exists
-  project:
-    name: "{{ proj_name }}"
-    scm_type: 'git'
-    scm_url: 'https://github.com/ansible/test-playbooks.git'
-    scm_update_on_launch: true
-    organization: Default
+- block:
+    - name: Create a project
+      project:
+        name: "{{ proj_name }}"
+        scm_type: 'git'
+        scm_url: 'https://github.com/ansible/test-playbooks.git'
+        scm_update_on_launch: true
+        organization: Default
 
-- name: Create a job template
-  job_template:
-    name: "{{ jt_name }}"
-    playbook: "sleep.yml"
-    job_type: run
-    project: "{{ proj_name }}"
-    inventory: "Demo Inventory"
-    extra_vars:
-      sleep_interval: 300
+    - name: Create a job template
+      job_template:
+        name: "{{ jt_name }}"
+        playbook: "sleep.yml"
+        job_type: run
+        project: "{{ proj_name }}"
+        inventory: "Demo Inventory"
+        extra_vars:
+          sleep_interval: 600
 
-- name: Check module fails with correct msg
-  job_wait:
-    job_id: "99999999"
-  register: result
-  ignore_errors: true
+    - name: Check module fails with correct msg
+      job_wait:
+        job_id: "99999999"
+      register: result
+      ignore_errors: true
 
-- assert:
-    that:
-      - result is failed
-      - "result.msg =='Unable to wait, no job_id 99999999 found: The requested object could not be found.' or
-        'Unable to wait on job 99999999; that ID does not exist.'"
+    - assert:
+        that:
+          - result is failed
+          - "result.msg =='Unable to wait, no job_id 99999999 found: The requested object could not be found.' or
+            'Unable to wait on job 99999999; that ID does not exist.'"
 
-- name: Launch Demo Job Template (take happy path)
-  job_launch:
-    job_template: "Demo Job Template"
-  register: job
+    - name: Launch Demo Job Template (take happy path)
+      job_launch:
+        job_template: "Demo Job Template"
+      register: job
 
-- assert:
-    that:
-      - job is changed
+    - assert:
+        that:
+          - job is changed
 
-- name: Wait for the Job to finish
-  job_wait:
-    job_id: "{{ job.id }}"
-  register: wait_results
+    - name: Wait for the Job to finish
+      job_wait:
+        job_id: "{{ job.id }}"
+      register: wait_results
 
-# Make sure it worked and that we have some data in our results
-- assert:
-    that:
-      - wait_results is successful
-      - "'elapsed' in wait_results"
-      - "'id' in wait_results"
+    # Make sure it worked and that we have some data in our results
+    - assert:
+        that:
+          - wait_results is successful
+          - "'elapsed' in wait_results"
+          - "'id' in wait_results"
 
-- name: Launch a long running job
-  job_launch:
-    job_template: "{{ jt_name }}"
-  register: job
+    - name: Launch a long running job
+      job_launch:
+        job_template: "{{ jt_name }}"
+      register: job
 
-- assert:
-    that:
-      - job is changed
+    - assert:
+        that:
+          - job is changed
 
-- name: Timeout waiting for the job to complete
-  job_wait:
-    job_id: "{{ job.id }}"
-    timeout: 5
-  ignore_errors: true
-  register: wait_results
+    - name: Timeout waiting for the job to complete
+      job_wait:
+        job_id: "{{ job.id }}"
+        timeout: 5
+      ignore_errors: true
+      register: wait_results
 
-# Make sure that we failed and that we have some data in our results
-- assert:
-    that:
-      - "wait_results.msg == 'Monitoring aborted due to timeout' or 'Timeout waiting for job to finish.'"
-      - "'id' in wait_results"
+    # Make sure that we failed and that we have some data in our results
+    - assert:
+        that:
+          - "wait_results.msg == 'Monitoring aborted due to timeout' or 'Timeout waiting for job to finish.'"
+          - "'id' in wait_results"
 
-- name: Async cancel the long running job
-  job_cancel:
-    job_id: "{{ job.id }}"
-  async: 3600
-  poll: 0
+    - name: Async cancel the long running job
+      job_cancel:
+        job_id: "{{ job.id }}"
+      async: 3600
+      poll: 0
 
-- name: Wait for the job to exit on cancel
-  job_wait:
-    job_id: "{{ job.id }}"
-  register: wait_results
-  ignore_errors: true
+    - name: Wait for the job to exit on cancel
+      job_wait:
+        job_id: "{{ job.id }}"
+      register: wait_results
+      ignore_errors: true
 
-- assert:
-    that:
-      - wait_results is failed
-      - 'wait_results.status == "canceled"'
-      - "wait_results.msg == 'Job with id {{ job.id }} failed' or 'Job with id={{ job.id }} failed, error: Job failed.'"
+    - assert:
+        that:
+          - wait_results is failed
+          - 'wait_results.status == "canceled"'
+          - "wait_results.msg == 'Job with id {{ job.id }} failed' or 'Job with id={{ job.id }} failed, error: Job failed.'"
 
-- name: Delete the job template
-  job_template:
-    name: "{{ jt_name }}"
-    playbook: "sleep.yml"
-    job_type: run
-    project: "{{ proj_name }}"
-    inventory: "Demo Inventory"
-    state: absent
+    # workflow wait test
+    - name: Generate a random string for test
+      set_fact:
+        test_id1: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+      when: test_id1 is not defined
 
-- name: Delete the project
-  project:
-    name: "{{ proj_name }}"
-    organization: Default
-    state: absent
+    - name: Generate names
+      set_fact:
+        wfjt_name2: "AWX-Collection-tests-workflow_launch--wfjt1-{{ test_id1 }}"
 
-# workflow wait test
-- name: Generate a random string for test
-  set_fact:
-    test_id1: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
-  when: test_id1 is not defined
+    - name: Create our workflow
+      workflow_job_template:
+        name: "{{ wfjt_name2 }}"
+        state: present
 
-- name: Generate names
-  set_fact:
-    wfjt_name2: "AWX-Collection-tests-workflow_launch--wfjt1-{{ test_id1 }}"
+    - name: Add a node
+      workflow_job_template_node:
+        workflow_job_template: "{{ wfjt_name2 }}"
+        unified_job_template: "Demo Job Template"
+        identifier: leaf
+      register: new_node
 
-- name: Create our workflow
-  workflow_job_template:
-    name: "{{ wfjt_name2 }}"
-    state: present
+    - name: Kick off a workflow
+      workflow_launch:
+        workflow_template: "{{ wfjt_name2 }}"
+      ignore_errors: true
+      register: workflow
 
-- name: Add a node
-  workflow_job_template_node:
-    workflow_job_template: "{{ wfjt_name2 }}"
-    unified_job_template: "Demo Job Template"
-    identifier: leaf
-  register: new_node
+    - name: Wait for the Workflow Job to finish
+      job_wait:
+        job_id: "{{ workflow.job_info.id }}"
+        job_type: "workflow_jobs"
+      register: wait_workflow_results
 
-- name: Kick off a workflow
-  workflow_launch:
-    workflow_template: "{{ wfjt_name2 }}"
-  ignore_errors: true
-  register: workflow
+    # Make sure it worked and that we have some data in our results
+    - assert:
+        that:
+          - wait_workflow_results is successful
+          - "'elapsed' in wait_workflow_results"
+          - "'id' in wait_workflow_results"
 
-- name: Wait for the Workflow Job to finish
-  job_wait:
-    job_id: "{{ workflow.job_info.id }}"
-    job_type: "workflow_jobs"
-  register: wait_workflow_results
+  always:
+    - name: Clean up test workflow
+      workflow_job_template:
+        name: "{{ wfjt_name2 }}"
+        state: absent
 
-# Make sure it worked and that we have some data in our results
-- assert:
-    that:
-      - wait_workflow_results is successful
-      - "'elapsed' in wait_workflow_results"
-      - "'id' in wait_workflow_results"
+    - name: Delete the job template
+      job_template:
+        name: "{{ jt_name }}"
+        playbook: "sleep.yml"
+        job_type: run
+        project: "{{ proj_name }}"
+        inventory: "Demo Inventory"
+        state: absent
 
-- name: Clean up test workflow
-  workflow_job_template:
-    name: "{{ wfjt_name2 }}"
-    state: absent
+    - name: Delete the project
+      project:
+        name: "{{ proj_name }}"
+        organization: Default
+        state: absent

--- a/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
@@ -27,20 +27,6 @@
     extra_vars:
       sleep_interval: 300
 
-- name: Validate that interval superceeds min/max
-  job_wait:
-    min_interval: 10
-    max_interval: 20
-    interval: 12
-    job_id: "99999999"
-  register: result
-  ignore_errors: true
-
-- assert:
-    that:
-      - "result.msg =='Unable to wait on job 99999999; that ID does not exist.' or
-        'min and max interval have been depricated, please use interval instead, interval will be set to 12'"
-
 - name: Check module fails with correct msg
   job_wait:
     job_id: "99999999"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Extends the timeout on a long running job
Removes a test which used depreciated fields that have finally been removed
Puts the tests into a block and always tries to remove objects it creates

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
