### PR TITLE
Fix for Save on the Jobs settings page not responding 

### DIFF
--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -155,7 +155,7 @@ function JobsEdit() {
                 />
                 <InputField
                   name="AWX_RUNNER_KEEPALIVE_SECONDS"
-                  config={jobs.AWX_RUNNER_KEEPALIVE_SECONDS}
+                  config={jobs.AWX_RUNNER_KEEPALIVE_SECONDS ?? null}
                   type={options?.AWX_RUNNER_KEEPALIVE_SECONDS ? 'number' : undefined}
                 />
                 <InputField

--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -156,7 +156,7 @@ function JobsEdit() {
                 <InputField
                   name="AWX_RUNNER_KEEPALIVE_SECONDS"
                   config={jobs.AWX_RUNNER_KEEPALIVE_SECONDS}
-                  type="number"
+                  type={options?.AWX_RUNNER_KEEPALIVE_SECONDS ? 'number' : undefined}
                 />
                 <InputField
                   name="DEFAULT_JOB_TIMEOUT"

--- a/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
+++ b/awx/ui/src/screens/Setting/Jobs/JobsEdit/JobsEdit.js
@@ -156,7 +156,9 @@ function JobsEdit() {
                 <InputField
                   name="AWX_RUNNER_KEEPALIVE_SECONDS"
                   config={jobs.AWX_RUNNER_KEEPALIVE_SECONDS ?? null}
-                  type={options?.AWX_RUNNER_KEEPALIVE_SECONDS ? 'number' : undefined}
+                  type={
+                    options?.AWX_RUNNER_KEEPALIVE_SECONDS ? 'number' : undefined
+                  }
                 />
                 <InputField
                   name="DEFAULT_JOB_TIMEOUT"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When configuring `AWX_RUNNER_KEEPALIVE_SECONDS` in setting.py the save of the Jobs page no longer responds. 

Similar issue: https://github.com/ansible/awx/issues/13371

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
bash-4.4$ awx-manage --version
4.3.9
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
To reproduce set `AWX_RUNNER_KEEPALIVE_SECONDS` in settings.py and then try to save a change to the Settings-->Jobs page

