### PR TITLE
Remove task that enables COPR receptor repo

### DIFF
--- a/awx/api/templates/instance_install_bundle/group_vars/all.yml
+++ b/awx/api/templates/instance_install_bundle/group_vars/all.yml
@@ -26,7 +26,7 @@ receptor_peers:
 {% endfor %}
 {% endif %}
 receptor_dependencies:
-  - python39-pip
+  - python3-pip
 {% verbatim %}
 podman_user: "{{ receptor_user }}"
 podman_group: "{{ receptor_group }}"

--- a/awx/api/templates/instance_install_bundle/install_receptor.yml
+++ b/awx/api/templates/instance_install_bundle/install_receptor.yml
@@ -7,8 +7,6 @@
       user:
         name: "{{ receptor_user }}"
         shell: /bin/bash
-    - name: Enable Copr repo for Receptor
-      command: dnf copr enable ansible-awx/receptor -y
     - import_role:
         name: ansible.receptor.podman
     - import_role:
@@ -16,5 +14,7 @@
     - name: Install ansible-runner
       pip:
         name: ansible-runner
-        executable: pip3.9
+    - name: Install receptorctl
+      pip:
+        name: receptorctl
 {% endverbatim %}

--- a/awx/api/templates/instance_install_bundle/inventory.yml
+++ b/awx/api/templates/instance_install_bundle/inventory.yml
@@ -3,5 +3,5 @@ all:
   hosts:
     remote-execution:
       ansible_host: {{ instance.hostname }}
-      ansible_user: <username> # user provided
+      ansible_user: username # user provided
       ansible_ssh_private_key_file: ~/.ssh/id_rsa


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
receptor-collection now supports installing receptor binaries from the receptor release page.

Other changes:
install python3-pip instead of python3.9-pip
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
