### PR TITLE
Add new ANSIBLE_COLLECTIONS_PATH in preparation for deprecation of plural version

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -919,6 +919,7 @@ class RunJob(SourceControlMixin, BaseTask):
         path_vars = (
             ('ANSIBLE_COLLECTIONS_PATHS', 'collections_paths', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
             ('ANSIBLE_ROLES_PATH', 'roles_path', 'requirements_roles', '~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles'),
+            ('ANSIBLE_COLLECTIONS_PATH', 'collections_path', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
         )
 
         config_values = read_ansible_config(os.path.join(private_data_dir, 'project'), list(map(lambda x: x[1], path_vars)))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Tested this by adding an ansible.cfg to my project: cat ansible.cfg

```
---
[defaults]

collections_path = /var/tmp/
```
After syncing project and selecting a playbook verbosity 2 shows the collection path:

```
ansible-playbook [core 2.15.0]
  config file = /runner/project/ansible.cfg
  ansible collection location = /runner/requirements_collections:/var/tmp:/root/.ansible/collections:/usr/share/ansible/collections

```

job api endpoint shows both environment variables:

```
"ANSIBLE_COLLECTIONS_PATHS": "/runner/requirements_collections:~/.ansible/collections:/usr/share/ansible/collections",
"ANSIBLE_ROLES_PATH": "/runner/requirements_roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles",
"ANSIBLE_COLLECTIONS_PATH": "/runner/requirements_collections:/var/tmp/:~/.ansible/collections:/usr/share/ansible/collections",
```

ansible-core prefers the singular collections_path to collections_paths
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
 make VERSION
awx: 22.3.1.dev23+gd9cbea77f4

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

