### PR TITLE
Fix rerouting issue after user authentication (#12815)

### DIFF
--- a/awx/ui/src/screens/Login/Login.js
+++ b/awx/ui/src/screens/Login/Login.js
@@ -129,6 +129,7 @@ function AWXLogin({ alt, isAuthenticated }) {
 
   const setLocalStorageAndRedirect = useCallback(() => {
     if (userId && !hasVerifiedUser.current) {
+      window.localStorage.setItem(SESSION_USER_ID, JSON.stringify(userId));
       const verifyIsNewUser = () => {
         const previousUserId = JSON.parse(
           window.localStorage.getItem(SESSION_USER_ID)
@@ -140,7 +141,6 @@ function AWXLogin({ alt, isAuthenticated }) {
       };
       isNewUser.current = verifyIsNewUser();
       hasVerifiedUser.current = true;
-      window.localStorage.setItem(SESSION_USER_ID, JSON.stringify(userId));
     }
   }, [userId]);
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes an issue with wrong user redirection after login. 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
22.3.1.dev76+g1078ec709c
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Before the change, user would be redirected to the dashboard instead of the original link.
`SESSION_USER_ID` would always be `null` after authentication, causing the user to be redirected to '/home/'.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
