### PR TITLE
Use patch to update users in awx cli

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -317,7 +317,10 @@ class ApiV2(base.Base):
                     if asset['natural_key']['type'] == 'project' and 'local_path' in post_data and _page['scm_type'] == post_data['scm_type']:
                         del post_data['local_path']
 
-                    _page = _page.put(post_data)
+                    if asset['natural_key']['type'] == 'user':
+                        _page = _page.patch(**post_data)
+                    else:
+                        _page = _page.put(post_data)
                     changed = True
             except (exc.Common, AssertionError) as e:
                 identifier = asset.get("name", None) or asset.get("username", None) or asset.get("hostname", None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Related to #14047

When exporting users, they have roles exported as well. When importing back, users are updated with `put` which fails and roles are skipped and not assigned.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
N/A
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before the fix, if a user exists, awx cli tries to update it with `put` but it fails and role assignment is skipped
```
/api/v2/users/ "user@com": Bad Request (400) received - {'password': ['This password is too short. It must contain at least 15 characters.', 'This password is too common.']}.
```

After the fix, the user is patched and after that all roles are assigned.