### PR TITLE
Automatically set up auth for integration tests, get rid of tower-cli reference

### DIFF
--- a/awx_collection/tools/README.md
+++ b/awx_collection/tools/README.md
@@ -19,23 +19,13 @@ It is intended as a tool for writing new modules or enforcing consistency.
 
 These instructions assume you have ansible-core and the collection installed.
 To install the collection in-place (to pick up any local changes to source)
-the `make symlink_collection` will simplink the `awx_collection/` folder to
-the approprate place under `~/.ansible/collections`.
+the `make symlink_collection` will simlink the `awx_collection/` folder to
+the appropriate place under `~/.ansible/collections`.
 
 This is a shortcut for quick validation of tests that bypasses `ansible-test`.
-To use this, you need the `~/.tower_cli.cfg` config file populated,
-which can be done via the deprecated `tower-cli login <username>` or manually
-writing it, where the format looks like:
 
-```
-[general]
-host = https://localhost:8043/
-verify_ssl = false
-username = admin
-password = password
-```
-
-TODO: adjust playbook to allow using environment variables as well.
+Authentication is automatically set up using the admin_password secret.
+This might stop working if you delete the `tools/docker-compose/_sources` folder.
 
 To run some sample modules:
 

--- a/awx_collection/tools/integration_testing.yml
+++ b/awx_collection/tools/integration_testing.yml
@@ -1,5 +1,28 @@
 ---
-- hosts: localhost
+# NOTE: Using a token makes tests run significantly faster
+- name: Generate an OAuth2 token for the test run
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  collections:
+    - awx.awx
+  tasks:
+    - name: Create a new token using username/password
+      awx.awx.token:
+        description: 'Token used for collection tests {{ now() }}'
+        scope: write
+        state: present
+        controller_username: admin
+        controller_password: >-
+          {{ (lookup('ansible.builtin.file',
+          '{{ playbook_dir }}/../../tools/docker-compose/_sources/secrets/admin_password.yml') | from_yaml
+          )['admin_password'] }}
+        validate_certs: false
+        controller_host: https://localhost:8043/
+
+
+- name: Run the integration tests
+  hosts: localhost
   gather_facts: false
   connection: local
   collections:
@@ -8,6 +31,11 @@
     collection_location: "{{ playbook_dir }}/.."
     loc_tests: "{{ collection_location }}/tests/integration/targets/"
     test: ad_hoc_command,host,role
+    auth_env:
+      CONTROLLER_VERIFY_SSL: false
+      CONTROLLER_HOST: https://localhost:8043/
+      CONTROLLER_OAUTH_TOKEN: "{{ controller_token['token'] }}"
+  environment: "{{ auth_env }}"
   tasks:
     - name: DEBUG - make sure variables are what we expect
       debug:


### PR DESCRIPTION
##### SUMMARY
This is a minor followup, as it was thought to be possible before, but I just never dived far enough in before now.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection

