### PR TITLE
Reduce connection usage by conventional means

### DIFF
--- a/awx/main/dispatch/periodic.py
+++ b/awx/main/dispatch/periodic.py
@@ -33,14 +33,14 @@ class Scheduler(Scheduler):
                     logger.warning(f'periodic beat exiting gracefully pid:{pid}')
                     raise SystemExit()
                 try:
-                    for conn in connections.all():
-                        # If the database connection has a hiccup, re-establish a new
-                        # connection
-                        conn.close_if_unusable_or_obsolete()
                     set_guid(generate_guid())
                     self.run_pending()
                 except Exception:
                     logger.exception('encountered an error while scheduling periodic tasks')
+                for conn in connections.all():
+                    # If the database connection has a hiccup, re-establish a new
+                    # connection
+                    conn.close()
                 time.sleep(idle_seconds)
 
         process = Process(target=run)

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -146,6 +146,7 @@ class AWXConsumerRedis(AWXConsumerBase):
 
         while True:
             logger.debug(f'{os.getpid()} is alive')
+            db.connection.close()
             time.sleep(60)
 
 

--- a/awx/main/management/commands/run_cache_clear.py
+++ b/awx/main/management/commands/run_cache_clear.py
@@ -2,6 +2,7 @@ import logging
 import json
 
 from django.core.management.base import BaseCommand
+
 from awx.main.dispatch import pg_bus_conn
 from awx.main.dispatch.worker.task import TaskWorker
 
@@ -18,7 +19,7 @@ class Command(BaseCommand):
 
     def handle(self, *arg, **options):
         try:
-            with pg_bus_conn(new_connection=True) as conn:
+            with pg_bus_conn() as conn:
                 conn.listen("tower_settings_change")
                 for e in conn.events(yield_timeouts=True):
                     if e is not None:

--- a/awx/main/management/commands/run_heartbeet.py
+++ b/awx/main/management/commands/run_heartbeet.py
@@ -7,6 +7,7 @@ import sys
 
 from django.core.management.base import BaseCommand
 from django.conf import settings
+from django.db import connection
 
 from awx.main.dispatch import pg_bus_conn
 
@@ -53,7 +54,7 @@ class Command(BaseCommand):
         return json.dumps(payload)
 
     def notify_listener_and_exit(self, *args):
-        with pg_bus_conn(new_connection=False) as conn:
+        with pg_bus_conn() as conn:
             conn.notify('web_heartbeet', self.construct_payload(action='offline'))
         sys.exit(0)
 
@@ -62,6 +63,7 @@ class Command(BaseCommand):
             with pg_bus_conn() as conn:
                 logger.debug('Sending heartbeat')
                 conn.notify('web_heartbeet', self.construct_payload())
+            connection.close()
             time.sleep(settings.BROADCAST_WEBSOCKET_BEACON_FROM_WEB_RATE_SECONDS)
 
     def handle(self, *arg, **options):

--- a/awx/main/management/commands/run_heartbeet.py
+++ b/awx/main/management/commands/run_heartbeet.py
@@ -58,11 +58,11 @@ class Command(BaseCommand):
         sys.exit(0)
 
     def do_hearbeat_loop(self):
-        with pg_bus_conn(new_connection=True) as conn:
-            while True:
+        while True:
+            with pg_bus_conn() as conn:
                 logger.debug('Sending heartbeat')
                 conn.notify('web_heartbeet', self.construct_payload())
-                time.sleep(settings.BROADCAST_WEBSOCKET_BEACON_FROM_WEB_RATE_SECONDS)
+            time.sleep(settings.BROADCAST_WEBSOCKET_BEACON_FROM_WEB_RATE_SECONDS)
 
     def handle(self, *arg, **options):
         self.print_banner()

--- a/awx/main/management/commands/run_rsyslog_configurer.py
+++ b/awx/main/management/commands/run_rsyslog_configurer.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
 
     def handle(self, *arg, **options):
         try:
-            with pg_bus_conn(new_connection=True) as conn:
+            with pg_bus_conn() as conn:
                 conn.listen("rsyslog_configurer")
                 # reconfigure rsyslog on start up
                 reconfigure_rsyslog()


### PR DESCRIPTION
##### SUMMARY
This reduces the number of connections used by the application. We can go over each here...

 - dispatcher main process close connection before starting its pg_notify listen (because the listening uses a _separate_ connection)
 - dispatcher workers close connection before listening to IPC queue for messages from main process
 - dispatcher periodic scheduler close connection before entering its `time.sleep` line
 - callback receiver closes connection before its 60 second sleep :hugs: 
 - Do not use a separate connection for run_clear_cache listening / ORM actions :hugs: 
 - Do not use a separate connection for run_rsyslog_configurer.py listening / ORM actions :hugs: 

I have marked the "safe" changes with :hugs: , with the intent that they can be backported, if desired.

What makes something safe? Take run_clear_cache, for example. This _consolidates_ 2 connections being used by a single process (no crazy threading issues). Since it will remain as a long-lived connection, there's no real trade-off. The safe changes get a benefit, but no apparent negative.

I've tried to put all "safe" changes in the first commit.

What makes something not-safe? If it results in re-opening the connection, then I'm calling it not safe. Closing, and then re-opening a connection results in lower memory use, but more overhead of re-opening the connection later, which is churn on the postgres server. Perhaps using pgbouncer can solve this problem as well, it's not yet known. On balance I am still pretty sure this is a good idea. After all, this behavior is _already_ what uWSGI does.

This includes and replaces https://github.com/ansible/awx/pull/13953

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

