### PR TITLE
[troubleshooting] Add dispatcher --history option

### DIFF
--- a/awx/main/dispatch/control.py
+++ b/awx/main/dispatch/control.py
@@ -34,6 +34,9 @@ class Control(object):
                 workers.append(r.get(key).decode('utf-8'))
             return '\n'.join(workers)
 
+    def history(self, *args, **kwargs):
+        return self.control_with_reply('history', *args, **kwargs)
+
     def running(self, *args, **kwargs):
         return self.control_with_reply('running', *args, **kwargs)
 

--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -140,12 +140,11 @@ class PoolWorker(object):
             uuid = finished_data['uuid']
             try:
                 # Manage timing data for performance and troubleshooting
-                task_data = self.managed_tasks[uuid]
-                task_data.update(self.managed_tasks[uuid])
+                self.managed_tasks[uuid].update(finished_data)
                 # record data to show in --history
                 self.finished_record.append(self.managed_tasks[uuid])
                 # echo that data to debug logs
-                logger.debug((f'Concluded {uuid} {task_data.get("task", "unknown")}, {self.display_timing(self.managed_tasks[uuid])}'))
+                logger.debug((f'Concluded {uuid} {self.managed_tasks[uuid].get("task", "unknown")}, {self.display_timing(self.managed_tasks[uuid])}'))
                 # Functionally, have worker marked as idle or ready for next task
                 del self.managed_tasks[uuid]
                 self.messages_finished += 1
@@ -290,7 +289,7 @@ class WorkerPool(object):
         if show_history:
             worker_extra = ''.join(['{% for task in w.finished_record %}', task_tmpl, '{% endfor %}'])
         tmpl = Template(
-            'Dispatcher started at: {{ st }} \n'
+            'Started at:  {{ st }} \n'
             'Recorded at: {{ dt }} \n'
             '{{ pool.name }}[pid:{{ pool.pid }}] workers total={{ workers|length }} {{ meta }} \n'
             '{% for w in workers %}'

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -26,6 +26,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--status', dest='status', action='store_true', help='print the internal state of any running dispatchers')
+        parser.add_argument('--history', dest='history', action='store_true', help='show completed tasks of workers up to a certain limit')
         parser.add_argument('--running', dest='running', action='store_true', help='print the UUIDs of any tasked managed by this dispatcher')
         parser.add_argument(
             '--reload',
@@ -44,12 +45,10 @@ class Command(BaseCommand):
         )
 
     def handle(self, *arg, **options):
-        if options.get('status'):
-            print(Control('dispatcher').status())
-            return
-        if options.get('running'):
-            print(Control('dispatcher').running())
-            return
+        for option in ('status', 'history', 'running'):
+            if options.get(option):
+                print(getattr(Control('dispatcher'), option)())
+                return
         if options.get('reload'):
             return Control('dispatcher').control({'control': 'reload'})
         if options.get('cancel'):


### PR DESCRIPTION
##### SUMMARY
Demo:

```
bash-5.1$ awx-manage run_dispatcher --history
2023-05-10 19:50:02,740 WARNING  [-] awx.main.dispatch checking dispatcher history for awx_1
listening on ['tower_broadcast_all', 'tower_settings_change', 'awx_1']
Dispatcher started at: 2023-05-10 19:48:03 UTC 
Recorded at: 2023-05-10 19:50:02 UTC 
awx_1[pid:2334] workers total=6 min=4 max=314 
.  worker[pid:2435] sent=5 finished=5 qsize=0 rss=129.227MB [IDLE]
     - finished cb49c32b-4eb7-43af-a1ca-ac4941e1d7bc send_subsystem_metrics(*[]) pub=19:48:23 UTC ack=0.0482s run=0.0745s
     - finished 6df6a3c1-176e-43e6-8ea5-193e66f76737 awx_periodic_scheduler(*[]) pub=19:48:33 UTC ack=0.0202s run=0.1036s
     - finished c8c02ef5-f0e2-449f-8138-cc1d62794b94 dependency_manager(*[]) pub=19:48:43 UTC ack=0.0126s run=0.0209s
     - finished 32eaa977-96f0-4dac-ab53-20133e90f630 cluster_node_heartbeat(*[]) pub=19:49:03 UTC ack=0.0195s run=0.0612s
     - finished d10d98cb-a0a6-4807-8ede-668c3c970257 send_subsystem_metrics(*[]) pub=19:49:44 UTC ack=0.0308s run=0.0090s
.  worker[pid:2436] sent=4 finished=4 qsize=0 rss=125.988MB [IDLE]
     - finished 361d75fa-ea1f-4d0b-9548-688c59a2a5f3 dependency_manager(*[]) pub=19:48:23 UTC ack=0.0496s run=0.0725s
     - finished 498a4264-5636-4e7e-85df-213a7bd9a112 task_manager(*[]) pub=19:48:43 UTC ack=0.0109s run=0.0338s
     - finished bbe32ea6-8d2b-4b1f-be4c-f6653439cf3c awx_periodic_scheduler(*[]) pub=19:49:03 UTC ack=0.0336s run=0.0573s
     - finished 3a66b327-c271-44b1-b471-101af7684742 task_manager(*[]) pub=19:49:24 UTC ack=0.0203s run=0.0481s
.  worker[pid:2437] sent=6 finished=6 qsize=0 rss=129.625MB [IDLE]
     - finished 26a98fe6-c484-4666-a802-86be4fafa23b task_manager(*[]) pub=19:48:23 UTC ack=0.0280s run=0.1184s
     - finished a51efb78-55d5-4f4a-8fd1-0d32f227a380 send_subsystem_metrics(*[]) pub=19:48:43 UTC ack=0.0121s run=0.0287s
     - finished b467991b-fdef-4068-8c3f-c45b56f11f5b awx_k8s_reaper(*[]) pub=19:49:03 UTC ack=0.0352s run=0.0096s
     - finished 04540fe7-7488-4381-9eda-cd55fbab592d task_manager(*[]) pub=19:49:03 UTC ack=0.0440s run=0.0289s
     - finished 6b8591b0-85a3-4d99-b561-6731ce8712e6 awx_periodic_scheduler(*[]) pub=19:49:34 UTC ack=0.0192s run=0.1430s
     - finished 51bf6483-6270-4847-b7ab-8f1e91818d94 task_manager(*[]) pub=19:49:44 UTC ack=0.0183s run=0.0441s
.  worker[pid:2438] sent=2 finished=2 qsize=0 rss=128.629MB [IDLE]
     - finished f0857a1d-ca11-45a1-9066-18847f34f20d awx_receptor_workunit_reaper(*[]) pub=19:49:03 UTC ack=0.0346s run=0.0302s
     - finished bf1460e4-d4f8-4258-839d-aaeb570b33c3 send_subsystem_metrics(*[]) pub=19:49:24 UTC ack=0.0352s run=0.0261s
.  worker[pid:2464] sent=3 finished=3 qsize=0 rss=126.910MB [IDLE]
     - finished 86311f22-48cf-4f2c-8c5c-abfb9e8d443c dependency_manager(*[]) pub=19:49:03 UTC ack=0.0435s run=0.0216s
     - finished 8cfa6b5e-83aa-4e0f-9760-3de25c26839a dependency_manager(*[]) pub=19:49:24 UTC ack=0.0367s run=0.0163s
     - finished 59903ac6-a778-4e87-b52c-84950f39aaad dependency_manager(*[]) pub=19:49:44 UTC ack=0.0319s run=0.0160s
.  worker[pid:2466] sent=1 finished=1 qsize=0 rss=128.559MB [IDLE]
     - finished d9950847-9030-42ac-8270-3777387fe19a send_subsystem_metrics(*[]) pub=19:49:03 UTC ack=0.0493s run=0.0265s
```

Brainstorming, as I discover that https://github.com/ansible/awx/pull/13975 kind of cripples the command from a practical standpoint - people run it expecting to see _something_. This will make it clear the ratio of periodic tasks compared to user-triggered tasks.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

