### PR TITLE
Add management command to precreate partitioned tables

### DIFF
--- a/awx/main/management/commands/cleanup_jobs.py
+++ b/awx/main/management/commands/cleanup_jobs.py
@@ -17,10 +17,7 @@ from django.utils.timezone import now
 
 # AWX
 from awx.main.models import Job, AdHocCommand, ProjectUpdate, InventoryUpdate, SystemJob, WorkflowJob, Notification
-
-
-def unified_job_class_to_event_table_name(job_class):
-    return f'main_{job_class().event_class.__name__.lower()}'
+from awx.main.utils import unified_job_class_to_event_table_name
 
 
 def partition_table_name(job_class, dt):

--- a/awx/main/management/commands/precreate_partitions.py
+++ b/awx/main/management/commands/precreate_partitions.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
         while count > 0:
             for table in tables:
                 create_partition(table, start)
-                print(f'Creating partitions for {table} {start}')
+                print(f'Created partitions for {table} {start}')
             start = start + timedelta(hours=1)
             count -= 1
 

--- a/awx/main/management/commands/precreate_partitions.py
+++ b/awx/main/management/commands/precreate_partitions.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.utils.timezone import now
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandParser
 from datetime import timedelta
 from awx.main.utils.common import create_partition
 
@@ -8,12 +8,17 @@ from awx.main.utils.common import create_partition
 class Command(BaseCommand):
     """Command used to precreate database partitions to avoid pg_dump locks"""
 
-    def _create_partitioned_tables(self):
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument('--count', dest='count', action='store', help='The amount of hours of partitions to create', type=int)
+
+    def _create_partitioned_tables(self, count):
         start = now()
-        next_hour = start + timedelta(hours=1)
-        for table in ("main_inventoryupdateevent", "main_jobevent", "main_projectupdateevent", "main_systemjobevent"):
-            create_partition(table, start)
-            create_partition(table, next_hour)
+        while count > 0:
+            for table in ("main_inventoryupdateevent", "main_jobevent", "main_projectupdateevent", "main_systemjobevent"):
+                create_partition(table, start)
+                print(f'Creating partitions for {table} {start}')
+            start = start + timedelta(hours=1)
+            count -= 1
 
     def handle(self, **options):
-        self._create_partitioned_tables()
+        self._create_partitioned_tables(options.get('count', 1))

--- a/awx/main/management/commands/precreate_partitions.py
+++ b/awx/main/management/commands/precreate_partitions.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     """Command used to precreate database partitions to avoid pg_dump locks"""
 
     def add_arguments(self, parser: CommandParser) -> None:
-        parser.add_argument('--count', dest='count', action='store', help='The amount of hours of partitions to create', type=int)
+        parser.add_argument('--count', dest='count', action='store', help='The amount of hours of partitions to create', type=int, default=1)
 
     def _create_partitioned_tables(self, count):
         start = now()
@@ -21,4 +21,4 @@ class Command(BaseCommand):
             count -= 1
 
     def handle(self, **options):
-        self._create_partitioned_tables(options.get('count', 1))
+        self._create_partitioned_tables(count=options.get('count'))

--- a/awx/main/management/commands/precreate_partitions.py
+++ b/awx/main/management/commands/precreate_partitions.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand, CommandParser
 from datetime import timedelta

--- a/awx/main/management/commands/precreate_partitions.py
+++ b/awx/main/management/commands/precreate_partitions.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+from django.utils.timezone import now
+from django.core.management.base import BaseCommand
+from datetime import timedelta
+from awx.main.utils.common import create_partition
+
+
+class Command(BaseCommand):
+    """Command used to precreate database partitions to avoid pg_dump locks"""
+
+    def _create_partitioned_tables(self):
+        start = now()
+        next_hour = start + timedelta(hours=1)
+        for table in ("main_inventoryupdateevent", "main_jobevent", "main_projectupdateevent", "main_systemjobevent"):
+            create_partition(table, start)
+            create_partition(table, next_hour)
+
+    def handle(self, **options):
+        self._create_partitioned_tables()

--- a/awx/main/management/commands/precreate_partitions.py
+++ b/awx/main/management/commands/precreate_partitions.py
@@ -1,7 +1,8 @@
 from django.utils.timezone import now
 from django.core.management.base import BaseCommand, CommandParser
 from datetime import timedelta
-from awx.main.utils.common import create_partition
+from awx.main.utils.common import create_partition, unified_job_class_to_event_table_name
+from awx.main.models import Job, SystemJob, ProjectUpdate, InventoryUpdate, AdHocCommand
 
 
 class Command(BaseCommand):
@@ -11,9 +12,12 @@ class Command(BaseCommand):
         parser.add_argument('--count', dest='count', action='store', help='The amount of hours of partitions to create', type=int, default=1)
 
     def _create_partitioned_tables(self, count):
+        tables = list()
+        for model in (Job, SystemJob, ProjectUpdate, InventoryUpdate, AdHocCommand):
+            tables.append(unified_job_class_to_event_table_name(model))
         start = now()
         while count > 0:
-            for table in ("main_inventoryupdateevent", "main_jobevent", "main_projectupdateevent", "main_systemjobevent"):
+            for table in tables:
                 create_partition(table, start)
                 print(f'Creating partitions for {table} {start}')
             start = start + timedelta(hours=1)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -90,6 +90,7 @@ __all__ = [
     'get_event_partition_epoch',
     'cleanup_new_process',
     'log_excess_runtime',
+    'unified_job_class_to_event_table_name',
 ]
 
 
@@ -1219,3 +1220,7 @@ def log_excess_runtime(func_logger, cutoff=5.0, debug_cutoff=5.0, msg=None, add_
         return _new_func
 
     return log_excess_runtime_decorator
+
+
+def unified_job_class_to_event_table_name(job_class):
+    return f'main_{job_class().event_class.__name__.lower()}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Useful for automating a pg_dump as it holds exclusive locks on main_jobevent etc during a pg_dump

example of automation:
```
- name: precreate partitioned tables
  shell: awx-manage precreate_partitions
  become_user: awx
  become: true
  register: partitions
```
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
make VERSION
awx: 22.3.1.dev22+gfdce6c9b35.d20230601

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
