### PR TITLE
Two silly internal cleanups

### DIFF
--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -3,7 +3,6 @@
 import logging
 import yaml
 
-from django.conf import settings
 from django.core.cache import cache as django_cache
 from django.core.management.base import BaseCommand
 from django.db import connection as django_connection
@@ -15,10 +14,6 @@ from awx.main.dispatch.worker import AWXConsumerPG, TaskWorker
 from awx.main.dispatch import periodic
 
 logger = logging.getLogger('awx.main.dispatch')
-
-
-def construct_bcast_queue_name(common_name):
-    return common_name + '_' + settings.CLUSTER_HOST_ID
 
 
 class Command(BaseCommand):

--- a/awx/main/management/commands/run_ws_heartbeat.py
+++ b/awx/main/management/commands/run_ws_heartbeat.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
             conn.notify('web_ws_heartbeat', self.construct_payload(action='offline'))
         sys.exit(0)
 
-    def do_hearbeat_loop(self):
+    def do_heartbeat_loop(self):
         while True:
             with pg_bus_conn() as conn:
                 logger.debug('Sending heartbeat')
@@ -42,4 +42,4 @@ class Command(BaseCommand):
 
         # Note: We don't really try any reconnect logic to pg_notify here,
         # just let supervisor restart if we fail.
-        self.do_hearbeat_loop()
+        self.do_heartbeat_loop()


### PR DESCRIPTION
##### SUMMARY

- Nix an unused function from run_dispatcher. This stopped being used in 558e92806b0e692939faf113029ad322960c7369 but was never removed.

- Fix a typo in run_ws_heartbeat: hearbeat -> heartbeat that has existed since the beginning of this daemon.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API