### PR TITLE
Only show the product version header when the requester is authenticated

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -232,7 +232,8 @@ class APIView(views.APIView):
 
         response = super(APIView, self).finalize_response(request, response, *args, **kwargs)
         time_started = getattr(self, 'time_started', None)
-        response['X-API-Product-Version'] = get_awx_version()
+        if request.user.is_authenticated:
+            response['X-API-Product-Version'] = get_awx_version()
         response['X-API-Product-Name'] = server_product_name()
 
         response['X-API-Node'] = settings.CLUSTER_HOST_ID

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -533,13 +533,7 @@ class ControllerAPIModule(ControllerModule):
                 controller_version = response.info().getheader('X-API-Product-Version', None)
 
             parsed_collection_version = Version(self._COLLECTION_VERSION).version
-            if not controller_version:
-                self.warn(
-                    "You are using the {0} version of this collection but connecting to a controller that did not return a version".format(
-                        self._COLLECTION_VERSION
-                    )
-                )
-            else:
+            if controller_version:
                 parsed_controller_version = Version(controller_version).version
                 if controller_type == 'AWX':
                     collection_compare_ver = parsed_collection_version[0]

--- a/awx_collection/test/awx/test_module_utils.py
+++ b/awx_collection/test/awx/test_module_utils.py
@@ -76,21 +76,6 @@ def test_version_warning(collection_import, silence_warning):
     )
 
 
-def test_no_version_warning(collection_import, silence_warning):
-    ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
-    cli_data = {'ANSIBLE_MODULE_ARGS': {}}
-    testargs = ['module_file2.py', json.dumps(cli_data)]
-    with mock.patch.object(sys, 'argv', testargs):
-        with mock.patch('ansible.module_utils.urls.Request.open', new=mock_no_ping_response):
-            my_module = ControllerAPIModule(argument_spec=dict())
-            my_module._COLLECTION_VERSION = "2.0.0"
-            my_module._COLLECTION_TYPE = "awx"
-            my_module.get_endpoint('ping')
-    silence_warning.assert_called_once_with(
-        'You are using the {0} version of this collection but connecting to a controller that did not return a version'.format(my_module._COLLECTION_VERSION)
-    )
-
-
 def test_version_warning_strictness_awx(collection_import, silence_warning):
     ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
     cli_data = {'ANSIBLE_MODULE_ARGS': {}}


### PR DESCRIPTION
##### SUMMARY

We should only show the product version when the user is authenticated as that could be considered sensitive information. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
Present in latest awx version 22.3.0
```

