### PR TITLE
Fix DELETE 500 KeyError due to eventless model events

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -661,7 +661,11 @@ class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificatio
 
     @property
     def event_processing_finished(self):
-        return True
+        return True  # workflow jobs do not have events
+
+    @property
+    def has_unpartitioned_events(self):
+        return False  # workflow jobs do not have events
 
     def _get_parent_field_name(self):
         if self.job_template_id:
@@ -914,7 +918,11 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
 
     @property
     def event_processing_finished(self):
-        return True
+        return True  # approval jobs do not have events
+
+    @property
+    def has_unpartitioned_events(self):
+        return False  # approval jobs do not have events
 
     def send_approval_notification(self, approval_status):
         from awx.main.tasks.system import send_notifications  # avoid circular import


### PR DESCRIPTION
##### SUMMARY
This has not been documented in any AWX issues to my knowledge, so I will describe the issue here.

People can receive a 500 error when doing a DELETE to `/api/v2/workflow_jobs/383/` or `/api/v2/workflow_approvals/385/` type endpoints, traceback:

```
django.request Internal Server Error: /api/v2/workflow_jobs/383/
tools_awx_1 | awx-uwsgi stderr | Traceback (most recent call last):
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner
tools_awx_1 | awx-uwsgi stderr |     response = get_response(request)
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
tools_awx_1 | awx-uwsgi stderr |     response = wrapped_callback(request, *callback_args, **callback_kwargs)
tools_awx_1 | awx-uwsgi stderr |   File "/usr/lib64/python3.9/contextlib.py", line 79, in inner
tools_awx_1 | awx-uwsgi stderr |     return func(*args, **kwds)
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
tools_awx_1 | awx-uwsgi stderr |     return view_func(*args, **kwargs)
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/views/generic/base.py", line 104, in view
tools_awx_1 | awx-uwsgi stderr |     return self.dispatch(request, *args, **kwargs)
tools_awx_1 | awx-uwsgi stderr |   File "/awx_devel/./awx/api/generics.py", line 331, in dispatch
tools_awx_1 | awx-uwsgi stderr |     return super(APIView, self).dispatch(request, *args, **kwargs)
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/rest_framework/views.py", line 509, in dispatch
tools_awx_1 | awx-uwsgi stderr |     response = self.handle_exception(exc)
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/rest_framework/views.py", line 469, in handle_exception
tools_awx_1 | awx-uwsgi stderr |     self.raise_uncaught_exception(exc)
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
tools_awx_1 | awx-uwsgi stderr |     raise exc
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
tools_awx_1 | awx-uwsgi stderr |     response = handler(request, *args, **kwargs)
tools_awx_1 | awx-uwsgi stderr |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/rest_framework/generics.py", line 217, in delete
tools_awx_1 | awx-uwsgi stderr |     return self.destroy(request, *args, **kwargs)
tools_awx_1 | awx-uwsgi stderr |   File "/awx_devel/./awx/api/views/mixin.py", line 57, in destroy
tools_awx_1 | awx-uwsgi stderr |     obj.get_event_queryset().delete()
tools_awx_1 | awx-uwsgi stderr |   File "/awx_devel/./awx/main/models/unified_jobs.py", line 1057, in get_event_queryset
tools_awx_1 | awx-uwsgi stderr |     self.event_parent_key: self.id,
tools_awx_1 | awx-uwsgi stderr |   File "/awx_devel/./awx/main/models/unified_jobs.py", line 1042, in event_parent_key
tools_awx_1 | awx-uwsgi stderr |     return {
tools_awx_1 | awx-uwsgi stderr | KeyError: 'main_workflowjob'
```

This can happen if you are deleting a workflow job that ran before the migration to event partitioning (migration: main 0144) happened. When deleting a pre-migration job, it tries to delete all events in the old (unpartitioned) events table linked to that job.

The problem for workflow jobs (and approvals) is that there is no corresponding pre-migration events table, because there are no events for workflow jobs at all. This results in a `KeyError` as it tries to look up the name of the table in an internal data structure.

Using our model inheritance, this change turns off stuff related to events for those models.

![events_forehead](https://github.com/ansible/awx/assets/1385596/1721c960-9b30-4bec-a8a7-f17c37a29ce2)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

