### PR TITLE
Reduce queue checks needed for task assignment

### DIFF
--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -182,7 +182,7 @@ class TestAutoScaling:
 
         # wait for the subprocesses to start working on their tasks and be marked busy
         time.sleep(1)
-        assert self.pool.should_grow
+        assert len(self.pool.workers) == self.pool.max_workers
 
         # write a third message, expect a new worker to spawn because all
         # workers are busy
@@ -242,7 +242,6 @@ class TestAutoScaling:
 
         # start with two workers, kill one of them
         assert len(self.pool) == 2
-        assert not self.pool.should_grow
         alive_pid = self.pool.workers[1].pid
         self.pool.workers[0].process.kill()
         self.pool.workers[0].process.join()  # waits for process to full terminate


### PR DESCRIPTION
##### SUMMARY
Another patch to offer to use https://github.com/ansible/awx/pull/13989 to test with.

We have to check the finished queue to evaluate a worker's idle/busy state this is triggered
 - for _all_ workers when `should_grow` is called
 - for each worker as we are searching for an idle worker

the argument here is that we are checking the finished queue two times before dispatching a task. So we just don't check the first time.

This is presented as something which should increase the `dispatcher_availability`, but this should be most acute in the scenario that we are under very high loads, because in this case we will have the largest number of finished queues to check.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
