### PR TITLE
Remove reference to unmaintained runner image

### DIFF
--- a/awxkit/awxkit/api/pages/execution_environments.py
+++ b/awxkit/awxkit/api/pages/execution_environments.py
@@ -20,7 +20,7 @@ class ExecutionEnvironment(HasCreate, HasCopy, base.Base):
     NATURAL_KEY = ('name',)
 
     # fields are name, image, organization, managed, credential
-    def create(self, name='', image='quay.io/ansible/ansible-runner:devel', organization=Organization, credential=None, pull='', **kwargs):
+    def create(self, name='', image='quay.io/ansible/awx-ee:latest', organization=Organization, credential=None, pull='', **kwargs):
         # we do not want to make a credential by default
         payload = self.create_payload(name=name, image=image, organization=organization, credential=credential, pull=pull, **kwargs)
         ret = self.update_identity(ExecutionEnvironments(self.connection).post(payload))


### PR DESCRIPTION
##### SUMMARY
This default is used when doing `factories.execution_environment()` with awxkit. With builder v3, this image is sun-setted. @nitzmahone 

I don't _think_ that pinning this to the awx-ee (already the default EE) will cause a problem?

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

