### PR TITLE
Add feature flag to allow instance API on non K8s environments

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5435,7 +5435,7 @@ class InstanceSerializer(BaseSerializer):
         res = super(InstanceSerializer, self).get_related(obj)
         res['jobs'] = self.reverse('api:instance_unified_jobs_list', kwargs={'pk': obj.pk})
         res['instance_groups'] = self.reverse('api:instance_instance_groups_list', kwargs={'pk': obj.pk})
-        if obj.node_type in [Instance.Types.EXECUTION, Instance.Types.HOP]:
+        if (settings.FEATURE_API_INSTANCE_MANAGEMENT or settings.IS_K8S) and obj.node_type in (Instance.Types.EXECUTION, Instance.Types.HOP):
             res['install_bundle'] = self.reverse('api:instance_install_bundle', kwargs={'pk': obj.pk})
         res['peers'] = self.reverse('api:instance_peers_list', kwargs={"pk": obj.pk})
         if self.context['request'].user.is_superuser or self.context['request'].user.is_system_auditor:
@@ -5469,8 +5469,9 @@ class InstanceSerializer(BaseSerializer):
             if self.instance.node_type == Instance.Types.HOP:
                 raise serializers.ValidationError("Hop node instances may not be changed.")
         else:
-            if not settings.IS_K8S:
+            if not settings.IS_K8S and not settings.FEATURE_API_INSTANCE_MANAGEMENT:
                 raise serializers.ValidationError("Can only create instances on Kubernetes or OpenShift.")
+
         return data
 
     def validate_node_type(self, value):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1047,3 +1047,5 @@ CLEANUP_HOST_METRICS_LAST_TS = None
 CLEANUP_HOST_METRICS_INTERVAL = 30  # days
 # Host metrics cleanup - soft-delete HostMetric records with last_automation < [threshold] (in months)
 CLEANUP_HOST_METRICS_THRESHOLD = 12  # months
+# Feature flag to allow Instance API regardless if AWX is running on K8s
+FEATURE_API_INSTANCE_MANAGEMENT = False


### PR DESCRIPTION
##### SUMMARY

It should be possible to add remote execution nodes via the API, 
regardless if AWX is running on K8s or not.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
0.1.dev33318+g1adcbe4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
