### PR TITLE
Upgrade issue labeler to fix 404 errors

### DIFF
--- a/.github/workflows/label_issue.yml
+++ b/.github/workflows/label_issue.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Label Issue
-        uses: github/issue-labeler@v2.4.1
+        uses: github/issue-labeler@v3.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           not-before: 2021-12-07T07:00:00Z


### PR DESCRIPTION
##### SUMMARY
Pick up fix from github action for https://github.com/github/issue-labeler/issues/5

Changelog for v3.0

> Breaking change: Issue labels that do not match a regex will no longer be removed by default unless you set sync-labels: to 1

Thanks, I don't _want_ you to remove any labels!

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

