### PR TITLE
Fix selinux errors with Redis mount in dev env

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -71,7 +71,7 @@ services:
     image: redis:latest
     container_name: tools_redis_{{ container_postfix }}
     volumes:
-      - "../../redis/redis.conf:/usr/local/etc/redis/redis.conf"
+      - "../../redis/redis.conf:/usr/local/etc/redis/redis.conf:Z"
       - "redis_socket_{{ container_postfix }}:/var/run/redis/:rw"
     entrypoint: ["redis-server"]
     command: ["/usr/local/etc/redis/redis.conf"]


### PR DESCRIPTION
##### SUMMARY
Before this change, Redis was crashing with this in the logs:

```
1:C 03 Jul 2023 13:23:26.982 # Fatal error, can't open config file '/usr/local/etc/redis/redis.conf': Permission denied
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task --> - Other
