### PR TITLE
DROP unnecessary unpartioned event tables

### DIFF
--- a/awx/main/management/commands/cleanup_jobs.py
+++ b/awx/main/management/commands/cleanup_jobs.py
@@ -195,14 +195,35 @@ class Command(BaseCommand):
         delete_meta.delete_jobs()
         return (delete_meta.jobs_no_delete_count, delete_meta.jobs_to_delete_count)
 
-    def _cascade_delete_job_events(self, model, pk_list):
+    def _handle_unpartitioned_events(self, model, pk_list):
+        """
+        If unpartitioned job events remain, it will cascade those from jobs in pk_list
+        if the unpartitioned table is no longe necessary, it will drop the table
+        """
+        tblname = unified_job_class_to_event_table_name(model)
+        rel_name = model().event_parent_key
+        with connection.cursor() as cursor:
+            cursor.execute(f"SELECT 1 FROM pg_tables WHERE tablename = '_unpartitioned_{tblname}';")
+            row = cursor.fetchone()
+            if row is None:
+                self.logger.debug(f'Unpartitioned table for {rel_name} does not exist, you are fully migrated')
+                return
         if pk_list:
             with connection.cursor() as cursor:
-                tblname = unified_job_class_to_event_table_name(model)
-
                 pk_list_csv = ','.join(map(str, pk_list))
-                rel_name = model().event_parent_key
                 cursor.execute(f"DELETE FROM _unpartitioned_{tblname} WHERE {rel_name} IN ({pk_list_csv})")
+        with connection.cursor() as cursor:
+            # same as UnpartitionedJobEvent.objects.aggregate(Max('created'))
+            cursor.execute(f'SELECT MAX("_unpartitioned_{tblname}"."created") FROM "_unpartitioned_{tblname}"')
+            row = cursor.fetchone()
+            last_created = row[0]
+            if last_created:
+                self.logger.info(f'Last event created in _unpartitioned_{tblname} was {last_created.isoformat()}')
+            else:
+                self.logger.info(f'Table _unpartitioned_{tblname} has no events in it')
+            if (last_created is None) or (last_created < self.cutoff):
+                self.logger.warning(f'Dropping table _unpartitioned_{tblname} since no records are newer than {self.cutoff}')
+                cursor.execute(f'DROP TABLE _unpartitioned_{tblname}')
 
     def cleanup_jobs(self):
         batch_size = 100000
@@ -227,7 +248,7 @@ class Command(BaseCommand):
 
                 _, results = qs_batch.delete()
                 deleted += results['main.Job']
-                self._cascade_delete_job_events(Job, pk_list)
+                self._handle_unpartitioned_events(Job, pk_list)
 
         return skipped, deleted
 
@@ -250,7 +271,7 @@ class Command(BaseCommand):
                 deleted += 1
 
         if not self.dry_run:
-            self._cascade_delete_job_events(AdHocCommand, pk_list)
+            self._handle_unpartitioned_events(AdHocCommand, pk_list)
 
         skipped += AdHocCommand.objects.filter(created__gte=self.cutoff).count()
         return skipped, deleted
@@ -278,7 +299,7 @@ class Command(BaseCommand):
                 deleted += 1
 
         if not self.dry_run:
-            self._cascade_delete_job_events(ProjectUpdate, pk_list)
+            self._handle_unpartitioned_events(ProjectUpdate, pk_list)
 
         skipped += ProjectUpdate.objects.filter(created__gte=self.cutoff).count()
         return skipped, deleted
@@ -306,7 +327,7 @@ class Command(BaseCommand):
                 deleted += 1
 
         if not self.dry_run:
-            self._cascade_delete_job_events(InventoryUpdate, pk_list)
+            self._handle_unpartitioned_events(InventoryUpdate, pk_list)
 
         skipped += InventoryUpdate.objects.filter(created__gte=self.cutoff).count()
         return skipped, deleted
@@ -330,7 +351,7 @@ class Command(BaseCommand):
                 deleted += 1
 
         if not self.dry_run:
-            self._cascade_delete_job_events(SystemJob, pk_list)
+            self._handle_unpartitioned_events(SystemJob, pk_list)
 
         skipped += SystemJob.objects.filter(created__gte=self.cutoff).count()
         return skipped, deleted

--- a/awx/main/management/commands/cleanup_jobs.py
+++ b/awx/main/management/commands/cleanup_jobs.py
@@ -198,7 +198,7 @@ class Command(BaseCommand):
     def _handle_unpartitioned_events(self, model, pk_list):
         """
         If unpartitioned job events remain, it will cascade those from jobs in pk_list
-        if the unpartitioned table is no longe necessary, it will drop the table
+        if the unpartitioned table is no longer necessary, it will drop the table
         """
         tblname = unified_job_class_to_event_table_name(model)
         rel_name = model().event_parent_key


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/13152

> TODO:
> adjust cleanup_jobs to remove events (particularly from the unpartitioned tables) without necessarily having to tie them to an existing job

Connect https://github.com/ansible/awx/issues/10341

> Eventually, the old unpartitioned job events table will become empty. BUT, without a postgres full vacuum the storage will not be returned to the OS ("normal" autovacuum will only make the space available within the same table). As a nicety we should drop the old unpartitioned job events table when it becomes empty.

This PR carries out the "we should drop" part of that, but I have abandoned the suggested heuristics from that issue, the "when it becomes empty". Because, refer back to #13152, you can't count on it becoming empty because orphaned events clearly exist.

So the new heuristic this uses is "drop the table when it is obviously irrelevant". For that, I just check if `created` timestamps are all before the cutoff time given to `awx-manage cleanup_jobs`.

I believe that a full and simple DROP is the safest option. This command is extremely scale-hardened, and I don't want to get into any row-by-row things. I don't even like that this keeps the old logic for cascade deleting. There is a good argument that we should ditch that too.

I tested this by artificially creating an unpartitioned job event and re-running the system job.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

