### PR TITLE
Skip constructed_inventory endpoint in awxkit import

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -404,6 +404,11 @@ class ApiV2(base.Base):
 
         for resource in self._dependent_resources():
             endpoint = getattr(self, resource)
+            # The /api/v2/constructed_inventories endpoint is for the UI but will register as an Inventory endpoint causing import issues, so skip it
+            if endpoint == '/api/v2/constructed_inventories/':
+                log.debug("Ignoring /api/v2/constructed_inventories/ endpoint.")
+                continue
+
             # Load up existing objects, so that we can try to update or link to them
             self._cache.get_page(endpoint)
             imported = self._import_list(endpoint, data.get(resource) or [])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When running an import from awxkit it preloads data scanning endpoints from /api/v2/. With debug output turned on you can see it setting the class for both `/inventoty` and `/constructed_inventory` as `Inventory`:
```
DEBUG:awxkit.api.registry:Retrieved <class 'awxkit.api.pages.inventory.Inventories'> by url: /api/v2/inventories/
DEBUG:awxkit.api.registry:Retrieved <class 'awxkit.api.pages.inventory.Inventories'> by url: /api/v2/constructed_inventories/
```

Later on when it attempts to resolve the inventory for an import of something like a job template its unable to (unless the inventory is constructed):
```
DEBUG:awxkit.api.pages.page:get_by_natural_key: {'organization': {'name': 'Organization - DeathMany', 'type': 'organization'}, 'name': 'Inventory - RestPopulation', 'type': 'inventory'}, endpoint: None
DEBUG:awxkit.api.pages.page:get_by_natural_key: {'organization': {'name': 'Organization - DeathMany', 'type': DEBUG:awxkit.api.pages.page:get_by_natural_key: {'organization': {'name': 'Organization - DeathMany', 'type': 'organization'}, 'name': 'JobTemplate - BuyProfessor', 'type': 'job_template'}, endpoint: None
```

Because it was unable to resolve the inventory to an existing item a JT would fail with a message like:
```
/api/v2/job_templates/ "JobTemplate - GrassRub�": Bad Request (400) received - {'inventory': ['Must either set a default value or ask to prompt on launch.']}.
```

Since the `/constructed_inventory` is just a connivence endpoint this PR has awxkit skipping it which allows the inventories to properly be imported.


May fix #13521 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
