### PR TITLE
Fix filter experience when assigning access to teams

### DIFF
--- a/awx/ui/src/components/AddRole/AddResourceRole.js
+++ b/awx/ui/src/components/AddRole/AddResourceRole.js
@@ -50,7 +50,7 @@ const userSortColumns = [
 const teamSearchColumns = [
   {
     name: t`Name`,
-    key: 'name',
+    key: 'name__icontains',
     isDefault: true,
   },
   {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When adding users or teams to a job template the search filter experience in inconsistent between adding users and adding teams. 
Users are filtered correctly using partial text but filtering teams using partial text (Example: Searching with text "ummy" for team with name "dummyteam") yields no results. 

The cause of the issue is that the search key used in the users filter is `username__icontains` but for teams it is `name` which does an exact search. This PR updates the search query param for the teams filter to be `name__icontains` so that the teams can be filtered correctly using partial names.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
#### Steps to Reproduce

1. Create a user "dummyuser" in the Default organization
2. Create a team "dummyteam" in the Default organization
3. Create a job template "dummytemplate" in the Default organization
4. From the Access menu in the template, click Add
5. First click Users then Next and in the filter type "ummy". The user "dummyuser" should show up in the search results.
6. Now click Back and select Teams
7. Enter "ummy" in the filter box and observe the results. The team "dummyteam" should show up in the search results.

![image](https://github.com/ansible/awx/assets/43621546/2ff2051a-fb9a-456d-8851-fb383e827867)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

