### PR TITLE
Changed pin of rsyslog version

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -122,7 +122,7 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     python3-psycopg2 \
     python3-setuptools \
     rsync \
-    rsyslog-8.2102.0-106.el9 \
+    https://download.copr.fedorainfracloud.org/results/ansible/Rsyslog/epel-9-x86_64/06076718-rsyslog/rsyslog-8.2102.0-106.el9.x86_64.rpm \
     subversion \
     sudo \
     vim-minimal \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
We had previously pinned rsyslog to a specific version in https://github.com/ansible/awx/pull/13395. This is because rsyslog added a new feature that broke it running inside a container:
```
=================================== FAILURES ===================================
________________ test_logging_aggregator_connection_test_valid _________________
[gw0] linux -- Python 3.9.16 /var/lib/awx/venv/awx/bin/python3.9
Traceback (most recent call last):
  File "/awx_devel/awx/main/tests/functional/api/test_settings.py", line 320, in test_logging_aggregator_connection_test_valid
    post(url, {}, user=admin, expect=202)
  File "/awx_devel/awx/main/tests/functional/conftest.py", line 633, in rf
    assert response.status_code == expect, 'Response data: {}'.format(getattr(response, 'data', None))
AssertionError: Response data: {'error': "b'rsyslog internal message (3,-2455): could not transfer  the  specified  internal posix  capabilities settings to the kernel, capng_apply=-5\\n [v8.2102.0-115.el9 try https://www.rsyslog.com/e/2455 ]\\n'"}
assert 400 == 202
 +  where 400 = <Response status_code=400, "text/html; charset=utf-8">.status_code
```
There is a PR against rsyslog to make the option a runtime option rather than a compiled option https://github.com/rsyslog/rsyslog/pull/5144 but until that is merged we need to continue to run on an older version. The version we used to run on was removed from the repositories so all builds were failing. This PR pins the version of rsyslog that we use a slightly newer version that still works. This is considered to be a temporary solution to get things working again until we can find a more permanent solution.

Fixes https://github.com/ansible/awx/issues/14115

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
