### PR TITLE
Use the proper queryset to filter project update events

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1629,8 +1629,8 @@ class ProjectUpdateDetailSerializer(ProjectUpdateSerializer):
         fields = ('*', 'host_status_counts', 'playbook_counts')
 
     def get_playbook_counts(self, obj):
-        task_count = obj.project_update_events.filter(event='playbook_on_task_start').count()
-        play_count = obj.project_update_events.filter(event='playbook_on_play_start').count()
+        task_count = obj.get_event_queryset().filter(event='playbook_on_task_start').count()
+        play_count = obj.get_event_queryset().filter(event='playbook_on_play_start').count()
 
         data = {'play_count': play_count, 'task_count': task_count}
 


### PR DESCRIPTION
##### SUMMARY
This intends to address a bug described in https://github.com/ansible/awx/issues/13698

The core belief here is that the reverse relationship - `project_update_events` is not properly filtered to the `job_created` field, which is used for our range-based partitioning. By including that field, we tell postgres it only has to search the partition that the job_created time lies in the range of.

Confirmed counts are still working, this is about all the verification I care to do for this.

```json
    "playbook_counts": {
        "play_count": 3,
        "task_count": 7
    }
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
