### PR TITLE
[cleanup] Move websockets emit function to utils

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -6,7 +6,7 @@ import logging
 from django.conf import settings
 from django.apps import apps
 
-from awx.main.consumers import emit_channel_notification
+from awx.main.utils.websockets import emit_websocket_payload
 from awx.main.utils import is_testing
 
 root_key = settings.SUBSYSTEM_METRICS_REDIS_KEY_PREFIX
@@ -310,7 +310,7 @@ class Metrics:
                 }
                 # store the serialized data locally as well, so that load_other_metrics will read it
                 self.conn.set(root_key + '_instance_' + self.instance_name, serialized_metrics)
-                emit_channel_notification("metrics", payload)
+                emit_websocket_payload("metrics", payload)
 
                 self.previous_send_metrics.set(current_time)
                 self.previous_send_metrics.store_value(self.conn)

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -15,11 +15,11 @@ import psutil
 
 import redis
 
-from awx.main.consumers import emit_channel_notification
 from awx.main.models import JobEvent, AdHocCommandEvent, ProjectUpdateEvent, InventoryUpdateEvent, SystemJobEvent, UnifiedJob
 from awx.main.constants import ACTIVE_STATES
 from awx.main.models.events import emit_event_detail
 from awx.main.utils.profiling import AWXProfiler
+from awx.main.utils.websockets import emit_websocket_payload
 import awx.main.analytics.subsystem_metrics as s_metrics
 from .base import BaseWorker
 
@@ -250,7 +250,7 @@ class CallbackBrokerWorker(BaseWorker):
                         # closed. don't actually persist them to the database; we
                         # just use them to report `summary` websocket events as an
                         # approximation for when a job is "done"
-                        emit_channel_notification('jobs-summary', dict(group_name='jobs', unified_job_id=job_identifier, final_counter=final_counter))
+                        emit_websocket_payload('jobs-summary', dict(group_name='jobs', unified_job_id=job_identifier, final_counter=final_counter))
 
                         if notification_trigger_event:
                             job_stats_wrapup(job_identifier)

--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -17,12 +17,12 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.encoding import force_str
 
 from awx.api.versioning import reverse
-from awx.main import consumers
 from awx.main.fields import JSONBlob
 from awx.main.managers import DeferJobCreatedManager
 from awx.main.constants import MINIMAL_EVENTS
 from awx.main.models.base import CreatedModifiedModel
 from awx.main.utils import ignore_inventory_computed_fields, camelcase_to_underscore
+from awx.main.utils.websockets import emit_websocket_payload
 
 analytics_logger = logging.getLogger('awx.analytics.job_events')
 
@@ -78,7 +78,7 @@ def emit_event_detail(event):
         url = '/api/v2/ad_hoc_command_events/{}'.format(event.id)
     group = camelcase_to_underscore(cls.__name__) + 's'
     timestamp = event.created.isoformat()
-    consumers.emit_channel_notification(
+    emit_websocket_payload(
         '-'.join([group, str(getattr(event, relation))]),
         {
             'id': event.id,

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -29,7 +29,6 @@ from rest_framework.exceptions import ParseError
 # AWX
 from awx.api.versioning import reverse
 from awx.main.constants import CLOUD_PROVIDERS
-from awx.main.consumers import emit_channel_notification
 from awx.main.fields import (
     ImplicitRoleField,
     SmartFilterField,
@@ -54,6 +53,7 @@ from awx.main.utils import _inventory_updates
 from awx.main.utils.safe_yaml import sanitize_jinja
 from awx.main.utils.execution_environments import to_container_path, get_control_plane_execution_environment
 from awx.main.utils.licensing import server_product_name
+from awx.main.utils.websockets import emit_websocket_payload
 
 
 __all__ = ['Inventory', 'Host', 'Group', 'InventorySource', 'InventoryUpdate', 'SmartInventoryMembership', 'HostMetric', 'HostMetricSummaryMonthly']
@@ -428,7 +428,7 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin):
 
     def websocket_emit_status(self, status):
         connection.on_commit(
-            lambda: emit_channel_notification('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': self.id, 'status': status})
+            lambda: emit_websocket_payload('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': self.id, 'status': status})
         )
 
     @property

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -22,7 +22,7 @@ from awx.main.fields import OrderedManyToManyField
 from awx.main.models.base import PrimordialModel
 from awx.main.models.jobs import LaunchTimeConfig
 from awx.main.utils import ignore_inventory_computed_fields
-from awx.main.consumers import emit_channel_notification
+from awx.main.utils.websockets import emit_websocket_payload
 
 import pytz
 
@@ -292,7 +292,7 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         changed = self.update_computed_fields_no_save()
         if not changed:
             return
-        emit_channel_notification('schedules-changed', dict(id=self.id, group_name='schedules'))
+        emit_websocket_payload('schedules-changed', dict(id=self.id, group_name='schedules'))
         # Must save self here before calling unified_job_template computed fields
         # in order for that method to be correct
         # by adding modified to update fields, we avoid updating modified time

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -51,10 +51,10 @@ from awx.main.utils.common import (
     get_capacity_type,
 )
 from awx.main.utils.encryption import encrypt_dict, decrypt_field
+from awx.main.utils.websockets import emit_websocket_payload
 from awx.main.utils import polymorphic
 from awx.main.constants import ACTIVE_STATES, CAN_CANCEL, JOB_VARIABLE_PREFIXES
 from awx.main.redact import UriCleaner, REPLACE_STR
-from awx.main.consumers import emit_channel_notification
 from awx.main.fields import AskForField, OrderedManyToManyField, JSONBlob
 
 __all__ = ['UnifiedJobTemplate', 'UnifiedJob', 'StdoutMaxBytesExceeded']
@@ -1310,12 +1310,12 @@ class UnifiedJob(
             status_data['group_name'] = 'jobs'
             if getattr(self, 'unified_job_template_id', None):
                 status_data['unified_job_template_id'] = self.unified_job_template_id
-            emit_channel_notification('jobs-status_changed', status_data)
+            emit_websocket_payload('jobs-status_changed', status_data)
 
             if self.spawned_by_workflow:
                 status_data['group_name'] = "workflow_events"
                 status_data['workflow_job_template_id'] = self.unified_job_template.id
-                emit_channel_notification('workflow_events-' + str(self.workflow_job_id), status_data)
+                emit_websocket_payload('workflow_events-' + str(self.workflow_job_id), status_data)
         except IOError:  # includes socket errors
             logger.exception('%s failed to emit channel msg about status change', self.log_format)
 

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -55,6 +55,7 @@ from awx.main.models import (
     ROLE_SINGLETON_SYSTEM_ADMINISTRATOR,
 )
 from awx.main.constants import CENSOR_VALUE
+from awx.main.utils.websockets import emit_websocket_payload
 from awx.main.utils import model_instance_diff, model_to_dict, camelcase_to_underscore, get_current_apps
 from awx.main.utils import ignore_inventory_computed_fields, ignore_inventory_group_removal, _inventory_updates
 from awx.main.tasks.system import update_inventory_computed_fields, handle_removed_image
@@ -62,8 +63,6 @@ from awx.main.fields import (
     is_implicit_parent,
     update_role_parentage_for_instance,
 )
-
-from awx.main import consumers
 
 from awx.conf.utils import conf_to_dict
 
@@ -664,7 +663,7 @@ def save_user_session_membership(sender, **kwargs):
             Session.objects.filter(session_key__in=[membership.session_id]).delete()
             membership.delete()
         if len(expired):
-            consumers.emit_channel_notification('control-limit_reached_{}'.format(user_id), dict(group_name='control', reason='limit_reached'))
+            emit_websocket_payload('control-limit_reached_{}'.format(user_id), dict(group_name='control', reason='limit_reached'))
 
 
 @receiver(post_save, sender=OAuth2AccessToken)

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -62,8 +62,8 @@ from awx.main.utils.common import (
 
 from awx.main.utils.reload import stop_local_services
 from awx.main.utils.pglock import advisory_lock
+from awx.main.utils.websockets import emit_websocket_payload
 from awx.main.tasks.receptor import get_receptor_ctl, worker_info, worker_cleanup, administrative_workunit_reaper, write_receptor_config
-from awx.main.consumers import emit_channel_notification
 from awx.main import analytics
 from awx.conf import settings_registry
 from awx.main.analytics.subsystem_metrics import Metrics
@@ -707,7 +707,7 @@ def awx_periodic_scheduler():
                 )
                 new_unified_job.save(update_fields=['status', 'job_explanation'])
                 new_unified_job.websocket_emit_status("failed")
-            emit_channel_notification('schedules-changed', dict(id=schedule.id, group_name="schedules"))
+            emit_websocket_payload('schedules-changed', dict(id=schedule.id, group_name="schedules"))
         state.save()
 
 
@@ -843,7 +843,7 @@ def delete_inventory(inventory_id, user_id, retries=5):
             for host in i.hosts.iterator():
                 host.job_events_as_primary_host.update(host=None)
             i.delete()
-            emit_channel_notification('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': inventory_id, 'status': 'deleted'})
+            emit_websocket_payload('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': inventory_id, 'status': 'deleted'})
             logger.debug('Deleted inventory {} as user {}.'.format(inventory_id, user_id))
         except Inventory.DoesNotExist:
             logger.exception("Delete Inventory failed due to missing inventory: " + str(inventory_id))

--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -80,7 +80,7 @@ class TestComputedFields:
             Schedule.objects.filter(pk=s.pk).update(next_run=old_next_run)
             s.next_run = old_next_run
             prior_modified = s.modified
-            with mock.patch('awx.main.models.schedules.emit_channel_notification'):
+            with mock.patch('awx.main.models.schedules.emit_websocket_payload'):
                 s.update_computed_fields()
             assert s.next_run != old_next_run
             assert s.modified == prior_modified
@@ -102,7 +102,7 @@ class TestComputedFields:
             assert s.next_run is None
             assert job_template.next_schedule is None
             s.rrule = self.distant_rrule
-            with mock.patch('awx.main.models.schedules.emit_channel_notification'):
+            with mock.patch('awx.main.models.schedules.emit_websocket_payload'):
                 s.update_computed_fields()
             assert s.next_run is not None
             assert job_template.next_schedule == s

--- a/awx/main/tests/functional/test_session.py
+++ b/awx/main/tests/functional/test_session.py
@@ -26,7 +26,7 @@ def test_login_json_not_allowed(get, accept, status):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.main.consumers.emit_channel_notification')
+@mock.patch('awx.utils.websockets.emit_websocket_payload')
 def test_sessions_unlimited(emit, admin):
     assert Session.objects.count() == 0
     for i in range(5):
@@ -37,7 +37,7 @@ def test_sessions_unlimited(emit, admin):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.main.consumers.emit_channel_notification')
+@mock.patch('awx.utils.websockets.emit_websocket_payload')
 def test_session_overlimit(emit, admin, alice):
     # If SESSIONS_PER_USER=3, only persist the three most recently created sessions
     assert Session.objects.count() == 0

--- a/awx/main/tests/functional/test_session.py
+++ b/awx/main/tests/functional/test_session.py
@@ -26,7 +26,7 @@ def test_login_json_not_allowed(get, accept, status):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.main.utils.websockets.emit_websocket_payload')
+@mock.patch('awx.main.signals.emit_websocket_payload')
 def test_sessions_unlimited(emit, admin):
     assert Session.objects.count() == 0
     for i in range(5):
@@ -37,7 +37,7 @@ def test_sessions_unlimited(emit, admin):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.main.utils.websockets.emit_websocket_payload')
+@mock.patch('awx.main.signals.emit_websocket_payload')
 def test_session_overlimit(emit, admin, alice):
     # If SESSIONS_PER_USER=3, only persist the three most recently created sessions
     assert Session.objects.count() == 0

--- a/awx/main/tests/functional/test_session.py
+++ b/awx/main/tests/functional/test_session.py
@@ -26,7 +26,7 @@ def test_login_json_not_allowed(get, accept, status):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.utils.websockets.emit_websocket_payload')
+@mock.patch('awx.main.utils.websockets.emit_websocket_payload')
 def test_sessions_unlimited(emit, admin):
     assert Session.objects.count() == 0
     for i in range(5):
@@ -37,7 +37,7 @@ def test_sessions_unlimited(emit, admin):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.utils.websockets.emit_websocket_payload')
+@mock.patch('awx.main.utils.websockets.emit_websocket_payload')
 def test_session_overlimit(emit, admin, alice):
     # If SESSIONS_PER_USER=3, only persist the three most recently created sessions
     assert Session.objects.count() == 0

--- a/awx/main/utils/websockets.py
+++ b/awx/main/utils/websockets.py
@@ -1,0 +1,30 @@
+import asyncio
+import json
+import logging
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+from channels.layers import get_channel_layer
+
+logger = logging.getLogger('awx.main.utils.websockets')
+
+__all__ = ["emit_websocket_payload"]
+
+
+def emit_websocket_payload(group, payload):
+    try:
+        payload_dumped = json.dumps(payload, cls=DjangoJSONEncoder)
+    except ValueError:
+        logger.error("Invalid payload to emit")
+        return
+
+    channel_layer = get_channel_layer()
+
+    event_loop = asyncio.new_event_loop()
+    event_loop.run_until_complete(
+        channel_layer.group_send(
+            group,
+            {"type": "internal.message", "text": payload_dumped, "needs_relay": True},
+        )
+    )
+    event_loop.close()

--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -162,7 +162,7 @@ class WebsocketRelayConnection:
                 try:
                     msg = await asyncio.wait_for(self.channel_layer.receive(consumer_channel), timeout=10)
                     if not msg.get("needs_relay"):
-                        # This is added in by emit_channel_notification(). It prevents us from looping
+                        # This is added in by emit_websocket_payload(). It prevents us from looping
                         # in the event that we are sharing a redis with a web instance. We'll see the
                         # message once (it'll have needs_relay=True), we'll delete that, and then forward
                         # the message along. The web instance will add it back to the same channels group,

--- a/docs/websockets.md
+++ b/docs/websockets.md
@@ -34,10 +34,10 @@ The notable modules for this component are:
   clients are actually handled (think of these like views, but specific to
   websockets).
 
-  * This is also where `emit_channel_notification` is defined, which is what the
-    task system calls to actually send out notifications. This sends a message
-    to the local Redis instance where wsrelay (discussed below) will pick it
-    up and relay it out to the web nodes.
+* `awx/main/utils/websockets.py` - this is where `emit_websocket_payload` is
+  defined, which is what the task system calls to actually send out
+  notifications. This sends a message to the local Redis instance where wsrelay
+  (discussed below) will pick it up and relay it out to the web nodes.
 
 * `awx/main/wsrelay.py` (formerly `awx/main/wsbroadcast.py`) - an asyncio
   websockets _client_ that connects to the "relay" (fka. "broadcast")


### PR DESCRIPTION
##### SUMMARY

This cleans up consumers.py and removes several utility functions from it. The main one being `emit_channel_notification` which here has been renamed to `emit_websocket_payload` to be more descriptive, and moved into the module `awx.main.utils.websockets`.


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
