### PR TITLE
[troubleshooting] Configurable filtering of high-volume logs

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -67,7 +67,6 @@ __all__ = [
 ]
 
 logger = logging.getLogger('awx.api.generics')
-analytics_logger = logging.getLogger('awx.analytics.performance')
 
 
 class LoggedLoginView(auth_views.LoginView):

--- a/awx/api/permissions.py
+++ b/awx/api/permissions.py
@@ -120,23 +120,17 @@ class ModelAccessPermission(permissions.BasePermission):
         return result
 
     def has_permission(self, request, view, obj=None):
+        response = self.check_permissions(request, view, obj)
         logger.debug(
-            'has_permission(user=%s method=%s data=%r, %s, %r)',
+            'has_permission(user=%s method=%s, %s, %r) returned %r',
             request.user,
             request.method,
-            request.data,
             view.__class__.__name__,
             obj,
+            response,
             extra={'volume_tag': 'rbac'},
         )
-        try:
-            response = self.check_permissions(request, view, obj)
-        except Exception as e:
-            logger.debug('has_permission raised %r', e, exc_info=True, extra={'volume_tag': 'rbac'})
-            raise
-        else:
-            logger.debug('has_permission returned %r', response, extra={'volume_tag': 'rbac'})
-            return response
+        return response
 
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view, obj)

--- a/awx/api/permissions.py
+++ b/awx/api/permissions.py
@@ -120,14 +120,22 @@ class ModelAccessPermission(permissions.BasePermission):
         return result
 
     def has_permission(self, request, view, obj=None):
-        logger.debug('has_permission(user=%s method=%s data=%r, %s, %r)', request.user, request.method, request.data, view.__class__.__name__, obj)
+        logger.debug(
+            'has_permission(user=%s method=%s data=%r, %s, %r)',
+            request.user,
+            request.method,
+            request.data,
+            view.__class__.__name__,
+            obj,
+            extra={'volume_tag': 'rbac'},
+        )
         try:
             response = self.check_permissions(request, view, obj)
         except Exception as e:
-            logger.debug('has_permission raised %r', e, exc_info=True)
+            logger.debug('has_permission raised %r', e, exc_info=True, extra={'volume_tag': 'rbac'})
             raise
         else:
-            logger.debug('has_permission returned %r', response)
+            logger.debug('has_permission returned %r', response, extra={'volume_tag': 'rbac'})
             return response
 
     def has_object_permission(self, request, view, obj):

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -159,7 +159,9 @@ def check_user_access(user, model_class, action, *args, **kwargs):
     access_instance = access_class(user)
     access_method = getattr(access_instance, 'can_%s' % action)
     result = access_method(*args, **kwargs)
-    logger.debug('%s.%s %r returned %r', access_instance.__class__.__name__, getattr(access_method, '__name__', 'unknown'), args, result)
+    logger.debug(
+        '%s.%s %r returned %r', access_instance.__class__.__name__, getattr(access_method, '__name__', 'unknown'), args, result, extra={'volume_tag': 'rbac'}
+    )
     return result
 
 
@@ -171,7 +173,7 @@ def check_user_access_with_errors(user, model_class, action, *args, **kwargs):
     access_instance = access_class(user, save_messages=True)
     access_method = getattr(access_instance, 'can_%s' % action, None)
     result = access_method(*args, **kwargs)
-    logger.debug('%s.%s %r returned %r', access_instance.__class__.__name__, access_method.__name__, args, result)
+    logger.debug('%s.%s %r returned %r', access_instance.__class__.__name__, access_method.__name__, args, result, extra={'volume_tag': 'rbac'})
     return (result, access_instance.messages)
 
 

--- a/awx/main/analytics/analytics_tasks.py
+++ b/awx/main/analytics/analytics_tasks.py
@@ -1,12 +1,7 @@
-# Python
-import logging
-
 # AWX
 from awx.main.analytics.subsystem_metrics import Metrics
 from awx.main.dispatch.publish import task
 from awx.main.dispatch import get_task_queuename
-
-logger = logging.getLogger('awx.main.scheduler')
 
 
 @task(queue=get_task_queuename)

--- a/awx/main/analytics/broadcast_websocket.py
+++ b/awx/main/analytics/broadcast_websocket.py
@@ -88,8 +88,8 @@ class RelayWebsocketStatsManager:
                 await redis_conn.set(self._redis_key, stats_data_str)
 
                 await asyncio.sleep(settings.BROADCAST_WEBSOCKET_STATS_POLL_RATE_SECONDS)
-        except Exception as e:
-            logger.warning(e)
+        except Exception:
+            logger.exception('Error in run loop for relay websocket manager')
             await asyncio.sleep(settings.BROADCAST_WEBSOCKET_STATS_POLL_RATE_SECONDS)
             self.start()
 

--- a/awx/main/analytics/broadcast_websocket.py
+++ b/awx/main/analytics/broadcast_websocket.py
@@ -20,7 +20,7 @@ from django.conf import settings
 BROADCAST_WEBSOCKET_REDIS_KEY_NAME = 'broadcast_websocket_stats'
 
 
-logger = logging.getLogger('awx.analytics.broadcast_websocket')
+logger = logging.getLogger('awx.main.analytics.broadcast_websocket')
 
 
 def dt_to_seconds(dt):

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -579,16 +579,20 @@ register(
 register(
     'LOG_AGGREGATOR_LOGGERS',
     field_class=fields.StringListField,
-    default=['awx', 'activity_stream', 'job_events', 'system_tracking', 'broadcast_websocket'],
-    label=_('Loggers Sending Data to Log Aggregator Form'),
+    default=['awx', 'activity_stream', 'job_events', 'system_tracking', 'job_lifecycle', 'websockets'],
+    label=_('Select Loggers to Enable'),
     help_text=_(
-        'List of loggers that will send HTTP logs to the collector, these can '
-        'include any or all of: \n'
-        'awx - service logs\n'
+        'Enable logging for special tags.\n'
+        'awx - (external) include to send general system logs to external log collector\n'
+        'job_events - (external) callback data from Ansible job events\n'
+        'events - (non-default) system logs related to processing of events\n'
+        'system_tracking - (external) facts gathered from scan jobs\n'
         'activity_stream - activity stream records\n'
-        'job_events - callback data from Ansible job events\n'
-        'system_tracking - facts gathered from scan jobs\n'
-        'broadcast_websocket - errors pertaining to websockets broadcast metrics\n'
+        'system_tasks - (non-default) periodically emitted logs about internal tasks.\n'
+        'performance - (non-default) give internally measured timing data for requests.\n'
+        'websockets - processing of messages to send websockets to clients.\n'
+        'rbac - permission check activity for requests.\n'
+        'metrics - activity recording and saving data for /api/v2/metrics/.'
     ),
     category=_('Logging'),
     category_slug='logging',
@@ -675,22 +679,6 @@ register(
         ' are DEBUG, INFO, WARNING, ERROR, CRITICAL. Messages less severe '
         'than the threshold will be ignored by log handler. (messages under category '
         'awx.anlytics ignore this setting)'
-    ),
-    category=_('Logging'),
-    category_slug='logging',
-)
-register(
-    'LOG_AGGREGATOR_HIGH_VOLUME_ALLOW_LIST',
-    field_class=fields.StringListField,
-    label=_('High Volume DEBUG-level Loggers to Allow'),
-    help_text=_(
-        'Normally these loggers are filtered out, add to this list to emit these logs. '
-        'Choices are [events, system_tasks, websockets, rbac, metrics]. '
-        'events - logs reated to processing of job output. '
-        'system_tasks - periodically emitted logs about internal tasks. '
-        'websockets - processing of messages to send websockets to clients. '
-        'rbac - permission check activity for requests. '
-        'metrics - activity recording and saving data for /api/v2/metrics/.'
     ),
     category=_('Logging'),
     category_slug='logging',

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -585,7 +585,7 @@ register(
         'Enable logging for special tags.\n'
         'awx - (external) include to send general system logs to external log collector\n'
         'job_events - (external) callback data from Ansible job events\n'
-        'events - (non-default) system logs related to processing of events\n'
+        'event_processing - (non-default) system logs related to processing of events\n'
         'system_tracking - (external) facts gathered from scan jobs\n'
         'activity_stream - activity stream records\n'
         'system_tasks - (non-default) periodically emitted logs about internal tasks.\n'

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -680,6 +680,22 @@ register(
     category_slug='logging',
 )
 register(
+    'LOG_AGGREGATOR_HIGH_VOLUME_ALLOW_LIST',
+    field_class=fields.StringListField,
+    label=_('High Volume DEBUG-level Loggers to Allow'),
+    help_text=_(
+        'Normally these loggers are filtered out, add to this list to emit these logs. '
+        'Choices are [events, system_tasks, websockets, rbac, metrics]. '
+        'events - logs reated to processing of job output. '
+        'system_tasks - periodically emitted logs about internal tasks. '
+        'websockets - processing of messages to send websockets to clients. '
+        'rbac - permission check activity for requests. '
+        'metrics - activity recording and saving data for /api/v2/metrics/.'
+    ),
+    category=_('Logging'),
+    category_slug='logging',
+)
+register(
     'LOG_AGGREGATOR_MAX_DISK_USAGE_GB',
     field_class=fields.IntegerField,
     default=1,

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -156,7 +156,7 @@ class CallbackBrokerWorker(BaseWorker):
             for cls, events in self.buff.items():
                 if not events:
                     continue
-                logger.debug(f'{cls.__name__}.objects.bulk_create({len(events)})', extra={'volume_tag': 'events'})
+                logger.debug(f'{cls.__name__}.objects.bulk_create({len(events)})', extra={'volume_tag': 'event_processing'})
                 for e in events:
                     e.modified = now  # this can be set before created because now is set above on line 149
                     if not e.created:

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -156,7 +156,7 @@ class CallbackBrokerWorker(BaseWorker):
             for cls, events in self.buff.items():
                 if not events:
                     continue
-                logger.debug(f'{cls.__name__}.objects.bulk_create({len(events)})')
+                logger.debug(f'{cls.__name__}.objects.bulk_create({len(events)})', extra={'volume_tag': 'events'})
                 for e in events:
                     e.modified = now  # this can be set before created because now is set above on line 149
                     if not e.created:

--- a/awx/main/dispatch/worker/task.py
+++ b/awx/main/dispatch/worker/task.py
@@ -73,7 +73,7 @@ class TaskWorker(BaseWorker):
                 log_extra = f' took {time_publish:.4f} to ack, {time_waiting:.4f} in local dispatcher'
                 logger_method = logger.info
         # don't print kwargs, they often contain launch-time secrets
-        logger_method(f'task {uuid} starting {task}(*{args}){log_extra}')
+        logger_method(f'task {uuid} starting {task}(*{args}){log_extra}', extra={'volume_tag': 'system_tasks'})
 
         return _call(*args, **kwargs)
 

--- a/awx/main/management/commands/run_ws_heartbeat.py
+++ b/awx/main/management/commands/run_ws_heartbeat.py
@@ -32,7 +32,7 @@ class Command(BaseCommand):
     def do_heartbeat_loop(self):
         while True:
             with pg_bus_conn() as conn:
-                logger.debug('Sending heartbeat')
+                logger.debug('Sending heartbeat', extra={'volume_tag': 'system_tasks'})
                 conn.notify('web_ws_heartbeat', self.construct_payload())
             time.sleep(settings.BROADCAST_WEBSOCKET_BEACON_FROM_WEB_RATE_SECONDS)
 

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -58,7 +58,7 @@ class TimingMiddleware(threading.local, MiddlewareMixin):
             response['X-API-Profile-File'] = self.prof.stop()
         perf_logger.debug(
             f'request: {request}, response_time: {response["X-API-Total-Time"]}',
-            extra=dict(python_objects=dict(request=request, response=response, X_API_TOTAL_TIME=response["X-API-Total-Time"])),
+            extra=dict(python_objects=dict(request=request, response=response, X_API_TOTAL_TIME=response["X-API-Total-Time"]), volume_tag='performance'),
         )
         return response
 

--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -401,7 +401,7 @@ class BasePlaybookEvent(CreatedModifiedModel):
             if value != getattr(self, field):
                 setattr(self, field, value)
         if settings.LOG_AGGREGATOR_ENABLED:
-            analytics_logger.info('Event data saved.', extra=dict(python_objects=dict(job_event=self)))
+            analytics_logger.info('Event data saved.', extra=dict(python_objects=dict(job_event=self), volume_tag='job_events'))
 
     @classmethod
     def create_from_data(cls, **kwargs):
@@ -866,7 +866,7 @@ class AdHocCommandEvent(BaseCommandEvent):
         if isinstance(res, dict) and res.get('changed', False):
             self.changed = True
 
-        analytics_logger.info('Event data saved.', extra=dict(python_objects=dict(job_event=self)))
+        analytics_logger.info('Event data saved.', extra=dict(python_objects=dict(job_event=self), volume_tag='job_events'))
 
 
 class UnpartitionedAdHocCommandEvent(AdHocCommandEvent):

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1574,12 +1574,7 @@ class UnifiedJob(
         return False
 
     def log_lifecycle(self, state, blocked_by=None):
-        extra = {
-            'type': self._meta.model_name,
-            'task_id': self.id,
-            'state': state,
-            'work_unit_id': self.work_unit_id,
-        }
+        extra = {'type': self._meta.model_name, 'task_id': self.id, 'state': state, 'work_unit_id': self.work_unit_id, 'volume_tag': 'job_lifecycle'}
         if self.name:
             extra["task_name"] = self.name
         if state == "blocked" and blocked_by:

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -112,11 +112,11 @@ class TaskBase:
             current_time = time.time()
             time_last_recorded = current_time - self.subsystem_metrics.decode(f"{self.prefix}_recorded_timestamp")
             if time_last_recorded > settings.SUBSYSTEM_METRICS_TASK_MANAGER_RECORD_INTERVAL:
-                logger.debug(f"recording {self.prefix} metrics, last recorded {time_last_recorded} seconds ago")
+                logger.debug(f"recording {self.prefix} metrics, last recorded {time_last_recorded} seconds ago", extra={'volume_tag': 'metrics'})
                 self.subsystem_metrics.set(f"{self.prefix}_recorded_timestamp", current_time)
                 self.subsystem_metrics.pipe_execute()
             else:
-                logger.debug(f"skipping recording {self.prefix} metrics, last recorded {time_last_recorded} seconds ago")
+                logger.debug(f"skipping recording {self.prefix} metrics, last recorded {time_last_recorded} seconds ago", extra={'volume_tag': 'metrics'})
 
     def record_aggregate_metrics_and_exit(self, *args):
         self.record_aggregate_metrics()
@@ -128,9 +128,9 @@ class TaskBase:
             with advisory_lock(f"{self.prefix}_lock", wait=False) as acquired:
                 with transaction.atomic():
                     if acquired is False:
-                        logger.debug(f"Not running {self.prefix} scheduler, another task holds lock")
+                        logger.debug(f"Not running {self.prefix} scheduler, another task holds lock", extra={'volume_tag': 'system_tasks'})
                         return
-                    logger.debug(f"Starting {self.prefix} Scheduler")
+                    logger.debug(f"Starting {self.prefix} Scheduler", extra={'volume_tag': 'system_tasks'})
                     # if sigterm due to timeout, still record metrics
                     signal.signal(signal.SIGTERM, self.record_aggregate_metrics_and_exit)
                     self._schedule()
@@ -139,7 +139,7 @@ class TaskBase:
                 if self.prefix == "task_manager":
                     self.subsystem_metrics.set(f"{self.prefix}_commit_seconds", time.time() - commit_start)
                 self.record_aggregate_metrics()
-                logger.debug(f"Finishing {self.prefix} Scheduler")
+                logger.debug(f"Finishing {self.prefix} Scheduler", extra={'volume_tag': 'system_tasks'})
 
 
 class WorkflowManager(TaskBase):

--- a/awx/main/scheduler/task_manager_models.py
+++ b/awx/main/scheduler/task_manager_models.py
@@ -277,7 +277,6 @@ class TaskManagerModels:
             from awx.main.models import UnifiedJob
 
             if instance_group_queryset is not None:
-                logger.debug("******************INSTANCE GROUP QUERYSET PASSED -- FILTERING TASKS ****************************")
                 # Sometimes things like the serializer pass a queryset that looks at not all instance groups. in this case,
                 # we also need to filter the tasks we look at
                 tasks = UnifiedJob.objects.filter(status__in=task_status_filter_list, instance_group__in=[ig.id for ig in instance_group_queryset]).only(

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -422,6 +422,7 @@ def emit_activity_stream_change(instance):
             object1=instance.object1,
             object2=instance.object2,
             summary_fields=summary_fields,
+            volume_tag='activity_stream',
         ),
     )
 

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -508,7 +508,6 @@ def inspect_execution_nodes(instance_list):
 
 @task(queue=get_task_queuename, bind_kwargs=['dispatch_time', 'worker_tasks'])
 def cluster_node_heartbeat(dispatch_time=None, worker_tasks=None):
-    logger.debug("Cluster node heartbeat task.")
     nowtime = now()
     instance_list = list(Instance.objects.filter(node_state__in=(Instance.States.READY, Instance.States.UNAVAILABLE, Instance.States.INSTALLED)))
     this_inst = None
@@ -618,7 +617,6 @@ def awx_receptor_workunit_reaper():
     """
     if not settings.RECEPTOR_RELEASE_WORK:
         return
-    logger.debug("Checking for unreleased receptor work units")
     receptor_ctl = get_receptor_ctl()
     receptor_work_list = receptor_ctl.simple_command("work list")
 
@@ -656,14 +654,13 @@ def awx_k8s_reaper():
 def awx_periodic_scheduler():
     with advisory_lock('awx_periodic_scheduler_lock', wait=False) as acquired:
         if acquired is False:
-            logger.debug("Not running periodic scheduler, another task holds lock")
+            logger.debug("Not running periodic scheduler, another task holds lock", extra={'volume_tag': 'system_tasks'})
             return
-        logger.debug("Starting periodic scheduler")
 
         run_now = now()
         state = TowerScheduleState.get_solo()
         last_run = state.schedule_last_run
-        logger.debug("Last scheduler run was: %s", last_run)
+        logger.debug(f"Starting periodic scheduler, last run was {last_run}", extra={'volume_tag': 'system_tasks'})
         state.schedule_last_run = run_now
         state.save()
 

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -63,7 +63,7 @@ def record_is_blocked(record):
 
 
 class ExternalLoggerEnabled(Filter):
-    enabled_loggers = FieldFromSettings('LOG_AGGREGATOR_LOGGERS')
+    dynamic_loggers = FieldFromSettings('LOG_AGGREGATOR_LOGGERS')
     enabled_flag = FieldFromSettings('LOG_AGGREGATOR_ENABLED')
 
     def __init__(self, **kwargs):
@@ -83,47 +83,43 @@ class ExternalLoggerEnabled(Filter):
         False - should not be logged
         True - should be logged
         """
-        # Do not send exceptions to external logger
+        # Do not send logging exceptions to external logger
         if record_is_blocked(record):
             return False
+
         # General enablement
         if not self.enabled_flag:
             return False
 
-        # Logger type enablement
-        loggers = self.enabled_loggers
-        if not loggers:
-            return False
-        if record.name.startswith('awx.analytics'):
-            base_path, headline_name = record.name.rsplit('.', 1)
-            return bool(headline_name in loggers)
-        else:
-            if '.' in record.name:
-                base_name, trailing_path = record.name.split('.', 1)
-            else:
-                base_name = record.name
-            return bool(base_name in loggers)
+        # External log handler uses this filter AND the dynamic level filter
+        # we send general server logs only if "awx" is in LOG_AGGREGATOR_LOGGERS
+        return bool(record.name.startswith('awx.analytics') or ('awx' in self.dynamic_loggers))
 
 
 class DynamicLevelFilter(Filter):
-    allow_list = FieldFromSettings('LOG_AGGREGATOR_HIGH_VOLUME_ALLOW_LIST')
+    dynamic_loggers = FieldFromSettings('LOG_AGGREGATOR_LOGGERS')
+    dynamic_level = FieldFromSettings('LOG_AGGREGATOR_LEVEL')
 
     def filter(self, record):
-        """Filters out logs that have a level below the threshold defined
-        by the databse setting LOG_AGGREGATOR_LEVEL
         """
+        Filters out logs that
+        have a level below the threshold defined by the databse setting LOG_AGGREGATOR_LEVEL
+        or have a volume_tag which is not in LOG_AGGREGATOR_LOGGERS
+        """
+        # Filter noisy logs that are not allowed by LOG_AGGREGATOR_LOGGERS
+        if hasattr(record, 'volume_tag'):
+            if record.volume_tag not in self.dynamic_loggers:
+                return False
+
+        # Filter according to global log level from database settings
         if record_is_blocked(record):
             # Fine to write denied loggers to file, apply default filtering level
             cutoff_level = logging.WARNING
         else:
             try:
-                cutoff_level = logging._nameToLevel[settings.LOG_AGGREGATOR_LEVEL]
+                cutoff_level = logging._nameToLevel[self.dynamic_level]
             except Exception:
                 cutoff_level = logging.WARNING
-
-        if hasattr(record, 'volume_tag'):
-            if record.volume_tag not in self.allow_list:
-                return False
 
         return bool(record.levelno >= cutoff_level)
 

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -106,6 +106,8 @@ class ExternalLoggerEnabled(Filter):
 
 
 class DynamicLevelFilter(Filter):
+    allow_list = FieldFromSettings('LOG_AGGREGATOR_HIGH_VOLUME_ALLOW_LIST')
+
     def filter(self, record):
         """Filters out logs that have a level below the threshold defined
         by the databse setting LOG_AGGREGATOR_LEVEL
@@ -118,6 +120,10 @@ class DynamicLevelFilter(Filter):
                 cutoff_level = logging._nameToLevel[settings.LOG_AGGREGATOR_LEVEL]
             except Exception:
                 cutoff_level = logging.WARNING
+
+        if hasattr(record, 'volume_tag'):
+            if record.volume_tag not in self.allow_list:
+                return False
 
         return bool(record.levelno >= cutoff_level)
 

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -34,13 +34,14 @@ class FieldFromSettings(object):
         over value in settings
     """
 
-    def __init__(self, setting_name):
+    def __init__(self, setting_name, default=None):
         self.setting_name = setting_name
+        self.default = default
 
     def __get__(self, instance, type=None):
         if self.setting_name in getattr(instance, 'settings_override', {}):
             return instance.settings_override[self.setting_name]
-        return getattr(settings, self.setting_name, None)
+        return getattr(settings, self.setting_name, self.default)
 
     def __set__(self, instance, value):
         if value is None:
@@ -63,8 +64,8 @@ def record_is_blocked(record):
 
 
 class ExternalLoggerEnabled(Filter):
-    dynamic_loggers = FieldFromSettings('LOG_AGGREGATOR_LOGGERS')
-    enabled_flag = FieldFromSettings('LOG_AGGREGATOR_ENABLED')
+    dynamic_loggers = FieldFromSettings('LOG_AGGREGATOR_LOGGERS', default=())
+    enabled_flag = FieldFromSettings('LOG_AGGREGATOR_ENABLED', default=False)
 
     def __init__(self, **kwargs):
         super(ExternalLoggerEnabled, self).__init__()
@@ -97,8 +98,8 @@ class ExternalLoggerEnabled(Filter):
 
 
 class DynamicLevelFilter(Filter):
-    dynamic_loggers = FieldFromSettings('LOG_AGGREGATOR_LOGGERS')
-    dynamic_level = FieldFromSettings('LOG_AGGREGATOR_LEVEL')
+    dynamic_loggers = FieldFromSettings('LOG_AGGREGATOR_LOGGERS', default=())
+    dynamic_level = FieldFromSettings('LOG_AGGREGATOR_LEVEL', default='INFO')
 
     def filter(self, record):
         """

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -796,6 +796,7 @@ LOG_AGGREGATOR_ACTION_MAX_DISK_USAGE_GB = 1  # Action queue
 LOG_AGGREGATOR_MAX_DISK_USAGE_PATH = '/var/lib/awx'
 LOG_AGGREGATOR_RSYSLOGD_DEBUG = False
 LOG_AGGREGATOR_RSYSLOGD_ERROR_LOG_FILE = '/var/log/tower/rsyslog.err'
+LOG_AGGREGATOR_HIGH_VOLUME_ALLOW_LIST = []
 API_400_ERROR_LOG_FORMAT = 'status {status_code} received by user {user_name} attempting to access {url_path} from {remote_addr}'
 
 ASGI_APPLICATION = "awx.main.routing.application"
@@ -855,26 +856,23 @@ LOGGING = {
         'awx.main': {'handlers': ['null']},
         'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver'], 'level': 'INFO'},  # very noisey debug-level logs
         'awx.main.dispatch': {'handlers': ['dispatcher']},
-        'awx.main.consumers': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'INFO'},
+        'awx.main.consumers': {'handlers': ['console', 'file', 'tower_warnings']},
         'awx.main.rsyslog_configurer': {'handlers': ['rsyslog_configurer']},
         'awx.main.cache_clear': {'handlers': ['cache_clear']},
         'awx.main.ws_heartbeat': {'handlers': ['ws_heartbeat']},
         'awx.main.wsrelay': {'handlers': ['wsrelay']},
         'awx.main.commands.inventory_import': {'handlers': ['inventory_import'], 'propagate': False},
         'awx.main.tasks': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
-        'awx.main.analytics': {'handlers': ['task_system', 'external_logger', 'console'], 'level': 'INFO', 'propagate': False},
+        'awx.main.analytics': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
         'awx.main.scheduler': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
-        'awx.main.access': {'level': 'INFO'},  # very verbose debug-level logs
-        'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
-        'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
-        'awx.analytics.broadcast_websocket': {'handlers': ['console', 'file', 'wsrelay', 'external_logger'], 'level': 'INFO', 'propagate': False},
-        'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
-        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'level': 'DEBUG', 'propagate': False},
-        'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'social': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
+        'awx.analytics.broadcast_websocket': {'handlers': ['console', 'file', 'wsrelay', 'external_logger'], 'propagate': False},
+        'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'propagate': False},
+        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'propagate': False},
+        'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings']},
+        'social': {'handlers': ['console', 'file', 'tower_warnings']},
+        'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
+        'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings']},
     },
 }
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -854,9 +854,8 @@ LOGGING = {
         'awx.conf': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.conf.settings': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.main': {'handlers': ['null']},
-        'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver'], 'level': 'INFO'},  # very noisey debug-level logs
+        'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver']},  # see volume_tag "events"
         'awx.main.dispatch': {'handlers': ['dispatcher']},
-        'awx.main.consumers': {'handlers': ['console', 'file', 'tower_warnings']},
         'awx.main.rsyslog_configurer': {'handlers': ['rsyslog_configurer']},
         'awx.main.cache_clear': {'handlers': ['cache_clear']},
         'awx.main.ws_heartbeat': {'handlers': ['ws_heartbeat']},
@@ -865,10 +864,12 @@ LOGGING = {
         'awx.main.tasks': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
         'awx.main.analytics': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
         'awx.main.scheduler': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
-        'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
-        'awx.analytics.broadcast_websocket': {'handlers': ['console', 'file', 'wsrelay', 'external_logger'], 'propagate': False},
-        'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'propagate': False},
-        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'propagate': False},
+        # awx.analytics.* are privileged for external logger, in addition to those listed, these have no customizations
+        # - awx.analytics.performance
+        # - awx.analytics.activity_stream
+        'awx.analytics.job_lifecycle': {'handlers': ['console', 'external_logger', 'job_lifecycle'], 'propagate': False},
+        'awx.analytics.job_events': {'handlers': ['external_logger'], 'propagate': False},
+        'awx.analytics.system_tracking': {'handlers': ['external_logger'], 'propagate': False},
         'django_auth_ldap': {'handlers': ['console', 'file', 'tower_warnings']},
         'social': {'handlers': ['console', 'file', 'tower_warnings']},
         'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings']},


### PR DESCRIPTION
##### SUMMARY
The pitch here is to make DEBUG level logging useful.

Before this, if you switched log level to debug, you got swamped with periodic messages. After this, the default behavior will be relatively quiet, and then you will have to enable certain things with the new setting to get the unusually noisy logs again.

This still needs some UI work to show the setting in the UI and allow for editing it there.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

