### PR TITLE
Try to fix CI by adding dropped coreapi lib

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,4 +1,5 @@
 build
+coreapi
 django-debug-toolbar==3.2.4
 drf-yasg
 # pprofile - re-add once https://github.com/vpelletier/pprofile/issues/41 is addressed


### PR DESCRIPTION
##### SUMMARY
This is an effort to fix our swagger stuff

https://drf-yasg.readthedocs.io/en/stable/changelog.html#id1

> IMPROVED: Remove required coreapi dependency ([#854](https://github.com/axnsan12/drf-yasg/pull/854)) IMPROVED: Feature: Migrate to PyYAML for yaml generator ([#845](https://github.com/axnsan12/drf-yasg/pull/845)) FIXED: Keep path parameters in their given order ([#841](https://github.com/axnsan12/drf-yasg/pull/841)) FIXED: Provide support for enums in codecs ([#837](https://github.com/axnsan12/drf-yasg/pull/837))

Because of this, we were missing that library, and that seems like the _best_ theory about what broke the checks. It was working before we did _that particular z-stream_ upgrade from 1.21.5 to 1.21.6.

Re-stating... checks where passing when @shanemcd merged the recent https://github.com/ansible/awx/pull/13197, which was 3 weeks ago. However, this version bump that dropped the `coreapi` dependency came out Jun 15, 2023, which was 11 days ago, which I'll call ~2 weeks, and it looks like checks broke at this point.

Compare to example with failing checks at https://github.com/ansible/awx/pull/14164

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
