### PR TITLE
Migration file to set peers_from_control_ nodes to true for existing execution nodes

### DIFF
--- a/awx/main/migrations/0185_hop_nodes.py
+++ b/awx/main/migrations/0185_hop_nodes.py
@@ -4,6 +4,11 @@ import django.core.validators
 from django.db import migrations, models
 
 
+def set_peers_from_control_nodes_true(apps, schema_editor):
+    Instance = apps.get_model('main', 'Instance')
+    Instance.objects.filter(node_type='execution').update(peers_from_control_nodes=True)
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ('main', '0184_django_indexes'),

--- a/awx/main/migrations/0185_hop_nodes.py
+++ b/awx/main/migrations/0185_hop_nodes.py
@@ -49,4 +49,5 @@ class Migration(migrations.Migration):
                 validators=[django.core.validators.MinValueValidator(1), django.core.validators.MaxValueValidator(65535)],
             ),
         ),
+        migrations.RunPython(set_peers_from_control_nodes_true),
     ]


### PR DESCRIPTION
Added function in hop nodes migration file to set peers_from_control_ nodes to true for existing execution nodes.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.3.1
```

