### PR TITLE
Move pid files and sockets to /tmp

### DIFF
--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -119,10 +119,10 @@ def construct_rsyslog_conf_template(settings=settings):
 def reconfigure_rsyslog():
     tmpl = construct_rsyslog_conf_template()
     # Write config to a temp file then move it to preserve atomicity
-    with tempfile.TemporaryDirectory(dir='/var/lib/awx/rsyslog/', prefix='rsyslog-conf-') as temp_dir:
+    with tempfile.TemporaryDirectory(dir='/tmp/', prefix='rsyslog-conf-') as temp_dir:
         path = temp_dir + '/rsyslog.conf.temp'
         with open(path, 'w') as f:
             os.chmod(path, 0o640)
             f.write(tmpl + '\n')
-        shutil.move(path, '/var/lib/awx/rsyslog/rsyslog.conf')
+        shutil.move(path, '/tmp/rsyslog.conf')
     supervisor_service_command(command='restart', service='awx-rsyslogd')

--- a/tools/ansible/roles/dockerfile/files/launch_awx_rsyslog.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx_rsyslog.sh
@@ -20,7 +20,7 @@ wait-for-migrations
 # This file will be re-written when the dispatcher calls reconfigure_rsyslog(),
 # but it needs to exist when supervisor initially starts rsyslog to prevent the
 # container from crashing. This was the most minimal config I could get working.
-cat << EOF > /var/lib/awx/rsyslog/rsyslog.conf
+cat << EOF > /tmp/rsyslog.conf
 action(type="omfile" file="/dev/null")
 EOF
 

--- a/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
@@ -3,10 +3,10 @@ nodaemon = True
 umask = 022
 logfile = /dev/stdout
 logfile_maxbytes = 0
-pidfile = /var/run/supervisor/supervisor.rsyslog.pid
+pidfile = /tmp/supervisor.rsyslog.pid
 
 [program:awx-rsyslogd]
-command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
+command = rsyslogd -n -i /tmp/rsyslog.pid -f /tmp/rsyslog.conf
 autorestart = true
 startsecs = 30
 stopasgroup=true
@@ -22,7 +22,7 @@ command = make run-rsyslog-configurer
 directory = /awx_devel
 {% else %}
 command = awx-manage run_rsyslog_configurer
-directory = /var/lib/awx
+directory = /tmp
 {% endif %}
 autorestart = true
 startsecs = 30
@@ -60,10 +60,10 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [unix_http_server]
-file=/var/run/supervisor/supervisor.rsyslog.sock
+file=/tmp/supervisor.rsyslog.sock
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor/supervisor.rsyslog.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///tmp/supervisor.rsyslog.sock ; use a unix:// URL  for a unix socket
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
@@ -3,7 +3,7 @@ nodaemon = True
 umask = 022
 logfile = /dev/stdout
 logfile_maxbytes = 0
-pidfile = /var/run/supervisor/supervisor.task.pid
+pidfile = /tmp/supervisor.task.pid
 
 [program:dispatcher]
 {% if kube_dev | bool %}
@@ -83,10 +83,10 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [unix_http_server]
-file=/var/run/supervisor/supervisor.task.sock
+file=/tmp/supervisor.task.sock
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor/supervisor.task.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///tmp/supervisor.task.sock ; use a unix:// URL  for a unix socket
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/tools/ansible/roles/dockerfile/templates/supervisor_web.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_web.conf.j2
@@ -3,7 +3,7 @@ nodaemon = True
 umask = 022
 logfile = /dev/stdout
 logfile_maxbytes = 0
-pidfile = /var/run/supervisor/supervisor.web.pid
+pidfile = /tmp/supervisor.web.pid
 
 [program:nginx]
 {% if kube_dev | bool %}
@@ -115,10 +115,10 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [unix_http_server]
-file=/var/run/supervisor/supervisor.web.sock
+file=/tmp/supervisor.web.sock
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor/supervisor.web.sock ; use a unix:// URL  for a unix socket
+serverurl=unix:///tmp/supervisor.web.sock ; use a unix:// URL  for a unix socket
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
Fixes #13951

Users without root access didn't have permission to `/var/run` and `/var/lib/awx`

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`/var/lib/awx/rsyslog`, `/var/run/supervisor`,  and `/var/run/awx-rsyslog` are owned by `root:root` and aren't world writable, so we can't create the sockets and temp files there unless we're the root user or in the root group. While `/tmp` isn't necessarily a conventional place to put these things (except `tempfile.TemporaryDirectory(...)` which probably should've always been there), we need a world writable place to create these files if we want to support non-root access.

An alternative could be to `chmod` `/var/lib/awx/rsyslog`, `/var/run/supervisor`, and `/var/run/awx-rsyslog` to be world writable.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.2.1.dev22+gfa05f55512.d20230519
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

To reproduce you just need to set the security context to a non-root user and group. For example:

```
---
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx
  namespace: awx
spec:
  security_context_settings:
    runAsUser: 1000
    runAsGroup: 1000
```

As a side note I noticed that the awx-web pod doesn't get the security context applied, this seems to be a separate bug that I'll file an issue for separately. 

