### PR TITLE
Fixed bug where a weekly rrule string without a BYDAY would result in the UI throwing a TypeError

### DIFF
--- a/awx/ui/src/components/Schedule/ScheduleDetail/FrequencyDetails.js
+++ b/awx/ui/src/components/Schedule/ScheduleDetail/FrequencyDetails.js
@@ -94,7 +94,7 @@ export default function FrequencyDetails({
           value={getRunEveryLabel()}
           dataCy={`${prefix}-run-every`}
         />
-        {type === 'week' ? (
+        {type === 'week' && options.daysOfWeek ? (
           <Detail
             label={t`On days`}
             value={options.daysOfWeek


### PR DESCRIPTION
##### SUMMARY
When creating a schedule with an rrule like: `DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1` the UI would crash and show a TypeError.  This patch fixes that.  The problem was that `BYDAY` is missing in the rrule string.  This seems to be a valid rrule string although confusing to me.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
