### PR TITLE
Remove random UUIDs from swagger json

### DIFF
--- a/awx/main/tests/docs/test_swagger_generation.py
+++ b/awx/main/tests/docs/test_swagger_generation.py
@@ -171,4 +171,8 @@ class TestSwaggerGeneration:
             data = re.sub(r'[0-9]{4}-[0-9]{2}-[0-9]{2}(T|\s)[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]+(Z|\+[0-9]{2}:[0-9]{2})?', r'2018-02-01T08:00:00.000000Z', data)
             data = re.sub(r'''(\s+"client_id": ")([a-zA-Z0-9]{40})("\,\s*)''', r'\1xxxx\3', data)
             data = re.sub(r'"action_node": "[^"]+"', '"action_node": "awx"', data)
+
+            # replace uuids to prevent needless diffs
+            pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'
+            data = re.sub(pattern, r'00000000-0000-0000-0000-000000000000', data)
             f.write(data)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
recent api schema CI checks have been failing, e.g.
```
diff -u -b reference-schema.json schema.json
make: *** [Makefile:551: detect-schema-change] Error 1
--- reference-schema.json	2023-06-05 14:02:43.155654972 +0000
+++ schema.json	2023-06-05 14:02:41.531636284 +0000
@@ -13164,7 +13164,7 @@
           "type": "integer"
         },
         "identifier": {
-          "default": "f8c69cfc-879d-4722-9cdd-1655c5dd5cdc",
+          "default": "07e4778b-1cc5-4596-9b2b-57e23a3e00c4",
           "description": "An identifier for this node that is unique within its workflow. It is copied to workflow job nodes corresponding to this node.",
           "maxLength": 512,
           "minLength": 1,
make: *** [Makefile:331: docker-runner] Error 2
```

we should just replace all UUIDs with a generic value so that the diff comes back clean.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
