### PR TITLE
Lazy init VERSION vars in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ NPM_BIN ?= npm
 CHROMIUM_BIN=/tmp/chrome-linux/chrome
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 MANAGEMENT_COMMAND ?= awx-manage
-VERSION := $(shell $(PYTHON) tools/scripts/scm_version.py)
+VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py)
 
 # ansible-test requires semver compatable version, so we allow overrides to hack it
 COLLECTION_VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py | cut -d . -f 1-3)


### PR DESCRIPTION
##### SUMMARY
Setup VERSION and COLLECTION_VERSION vars so that they're only initialized when needed. This avoids running everything you have from shells in the top level even when you just want to `make help`. It's especially frustrating since our version calculation has an external dependency! Anyway, here's a breakdown: Start them as recursive vars and skip evaluating the rhs at the top-level (GNU Make will only eval the lhs and save the rhs for later), then on use the rhs will start expanding, and after expansion it will rewrite VERSION as a simple var holding the version that we calculate with our expensive dependent shell operations (so it won't have to run them again, either).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Collection
 - CLI
 - Docs
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.3.1.dev31+g5a7cc88ace
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
