### PR TITLE
Add instance_groups on resource_list_param_keys in awx_collection

### DIFF
--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -235,6 +235,7 @@ def main():
         'workflows': 'workflow',
         'users': 'user',
         'teams': 'team',
+        'instance_groups': 'instance_group',
     }
 
     resources = {}


### PR DESCRIPTION
##### SUMMARY
Adding missing `instance_groups` field on awx_collection  `role.py`

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
22.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
