### PR TITLE
Fix spelling errors in readme of awx_collection/tools

### DIFF
--- a/awx_collection/tools/README.md
+++ b/awx_collection/tools/README.md
@@ -19,8 +19,8 @@ It is intended as a tool for writing new modules or enforcing consistency.
 
 These instructions assume you have ansible-core and the collection installed.
 To install the collection in-place (to pick up any local changes to source)
-the `make symlink_collection` will simplink the `awx_collection/` folder to
-the approprate place under `~/.ansible/collections`.
+the `make symlink_collection` will symlink the `awx_collection/` folder to
+the appropriate place under `~/.ansible/collections`.
 
 This is a shortcut for quick validation of tests that bypasses `ansible-test`.
 To use this, you need the `~/.tower_cli.cfg` config file populated,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixed two spelling errors in awx_collection/tools/README.md

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev33384+ge84e701
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
