### PR TITLE
Adds managed_by_policy checkbox to instances form.  Adds warnings when associating or disassociating instances from instance groups.

### DIFF
--- a/awx/ui/src/components/AssociateModal/AssociateModal.js
+++ b/awx/ui/src/components/AssociateModal/AssociateModal.js
@@ -27,6 +27,7 @@ function AssociateModal({
   isModalOpen = false,
   displayKey = 'name',
   ouiaId,
+  modalNote,
 }) {
   const history = useHistory();
   const { selected, handleSelect } = useSelected([]);
@@ -120,6 +121,7 @@ function AssociateModal({
         </Button>,
       ]}
     >
+      {modalNote}
       <OptionsList
         displayKey={displayKey}
         contentError={contentError}

--- a/awx/ui/src/components/DisassociateButton/DisassociateButton.js
+++ b/awx/ui/src/components/DisassociateButton/DisassociateButton.js
@@ -1,5 +1,13 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { arrayOf, func, shape, string, oneOfType, number } from 'prop-types';
+import {
+  arrayOf,
+  func,
+  shape,
+  string,
+  oneOfType,
+  number,
+  node,
+} from 'prop-types';
 
 import { t } from '@lingui/macro';
 import { Button, Tooltip, DropdownItem } from '@patternfly/react-core';
@@ -180,7 +188,7 @@ DisassociateButton.propTypes = {
       })
     ),
   ]),
-  modalNote: string,
+  modalNote: node,
   modalTitle: string,
   onDisassociate: func.isRequired,
 };

--- a/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceDetails/InstanceDetails.js
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { useParams, useHistory } from 'react-router-dom';
-import { t, Plural } from '@lingui/macro';
+import { t, Trans, Plural } from '@lingui/macro';
 import {
   Button,
   Progress,
@@ -70,6 +70,10 @@ function InstanceDetails({ setBreadcrumb, instanceGroup }) {
   const [healthCheck, setHealthCheck] = useState({});
   const [showHealthCheckAlert, setShowHealthCheckAlert] = useState(false);
   const [forks, setForks] = useState();
+
+  const policyRulesDocsLink = `${getDocsBaseUrl(
+    config
+  )}/html/administration/containers_instance_groups.html#ag-instance-group-policies`;
 
   const {
     isLoading,
@@ -319,6 +323,23 @@ function InstanceDetails({ setBreadcrumb, instanceGroup }) {
               itemsToDisassociate={[instance]}
               isProtectedInstanceGroup={instanceGroup.name === 'controlplane'}
               modalTitle={t`Disassociate instance from instance group?`}
+              modalNote={
+                instance.managed_by_policy ? (
+                  <Trans>
+                    <b>
+                      Note: This instance may be re-associated with this
+                      instance group if it is managed by{' '}
+                      <a
+                        href={policyRulesDocsLink}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        policy rules.
+                      </a>
+                    </b>
+                  </Trans>
+                ) : null
+              }
             />
           )}
           <InstanceToggle

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -348,7 +348,22 @@ function InstanceList({ instanceGroup }) {
             { key: 'node_type', name: t`Node Type` },
           ]}
           modalNote={
-            <b>{t`Note: Manually associated instances may be automatically disassociated from an instance group if the instance is managed by policy rules.`}</b>
+            <b>
+              <Trans>
+                <b>
+                  Note: Manually associated instances may be automatically
+                  disassociated from an instance group if the instance is
+                  managed by{' '}
+                  <a
+                    href={policyRulesDocsLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    policy rules.
+                  </a>
+                </b>
+              </Trans>
+            </b>
           }
         />
       )}

--- a/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
+++ b/awx/ui/src/screens/InstanceGroup/Instances/InstanceList.js
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { t } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import { useLocation, useParams } from 'react-router-dom';
 import 'styled-components/macro';
 
@@ -22,6 +22,8 @@ import useRequest, {
 import useSelected from 'hooks/useSelected';
 import { InstanceGroupsAPI, InstancesAPI } from 'api';
 import { getQSConfig, parseQueryString, mergeParams } from 'util/qs';
+import getDocsBaseUrl from 'util/getDocsBaseUrl';
+import { useConfig } from 'contexts/Config';
 import HealthCheckButton from 'components/HealthCheckButton/HealthCheckButton';
 import HealthCheckAlert from 'components/HealthCheckAlert';
 import InstanceListItem from './InstanceListItem';
@@ -33,12 +35,17 @@ const QS_CONFIG = getQSConfig('instance', {
 });
 
 function InstanceList({ instanceGroup }) {
+  const config = useConfig();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [showHealthCheckAlert, setShowHealthCheckAlert] = useState(false);
   const [pendingHealthCheck, setPendingHealthCheck] = useState(false);
   const [canRunHealthCheck, setCanRunHealthCheck] = useState(true);
   const location = useLocation();
   const { id: instanceGroupId } = useParams();
+
+  const policyRulesDocsLink = `${getDocsBaseUrl(
+    config
+  )}/html/administration/containers_instance_groups.html#ag-instance-group-policies`;
 
   const {
     result: {
@@ -262,6 +269,25 @@ function InstanceList({ instanceGroup }) {
                 itemsToDisassociate={selected}
                 modalTitle={t`Disassociate instance from instance group?`}
                 isProtectedInstanceGroup={instanceGroup.name === 'controlplane'}
+                modalNote={
+                  selected.some(
+                    (instance) => instance.managed_by_policy === true
+                  ) ? (
+                    <Trans>
+                      <b>
+                        Note: Instances may be re-associated with this instance
+                        group if they are managed by{' '}
+                        <a
+                          href={policyRulesDocsLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          policy rules.
+                        </a>
+                      </b>
+                    </Trans>
+                  ) : null
+                }
               />,
               <HealthCheckButton
                 isDisabled={!canAdd || !canRunHealthCheck}
@@ -321,6 +347,9 @@ function InstanceList({ instanceGroup }) {
             { key: 'hostname', name: t`Name` },
             { key: 'node_type', name: t`Node Type` },
           ]}
+          modalNote={
+            <b>{t`Note: Manually associated instances may be automatically disassociated from an instance group if the instance is managed by policy rules.`}</b>
+          }
         />
       )}
       {error && (

--- a/awx/ui/src/screens/Instances/Shared/InstanceForm.js
+++ b/awx/ui/src/screens/Instances/Shared/InstanceForm.js
@@ -58,6 +58,12 @@ function InstanceFormFields() {
           label={t`Enable Instance`}
           tooltip={t`Set the instance enabled or disabled. If disabled, jobs will not be assigned to this instance.`}
         />
+        <CheckboxField
+          id="managed-by-policy"
+          name="managed_by_policy"
+          label={t`Managed by Policy`}
+          tooltip={t`Controls whether or not this instance is managed by policy. If enabled, the instance will be available for automatic assignment to and unassignment from instance groups based on policy rules.`}
+        />
       </FormGroup>
     </>
   );
@@ -79,6 +85,7 @@ function InstanceForm({
           node_state: 'installed',
           listener_port: 27199,
           enabled: true,
+          managed_by_policy: true,
         }}
         onSubmit={(values) => {
           handleSubmit(values);

--- a/awx/ui/src/screens/Instances/Shared/InstanceForm.test.js
+++ b/awx/ui/src/screens/Instances/Shared/InstanceForm.test.js
@@ -89,6 +89,7 @@ describe('<InstanceForm />', () => {
     expect(handleSubmit).toBeCalledWith({
       description: 'This is a repeat song',
       enabled: true,
+      managed_by_policy: true,
       hostname: 'new Foo',
       listener_port: 'This is a repeat song',
       node_state: 'installed',


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible/awx/issues/13294 
Fixes https://github.com/ansible/awx/issues/13293

New field in the instances form:

<img width="1472" alt="Screenshot 2023-05-11 at 4 48 32 PM" src="https://github.com/ansible/awx/assets/9889020/10bbad8e-49ec-4544-b65e-f3d66125daa5">

Warning when manually associating instances:

<img width="1304" alt="Screenshot 2023-05-11 at 4 49 57 PM" src="https://github.com/ansible/awx/assets/9889020/614bcef4-d2b7-48db-b944-8e279dfa1864">

Warning when manually disassociating instances:

<img width="953" alt="Screenshot 2023-05-11 at 4 50 38 PM" src="https://github.com/ansible/awx/assets/9889020/3d009d7c-f354-4718-83e0-3290bd5f9194">

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - UI

