### PR TITLE
[hop node] update peer validation logic 

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5491,7 +5491,7 @@ class InstanceSerializer(BaseSerializer):
         if peers_from_control_nodes and node_type not in (Instance.Types.EXECUTION, Instance.Types.HOP):
             raise serializers.ValidationError(_("peers_from_control_nodes can only be enabled for execution or hop nodes."))
 
-        if node_type in (Instance.Types.CONTROL):
+        if node_type == (Instance.Types.CONTROL):
             if self.instance and 'peers' in attrs and set(self.instance.peers.all()) != set(attrs['peers']):
                 raise serializers.ValidationError(
                     _("Setting peers manually for control nodes is not allowed. Enable peers_from_control_nodes on the hop and execution nodes instead.")

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5491,7 +5491,7 @@ class InstanceSerializer(BaseSerializer):
         if peers_from_control_nodes and node_type not in (Instance.Types.EXECUTION, Instance.Types.HOP):
             raise serializers.ValidationError(_("peers_from_control_nodes can only be enabled for execution or hop nodes."))
 
-        if node_type == (Instance.Types.CONTROL):
+        if node_type == Instance.Types.CONTROL:
             if self.instance and 'peers' in attrs and set(self.instance.peers.all()) != set(attrs['peers']):
                 raise serializers.ValidationError(
                     _("Setting peers manually for control nodes is not allowed. Enable peers_from_control_nodes on the hop and execution nodes instead.")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
@relrod pointed out a bug in the validation logic for instance type when we are checking peers. this change moves the logic from membership to comparison since the code previously was working by happen stance since "control" was in the tuple/enum. 

I found no other instance of this in the current branch that is _new_ there are other instances of this type of membership logic but it is out of scope for the feature (and is also valid use of the membership logic IMO)
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Link to Rick's comment for context if folks want to see the full explanation https://github.com/ansible/awx/pull/13904#discussion_r1206104180

