### PR TITLE
 In collection, Add an enforced state to the modules

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -340,7 +340,305 @@ class ControllerAPIModule(ControllerModule):
         return self.make_request('GET', endpoint, **kwargs)
 
     def get_options_endpoint(self, endpoint, *args, **kwargs):
-        return self.make_request('OPTIONS', endpoint, **kwargs)
+        return self.make_request('OPTIONS', endpoint, **kwargs)['json']['actions']['POST']
+
+    def get_enforced_defaults(self, endpoint, *args, **kwargs):
+        endpoint_defaults = self.get_options_endpoint(endpoint)
+
+        default_fields = {
+            'applications': {
+                'new_fields': {
+                    'description': '' if endpoint != 'applications' else endpoint_defaults['description']['default'],
+                    'client_type': 'public',
+                    'redirect_uris': '' if endpoint != 'applications' else endpoint_defaults['redirect_uris']['default'],
+                    'authorization_grant_type': 'password',
+                    'skip_authorization': False if endpoint != 'applications' else endpoint_defaults['skip_authorization']['default'],
+                },
+                'association_fields': {},
+            },
+            'credentials': {
+                'new_fields': {
+                    'description': '' if endpoint != 'credentials' else endpoint_defaults['description']['default'],
+                    'inputs': {} if endpoint != 'credentials' else endpoint_defaults['inputs']['default'],
+                },
+                'association_fields': {},
+            },
+            'credential_types': {
+                'new_fields': {
+                    'description': '' if endpoint != 'credential_types' else endpoint_defaults['description']['default'],
+                    'kind': 'cloud',
+                    'inputs': {} if endpoint != 'credential_types' else endpoint_defaults['inputs']['default'],
+                    'injectors': {} if endpoint != 'credential_types' else endpoint_defaults['injectors']['default'],
+                },
+                'association_fields': {},
+            },
+            'credential_input_sources': {
+                'new_fields': {
+                    'description': '' if endpoint != 'credential_input_sources' else endpoint_defaults['description']['default'],
+                    'metadata': {} if endpoint != 'credential_input_sources' else endpoint_defaults['metadata']['default'],
+                },
+                'association_fields': {},
+            },
+            'execution_environments': {
+                'new_fields': {
+                    'description': '' if endpoint != 'execution_environments' else endpoint_defaults['description']['default'],
+                    'pull': 'missing',  # Module default, is '' in the API.
+                },
+                'association_fields': {},
+            },
+            'groups': {
+                'new_fields': {
+                    'description': '' if endpoint != 'groups' else endpoint_defaults['description']['default'],
+                    'variables': '' if endpoint != 'groups' else endpoint_defaults['variables']['default'],
+                },
+                'association_fields': {
+                    'hosts': [],
+                    'children': [],
+                },
+            },
+            'hosts': {
+                'new_fields': {
+                    'description': '' if endpoint != 'hosts' else endpoint_defaults['description']['default'],
+                    'variables': '' if endpoint != 'hosts' else endpoint_defaults['variables']['default'],
+                    'enabled': True if endpoint != 'hosts' else endpoint_defaults['enabled']['default'],
+                },
+                'association_fields': {},
+            },
+            'instance_groups': {
+                'new_fields': {
+                    'max_concurrent_jobs': 0 if endpoint != 'instance_groups' else endpoint_defaults['max_concurrent_jobs']['default'],
+                    'max_forks': 0 if endpoint != 'instance_groups' else endpoint_defaults['max_forks']['default'],
+                    'is_container_group': False,
+                    'policy_instance_percentage': 0 if endpoint != 'instance_groups' else endpoint_defaults['policy_instance_percentage']['default'],
+                    'policy_instance_minimum': 0 if endpoint != 'instance_groups' else endpoint_defaults['policy_instance_minimum']['default'],
+                    'policy_instance_list': [],
+                    'pod_spec_override': '' if endpoint != 'instance_groups' else dumps(endpoint_defaults['pod_spec_override']['default']),
+                },
+                'association_fields': {
+                    'instances': [],
+                },
+            },
+            'instances': {
+                'new_fields': {
+                    'capacity_adjustment': 1.0 if endpoint != 'instances' else endpoint_defaults['capacity_adjustment']['default'],
+                    'enabled': True if endpoint != 'instances' else endpoint_defaults['enabled']['default'],
+                    'managed_by_policy': True if endpoint != 'instances' else endpoint_defaults['managed_by_policy']['default'],
+                    'node_type': 'execution' if endpoint != 'instances' else endpoint_defaults['node_type']['default'],
+                    'listener_port': 27199 if endpoint != 'instances' else endpoint_defaults['listener_port']['default'],
+                },
+                'association_fields': {},
+            },
+            'inventory_sources': {
+                'new_fields': {
+                    'description': '' if endpoint != 'inventory_sources' else endpoint_defaults['description']['default'],
+                    'source': 'scm',  # this is what defaults in the module, no default in API.
+                    'source_path': '' if endpoint != 'inventory_sources' else endpoint_defaults['source_path']['default'],
+                    'source_vars': '' if endpoint != 'inventory_sources' else endpoint_defaults['source_vars']['default'],
+                    'scm_branch': '' if endpoint != 'inventory_sources' else endpoint_defaults['scm_branch']['default'],
+                    'enabled_var': '' if endpoint != 'inventory_sources' else endpoint_defaults['enabled_var']['default'],
+                    'enabled_value': '' if endpoint != 'inventory_sources' else endpoint_defaults['enabled_value']['default'],
+                    'host_filter': '' if endpoint != 'inventory_sources' else endpoint_defaults['host_filter']['default'],
+                    'overwrite': False if endpoint != 'inventory_sources' else endpoint_defaults['overwrite']['default'],
+                    'overwrite_vars': False if endpoint != 'inventory_sources' else endpoint_defaults['overwrite_vars']['default'],
+                    'timeout': 0 if endpoint != 'inventory_sources' else endpoint_defaults['timeout']['default'],
+                    'verbosity': 1 if endpoint != 'inventory_sources' else endpoint_defaults['verbosity']['default'],
+                    'limit': '' if endpoint != 'inventory_sources' else endpoint_defaults['limit']['default'],
+                    'update_on_launch': False if endpoint != 'inventory_sources' else endpoint_defaults['update_on_launch']['default'],
+                    'update_cache_timeout': 0 if endpoint != 'inventory_sources' else endpoint_defaults['update_cache_timeout']['default'],
+                    'source_project': '',  # No Default in the API, but this resets if set and default value is null.
+                },
+                'association_fields': {
+                    'notification_templates_started': [],
+                    'notification_templates_success': [],
+                    'notification_templates_error': [],
+                },
+            },
+            'inventories': {
+                'new_fields': {
+                    'description': '' if endpoint != 'inventories' else endpoint_defaults['description']['default'],
+                    'kind': '' if endpoint != 'inventories' else endpoint_defaults['kind']['default'],
+                    'host_filter': '' if endpoint != 'inventories' else endpoint_defaults['host_filter']['default'],
+                    'variables': '' if endpoint != 'inventories' else endpoint_defaults['variables']['default'],
+                    'prevent_instance_group_fallback': False if endpoint != 'inventories' else endpoint_defaults['prevent_instance_group_fallback']['default'],
+                },
+                'association_fields': {
+                    'instance_groups': [],
+                    'input_inventories': [],
+                },
+            },
+            'job_templates': {
+                'new_fields': {
+                    'description': '' if endpoint != 'job_templates' else endpoint_defaults['description']['default'],
+                    'job_type': 'run' if endpoint != 'job_templates' else endpoint_defaults['job_type']['default'],
+                    'scm_branch': '' if endpoint != 'job_templates' else endpoint_defaults['scm_branch']['default'],
+                    'forks': 0 if endpoint != 'job_templates' else endpoint_defaults['forks']['default'],
+                    'limit': '' if endpoint != 'job_templates' else endpoint_defaults['limit']['default'],
+                    'verbosity': 0 if endpoint != 'job_templates' else endpoint_defaults['verbosity']['default'],
+                    'extra_vars': '' if endpoint != 'job_templates' else endpoint_defaults['extra_vars']['default'],
+                    'job_tags': '' if endpoint != 'job_templates' else endpoint_defaults['job_tags']['default'],
+                    'force_handlers': False if endpoint != 'job_templates' else endpoint_defaults['force_handlers']['default'],
+                    'skip_tags': '' if endpoint != 'job_templates' else endpoint_defaults['skip_tags']['default'],
+                    'start_at_task': '' if endpoint != 'job_templates' else endpoint_defaults['start_at_task']['default'],
+                    'timeout': 0 if endpoint != 'job_templates' else endpoint_defaults['timeout']['default'],
+                    'use_fact_cache': False if endpoint != 'job_templates' else endpoint_defaults['use_fact_cache']['default'],
+                    'host_config_key': '' if endpoint != 'job_templates' else endpoint_defaults['host_config_key']['default'],
+                    'ask_scm_branch_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_scm_branch_on_launch']['default'],
+                    'ask_diff_mode_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_diff_mode_on_launch']['default'],
+                    'ask_variables_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_variables_on_launch']['default'],
+                    'ask_limit_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_limit_on_launch']['default'],
+                    'ask_tags_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_tags_on_launch']['default'],
+                    'ask_skip_tags_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_skip_tags_on_launch']['default'],
+                    'ask_job_type_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_job_type_on_launch']['default'],
+                    'ask_verbosity_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_verbosity_on_launch']['default'],
+                    'ask_inventory_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_inventory_on_launch']['default'],
+                    'ask_credential_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_credential_on_launch']['default'],
+                    'ask_execution_environment_on_launch': False
+                    if endpoint != 'job_templates'
+                    else endpoint_defaults['ask_execution_environment_on_launch']['default'],
+                    'ask_labels_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_labels_on_launch']['default'],
+                    'ask_forks_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_forks_on_launch']['default'],
+                    'ask_job_slice_count_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_job_slice_count_on_launch']['default'],
+                    'ask_instance_groups_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_instance_groups_on_launch']['default'],
+                    'ask_timeout_on_launch': False if endpoint != 'job_templates' else endpoint_defaults['ask_timeout_on_launch']['default'],
+                    'survey_enabled': False if endpoint != 'job_templates' else endpoint_defaults['survey_enabled']['default'],
+                    'become_enabled': False if endpoint != 'job_templates' else endpoint_defaults['become_enabled']['default'],
+                    'diff_mode': False if endpoint != 'job_templates' else endpoint_defaults['diff_mode']['default'],
+                    'allow_simultaneous': False if endpoint != 'job_templates' else endpoint_defaults['allow_simultaneous']['default'],
+                    'job_slice_count': 1 if endpoint != 'job_templates' else endpoint_defaults['job_slice_count']['default'],
+                    'webhook_service': '',
+                    'prevent_instance_group_fallback': False
+                    if endpoint != 'job_templates'
+                    else endpoint_defaults['prevent_instance_group_fallback']['default'],
+                },
+                'association_fields': {
+                    'credentials': [],
+                    'labels': [],
+                    'notification_templates_started': [],
+                    'notification_templates_success': [],
+                    'notification_templates_error': [],
+                    'instance_groups': [],
+                },
+            },
+            'notification_templates': {
+                'new_fields': {
+                    'description': '' if endpoint != 'notification_templates' else endpoint_defaults['description']['default'],
+                    'messages': {} if endpoint != 'notification_templates' else endpoint_defaults['messages']['default'],
+                },
+                'association_fields': {},
+            },
+            'organizations': {
+                'new_fields': {
+                    'description': '' if endpoint != 'organizations' else endpoint_defaults['description']['default'],
+                    'default_environment': '',
+                    'custom_virtualenv': '',
+                    'max_hosts': 0 if endpoint != 'organizations' else endpoint_defaults['max_hosts']['default'],
+                },
+                'association_fields': {
+                    'instance_groups': [],
+                    'notification_templates_started': [],
+                    'notification_templates_success': [],
+                    'notification_templates_error': [],
+                    'notification_templates_approvals': [],
+                    'galaxy_credentials': [],
+                },
+            },
+            'projects': {
+                'new_fields': {
+                    'description': '' if endpoint != 'projects' else endpoint_defaults['description']['default'],
+                    'scm_type': '' if endpoint != 'projects' else endpoint_defaults['scm_type']['default'],
+                    'scm_url': '' if endpoint != 'projects' else endpoint_defaults['scm_url']['default'],
+                    'scm_branch': '' if endpoint != 'projects' else endpoint_defaults['scm_branch']['default'],
+                    'scm_refspec': '' if endpoint != 'projects' else endpoint_defaults['scm_refspec']['default'],
+                    'scm_clean': False if endpoint != 'projects' else endpoint_defaults['scm_clean']['default'],
+                    'scm_delete_on_update': False if endpoint != 'projects' else endpoint_defaults['scm_delete_on_update']['default'],
+                    'scm_track_submodules': False if endpoint != 'projects' else endpoint_defaults['scm_track_submodules']['default'],
+                    'scm_update_on_launch': False if endpoint != 'projects' else endpoint_defaults['scm_update_on_launch']['default'],
+                    'scm_update_cache_timeout': 0 if endpoint != 'projects' else endpoint_defaults['scm_update_cache_timeout']['default'],
+                    'timeout': 0 if endpoint != 'projects' else endpoint_defaults['timeout']['default'],
+                    'allow_override': False if endpoint != 'projects' else endpoint_defaults['allow_override']['default'],
+                },
+                'association_fields': {
+                    'notification_templates_started': [],
+                    'notification_templates_success': [],
+                    'notification_templates_error': [],
+                },
+            },
+            'schedules': {
+                'new_fields': {
+                    'description': '' if endpoint != 'schedules' else endpoint_defaults['description']['default'],
+                    'job_type': None,
+                    'enabled': True,
+                    'job_slice_count': None,
+                    'timeout': None,
+                    'execution_environment': None,
+                },
+                'association_fields': {
+                    'labels': [],
+                    'instance_groups': [],
+                },
+            },
+            'teams': {
+                'new_fields': {
+                    'description': '' if endpoint != 'teams' else endpoint_defaults['description']['default'],
+                },
+                'association_fields': {},
+            },
+            'users': {
+                'new_fields': {
+                    'first_name': '',
+                    'last_name': '',
+                    'email': '',
+                    'is_superuser': False if endpoint != 'users' else endpoint_defaults['is_superuser']['default'],
+                    'is_system_auditor': False if endpoint != 'users' else endpoint_defaults['is_system_auditor']['default'],
+                },
+                'association_fields': {},
+            },
+            'workflow_job_templates': {
+                'new_fields': {
+                    'description': '' if endpoint != 'workflow_job_templates' else endpoint_defaults['description']['default'],
+                    'survey_enabled': False if endpoint != 'workflow_job_templates' else endpoint_defaults['survey_enabled']['default'],
+                    'allow_simultaneous': False if endpoint != 'workflow_job_templates' else endpoint_defaults['allow_simultaneous']['default'],
+                    'limit': None if endpoint != 'workflow_job_templates' else endpoint_defaults['limit']['default'],
+                    'scm_branch': None if endpoint != 'workflow_job_templates' else endpoint_defaults['scm_branch']['default'],
+                    'extra_vars': '',
+                    'ask_inventory_on_launch': False if endpoint != 'workflow_job_templates' else endpoint_defaults['ask_inventory_on_launch']['default'],
+                    'ask_scm_branch_on_launch': False if endpoint != 'workflow_job_templates' else endpoint_defaults['ask_scm_branch_on_launch']['default'],
+                    'ask_limit_on_launch': False if endpoint != 'workflow_job_templates' else endpoint_defaults['ask_limit_on_launch']['default'],
+                    'ask_variables_on_launch': False if endpoint != 'workflow_job_templates' else endpoint_defaults['ask_variables_on_launch']['default'],
+                    'ask_labels_on_launch': False if endpoint != 'workflow_job_templates' else endpoint_defaults['ask_labels_on_launch']['default'],
+                    'ask_tags_on_launch': False if endpoint != 'workflow_job_templates' else endpoint_defaults['ask_tags_on_launch']['default'],
+                    'ask_skip_tags_on_launch': False if endpoint != 'workflow_job_templates' else endpoint_defaults['ask_skip_tags_on_launch']['default'],
+                    'webhook_service': '',
+                    'job_tags': None if endpoint != 'workflow_job_templates' else endpoint_defaults['job_tags']['default'],
+                    'skip_tags': None if endpoint != 'workflow_job_templates' else endpoint_defaults['skip_tags']['default'],
+                },
+                'association_fields': {
+                    'notification_templates_started': [],
+                    'notification_templates_success': [],
+                    'notification_templates_error': [],
+                    'notification_templates_approvals': [],
+                    'labels': [],
+                },
+            },
+            'workflow_job_template_nodes': {
+                'new_fields': {
+                    'extra_data': '',
+                    'all_parents_must_converge': False
+                    if endpoint != 'workflow_job_template_nodes'
+                    else endpoint_defaults['all_parents_must_converge']['default'],
+                },
+                'association_fields': {
+                    'always_nodes': [],
+                    'success_nodes': [],
+                    'failure_nodes': [],
+                    'credentials': [],
+                    'instance_groups': [],
+                    'labels': [],
+                },
+            },
+        }
+
+        return default_fields[endpoint]['new_fields'], default_fields[endpoint]['association_fields']
 
     def patch_endpoint(self, endpoint, *args, **kwargs):
         # Handle check mode

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -350,7 +350,7 @@ class ControllerAPIModule(ControllerModule):
                 'new_fields': {
                     'description': '' if endpoint != 'applications' else endpoint_defaults['description']['default'],
                     'client_type': 'public',
-                    'redirect_uris': '' if endpoint != 'applications' else endpoint_defaults['redirect_uris']['default'],
+                    'redirect_uris': [],
                     'authorization_grant_type': 'password',
                     'skip_authorization': False if endpoint != 'applications' else endpoint_defaults['skip_authorization']['default'],
                 },

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -339,6 +339,9 @@ class ControllerAPIModule(ControllerModule):
     def get_endpoint(self, endpoint, *args, **kwargs):
         return self.make_request('GET', endpoint, **kwargs)
 
+    def get_options_endpoint(self, endpoint, *args, **kwargs):
+        return self.make_request('OPTIONS', endpoint, **kwargs)
+
     def patch_endpoint(self, endpoint, *args, **kwargs):
         # Handle check mode
         if self.check_mode:
@@ -468,7 +471,7 @@ class ControllerAPIModule(ControllerModule):
             # If we have a oauth token, we just use a bearer header
             headers['Authorization'] = 'Bearer {0}'.format(self.oauth_token)
 
-        if method in ['POST', 'PUT', 'PATCH']:
+        if method in ['POST', 'PUT', 'PATCH', 'OPTIONS']:
             headers.setdefault('Content-Type', 'application/json')
             kwargs['headers'] = headers
 

--- a/awx_collection/plugins/modules/label.py
+++ b/awx_collection/plugins/modules/label.py
@@ -39,7 +39,7 @@ options:
       type: str
     state:
       description:
-        - Desired state of the resource.
+        - Desired state of the resource. C(exists) will not modify the resource if it is present.
       default: "present"
       choices: ["present", "exists"]
       type: str

--- a/awx_collection/plugins/modules/organization.py
+++ b/awx_collection/plugins/modules/organization.py
@@ -47,12 +47,13 @@ options:
     max_hosts:
       description:
         - The max hosts allowed in this organizations
+        - Enforced state enforces default values of any option not provided.
       type: int
     state:
       description:
         - Desired state of the resource.
       default: "present"
-      choices: ["present", "absent", "exists"]
+      choices: ["present", "absent", "exists", "enforced"]
       type: str
     instance_groups:
       description:
@@ -130,7 +131,7 @@ def main():
         notification_templates_error=dict(type="list", elements='str'),
         notification_templates_approvals=dict(type="list", elements='str'),
         galaxy_credentials=dict(type="list", elements='str'),
-        state=dict(choices=['present', 'absent', 'exists'], default='present'),
+        state=dict(choices=['present', 'absent', 'exists', 'enforced'], default='present'),
     )
 
     # Create a module for ourselves
@@ -148,9 +149,17 @@ def main():
     # Attempt to look up organization based on the provided name
     organization = module.get_one('organizations', name_or_id=name, check_exists=(state == 'exists'))
 
+    # set the default for enforced defaults
+    enforced_defaults = False
+
     if state == 'absent':
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this
         module.delete_if_needed(organization)
+    elif state == 'enforced':
+        enforced_defaults = True
+        # organization_defaults = module.get_options_endpoint('organizations')
+        # module.fail_json(msg="{0}".format(organization_defaults))
+
     # Attempt to look up associated field items the user specified.
     association_fields = {}
 

--- a/awx_collection/tests/integration/targets/application/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/application/tasks/main.yml
@@ -53,6 +53,17 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      application:
+        name: "{{ app1_name }}"
+        organization: "Default"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Delete our application
       application:
         name: "{{ app1_name }}"

--- a/awx_collection/tests/integration/targets/application/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/application/tasks/main.yml
@@ -10,11 +10,16 @@
     app2_name: "AWX-Collection-tests-application-app2-{{ test_id }}"
     app3_name: "AWX-Collection-tests-application-app3-{{ test_id }}"
 
-- block:
+- name: Run Tests
+  block:
     - name: Create an application
       application:
         name: "{{ app1_name }}"
-        authorization_grant_type: "password"
+        description: this is a description
+        authorization_grant_type: password
+        redirect_uris:
+          - http://tower.com/api/v2/
+          - http://tower.com/api/v2/teams
         client_type: "public"
         organization: "Default"
         state: present
@@ -24,7 +29,7 @@
         that:
           - "result is changed"
 
-    - name: Run an application with exists
+    - name: Run an application with exists, with different parameters
       application:
         name: "{{ app1_name }}"
         authorization_grant_type: "password"
@@ -36,6 +41,17 @@
     - assert:
         that:
           - "result is not changed"
+
+    - name: Run an application with enforced and lacking fields
+      application:
+        name: "{{ app1_name }}"
+        organization: "Default"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
 
     - name: Delete our application
       application:

--- a/awx_collection/tests/integration/targets/credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential/tasks/main.yml
@@ -24,704 +24,578 @@
     insights_cred_name1: "AWX-Collection-tests-credential-insights-cred1-{{ test_id }}"
     tower_cred_name1: "AWX-Collection-tests-credential-tower-cred1-{{ test_id }}"
 
-- name: create a tempdir for an SSH key
-  local_action: shell mktemp -d
-  register: tempdir
-
-- name: Generate a local SSH key
-  local_action: "shell ssh-keygen -b 2048 -t rsa -f {{ tempdir.stdout }}/id_rsa -q -N 'passphrase'"
-
-- name: Read the generated key
-  set_fact:
-    ssh_key_data: "{{ lookup('file', tempdir.stdout + '/id_rsa') }}"
-
-- name: Create an Org-specific credential with an ID
-  credential:
-    name: "{{ ssh_cred_name1 }}"
-    organization: Default
-    credential_type: Machine
-    state: present
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create an Org-specific credential with an ID with exists
-  credential:
-    name: "{{ ssh_cred_name1 }}"
-    organization: Default
-    credential_type: Machine
-    state: exists
-  register: result
-
-- assert:
-    that:
-      - "result is not changed"
-
-- name: Delete an Org-specific credential with an ID
-  credential:
-    name: "{{ ssh_cred_name1 }}"
-    organization: Default
-    credential_type: Machine
-    state: absent
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create an Org-specific credential with an ID with exists
-  credential:
-    name: "{{ ssh_cred_name1 }}"
-    organization: Default
-    credential_type: Machine
-    state: exists
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a Org-specific credential
-  credential:
-    name: "{{ ssh_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Machine
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create the User-specific credential
-  credential:
-    name: "{{ ssh_cred_name1 }}"
-    user: admin
-    credential_type: 'Machine'
-    state: present
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a User-specific credential
-  credential:
-    name: "{{ ssh_cred_name1 }}"
-    user: admin
-    state: absent
-    credential_type: 'Machine'
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid SSH credential
-  credential:
-    name: "{{ ssh_cred_name2 }}"
-    organization: Default
-    state: present
-    credential_type: Machine
-    description: An example SSH credential
-    inputs:
-      username: joe
-      password: secret
-      become_method: sudo
-      become_username: superuser
-      become_password: supersecret
-      ssh_key_data: "{{ ssh_key_data }}"
-      ssh_key_unlock: "passphrase"
-  register: result
-
-- assert:
-    that:
-      - result is changed
-
-- name: Create a valid SSH credential
-  credential:
-    name: "{{ ssh_cred_name2 }}"
-    organization: Default
-    state: present
-    credential_type: Machine
-    description: An example SSH credential
-    inputs:
-      username: joe
-      become_method: sudo
-      become_username: superuser
-  register: result
-
-- assert:
-    that:
-      - result is changed
-
-- name: Check for inputs idempotency (when "inputs" is blank)
-  credential:
-    name: "{{ ssh_cred_name2 }}"
-    organization: Default
-    state: present
-    credential_type: Machine
-    description: An example SSH credential
-  register: result
-
-- assert:
-    that:
-      - result is not changed
-
-- name: Copy ssh Credential
-  credential:
-    name: "copy_{{ ssh_cred_name2 }}"
-    copy_from: "{{ ssh_cred_name2 }}"
-    credential_type: Machine
-  register: result
-
-- assert:
-    that:
-      - result.copied
-
-- name: Delete an SSH credential
-  credential:
-    name: "copy_{{ ssh_cred_name2 }}"
-    organization: Default
-    state: absent
-    credential_type: Machine
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid SSH credential from lookup source
-  credential:
-    name: "{{ ssh_cred_name3 }}"
-    organization: Default
-    state: present
-    credential_type: Machine
-    description: An example SSH credential from lookup source
-    inputs:
-      username: joe
-      password: secret
-      become_method: sudo
-      become_username: superuser
-      become_password: supersecret
-      ssh_key_data: "{{ lookup('file', tempdir.stdout + '/id_rsa') }}"
-      ssh_key_unlock: "passphrase"
-  register: result
-
-- assert:
-    that:
-      - result is changed
-
-- name: Delete an SSH credential
-  credential:
-    name: "{{ ssh_cred_name2 }}"
-    organization: Default
-    state: absent
-    credential_type: Machine
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Ensure existence of SSH credential
-  credential:
-    name: "{{ ssh_cred_name2 }}"
-    organization: Default
-    state: exists
-    credential_type: Machine
-    description: An example SSH awx.awx.credential
-    inputs:
-      username: joe
-      password: secret
-      become_method: sudo
-      become_username: superuser
-      become_password: supersecret
-      ssh_key_data: "{{ ssh_key_data }}"
-      ssh_key_unlock: "passphrase"
-  register: result
-
-- assert:
-    that:
-      - result is changed
-
-- name: Ensure existence of SSH credential, not updating any inputs
-  credential:
-    name: "{{ ssh_cred_name2 }}"
-    organization: Default
-    state: exists
-    credential_type: Machine
-    description: An example SSH awx.awx.credential
-    inputs:
-      username: joe
-      password: no-update-secret
-      become_method: sudo
-      become_username: some-other-superuser
-      become_password: some-other-secret
-      ssh_key_data: "{{ ssh_key_data }}"
-      ssh_key_unlock: "another-pass-phrase"
-  register: result
-
-- assert:
-    that:
-      - result is not changed
-
-- name: Create an invalid SSH credential (passphrase required)
-  credential:
-    name: SSH Credential
-    organization: Default
-    state: present
-    credential_type: Machine
-    inputs:
-      username: joe
-      ssh_key_data: "{{ ssh_key_data }}"
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - "result is failed"
-      - "'must be set when SSH key is encrypted' in result.msg"
-
-- name: Create an invalid SSH credential (Organization not found)
-  credential:
-    name: SSH Credential
-    organization: Missing_Organization
-    state: present
-    credential_type: Machine
-    inputs:
-      username: joe
-  ignore_errors: true
-  register: result
-
-- assert:
-    that:
-      - "result is failed"
-      - "result is not changed"
-      - "'Missing_Organization' in result.msg"
-      - "result.total_results == 0"
-
-- name: Delete an SSH credential
-  credential:
-    name: "{{ ssh_cred_name2 }}"
-    organization: Default
-    state: absent
-    credential_type: Machine
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an SSH credential
-  credential:
-    name: "{{ ssh_cred_name3 }}"
-    organization: Default
-    state: absent
-    credential_type: Machine
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an SSH credential
-  credential:
-    name: "{{ ssh_cred_name4 }}"
-    organization: Default
-    state: absent
-    credential_type: Machine
-  register: result
-
-# This one was never really created so it shouldn't be deleted
-- assert:
-    that:
-      - "result is not changed"
-
-- name: Create a valid Vault credential
-  credential:
-    name: "{{ vault_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Vault
-    description: An example Vault credential
-    inputs:
-      vault_id: bar
-      vault_password: secret-vault
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a Vault credential
-  credential:
-    name: "{{ vault_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Vault
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a Vault credential
-  credential:
-    name: "{{ vault_cred_name2 }}"
-    organization: Default
-    state: absent
-    credential_type: Vault
-  register: result
-
-# The creation of vault_cred_name2 never worked so we shouldn't actually need to delete it
-- assert:
-    that:
-      - "result is not changed"
-
-- name: Create a valid Network credential
-  credential:
-    name: "{{ net_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Network
-    inputs:
-      username: joe
-      password: secret
-      authorize: true
-      authorize_password: authorize-me
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a Network credential
-  credential:
-    name: "{{ net_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Network
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid SCM credential
-  credential:
-    name: "{{ scm_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Source Control
-    inputs:
-      username: joe
-      password: secret
-      ssh_key_data: "{{ ssh_key_data }}"
-      ssh_key_unlock: "passphrase"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an SCM credential
-  credential:
-    name: "{{ scm_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Source Control
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid AWS credential
-  credential:
-    name: "{{ aws_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Amazon Web Services
-    inputs:
-      username: joe
-      password: secret
-      security_token: aws-token
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an AWS credential
-  credential:
-    name: "{{ aws_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Amazon Web Services
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid VMWare credential
-  credential:
-    name: "{{ vmware_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: VMware vCenter
-    inputs:
-      host: https://example.org
-      username: joe
-      password: secret
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an VMWare credential
-  credential:
-    name: "{{ vmware_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: VMware vCenter
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid Satellite6 credential
-  credential:
-    name: "{{ sat6_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Red Hat Satellite 6
-    inputs:
-      host: https://example.org
-      username: joe
-      password: secret
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a Satellite6 credential
-  credential:
-    name: "{{ sat6_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Red Hat Satellite 6
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid GCE credential
-  credential:
-    name: "{{ gce_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Google Compute Engine
-    inputs:
-      username: joe
-      project: ABC123
-      ssh_key_data: "{{ ssh_key_data }}"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a GCE credential
-  credential:
-    name: "{{ gce_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Google Compute Engine
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid AzureRM credential
-  credential:
-    name: "{{ azurerm_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Microsoft Azure Resource Manager
-    inputs:
-      username: joe
-      password: secret
-      subscription: some-subscription
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid AzureRM credential with a tenant
-  credential:
-    name: "{{ azurerm_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Microsoft Azure Resource Manager
-    inputs:
-      client: some-client
-      secret: some-secret
-      tenant: some-tenant
-      subscription: some-subscription
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an AzureRM credential
-  credential:
-    name: "{{ azurerm_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Microsoft Azure Resource Manager
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid OpenStack credential
-  credential:
-    name: "{{ openstack_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: OpenStack
-    inputs:
-      host: https://keystone.example.org
-      username: joe
-      password: secret
-      project: tenant123
-      domain: some-domain
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a OpenStack credential
-  credential:
-    name: "{{ openstack_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: OpenStack
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid RHV credential
-  credential:
-    name: "{{ rhv_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Red Hat Virtualization
-    inputs:
-      host: https://example.org
-      username: joe
-      password: secret
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an RHV credential
-  credential:
-    name: "{{ rhv_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Red Hat Virtualization
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid Insights credential
-  credential:
-    name: "{{ insights_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Insights
-    inputs:
-      username: joe
-      password: secret
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete an Insights credential
-  credential:
-    name: "{{ insights_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Insights
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create a valid Tower-to-Tower credential
-  credential:
-    name: "{{ tower_cred_name1 }}"
-    organization: Default
-    state: present
-    credential_type: Red Hat Ansible Automation Platform
-    inputs:
-      host: https://controller.example.org
-      username: joe
-      password: secret
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete a Tower-to-Tower credential
-  credential:
-    name: "{{ tower_cred_name1 }}"
-    organization: Default
-    state: absent
-    credential_type: Red Hat Ansible Automation Platform
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Check module fails with correct msg
-  credential:
-    name: test-credential
-    description: Credential Description
-    credential_type: Machine
-    organization: test-non-existing-org
-    state: present
-  register: result
-  ignore_errors: true
-
-- assert:
-    that:
-      - "result is failed"
-      - "result is not changed"
-      - "'test-non-existing-org' in result.msg"
-      - "result.total_results == 0"
+- name: Run Tests
+  block:
+    - name: create a tempdir for an SSH key
+      local_action: shell mktemp -d
+      register: tempdir
+
+    - name: Generate a local SSH key
+      local_action: "shell ssh-keygen -b 2048 -t rsa -f {{ tempdir.stdout }}/id_rsa -q -N 'passphrase'"
+
+    - name: Read the generated key
+      set_fact:
+        ssh_key_data: "{{ lookup('file', tempdir.stdout + '/id_rsa') }}"
+
+    - name: Create an Org-specific credential with an ID
+      credential:
+        name: "{{ ssh_cred_name1 }}"
+        organization: Default
+        credential_type: Machine
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create an Org-specific credential with an ID with exists
+      credential:
+        name: "{{ ssh_cred_name1 }}"
+        organization: Default
+        credential_type: Machine
+        state: exists
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Delete an Org-specific credential with an ID
+      credential:
+        name: "{{ ssh_cred_name1 }}"
+        organization: Default
+        credential_type: Machine
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create an Org-specific credential with an ID with exists
+      credential:
+        name: "{{ ssh_cred_name1 }}"
+        organization: Default
+        credential_type: Machine
+        state: exists
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Delete a Org-specific credential
+      credential:
+        name: "{{ ssh_cred_name1 }}"
+        organization: Default
+        state: absent
+        credential_type: Machine
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create the User-specific credential
+      credential:
+        name: "{{ ssh_cred_name1 }}"
+        user: admin
+        credential_type: 'Machine'
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Delete a User-specific credential
+      credential:
+        name: "{{ ssh_cred_name1 }}"
+        user: admin
+        state: absent
+        credential_type: 'Machine'
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid SSH credential
+      credential:
+        name: "{{ ssh_cred_name2 }}"
+        organization: Default
+        state: present
+        credential_type: Machine
+        description: An example SSH credential
+        inputs:
+          username: joe
+          password: secret
+          become_method: sudo
+          become_username: superuser
+          become_password: supersecret
+          ssh_key_data: "{{ ssh_key_data }}"
+          ssh_key_unlock: "passphrase"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Create a valid SSH credential
+      credential:
+        name: "{{ ssh_cred_name2 }}"
+        organization: Default
+        state: present
+        credential_type: Machine
+        description: An example SSH credential
+        inputs:
+          username: joe
+          become_method: sudo
+          become_username: superuser
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Check for inputs idempotency (when "inputs" is blank)
+      credential:
+        name: "{{ ssh_cred_name2 }}"
+        organization: Default
+        state: present
+        credential_type: Machine
+        description: An example SSH credential
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Copy ssh Credential
+      credential:
+        name: "copy_{{ ssh_cred_name2 }}"
+        copy_from: "{{ ssh_cred_name2 }}"
+        credential_type: Machine
+      register: result
+
+    - assert:
+        that:
+          - result.copied
+
+    - name: Create a valid SSH credential from lookup source
+      credential:
+        name: "{{ ssh_cred_name3 }}"
+        organization: Default
+        state: present
+        credential_type: Machine
+        description: An example SSH credential from lookup source
+        inputs:
+          username: joe
+          password: secret
+          become_method: sudo
+          become_username: superuser
+          become_password: supersecret
+          ssh_key_data: "{{ lookup('file', tempdir.stdout + '/id_rsa') }}"
+          ssh_key_unlock: "passphrase"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Delete an SSH credential
+      credential:
+        name: "{{ ssh_cred_name2 }}"
+        organization: Default
+        state: absent
+        credential_type: Machine
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Ensure existence of SSH credential
+      credential:
+        name: "{{ ssh_cred_name2 }}"
+        organization: Default
+        state: exists
+        credential_type: Machine
+        description: An example SSH awx.awx.credential
+        inputs:
+          username: joe
+          password: secret
+          become_method: sudo
+          become_username: superuser
+          become_password: supersecret
+          ssh_key_data: "{{ ssh_key_data }}"
+          ssh_key_unlock: "passphrase"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Ensure existence of SSH credential, not updating any inputs
+      credential:
+        name: "{{ ssh_cred_name2 }}"
+        organization: Default
+        state: exists
+        credential_type: Machine
+        description: An example SSH awx.awx.credential
+        inputs:
+          username: joe
+          password: no-update-secret
+          become_method: sudo
+          become_username: some-other-superuser
+          become_password: some-other-secret
+          ssh_key_data: "{{ ssh_key_data }}"
+          ssh_key_unlock: "another-pass-phrase"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: Create an invalid SSH credential (passphrase required)
+      credential:
+        name: SSH Credential
+        organization: Default
+        state: present
+        credential_type: Machine
+        inputs:
+          username: joe
+          ssh_key_data: "{{ ssh_key_data }}"
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - "result is failed"
+          - "'must be set when SSH key is encrypted' in result.msg"
+
+    - name: Create an invalid SSH credential (Organization not found)
+      credential:
+        name: SSH Credential
+        organization: Missing_Organization
+        state: present
+        credential_type: Machine
+        inputs:
+          username: joe
+      ignore_errors: true
+      register: result
+
+    - assert:
+        that:
+          - "result is failed"
+          - "result is not changed"
+          - "'Missing_Organization' in result.msg"
+          - "result.total_results == 0"
+
+    - name: Delete an SSH credential
+      credential:
+        name: "{{ ssh_cred_name4 }}"
+        organization: Default
+        state: absent
+        credential_type: Machine
+      register: result
+
+    # This one was never really created so it shouldn't be deleted
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Create a valid Vault credential
+      credential:
+        name: "{{ vault_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Vault
+        description: An example Vault credential
+        inputs:
+          vault_id: bar
+          vault_password: secret-vault
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Delete a Vault credential
+      credential:
+        name: "{{ vault_cred_name2 }}"
+        organization: Default
+        state: absent
+        credential_type: Vault
+      register: result
+
+    # The creation of vault_cred_name2 never worked so we shouldn't actually need to delete it
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Create a valid Network credential
+      credential:
+        name: "{{ net_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Network
+        inputs:
+          username: joe
+          password: secret
+          authorize: true
+          authorize_password: authorize-me
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid SCM credential
+      credential:
+        name: "{{ scm_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Source Control
+        inputs:
+          username: joe
+          password: secret
+          ssh_key_data: "{{ ssh_key_data }}"
+          ssh_key_unlock: "passphrase"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid AWS credential
+      credential:
+        name: "{{ aws_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Amazon Web Services
+        inputs:
+          username: joe
+          password: secret
+          security_token: aws-token
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid VMWare credential
+      credential:
+        name: "{{ vmware_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: VMware vCenter
+        inputs:
+          host: https://example.org
+          username: joe
+          password: secret
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid Satellite6 credential
+      credential:
+        name: "{{ sat6_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Red Hat Satellite 6
+        inputs:
+          host: https://example.org
+          username: joe
+          password: secret
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid GCE credential
+      credential:
+        name: "{{ gce_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Google Compute Engine
+        inputs:
+          username: joe
+          project: ABC123
+          ssh_key_data: "{{ ssh_key_data }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a credential with enforced
+      credential:
+        name: "{{ gce_cred_name1 }}"
+        organization: Default
+        state: enforced
+        credential_type: Google Compute Engine
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Check that enforced values are set.
+      credential:
+        name: "{{ gce_cred_name1 }}"
+        organization: Default
+        description: ""
+        state: present
+        credential_type: Google Compute Engine
+        inputs: {}
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Create a valid AzureRM credential
+      credential:
+        name: "{{ azurerm_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Microsoft Azure Resource Manager
+        inputs:
+          username: joe
+          password: secret
+          subscription: some-subscription
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid AzureRM credential with a tenant
+      credential:
+        name: "{{ azurerm_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Microsoft Azure Resource Manager
+        inputs:
+          client: some-client
+          secret: some-secret
+          tenant: some-tenant
+          subscription: some-subscription
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid OpenStack credential
+      credential:
+        name: "{{ openstack_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: OpenStack
+        inputs:
+          host: https://keystone.example.org
+          username: joe
+          password: secret
+          project: tenant123
+          domain: some-domain
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid RHV credential
+      credential:
+        name: "{{ rhv_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Red Hat Virtualization
+        inputs:
+          host: https://example.org
+          username: joe
+          password: secret
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid Insights credential
+      credential:
+        name: "{{ insights_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Insights
+        inputs:
+          username: joe
+          password: secret
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create a valid Tower-to-Tower credential
+      credential:
+        name: "{{ tower_cred_name1 }}"
+        organization: Default
+        state: present
+        credential_type: Red Hat Ansible Automation Platform
+        inputs:
+          host: https://controller.example.org
+          username: joe
+          password: secret
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Check module fails with correct msg
+      credential:
+        name: test-credential
+        description: Credential Description
+        credential_type: Machine
+        organization: test-non-existing-org
+        state: present
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - "result is failed"
+          - "result is not changed"
+          - "'test-non-existing-org' in result.msg"
+          - "result.total_results == 0"
+
+  always:
+    - name: Delete all credentials
+      credential:
+        name: "{{ item.name }}"
+        organization: Default
+        state: absent
+        credential_type: "{{ item.type }}"
+      loop:
+        - {name: "{{ ssh_cred_name1 }}", type: "Machine"}
+        - {name: "{{ ssh_cred_name2 }}", type: "Machine"}
+        - {name: "{{ ssh_cred_name3 }}", type: "Machine"}
+        - {name: "{{ ssh_cred_name4 }}", type: "Machine"}
+        - {name: "{{ vault_cred_name1 }}", type: "Vault"}
+        - {name: "{{ vault_cred_name2 }}", type: "Vault"}
+        - {name: "{{ net_cred_name1 }}", type: "Network"}
+        - {name: "{{ scm_cred_name1 }}", type: "Source Control"}
+        - {name: "{{ aws_cred_name1 }}", type: "Amazon Web Services"}
+        - {name: "{{ vmware_cred_name1 }}", type: "VMware vCenter"}
+        - {name: "{{ sat6_cred_name1 }}", type: "Red Hat Satellite 6"}
+        - {name: "{{ gce_cred_name1 }}", type: "Google Compute Engine"}
+        - {name: "{{ azurerm_cred_name1 }}", type: "Microsoft Azure Resource Manager"}
+        - {name: "{{ openstack_cred_name1 }}", type: "OpenStack"}
+        - {name: "{{ rhv_cred_name1 }}", type: "Red Hat Virtualization"}
+        - {name: "{{ insights_cred_name1 }}", type: "Insights"}
+        - {name: "{{ tower_cred_name1 }}", type: "Red Hat Ansible Automation Platform"}

--- a/awx_collection/tests/integration/targets/credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential/tasks/main.yml
@@ -445,6 +445,18 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      credential:
+        name: "{{ gce_cred_name1 }}"
+        organization: Default
+        state: enforced
+        credential_type: Google Compute Engine
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Check that enforced values are set.
       credential:
         name: "{{ gce_cred_name1 }}"

--- a/awx_collection/tests/integration/targets/credential_input_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential_input_source/tasks/main.yml
@@ -9,7 +9,8 @@
     src_cred_name: "AWX-Collection-tests-credential_input_source-src_cred-{{ test_id }}"
     target_cred_name: "AWX-Collection-tests-credential_input_source-target_cred-{{ test_id }}"
 
-- block:
+- name: Run Tests
+  block:
     - name: Add credential Lookup
       credential:
         description: Credential for Testing Source
@@ -42,6 +43,7 @@
     - name: Add credential Input Source
       credential_input_source:
         input_field_name: password
+        description: this is a description
         target_credential: "{{ target_cred_result.id }}"
         source_credential: "{{ src_cred_result.id }}"
         metadata:
@@ -68,6 +70,42 @@
     - assert:
         that:
           - "result is not changed"
+
+    - name: Add credential Lookup
+      credential:
+        description: Credential for Testing Source
+        name: "{{ src_cred_name }}-Conjur"
+        credential_type: CyberArk Conjur Secrets Manager Lookup
+        inputs:
+          url: "https://cyberark.example.com"
+          api_key: "1234"
+          account: admin
+          username: admin
+        organization: Default
+
+    - name: Add credential Input Source with enforced
+      credential_input_source:
+        input_field_name: password
+        target_credential: "{{ target_cred_result.id }}"
+        source_credential: "{{ src_cred_name }}-Conjur"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Add credential Input Source after enforced ensure not changed
+      credential_input_source:
+        input_field_name: password
+        target_credential: "{{ target_cred_result.id }}"
+        source_credential: "{{ src_cred_name }}-Conjur"
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
 
     - name: Delete credential Input Source
       credential_input_source:
@@ -146,6 +184,14 @@
         name: "{{ src_cred_name }}-2"
         organization: Default
         credential_type: CyberArk Central Credential Provider Lookup
+        state: absent
+      register: result
+
+    - name: Remove Conjur credential
+      credential:
+        name: "{{ src_cred_name }}-Conjur"
+        organization: Default
+        credential_type: Machine
         state: absent
       register: result
 

--- a/awx_collection/tests/integration/targets/credential_type/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential_type/tasks/main.yml
@@ -8,7 +8,8 @@
   set_fact:
     cred_type_name: "AWX-Collection-tests-credential_type-cred-type-{{ test_id }}"
 
-- block:
+- name: Run Tests
+  block:
     - name: Add Tower credential type
       credential_type:
         description: Credential type for Test
@@ -30,6 +31,29 @@
         inputs: {"fields": [{"type": "string", "id": "username", "label": "Username"}, {"secret": true, "type": "string", "id": "password", "label": "Password"}], "required": ["username", "password"]}
         injectors: {"extra_vars": {"test": "foo"}}
         state: exists
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Add credential type with enforced
+      credential_type:
+        name: "{{ cred_type_name }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Add credential type with present expecting no change
+      credential_type:
+        description: ''
+        name: "{{ cred_type_name }}"
+        inputs: {}
+        injectors: {}
+        state: present
       register: result
 
     - assert:
@@ -85,7 +109,3 @@
       loop:
         - "{{ cred_type_name }}"
         - "{{ cred_type_name }}a"
-
-    - assert:
-        that:
-          - "result is changed"

--- a/awx_collection/tests/integration/targets/credential_type/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential_type/tasks/main.yml
@@ -47,6 +47,16 @@
         that:
           - "result is changed"
 
+    - name: Add credential type with enforced
+      credential_type:
+        name: "{{ cred_type_name }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Add credential type with present expecting no change
       credential_type:
         description: ''

--- a/awx_collection/tests/integration/targets/execution_environment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/execution_environment/tasks/main.yml
@@ -77,6 +77,18 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      execution_environment:
+        name: "{{ ee_name }}"
+        image: quay.io/ansible/awx-ee
+        organization: Default
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Add an EE with default values that don't change
       execution_environment:
         name: "{{ ee_name }}"

--- a/awx_collection/tests/integration/targets/execution_environment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/execution_environment/tasks/main.yml
@@ -8,7 +8,8 @@
   set_fact:
     ee_name: "AWX-Collection-tests-ee-{{ test_id }}"
 
-- block:
+- name: Run Tests
+  block:
     - name: Add an EE
       execution_environment:
         name: "{{ ee_name }}"
@@ -63,6 +64,31 @@
     - assert:
         that:
           - "result is changed"
+
+    - name: Add an EE with enforced
+      execution_environment:
+        name: "{{ ee_name }}"
+        image: quay.io/ansible/awx-ee
+        organization: Default
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Add an EE with default values that don't change
+      execution_environment:
+        name: "{{ ee_name }}"
+        description: ""
+        image: quay.io/ansible/awx-ee
+        pull: missing
+        organization: Default
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
 
     - name: Associate the Test EE with Default Org (this should fail)
       execution_environment:

--- a/awx_collection/tests/integration/targets/export/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/export/tasks/main.yml
@@ -10,7 +10,8 @@
     org_name2: "AWX-Collection-tests-export-organization2-{{ test_id }}"
     inventory_name1: "AWX-Collection-tests-export-inv1-{{ test_id }}"
 
-- block:
+- name: Run Tests
+  block:
     - name: Create some organizations
       organization:
         name: "{{ item }}"

--- a/awx_collection/tests/integration/targets/group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/group/tasks/main.yml
@@ -16,246 +16,275 @@
     host_name3: "AWX-Collection-tests-group-host3-{{ test_id }}"
     host_name4: "AWX-Collection-tests-group-host4-{{ test_id }}"
 
-- name: Create an Inventory
-  inventory:
-    name: "{{ inv_name }}"
-    organization: Default
-    state: present
-  register: result
+- name: Run Tests
+  block:
+    - name: Create an Inventory
+      inventory:
+        name: "{{ inv_name }}"
+        organization: Default
+        state: present
+      register: result
 
-- name: Create a Host
-  host:
-    name: "{{ host_name4 }}"
-    inventory: "{{ inv_name }}"
-    state: present
-  register: result
+    - name: Create a Host
+      host:
+        name: "{{ host_name4 }}"
+        inventory: "{{ inv_name }}"
+        state: present
+      register: result
 
-- name: Add Host to Group
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ inv_name }}"
-    hosts:
-      - "{{ host_name4 }}"
-    preserve_existing_hosts: true
-  register: result
+    - name: Add Host to Group
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        hosts:
+          - "{{ host_name4 }}"
+        preserve_existing_hosts: true
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create Group 1
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ result.id }}"
-    state: present
-    variables:
-      foo: bar
-  register: result
+    - name: Create Group 1
+      group:
+        name: "{{ group_name1 }}"
+        description: this is a description
+        inventory: "{{ result.id }}"
+        state: present
+        variables:
+          foo: bar
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create Group 1 with exists
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ inv_name }}"
-    state: exists
-    variables:
-      foo: bar
-  register: result
+    - name: Create Group 1 with exists
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        state: exists
+        variables:
+          foo: bar
+      register: result
 
-- assert:
-    that:
-      - "result is not changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Delete Group 1
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ inv_name }}"
-    state: absent
-    variables:
-      foo: bar
-  register: result
+    - name: Create Group 1 with enforced
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        state: enforced
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create Group 1 with exists
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ inv_name }}"
-    state: exists
-    variables:
-      foo: bar
-  register: result
+    - name: Create Group 1 with enforced values
+      group:
+        name: "{{ group_name1 }}"
+        description: ''
+        inventory: "{{ inv_name }}"
+        variables: {}
+        hosts: []
+        children: []
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Create Group 2
-  group:
-    name: "{{ group_name2 }}"
-    inventory: "{{ inv_name }}"
-    state: present
-    variables:
-      foo: bar
-  register: result
+    - name: Delete Group 1
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+        variables:
+          foo: bar
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create Group 3
-  group:
-    name: "{{ group_name3 }}"
-    inventory: "{{ inv_name }}"
-    state: present
-    variables:
-      foo: bar
-  register: result
+    - name: Create Group 1 with exists
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        state: exists
+        variables:
+          foo: bar
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: add hosts
-  host:
-    name: "{{ item }}"
-    inventory: "{{ inv_name }}"
-  loop:
-    - "{{ host_name1 }}"
-    - "{{ host_name2 }}"
-    - "{{ host_name3 }}"
+    - name: Create Group 2
+      group:
+        name: "{{ group_name2 }}"
+        inventory: "{{ inv_name }}"
+        state: present
+        variables:
+          foo: bar
+      register: result
 
-- name: Create Group 1 with hosts and sub group of Group 2
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ inv_name }}"
-    hosts:
-      - "{{ host_name1 }}"
-      - "{{ host_name2 }}"
-    children:
-      - "{{ group_name2 }}"
-    state: present
-    variables:
-      foo: bar
-  register: result
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create Group 1 with hosts and sub group
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ inv_name }}"
-    hosts:
-      - "{{ host_name3 }}"
-    children:
-      - "{{ group_name3 }}"
-    state: present
-    preserve_existing_hosts: true
-    preserve_existing_children: true
-  register: result
+    - name: Create Group 3
+      group:
+        name: "{{ group_name3 }}"
+        inventory: "{{ inv_name }}"
+        state: present
+        variables:
+          foo: bar
+      register: result
 
-- name: "Find number of hosts in {{ group_name1 }}"
-  set_fact:
-    group1_host_count: "{{ lookup('awx.awx.controller_api', 'groups/{{result.id}}/all_hosts/') |length}}"
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - group1_host_count  == "3"
+    - name: add hosts
+      host:
+        name: "{{ item }}"
+        inventory: "{{ inv_name }}"
+      loop:
+        - "{{ host_name1 }}"
+        - "{{ host_name2 }}"
+        - "{{ host_name3 }}"
 
-- name: Delete Group 2
-  group:
-    name: "{{ group_name2 }}"
-    inventory: "{{ inv_name }}"
-    state: absent
-  register: result
+    - name: Create Group 1 with hosts and sub group of Group 2
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        hosts:
+          - "{{ host_name1 }}"
+          - "{{ host_name2 }}"
+        children:
+          - "{{ group_name2 }}"
+        state: present
+        variables:
+          foo: bar
+      register: result
 
-# In this case, group 2 was last a child of group1 so deleting group1 deleted group2
-- assert:
-    that:
-      - "result is not changed"
+    - name: Create Group 1 with hosts and sub group
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        hosts:
+          - "{{ host_name3 }}"
+        children:
+          - "{{ group_name3 }}"
+        state: present
+        preserve_existing_hosts: true
+        preserve_existing_children: true
+      register: result
 
-- name: Delete Group 3
-  group:
-    name: "{{ group_name3 }}"
-    inventory: "{{ inv_name }}"
-    state: absent
-  register: result
+    - name: "Find number of hosts in {{ group_name1 }}"
+      set_fact:
+        group1_host_count: "{{ lookup('awx.awx.controller_api', 'groups/{{result.id}}/all_hosts/') |length}}"
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - group1_host_count  == "3"
 
-# If we delete group 1 first it will delete group 2 and 3
-- name: Delete Group 1
-  group:
-    name: "{{ group_name1 }}"
-    inventory: "{{ inv_name }}"
-    state: absent
-  register: result
+    - name: Delete Group 2
+      group:
+        name: "{{ group_name2 }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    # In this case, group 2 was last a child of group1 so deleting group1 deleted group2
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Check module fails with correct msg
-  group:
-    name: test-group
-    description: Group Description
-    inventory: test-non-existing-inventory
-    state: present
-  register: result
-  ignore_errors: true
+    - name: Delete Group 3
+      group:
+        name: "{{ group_name3 }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - "result is failed"
-      - "result is not changed"
-      - "'test-non-existing-inventory' in result.msg"
-      - "result.total_results == 0"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: add hosts
-  host:
-    name: "{{ item }}"
-    inventory: "{{ inv_name }}"
-  loop:
-    - "{{ host_name1 }}"
-    - "{{ host_name2 }}"
-    - "{{ host_name3 }}"
+    # If we delete group 1 first it will delete group 2 and 3
+    - name: Delete Group 1
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+      register: result
 
-- name: add mid level group
-  group:
-    name: "{{ group_name2 }}"
-    inventory: "{{ inv_name }}"
-    hosts:
-      - "{{ host_name3 }}"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: add top group
-  group:
-    name: "{{ group_name3 }}"
-    inventory: "{{ inv_name }}"
-    hosts:
-      - "{{ host_name1 }}"
-      - "{{ host_name2 }}"
-    children:
-      - "{{ group_name2 }}"
+    - name: Check module fails with correct msg
+      group:
+        name: test-group
+        description: Group Description
+        inventory: test-non-existing-inventory
+        state: present
+      register: result
+      ignore_errors: true
 
-- name: Delete the parent group
-  group:
-    name: "{{ group_name3 }}"
-    inventory: "{{ inv_name }}"
-    state: absent
+    - assert:
+        that:
+          - "result is failed"
+          - "result is not changed"
+          - "'test-non-existing-inventory' in result.msg"
+          - "result.total_results == 0"
 
-- name: Delete the child group
-  group:
-    name: "{{ group_name2 }}"
-    inventory: "{{ inv_name }}"
-    state: absent
+    - name: add hosts
+      host:
+        name: "{{ item }}"
+        inventory: "{{ inv_name }}"
+      loop:
+        - "{{ host_name1 }}"
+        - "{{ host_name2 }}"
+        - "{{ host_name3 }}"
 
-- name: Delete an Inventory
-  inventory:
-    name: "{{ inv_name }}"
-    organization: Default
-    state: absent
+    - name: add mid level group
+      group:
+        name: "{{ group_name2 }}"
+        inventory: "{{ inv_name }}"
+        hosts:
+          - "{{ host_name3 }}"
+
+    - name: add top group
+      group:
+        name: "{{ group_name3 }}"
+        inventory: "{{ inv_name }}"
+        hosts:
+          - "{{ host_name1 }}"
+          - "{{ host_name2 }}"
+        children:
+          - "{{ group_name2 }}"
+
+    - name: Delete the parent group
+      group:
+        name: "{{ group_name3 }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+
+    - name: Delete the child group
+      group:
+        name: "{{ group_name2 }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+
+  always:
+    - name: Delete an Inventory
+      inventory:
+        name: "{{ inv_name }}"
+        organization: Default
+        state: absent

--- a/awx_collection/tests/integration/targets/host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/host/tasks/main.yml
@@ -58,6 +58,17 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      host:
+        name: "{{ host_name }}"
+        inventory: "{{ inv_name }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Create a Host with enforced values
       host:
         name: "{{ host_name }}"

--- a/awx_collection/tests/integration/targets/host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/host/tasks/main.yml
@@ -9,87 +9,129 @@
     host_name: "AWX-Collection-tests-host-host-{{ test_id }}"
     inv_name: "AWX-Collection-tests-host-inv-{{ test_id }}"
 
-- name: Create an Inventory
-  inventory:
-    name: "{{ inv_name }}"
-    organization: Default
-    state: present
-  register: result
+- name: Run Tests
+  block:
+    - name: Create an Inventory
+      inventory:
+        name: "{{ inv_name }}"
+        organization: Default
+        state: present
+      register: result
 
-- name: Create a Host
-  host:
-    name: "{{ host_name }}"
-    inventory: "{{ result.id }}"
-    state: present
-    variables:
-      foo: bar
-  register: result
+    - name: Create a Host
+      host:
+        name: "{{ host_name }}"
+        description: this is a description
+        enabled: False
+        inventory: "{{ result.id }}"
+        state: present
+        variables:
+          foo: bar
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create a Host with exists
-  host:
-    name: "{{ host_name }}"
-    inventory: "{{ inv_name }}"
-    state: exists
-    variables:
-      foo: bar
-  register: result
+    - name: Create a Host with exists
+      host:
+        name: "{{ host_name }}"
+        inventory: "{{ inv_name }}"
+        state: exists
+        variables:
+          foo: bar
+      register: result
 
-- assert:
-    that:
-      - "result is not changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Delete a Host
-  host:
-    name: "{{ host_name }}"
-    inventory: "{{ inv_name }}"
-    state: absent
-    variables:
-      foo: bar
-  register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - name: Create a Host with enforced
+      host:
+        name: "{{ host_name }}"
+        inventory: "{{ inv_name }}"
+        state: enforced
+      register: result
 
-- name: Create a Host with exists
-  host:
-    name: "{{ host_name }}"
-    inventory: "{{ inv_name }}"
-    state: exists
-    variables:
-      foo: bar
-  register: result
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - "result is changed"
+    - name: Create a Host with enforced values
+      host:
+        name: "{{ host_name }}"
+        inventory: "{{ inv_name }}"
+        description: ""
+        enabled: True
+        variables: {}
+      register: result
 
-- name: Delete a Host
-  host:
-    name: "{{ result.id }}"
-    inventory: "{{ inv_name }}"
-    state: absent
-  register: result
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - "result is changed"
+    - name: Delete a Host
+      host:
+        name: "{{ host_name }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+        variables:
+          foo: bar
+      register: result
 
-- name: Check module fails with correct msg
-  host:
-    name: test-host
-    description: Host Description
-    inventory: test-non-existing-inventory
-    state: present
-  register: result
-  ignore_errors: true
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - "result is failed"
-      - "'test-non-existing-inventory' in result.msg"
-      - "result.total_results == 0"
+    - name: Create a Host with exists
+      host:
+        name: "{{ host_name }}"
+        inventory: "{{ inv_name }}"
+        state: exists
+        variables:
+          foo: bar
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Delete a Host
+      host:
+        name: "{{ result.id }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Check module fails with correct msg
+      host:
+        name: test-host
+        description: Host Description
+        inventory: test-non-existing-inventory
+        state: present
+      register: result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - "result is failed"
+          - "'test-non-existing-inventory' in result.msg"
+          - "result.total_results == 0"
+
+  always:
+    - name: Delete Host
+      host:
+        name: "{{ host_name }}"
+        inventory: "{{ inv_name }}"
+        state: absent
+
+    - name: Delete Inventory
+      inventory:
+        name: "{{ inv_name }}"
+        organization: Default
+        state: absent

--- a/awx_collection/tests/integration/targets/instance/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/instance/tasks/main.yml
@@ -70,6 +70,16 @@
         that:
           - result is changed
 
+    - name: Rerun to ensure no changes with enforced
+      instance:
+        hostname: "{{ hostname1 }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
     - name: Update an instance enforced defaults for no change
       instance:
         hostname: "{{ hostname1 }}"

--- a/awx_collection/tests/integration/targets/instance/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/instance/tasks/main.yml
@@ -21,9 +21,10 @@
     msg: "Skipping instance test since this is instance is not running on a K8s platform"
   when: not IS_K8S
 
-- block:
+- name: Run Tests
+  block:
     - name: Create an instance
-      awx.awx.instance:
+      instance:
         hostname: "{{ item }}"
         node_type: execution
         node_state: installed
@@ -37,7 +38,7 @@
           - result is changed
 
     - name: Create an instance with non-default config
-      awx.awx.instance:
+      instance:
         hostname: "{{ hostname3 }}"
         node_type: execution
         node_state: installed
@@ -50,7 +51,7 @@
           - result is changed
 
     - name: Update an instance
-      awx.awx.instance:
+      instance:
         hostname: "{{ hostname1 }}"
         capacity_adjustment: 0.7
       register: result
@@ -59,9 +60,34 @@
         that:
           - result is changed
 
+    - name: Set an instance with enforced
+      instance:
+        hostname: "{{ hostname1 }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Update an instance enforced defaults for no change
+      instance:
+        hostname: "{{ hostname1 }}"
+        capacity_adjustment: 1.0
+        enabled: True
+        manged_by_policy: True
+        node_type: execution
+        listener_port: 27199
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+
   always:
     - name: Deprovision the instances
-      awx.awx.instance:
+      instance:
         hostname: "{{ item }}"
         node_state: deprovisioning
       with_items:

--- a/awx_collection/tests/integration/targets/instance_group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/instance_group/tasks/main.yml
@@ -10,7 +10,8 @@
     group_name2: "AWX-Collection-tests-instance_group-group2-{{ test_id }}"
     cred_name1: "AWX-Collection-tests-instance_group-cred1-{{ test_id }}"
 
-- block:
+- name: Run Tests
+  block:
     - name: Create an OpenShift Credential
       credential:
         name: "{{ cred_name1 }}"
@@ -44,6 +45,30 @@
         policy_instance_percentage: 34
         policy_instance_minimum: 12
         state: exists
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Create an Instance Group with enforced
+      instance_group:
+        name: "{{ group_name1 }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create an Instance Group with enforced values
+      instance_group:
+        name: "{{ group_name1 }}"
+        max_concurrent_jobs: 0
+        max_forks: 0
+        policy_instance_percentage: 0
+        policy_instance_minimum: 0
+        policy_instance_list: []
       register: result
 
     - assert:

--- a/awx_collection/tests/integration/targets/instance_group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/instance_group/tasks/main.yml
@@ -61,6 +61,16 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      instance_group:
+        name: "{{ group_name1 }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Create an Instance Group with enforced values
       instance_group:
         name: "{{ group_name1 }}"

--- a/awx_collection/tests/integration/targets/inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory/tasks/main.yml
@@ -78,6 +78,17 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      inventory:
+        name: "{{ inv_name1 }}"
+        organization: Default
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Check enforced values
       inventory:
         name: "{{ inv_name1 }}"

--- a/awx_collection/tests/integration/targets/inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory/tasks/main.yml
@@ -11,8 +11,8 @@
     cred_name1: "AWX-Collection-tests-inventory-cred1-{{ test_id }}"
     group_name1: "AWX-Collection-tests-instance_group-group1-{{ test_id }}"
 
-- block:
-
+- name: Run Tests
+  block:
     - name: Create an Instance Group
       instance_group:
         name: "{{ group_name1 }}"
@@ -41,7 +41,10 @@
     - name: Create an Inventory
       inventory:
         name: "{{ inv_name1 }}"
+        description: this is a description
         organization: Default
+        variables:
+          foo: bar
         instance_groups:
           - "{{ group_name1 }}"
         state: present
@@ -57,6 +60,31 @@
         organization: Default
         instance_groups:
           - "{{ group_name1 }}"
+        state: exists
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Create an Inventory with enforced
+      inventory:
+        name: "{{ inv_name1 }}"
+        organization: Default
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Check enforced values
+      inventory:
+        name: "{{ inv_name1 }}"
+        description: ''
+        organization: Default
+        instance_groups: []
+        variables: {}
         state: exists
       register: result
 

--- a/awx_collection/tests/integration/targets/inventory_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source/tasks/main.yml
@@ -79,6 +79,18 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        inventory: "{{ openstack_inv }}"
+        state: enforced
+        source: openstack
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Check enforced values set
       inventory_source:
         name: "{{ openstack_inv_source }}"

--- a/awx_collection/tests/integration/targets/inventory_source/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source/tasks/main.yml
@@ -10,134 +10,165 @@
     openstack_inv: "AWX-Collection-tests-inventory_source-inv-openstack-{{ test_id }}"
     openstack_inv_source: "AWX-Collection-tests-inventory_source-inv-source-openstack-{{ test_id }}"
 
-- name: Add a credential
-  credential:
-    description: Credentials for Openstack Test project
-    name: "{{ openstack_cred }}"
-    credential_type: OpenStack
-    organization: Default
-    inputs:
-      project: Test
-      username: admin
-      host: https://example.org:5000
-      password: passw0rd
-      domain: test
-  register: credential_result
+- name: Run Tests
+  block:
+    - name: Add a credential
+      credential:
+        description: Credentials for Openstack Test project
+        name: "{{ openstack_cred }}"
+        credential_type: OpenStack
+        organization: Default
+        inputs:
+          project: Test
+          username: admin
+          host: https://example.org:5000
+          password: passw0rd
+          domain: test
+      register: credential_result
 
-- name: Add an inventory
-  inventory:
-    description: Test inventory
-    organization: Default
-    name: "{{ openstack_inv }}"
+    - name: Add an inventory
+      inventory:
+        description: Test inventory
+        organization: Default
+        name: "{{ openstack_inv }}"
 
-- name: Create an source inventory
-  inventory_source:
-    name: "{{ openstack_inv_source }}"
-    description: Source for Test inventory
-    inventory: "{{ openstack_inv }}"
-    credential: "{{ credential_result.id }}"
-    overwrite: true
-    update_on_launch: true
-    source_vars:
-      private: false
-    source: openstack
-  register: result
+    - name: Create an source inventory
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        description: Source for Test inventory
+        inventory: "{{ openstack_inv }}"
+        credential: "{{ credential_result.id }}"
+        overwrite: true
+        update_on_launch: true
+        source_vars:
+          private: false
+        source: openstack
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create an source inventory with exists
-  inventory_source:
-    name: "{{ openstack_inv_source }}"
-    description: Source for Test inventory
-    inventory: "{{ openstack_inv }}"
-    credential: "{{ credential_result.id }}"
-    overwrite: true
-    update_on_launch: true
-    source_vars:
-      private: false
-    source: openstack
-    state: exists
-  register: result
+    - name: Create an source inventory with exists
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        description: Source for Test inventory
+        inventory: "{{ openstack_inv }}"
+        credential: "{{ credential_result.id }}"
+        overwrite: true
+        update_on_launch: true
+        source_vars:
+          private: false
+        source: openstack
+        state: exists
+      register: result
 
-- assert:
-    that:
-      - "result is not changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Delete an source inventory
-  inventory_source:
-    name: "{{ openstack_inv_source }}"
-    description: Source for Test inventory
-    inventory: "{{ openstack_inv }}"
-    credential: "{{ credential_result.id }}"
-    overwrite: true
-    update_on_launch: true
-    source_vars:
-      private: false
-    source: openstack
-    state: absent
-  register: result
+    - name: Create an source inventory with enforced
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        inventory: "{{ openstack_inv }}"
+        state: enforced
+        source: openstack
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create an source inventory with exists
-  inventory_source:
-    name: "{{ openstack_inv_source }}"
-    description: Source for Test inventory
-    inventory: "{{ openstack_inv }}"
-    credential: "{{ credential_result.id }}"
-    overwrite: true
-    update_on_launch: true
-    source_vars:
-      private: false
-    source: openstack
-    state: exists
-  register: result
+    - name: Check enforced values set
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        description: ''
+        inventory: "{{ openstack_inv }}"
+        credential: "{{ credential_result.id }}"
+        overwrite: False
+        update_on_launch: False
+        source_vars: {}
+        source: openstack
+        state: exists
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Delete the inventory source with an invalid cred and source_project specified
-  inventory_source:
-    name: "{{ result.id }}"
-    inventory: "{{ openstack_inv }}"
-    credential: "Does Not Exit"
-    source_project: "Does Not Exist"
-    state: absent
 
-- assert:
-    that:
-      - "result is changed"
+    - name: Delete an source inventory
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        description: Source for Test inventory
+        inventory: "{{ openstack_inv }}"
+        credential: "{{ credential_result.id }}"
+        overwrite: true
+        update_on_launch: true
+        source_vars:
+          private: false
+        source: openstack
+        state: absent
+      register: result
 
-- name: Delete the credential
-  credential:
-    description: Credentials for Openstack Test project
-    name: "{{ openstack_cred }}"
-    credential_type: OpenStack
-    organization: Default
-    inputs:
-      project: Test
-      username: admin
-      host: https://example.org:5000
-      password: passw0rd
-      domain: test
-    state: absent
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - "result is changed"
+    - name: Create an source inventory with exists
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        description: Source for Test inventory
+        inventory: "{{ openstack_inv }}"
+        credential: "{{ credential_result.id }}"
+        overwrite: true
+        update_on_launch: true
+        source_vars:
+          private: false
+        source: openstack
+        state: exists
+      register: result
 
-- name: Delete the inventory
-  inventory:
-    description: Test inventory
-    organization: Default
-    name: "{{ openstack_inv }}"
-    state: absent
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - "result is changed"
+    - name: Delete the inventory source with an invalid cred and source_project specified
+      inventory_source:
+        name: "{{ result.id }}"
+        inventory: "{{ openstack_inv }}"
+        credential: "Does Not Exit"
+        source_project: "Does Not Exist"
+        state: absent
+
+    - assert:
+        that:
+          - "result is changed"
+
+  always:
+    - name: Delete the inventory source with an invalid cred and source_project specified
+      inventory_source:
+        name: "{{ openstack_inv_source }}"
+        inventory: "{{ openstack_inv }}"
+        state: absent
+
+    - name: Delete the credential
+      credential:
+        description: Credentials for Openstack Test project
+        name: "{{ openstack_cred }}"
+        credential_type: OpenStack
+        organization: Default
+        inputs:
+          project: Test
+          username: admin
+          host: https://example.org:5000
+          password: passw0rd
+          domain: test
+        state: absent
+
+    - name: Delete the inventory
+      inventory:
+        description: Test inventory
+        organization: Default
+        name: "{{ openstack_inv }}"
+        state: absent

--- a/awx_collection/tests/integration/targets/job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_template/tasks/main.yml
@@ -19,502 +19,547 @@
     webhook_not: "AWX-Collection-tests-notification_template-wehbook-not-{{ test_id }}"
     group_name1: "AWX-Collection-tests-instance_group-group1-{{ test_id }}"
 
-- name: "Create a new organization"
-  organization:
-    name: "{{ org_name }}"
-    galaxy_credentials:
-      - Ansible Galaxy
-  register: result
-
-- name: Create an inventory
-  inventory:
-    name: "{{ inv1 }}"
-    organization: "{{ org_name }}"
-
-- name: Create a Demo Project
-  project:
-    name: "{{ proj1 }}"
-    organization: Default
-    state: present
-    scm_type: git
-    scm_url: https://github.com/ansible/ansible-tower-samples.git
-  register: proj_result
-
-- name: Create Credential1
-  credential:
-    name: "{{ cred1 }}"
-    organization: Default
-    credential_type: Red Hat Ansible Automation Platform
-  register: cred1_result
-
-- name: Create Credential2
-  credential:
-    name: "{{ cred2 }}"
-    organization: Default
-    credential_type: Machine
-
-- name: Create Credential3
-  credential:
-    name: "{{ cred3 }}"
-    organization: Default
-    credential_type: Machine
-
-- name: Create Labels
-  label:
-    name: "{{ lab1 }}"
-    organization: "{{ item }}"
-  loop:
-    - Default
-    - "{{ org_name }}"
-
-- name: Create an Instance Group
-  instance_group:
-    name: "{{ group_name1 }}"
-    state: present
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Add email notification
-  notification_template:
-    name: "{{ email_not }}"
-    organization: Default
-    notification_type: email
-    notification_configuration:
-      username: user
-      password: s3cr3t
-      sender: tower@example.com
-      recipients:
-        - user1@example.com
-      host: smtp.example.com
-      port: 25
-      use_tls: false
-      use_ssl: false
-    state: present
-
-- name: Add webhook notification
-  notification_template:
-    name: "{{ webhook_not }}"
-    organization: Default
-    notification_type: webhook
-    notification_configuration:
-      url: http://www.example.com/hook
-      headers:
-        X-Custom-Header: value123
-    state: present
-  register: result
-
-- name: Create Job Template 1
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj1 }}"
-    inventory: "{{ inv1 }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1 }}"
-      - "{{ cred2 }}"
-    instance_groups:
-      - "{{ group_name1 }}"
-    job_type: run
-    state: present
-  register: jt1_result
-
-- assert:
-    that:
-      - "jt1_result is changed"
-
-- name: Create Job Template 1 with exists
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj1 }}"
-    inventory: "{{ inv1 }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1 }}"
-      - "{{ cred2 }}"
-    instance_groups:
-      - "{{ group_name1 }}"
-    job_type: run
-    state: exists
-  register: jt1_result
-
-- assert:
-    that:
-      - "jt1_result is not changed"
-
-- name: Delete Job Template 1
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj1 }}"
-    inventory: "{{ inv1 }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1 }}"
-      - "{{ cred2 }}"
-    instance_groups:
-      - "{{ group_name1 }}"
-    job_type: run
-    state: absent
-  register: jt1_result
-
-- assert:
-    that:
-      - "jt1_result is changed"
-
-- name: Create Job Template 1 with exists
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj1 }}"
-    inventory: "{{ inv1 }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1 }}"
-      - "{{ cred2 }}"
-    instance_groups:
-      - "{{ group_name1 }}"
-    job_type: run
-    state: exists
-  register: jt1_result
-
-- assert:
-    that:
-      - "jt1_result is changed"
-
-- name: Add a credential to this JT
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj_result.id }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1_result.id }}"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Try to add the same credential to this JT
-  job_template:
-    name: "{{ jt1_result.id }}"
-    project: "{{ proj1 }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1 }}"
-  register: result
-
-- assert:
-    that:
-      - "result is not changed"
-
-- name: Add another credential to this JT
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj1 }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1 }}"
-      - "{{ cred2 }}"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Remove a credential for this JT
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj1 }}"
-    playbook: hello_world.yml
-    credentials:
-      - "{{ cred1 }}"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Remove all credentials from this JT
-  job_template:
-    name: "{{ jt1 }}"
-    project: "{{ proj1 }}"
-    playbook: hello_world.yml
-    credentials: []
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Copy Job Template
-  job_template:
-    name: "copy_{{ jt1 }}"
-    copy_from: "{{ jt1 }}"
-    state: "present"
-
-- name: Delete copied Job Template
-  job_template:
-    name: "copy_{{ jt1 }}"
-    job_type: run
-    state: absent
-  register: result
-
-# This doesnt work if you include the credentials parameter
-- name: Delete Job Template 1
-  job_template:
-    name: "{{ jt1 }}"
-    playbook: hello_world.yml
-    job_type: run
-    project: "Does Not Exist"
-    inventory: "Does Not Exist"
-    webhook_credential: "Does Not Exist"
-    state: absent
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Create Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    organization: Default
-    project: "{{ proj1 }}"
-    inventory: "{{ inv1 }}"
-    playbook: hello_world.yml
-    credential: "{{ cred3 }}"
-    job_type: run
-    labels:
-      - "{{ lab1 }}"
-    state: present
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: add bad label to Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    organization: Default
-    project: "{{ proj1 }}"
-    inventory: "{{ inv1 }}"
-    playbook: hello_world.yml
-    credential: "{{ cred3 }}"
-    job_type: run
-    labels:
-      - label_bad
-    state: present
-  register: bad_label_results
-  ignore_errors: true
-
-- assert:
-    that:
-      - "bad_label_results.msg == 'Could not find label entry with name label_bad'"
-
-- name: Add survey to Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    survey_enabled: true
-    survey_spec:
-      name: ""
-      description: ""
-      spec:
-        - question_name: "Q1"
-          question_description: "The first question"
-          required: true
-          type: "text"
-          variable: "q1"
-          min: 5
-          max: 15
-          default: "hello"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Re Add survey to Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    survey_enabled: true
-    survey_spec:
-      name: ""
-      description: ""
-      spec:
-        - question_name: "Q1"
-          question_description: "The first question"
-          required: true
-          type: "text"
-          variable: "q1"
-          min: 5
-          max: 15
-          default: "hello"
-  register: result
-
-- assert:
-    that:
-      - "result is not changed"
-
-- name: Add question to survey to Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    survey_enabled: true
-    survey_spec:
-      name: ""
-      description: ""
-      spec:
-        - question_name: "Q1"
-          question_description: "The first question"
-          required: true
-          type: "text"
-          variable: "q1"
-          min: 5
-          max: 15
-          default: "hello"
-          choices: ""
-        - question_name: "Q2"
-          type: "text"
-          variable: "q2"
-          required: false
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Remove survey from Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    survey_enabled: false
-    survey_spec: {}
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Add started notifications to Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    notification_templates_started:
-      - "{{ email_not }}"
-      - "{{ webhook_not }}"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Re Add started notifications to Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    notification_templates_started:
-      - "{{ email_not }}"
-      - "{{ webhook_not }}"
-  register: result
-
-- assert:
-    that:
-      - "result is not changed"
-
-- name: Add success notifications to Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    notification_templates_success:
-      - "{{ email_not }}"
-      - "{{ webhook_not }}"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Remove "on start" webhook notification from Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    notification_templates_started:
-      - "{{ email_not }}"
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-
-- name: Delete Job Template 2
-  job_template:
-    name: "{{ jt2 }}"
-    project: "{{ proj1 }}"
-    inventory: "{{ inv1 }}"
-    playbook: hello_world.yml
-    credential: "{{ cred3 }}"
-    job_type: run
-    state: absent
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Delete the Demo Project
-  project:
-    name: "{{ proj1 }}"
-    organization: Default
-    state: absent
-    scm_type: git
-    scm_url: https://github.com/ansible/ansible-tower-samples.git
-  register: result
-
-- name: Delete Credential1
-  credential:
-    name: "{{ cred1 }}"
-    organization: Default
-    credential_type: Red Hat Ansible Automation Platform
-    state: absent
-
-- name: Delete Credential2
-  credential:
-    name: "{{ cred2 }}"
-    organization: Default
-    credential_type: Machine
-    state: absent
-
-- name: Delete Credential3
-  credential:
-    name: "{{ cred3 }}"
-    organization: Default
-    credential_type: Machine
-    state: absent
-
-# You can't delete a label directly so no cleanup needed
-
-- name: Delete email notification
-  notification_template:
-    name: "{{ email_not }}"
-    organization: Default
-    state: absent
-
-- name: Delete the instance groups
-  instance_group:
-    name: "{{ group_name1 }}"
-    state: absent
-
-- name: Delete webhook notification
-  notification_template:
-    name: "{{ webhook_not }}"
-    organization: Default
-    state: absent
-
-- name: Delete an inventory
-  inventory:
-    name: "{{ inv1 }}"
-    organization: "{{ org_name }}"
-    state: absent
-
-- name: "Remove the organization"
-  organization:
-    name: "{{ org_name }}"
-    state: absent
-  register: result
+- name: Run Tests
+  block:
+    - name: "Create a new organization"
+      organization:
+        name: "{{ org_name }}"
+        galaxy_credentials:
+          - Ansible Galaxy
+      register: result
+
+    - name: Create an inventory
+      inventory:
+        name: "{{ inv1 }}"
+        organization: "{{ org_name }}"
+
+    - name: Create a Demo Project
+      project:
+        name: "{{ proj1 }}"
+        organization: Default
+        allow_override: true
+        state: present
+        scm_type: git
+        scm_url: https://github.com/ansible/ansible-tower-samples.git
+      register: proj_result
+
+    - name: Create Credential1
+      credential:
+        name: "{{ cred1 }}"
+        organization: Default
+        credential_type: Red Hat Ansible Automation Platform
+      register: cred1_result
+
+    - name: Create Credential2
+      credential:
+        name: "{{ cred2 }}"
+        organization: Default
+        credential_type: Machine
+
+    - name: Create Credential3
+      credential:
+        name: "{{ cred3 }}"
+        organization: Default
+        credential_type: Machine
+
+    - name: Create Labels
+      label:
+        name: "{{ lab1 }}"
+        organization: "{{ item }}"
+      loop:
+        - Default
+        - "{{ org_name }}"
+
+    - name: Create an Instance Group
+      instance_group:
+        name: "{{ group_name1 }}"
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Add email notification
+      notification_template:
+        name: "{{ email_not }}"
+        organization: Default
+        notification_type: email
+        notification_configuration:
+          username: user
+          password: s3cr3t
+          sender: tower@example.com
+          recipients:
+            - user1@example.com
+          host: smtp.example.com
+          port: 25
+          use_tls: false
+          use_ssl: false
+        state: present
+
+    - name: Add webhook notification
+      notification_template:
+        name: "{{ webhook_not }}"
+        organization: Default
+        notification_type: webhook
+        notification_configuration:
+          url: http://www.example.com/hook
+          headers:
+            X-Custom-Header: value123
+        state: present
+      register: result
+
+    - name: Create Job Template 1
+      job_template:
+        name: "{{ jt1 }}"
+        description: this is a description.
+        scm_branch: devel
+        ask_scm_branch_on_launch: true
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1 }}"
+          - "{{ cred2 }}"
+        instance_groups:
+          - "{{ group_name1 }}"
+        job_type: run
+        state: present
+      register: jt1_result
+
+    - assert:
+        that:
+          - "jt1_result is changed"
+
+    - name: Create Job Template 1 with exists
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1 }}"
+          - "{{ cred2 }}"
+        instance_groups:
+          - "{{ group_name1 }}"
+        job_type: run
+        state: exists
+      register: jt1_result
+
+    - assert:
+        that:
+          - "jt1_result is not changed"
+
+    - name: Create Job Template 1 with enforced
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        state: enforced
+      register: jt1_result
+
+    - assert:
+        that:
+          - "jt1_result is changed"
+
+    - name: Make sure enforced values went through
+      job_template:
+        name: "{{ jt1 }}"
+        description: ''
+        scm_branch: ''
+        ask_scm_branch_on_launch: false
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credentials: []
+        instance_groups: []
+        state: exists
+      register: jt1_result
+
+    - assert:
+        that:
+          - "jt1_result is not changed"
+
+
+    - name: Delete Job Template 1
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1 }}"
+          - "{{ cred2 }}"
+        instance_groups:
+          - "{{ group_name1 }}"
+        job_type: run
+        state: absent
+      register: jt1_result
+
+    - assert:
+        that:
+          - "jt1_result is changed"
+
+    - name: Create Job Template 1 with exists
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1 }}"
+          - "{{ cred2 }}"
+        instance_groups:
+          - "{{ group_name1 }}"
+        job_type: run
+        state: exists
+      register: jt1_result
+
+    - assert:
+        that:
+          - "jt1_result is changed"
+
+    - name: Add a credential to this JT
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj_result.id }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1_result.id }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Try to add the same credential to this JT
+      job_template:
+        name: "{{ jt1_result.id }}"
+        project: "{{ proj1 }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1 }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Add another credential to this JT
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1 }}"
+          - "{{ cred2 }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Remove a credential for this JT
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        playbook: hello_world.yml
+        credentials:
+          - "{{ cred1 }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Remove all credentials from this JT
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        playbook: hello_world.yml
+        credentials: []
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Copy Job Template
+      job_template:
+        name: "copy_{{ jt1 }}"
+        copy_from: "{{ jt1 }}"
+        state: "present"
+
+    - name: Delete copied Job Template
+      job_template:
+        name: "copy_{{ jt1 }}"
+        job_type: run
+        state: absent
+      register: result
+
+    # This doesnt work if you include the credentials parameter
+    - name: Delete Job Template 1
+      job_template:
+        name: "{{ jt1 }}"
+        playbook: hello_world.yml
+        job_type: run
+        project: "Does Not Exist"
+        inventory: "Does Not Exist"
+        webhook_credential: "Does Not Exist"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Create Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        organization: Default
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credential: "{{ cred3 }}"
+        job_type: run
+        labels:
+          - "{{ lab1 }}"
+        state: present
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: add bad label to Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        organization: Default
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credential: "{{ cred3 }}"
+        job_type: run
+        labels:
+          - label_bad
+        state: present
+      register: bad_label_results
+      ignore_errors: true
+
+    - assert:
+        that:
+          - "bad_label_results.msg == 'Could not find label entry with name label_bad'"
+
+    - name: Add survey to Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        survey_enabled: true
+        survey_spec:
+          name: ""
+          description: ""
+          spec:
+            - question_name: "Q1"
+              question_description: "The first question"
+              required: true
+              type: "text"
+              variable: "q1"
+              min: 5
+              max: 15
+              default: "hello"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Re Add survey to Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        survey_enabled: true
+        survey_spec:
+          name: ""
+          description: ""
+          spec:
+            - question_name: "Q1"
+              question_description: "The first question"
+              required: true
+              type: "text"
+              variable: "q1"
+              min: 5
+              max: 15
+              default: "hello"
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Add question to survey to Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        survey_enabled: true
+        survey_spec:
+          name: ""
+          description: ""
+          spec:
+            - question_name: "Q1"
+              question_description: "The first question"
+              required: true
+              type: "text"
+              variable: "q1"
+              min: 5
+              max: 15
+              default: "hello"
+              choices: ""
+            - question_name: "Q2"
+              type: "text"
+              variable: "q2"
+              required: false
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Remove survey from Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        survey_enabled: false
+        survey_spec: {}
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Add started notifications to Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        notification_templates_started:
+          - "{{ email_not }}"
+          - "{{ webhook_not }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Re Add started notifications to Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        notification_templates_started:
+          - "{{ email_not }}"
+          - "{{ webhook_not }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Add success notifications to Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        notification_templates_success:
+          - "{{ email_not }}"
+          - "{{ webhook_not }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Remove "on start" webhook notification from Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        notification_templates_started:
+          - "{{ email_not }}"
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+  always:
+    - name: Delete Job Template 1
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credential: "{{ cred3 }}"
+        job_type: run
+        state: absent
+      register: result
+
+    - name: Delete Job Template 2
+      job_template:
+        name: "{{ jt2 }}"
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        credential: "{{ cred3 }}"
+        job_type: run
+        state: absent
+      register: result
+
+    - name: Delete the Demo Project
+      project:
+        name: "{{ proj1 }}"
+        organization: Default
+        state: absent
+        scm_type: git
+        scm_url: https://github.com/ansible/ansible-tower-samples.git
+      register: result
+
+    - name: Delete Credential1
+      credential:
+        name: "{{ cred1 }}"
+        organization: Default
+        credential_type: Red Hat Ansible Automation Platform
+        state: absent
+
+    - name: Delete Credential2
+      credential:
+        name: "{{ cred2 }}"
+        organization: Default
+        credential_type: Machine
+        state: absent
+
+    - name: Delete Credential3
+      credential:
+        name: "{{ cred3 }}"
+        organization: Default
+        credential_type: Machine
+        state: absent
+
+    # You can't delete a label directly so no cleanup needed
+
+    - name: Delete email notification
+      notification_template:
+        name: "{{ email_not }}"
+        organization: Default
+        state: absent
+
+    - name: Delete the instance groups
+      instance_group:
+        name: "{{ group_name1 }}"
+        state: absent
+
+    - name: Delete webhook notification
+      notification_template:
+        name: "{{ webhook_not }}"
+        organization: Default
+        state: absent
+
+    - name: Delete an inventory
+      inventory:
+        name: "{{ inv1 }}"
+        organization: "{{ org_name }}"
+        state: absent
+
+    - name: "Remove the organization"
+      organization:
+        name: "{{ org_name }}"
+        state: absent
+      register: result

--- a/awx_collection/tests/integration/targets/job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_template/tasks/main.yml
@@ -163,6 +163,19 @@
         that:
           - "jt1_result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        inventory: "{{ inv1 }}"
+        playbook: hello_world.yml
+        state: enforced
+      register: jt1_result
+
+    - assert:
+        that:
+          - "jt1_result is not changed"
+
     - name: Make sure enforced values went through
       job_template:
         name: "{{ jt1 }}"

--- a/awx_collection/tests/integration/targets/notification_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/notification_template/tasks/main.yml
@@ -6,282 +6,305 @@
 
 - name: Generate names
   set_fact:
-    slack_not: "AWX-Collection-tests-notification_template-slack-not-{{ test_id }}"
+    slack_not: "AWX-Collection-tests-notification_template-slack-{{ test_id }}"
     webhook_not: "AWX-Collection-tests-notification_template-wehbook-not-{{ test_id }}"
     email_not: "AWX-Collection-tests-notification_template-email-not-{{ test_id }}"
     twillo_not: "AWX-Collection-tests-notification_template-twillo-not-{{ test_id }}"
     pd_not: "AWX-Collection-tests-notification_template-pd-not-{{ test_id }}"
     irc_not: "AWX-Collection-tests-notification_template-irc-not-{{ test_id }}"
 
-- name: Create Slack notification with custom messages
-  notification_template:
-    name: "{{ slack_not }}"
-    organization: Default
-    notification_type: slack
-    notification_configuration:
-      token: a_token
-      channels:
-        - general
-    messages:
-      started:
-        message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
-      success:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
-      error:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
-    state: present
-  register: result
+- name: Run Tests
+  block:
+    - name: Create Slack notification with custom messages
+      notification_template:
+        name: "{{ slack_not }}"
+        organization: Default
+        notification_type: slack
+        notification_configuration:
+          token: a_token
+          channels:
+            - general
+        messages:
+          started:
+            message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
+          success:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
+          error:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
+        state: present
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Create Slack notification with custom messages with exists
-  notification_template:
-    name: "{{ slack_not }}"
-    organization: Default
-    notification_type: slack
-    notification_configuration:
-      token: a_token
-      channels:
-        - general
-    messages:
-      started:
-        message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
-      success:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
-      error:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
-    state: exists
-  register: result
+    - name: Create Slack notification with custom messages with exists
+      notification_template:
+        name: "{{ slack_not }}"
+        description: this is a description
+        organization: Default
+        notification_type: slack
+        notification_configuration:
+          token: a_token
+          channels:
+            - general
+        messages:
+          started:
+            message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
+          success:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
+          error:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
+        state: exists
+      register: result
 
-- assert:
-    that:
-      - result is not changed
+    - assert:
+        that:
+          - result is not changed
 
-- name: Delete Slack notification with custom messages
-  notification_template:
-    name: "{{ slack_not }}"
-    organization: Default
-    notification_type: slack
-    notification_configuration:
-      token: a_token
-      channels:
-        - general
-    messages:
-      started:
-        message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
-      success:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
-      error:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
-    state: absent
-  register: result
+    - name: Create Slack notification with custom messages with enforced
+      notification_template:
+        name: "{{ slack_not }}"
+        organization: Default
+        notification_type: slack
+        messages: {}
+        notification_configuration:
+          token: a_token
+          channels:
+            - general
+        state: enforced
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Create Slack notification with custom messages with exists
-  notification_template:
-    name: "{{ slack_not }}"
-    organization: Default
-    notification_type: slack
-    notification_configuration:
-      token: a_token
-      channels:
-        - general
-    messages:
-      started:
-        message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
-      success:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
-      error:
-        message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
-    state: exists
-  register: result
+    - name: Delete Slack notification with custom messages
+      notification_template:
+        name: "{{ slack_not }}"
+        organization: Default
+        notification_type: slack
+        notification_configuration:
+          token: a_token
+          channels:
+            - general
+        messages:
+          started:
+            message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
+          success:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
+          error:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Delete Slack notification
-  notification_template:
-    name: "{{ slack_not }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Create Slack notification with custom messages with exists
+      notification_template:
+        name: "{{ slack_not }}"
+        organization: Default
+        notification_type: slack
+        notification_configuration:
+          token: a_token
+          channels:
+            - general
+        messages:
+          started:
+            message: "{{ '{{' }} job_friendly_name {{' }}' }} {{ '{{' }} job.id {{' }}' }} started"
+          success:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} completed in {{ '{{' }} job.elapsed {{ '}}' }} seconds"
+          error:
+            message: "{{ '{{' }} job_friendly_name {{ '}}' }} FAILED! Please look at {{ '{{' }} job.url {{ '}}' }}"
+        state: exists
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Add webhook notification
-  notification_template:
-    name: "{{ webhook_not }}"
-    organization: Default
-    notification_type: webhook
-    notification_configuration:
-      url: http://www.example.com/hook
-      headers:
-        X-Custom-Header: value123
-    state: present
-  register: result
+    - name: Delete Slack notification
+      notification_template:
+        name: "{{ slack_not }}"
+        organization: Default
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Delete webhook notification
-  notification_template:
-    name: "{{ webhook_not }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Add webhook notification
+      notification_template:
+        name: "{{ webhook_not }}"
+        organization: Default
+        notification_type: webhook
+        notification_configuration:
+          url: http://www.example.com/hook
+          headers:
+            X-Custom-Header: value123
+        state: present
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Add email notification
-  notification_template:
-    name: "{{ email_not }}"
-    organization: Default
-    notification_type: email
-    notification_configuration:
-      username: user
-      password: s3cr3t
-      sender: tower@example.com
-      recipients:
-        - user1@example.com
-      host: smtp.example.com
-      port: 25
-      use_tls: false
-      use_ssl: false
-    state: present
-  register: result
+    - name: Delete webhook notification
+      notification_template:
+        name: "{{ webhook_not }}"
+        organization: Default
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Copy email notification
-  notification_template:
-    name: "copy_{{ email_not }}"
-    copy_from: "{{ email_not }}"
-    organization: Default
-  register: result
+    - name: Add email notification
+      notification_template:
+        name: "{{ email_not }}"
+        organization: Default
+        notification_type: email
+        notification_configuration:
+          username: user
+          password: s3cr3t
+          sender: tower@example.com
+          recipients:
+            - user1@example.com
+          host: smtp.example.com
+          port: 25
+          use_tls: false
+          use_ssl: false
+        state: present
+      register: result
 
-- assert:
-    that:
-      - result.copied
+    - assert:
+        that:
+          - result is changed
 
-- name: Delete copied email notification
-  notification_template:
-    name: "copy_{{ email_not }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Copy email notification
+      notification_template:
+        name: "copy_{{ email_not }}"
+        copy_from: "{{ email_not }}"
+        organization: Default
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result.copied
 
-- name: Delete email notification
-  notification_template:
-    name: "{{ email_not }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Delete copied email notification
+      notification_template:
+        name: "copy_{{ email_not }}"
+        organization: Default
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Add twilio notification
-  notification_template:
-    name: "{{ twillo_not }}"
-    organization: Default
-    notification_type: twilio
-    notification_configuration:
-      account_token: a_token
-      account_sid: a_sid
-      from_number: '+15551112222'
-      to_numbers:
-        - '+15553334444'
-    state: present
-  register: result
+    - name: Delete email notification
+      notification_template:
+        name: "{{ email_not }}"
+        organization: Default
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Delete twilio notification
-  notification_template:
-    name: "{{ twillo_not }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Add twilio notification
+      notification_template:
+        name: "{{ twillo_not }}"
+        organization: Default
+        notification_type: twilio
+        notification_configuration:
+          account_token: a_token
+          account_sid: a_sid
+          from_number: '+15551112222'
+          to_numbers:
+            - '+15553334444'
+        state: present
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Add PagerDuty notification
-  notification_template:
-    name: "{{ pd_not }}"
-    organization: Default
-    notification_type: pagerduty
-    notification_configuration:
-      token: a_token
-      subdomain: sub
-      client_name: client
-      service_key: a_key
-    state: present
-  register: result
+    - name: Delete twilio notification
+      notification_template:
+        name: "{{ twillo_not }}"
+        organization: Default
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Delete PagerDuty notification
-  notification_template:
-    name: "{{ pd_not }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Add PagerDuty notification
+      notification_template:
+        name: "{{ pd_not }}"
+        organization: Default
+        notification_type: pagerduty
+        notification_configuration:
+          token: a_token
+          subdomain: sub
+          client_name: client
+          service_key: a_key
+        state: present
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Add IRC notification
-  notification_template:
-    name: "{{ irc_not }}"
-    organization: Default
-    notification_type: irc
-    notification_configuration:
-      nickname: tower
-      password: s3cr3t
-      targets:
-        - user1
-      port: 8080
-      server: irc.example.com
-      use_ssl: false
-    state: present
-  register: result
+    - name: Delete PagerDuty notification
+      notification_template:
+        name: "{{ pd_not }}"
+        organization: Default
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
 
-- name: Delete IRC notification
-  notification_template:
-    name: "{{ irc_not }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Add IRC notification
+      notification_template:
+        name: "{{ irc_not }}"
+        organization: Default
+        notification_type: irc
+        notification_configuration:
+          nickname: tower
+          password: s3cr3t
+          targets:
+            - user1
+          port: 8080
+          server: irc.example.com
+          use_ssl: false
+        state: present
+      register: result
 
-- assert:
-    that:
-      - result is changed
+    - assert:
+        that:
+          - result is changed
+  always:
+    - name: Delete notifications
+      notification_template:
+        name: "{{ item }}"
+        organization: Default
+        state: absent
+      register: result
+      loop:
+        - "{{ slack_not }}"
+        - "{{ webhook_not }}"
+        - "{{ email_not }}"
+        - "{{ twillo_not }}"
+        - "{{ pd_not }}"
+        - "{{ irc_not }}"

--- a/awx_collection/tests/integration/targets/organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/organization/tasks/main.yml
@@ -48,6 +48,15 @@
     - assert:
         that: "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      organization:
+        name: "{{ org_name }}"
+        state: enforced
+      register: result
+
+    - assert:
+        that: "result is not changed"
+
     - name: "Add back items to organization to show enforced default worked"
       organization:
         name: "{{ org_name }}"

--- a/awx_collection/tests/integration/targets/organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/organization/tasks/main.yml
@@ -9,145 +9,178 @@
     org_name: "AWX-Collection-tests-organization-org-{{ test_id }}"
     group_name1: "AWX-Collection-tests-instance_group-group1-{{ test_id }}"
 
-- name: Make sure {{ org_name }} is not there
-  organization:
-    name: "{{ org_name }}"
-    state: absent
-  register: result
+- name: Run Tests
+  block:
+    - name: Make sure {{ org_name }} is not there
+      organization:
+        name: "{{ org_name }}"
+        state: absent
+      register: result
 
-- name: "Create a new organization"
-  organization:
-    name: "{{ org_name }}"
-    galaxy_credentials:
-      - Ansible Galaxy
-  register: result
+    - name: "Create a new organization"
+      organization:
+        name: "{{ org_name }}"
+        description: insert generic description here
+        galaxy_credentials:
+          - Ansible Galaxy
+      register: result
 
-- assert:
-    that: "result is changed"
+    - assert:
+        that: "result is changed"
 
-- name: "Create a new organization with exists"
-  organization:
-    name: "{{ org_name }}"
-    galaxy_credentials:
-      - Ansible Galaxy
-    state: exists
-  register: result
+    - name: "Create a new organization with exists"
+      organization:
+        name: "{{ org_name }}"
+        galaxy_credentials:
+          - Ansible Galaxy
+        state: exists
+      register: result
 
-- assert:
-    that: "result is not changed"
+    - assert:
+        that: "result is not changed"
 
-- name: "Delete a new organization"
-  organization:
-    name: "{{ org_name }}"
-    galaxy_credentials:
-      - Ansible Galaxy
-    state: absent
-  register: result
+    - name: "Enforced default organization to reset options"
+      organization:
+        name: "{{ org_name }}"
+        state: enforced
+      register: result
 
-- assert:
-    that: "result is changed"
+    - assert:
+        that: "result is changed"
 
-- name: "Create a new organization with exists"
-  organization:
-    name: "{{ org_name }}"
-    galaxy_credentials:
-      - Ansible Galaxy
-    state: exists
-  register: result
+    - name: "Add back items to organization to show enforced default worked"
+      organization:
+        name: "{{ org_name }}"
+        galaxy_credentials:
+          - Ansible Galaxy
+      register: result
 
-- assert:
-    that: "result is changed"
+    - assert:
+        that: "result is changed"
 
-- name: "Make sure making the same org is not a change"
-  organization:
-    name: "{{ org_name }}"
-  register: result
+    - name: "Delete a new organization"
+      organization:
+        name: "{{ org_name }}"
+        galaxy_credentials:
+          - Ansible Galaxy
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - "result is not changed"
+    - assert:
+        that: "result is changed"
 
-- name: Create an Instance Group
-  instance_group:
-    name: "{{ group_name1 }}"
-    state: present
-  register: result
+    - name: "Create a new organization with exists"
+      organization:
+        name: "{{ org_name }}"
+        galaxy_credentials:
+          - Ansible Galaxy
+        state: exists
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that: "result is changed"
 
-- name: "Pass in all parameters"
-  organization:
-    name: "{{ org_name }}"
-    description: "A description"
-    instance_groups:
-      - "{{ group_name1 }}"
-  register: result
+    - name: "Make sure making the same org is not a change"
+      organization:
+        name: "{{ org_name }}"
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: "Change the description"
-  organization:
-    name: "{{ org_name }}"
-    description: "A new description"
-  register: result
+    - name: Create an Instance Group
+      instance_group:
+        name: "{{ group_name1 }}"
+        state: present
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Delete the instance groups
-  instance_group:
-    name: "{{ group_name1 }}"
-    state: absent
+    - name: "Pass in all parameters"
+      organization:
+        name: "{{ org_name }}"
+        description: "A description"
+        instance_groups:
+          - "{{ group_name1 }}"
+      register: result
 
-- name: "Rename the organization"
-  organization:
-    name: "{{ org_name }}"
-    new_name: "{{ org_name }}a"
-  register: result
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - "result is changed"
+    - name: "Change the description"
+      organization:
+        name: "{{ org_name }}"
+        description: "A new description"
+      register: result
 
-- name: "Remove the organization"
-  organization:
-    name: "{{ org_name }}a"
-    state: absent
-  register: result
+    - assert:
+        that:
+          - "result is changed"
 
-- assert:
-    that:
-      - "result is changed"
+    - name: Delete the instance groups
+      instance_group:
+        name: "{{ group_name1 }}"
+        state: absent
 
-- name: "Remove a missing organization"
-  organization:
-    name: "{{ org_name }}"
-    state: absent
-  register: result
+    - name: "Rename the organization"
+      organization:
+        name: "{{ org_name }}"
+        new_name: "{{ org_name }}a"
+      register: result
 
-- assert:
-    that:
-      - "result is not changed"
+    - assert:
+        that:
+          - "result is changed"
 
-# Test behaviour common to all controller modules
-- name: Check that SSL is available and verify_ssl is enabled (task must fail)
-  organization:
-    name: Default
-    validate_certs: true
-  ignore_errors: true
-  register: check_ssl_is_used
+    - name: "Remove the organization"
+      organization:
+        name: "{{ org_name }}a"
+        state: absent
+      register: result
 
-- name: Check that connection failed
-  assert:
-    that:
-      - "'CERTIFICATE_VERIFY_FAILED' in check_ssl_is_used['msg']"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Check that verify_ssl is disabled (task must not fail)
-  organization:
-    name: Default
-    validate_certs: false
+    - name: "Remove a missing organization"
+      organization:
+        name: "{{ org_name }}"
+        state: absent
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    # Test behaviour common to all controller modules
+    - name: Check that SSL is available and verify_ssl is enabled (task must fail)
+      organization:
+        name: Default
+        validate_certs: true
+      ignore_errors: true
+      register: check_ssl_is_used
+
+    - name: Check that connection failed
+      assert:
+        that:
+          - "'CERTIFICATE_VERIFY_FAILED' in check_ssl_is_used['msg']"
+
+    - name: Check that verify_ssl is disabled (task must not fail)
+      organization:
+        name: Default
+        validate_certs: false
+
+
+  always:
+    - name: "Remove organizations"
+      organization:
+        name: "{{ item }}"
+        state: absent
+      register: result
+      loop:
+        - "{{ org_name }}"
+        - "{{ org_name }}a"

--- a/awx_collection/tests/integration/targets/project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project/tasks/main.yml
@@ -75,6 +75,23 @@
         that:
           - result is changed
 
+    - name: Rerun to ensure no changes with enforced
+      project:
+        name: "{{ project_name1 }}"
+        description: ""
+        organization: Default
+        scm_delete_on_update: False
+        scm_update_on_launch: False
+        timeout: 0
+        scm_type: git
+        scm_url: https://github.com/ansible/test-playbooks
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
     - name: Check enforced options set
       project:
         name: "{{ project_name1 }}"

--- a/awx_collection/tests/integration/targets/project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project/tasks/main.yml
@@ -14,7 +14,8 @@
     org_name: "AWX-Collection-tests-project-org-{{ test_id }}"
     cred_name: "AWX-Collection-tests-project-cred-{{ test_id }}"
 
-- block:
+- name: Run Tests
+  block:
     - name: Create an SCM Credential
       credential:
         name: "{{ scm_cred_name }}"
@@ -29,7 +30,11 @@
     - name: Create a git project without credentials and wait
       project:
         name: "{{ project_name1 }}"
+        description: this is a description
         organization: Default
+        scm_delete_on_update: True
+        scm_update_on_launch: True
+        timeout: 400
         scm_type: git
         scm_url: https://github.com/ansible/test-playbooks
         wait: true
@@ -52,6 +57,37 @@
     - assert:
         that:
           - result is not changed
+
+    - name: Create a git project with enforced
+      project:
+        name: "{{ project_name1 }}"
+        description: ""
+        organization: Default
+        scm_delete_on_update: False
+        scm_update_on_launch: False
+        timeout: 0
+        scm_type: git
+        scm_url: https://github.com/ansible/test-playbooks
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Check enforced options set
+      project:
+        name: "{{ project_name1 }}"
+        organization: Default
+        scm_type: git
+        scm_url: https://github.com/ansible/test-playbooks
+        wait: true
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
 
     - name: Delete a git project without credentials and wait
       project:

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -90,6 +90,18 @@
         that:
           - result is changed
 
+    - name: Rerun to ensure no changes with enforced
+      schedule:
+        name: "{{ sched1 }}"
+        state: enforced
+        unified_job_template: "Demo Job Template"
+        rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
     - name: Ensure defaults were reset.
       schedule:
         name: "{{ sched1 }}"

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -68,6 +68,8 @@
       schedule:
         name: "{{ sched1 }}"
         state: present
+        description: insert generic description here
+        enabled: false
         unified_job_template: "Demo Job Template"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
@@ -75,6 +77,30 @@
     - assert:
         that:
           - result is changed
+
+    - name: Set enforced to reset defaults on schedule
+      schedule:
+        name: "{{ sched1 }}"
+        state: enforced
+        unified_job_template: "Demo Job Template"
+        rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
+    - name: Ensure defaults were reset.
+      schedule:
+        name: "{{ sched1 }}"
+        state: present
+        unified_job_template: "Demo Job Template"
+        rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
 
     - name: Build a real schedule with exists
       schedule:

--- a/awx_collection/tests/integration/targets/team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/team/tasks/main.yml
@@ -59,6 +59,17 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      team:
+        name: "{{ team_name }}"
+        organization: Default
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Check enforced options worked
       team:
         name: "{{ team_name }}"

--- a/awx_collection/tests/integration/targets/team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/team/tasks/main.yml
@@ -8,88 +8,110 @@
   set_fact:
     team_name: "AWX-Collection-tests-team-team-{{ test_id }}"
 
-- name: Attempt to add a team to a non-existant Organization
-  team:
-    name: Test Team
-    organization: Missing_Organization
-    state: present
-  register: result
-  ignore_errors: true
+- name: Run Tests
+  block:
+    - name: Attempt to add a team to a non-existant Organization
+      team:
+        name: Test Team
+        organization: Missing_Organization
+        state: present
+      register: result
+      ignore_errors: true
 
-- name: Assert a meaningful error was provided for the failed team creation
-  assert:
-    that:
-      - "result is failed"
-      - "result is not changed"
-      - "'Missing_Organization' in result.msg"
-      - "result.total_results == 0"
+    - name: Assert a meaningful error was provided for the failed team creation
+      assert:
+        that:
+          - "result is failed"
+          - "result is not changed"
+          - "'Missing_Organization' in result.msg"
+          - "result.total_results == 0"
 
-- name: Create a team
-  team:
-    name: "{{ team_name }}"
-    organization: Default
-  register: result
+    - name: Create a team
+      team:
+        name: "{{ team_name }}"
+        description: this is a description
+        organization: Default
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create a team with exists
-  team:
-    name: "{{ team_name }}"
-    organization: Default
-    state: exists
-  register: result
+    - name: Create a team with exists
+      team:
+        name: "{{ team_name }}"
+        organization: Default
+        state: exists
+      register: result
 
-- assert:
-    that:
-      - "result is not changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Delete a team
-  team:
-    name: "{{ team_name }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Create a team with enforced
+      team:
+        name: "{{ team_name }}"
+        organization: Default
+        state: enforced
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Create a team with exists
-  team:
-    name: "{{ team_name }}"
-    organization: Default
-    state: exists
-  register: result
+    - name: Check enforced options worked
+      team:
+        name: "{{ team_name }}"
+        description: ''
+        organization: Default
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is not changed"
 
-- name: Delete a team
-  team:
-    name: "{{ team_name }}"
-    organization: Default
-    state: absent
-  register: result
+    - name: Delete a team
+      team:
+        name: "{{ team_name }}"
+        organization: Default
+        state: absent
+      register: result
 
-- assert:
-    that:
-      - "result is changed"
+    - assert:
+        that:
+          - "result is changed"
 
-- name: Check module fails with correct msg
-  team:
-    name: "{{ team_name }}"
-    organization: Non_Existing_Org
-    state: present
-  register: result
-  ignore_errors: true
+    - name: Create a team with exists
+      team:
+        name: "{{ team_name }}"
+        organization: Default
+        state: exists
+      register: result
 
-- name: Lookup of the related organization should cause a failure
-  assert:
-    that:
-      - "result is failed"
-      - "result is not changed"
-      - "'Non_Existing_Org' in result.msg"
-      - "result.total_results == 0"
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Check module fails with correct msg
+      team:
+        name: "{{ team_name }}"
+        organization: Non_Existing_Org
+        state: present
+      register: result
+      ignore_errors: true
+
+    - name: Lookup of the related organization should cause a failure
+      assert:
+        that:
+          - "result is failed"
+          - "result is not changed"
+          - "'Non_Existing_Org' in result.msg"
+          - "result.total_results == 0"
+
+  always:
+    - name: Delete a team
+      team:
+        name: "{{ team_name }}"
+        organization: Default
+        state: absent
+      register: result

--- a/awx_collection/tests/integration/targets/user/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/user/tasks/main.yml
@@ -32,6 +32,17 @@
     that:
       - "result is not changed"
 
+- name: Create a User with exists
+  user:
+    username: "{{ username }}"
+    password: "{{ 65535 | random | to_uuid }}"
+    state: enforced
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+
 - name: Delete a User
   user:
     username: "{{ username }}"
@@ -171,7 +182,8 @@
       - "'Unable to resolve controller_host' in result.msg or
         'Can not verify ssl with non-https protocol' in result.exception"
 
-- block:
+- name: Run Tests
+  block:
     - name: Generate an org name
       set_fact:
         org_name: "AWX-Collection-tests-organization-org-{{ test_id }}"

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -258,6 +258,7 @@
       workflow_job_template:
         name: "{{ wfjt_name }}"
         organization: Default
+        description: this is a description
         inventory: Demo Inventory
         extra_vars: {'foo': 'bar', 'another-foo': {'barz': 'bar2'}}
         labels:
@@ -268,6 +269,37 @@
         ask_tags_on_launch: true
         ask_variables_on_launch: true
         state: exists
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
+    - name: Create a workflow job template with enforced
+      workflow_job_template:
+        name: "{{ wfjt_name }}"
+        organization: Default
+        inventory: Demo Inventory
+        # We don't try with the label here because after we delete the first WFJT the label is delete with it because it has no references
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is changed"
+
+    - name: Check enforced options
+      workflow_job_template:
+        name: "{{ wfjt_name }}"
+        description: ''
+        organization: Default
+        inventory: Demo Inventory
+
+        ask_inventory_on_launch: False
+        ask_scm_branch_on_launch: False
+        ask_limit_on_launch: False
+        ask_tags_on_launch: False
+        ask_variables_on_launch: False
       register: result
 
     - assert:
@@ -820,6 +852,7 @@
     - name: Delete copied workflow job template
       workflow_job_template:
         name: "copy_{{ wfjt_name }}"
+        organization: Default
         state: absent
       register: result
 

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -288,6 +288,19 @@
         that:
           - "result is changed"
 
+    - name: Rerun to ensure no changes with enforced
+      workflow_job_template:
+        name: "{{ wfjt_name }}"
+        organization: Default
+        inventory: Demo Inventory
+        # We don't try with the label here because after we delete the first WFJT the label is delete with it because it has no references
+        state: enforced
+      register: result
+
+    - assert:
+        that:
+          - "result is not changed"
+
     - name: Check enforced options
       workflow_job_template:
         name: "{{ wfjt_name }}"


### PR DESCRIPTION
##### SUMMARY
Follow up PR from #13927, #13960

This enforces default values being submitted to the API, this PR is an overview of how that enforcement mechanism would be achieved across the collection, This PR is for feedback on how this was achieved so that I can go through and add it to the rest of the modules. The idea is to enforce a state to prevent drift when an option is not provided and option is enforced. This is compared to exists that makes no changes if the object exists, or present that only makes changes for the options given to the module.

However some are the same as the default value set in the get parameter, others are related fields that have no defaults in the options. The idea of this PR is to do two modules to show how it would be implemented, so it can be approved, before it is extrapolated to every module.

In addition while going through things
Credential types:
      Removed managed, it technically does nothing on post, unable to change it through API.

Applications:
      Fixed bug where Skip authorization was never sent to API. Tried to track down but this has been this way in the code for 3 years.

Added blocks to following tests and brought to the standard way we do the other tests with an always to cleanup after everything.
    groups 
    job templates
    organizations
    credentials
    hosts
    inventory sources
    teams

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
22.4.0
```

