### PR TITLE
[hop node] migration peers_from_control_nodes only in k8s

### DIFF
--- a/awx/main/migrations/0186_hop_nodes.py
+++ b/awx/main/migrations/0186_hop_nodes.py
@@ -2,11 +2,11 @@
 
 import django.core.validators
 from django.db import migrations, models
-from django.test.utils import override_settings
+from django.conf import settings
 
 
 def automatically_peer_from_control_plane(apps, schema_editor):
-    with override_settings(IS_K8S=True):
+    if settings.IS_K8S:
         Instance = apps.get_model('main', 'Instance')
         Instance.objects.filter(node_type='execution').update(peers_from_control_nodes=True)
         Instance.objects.filter(node_type='control').update(listener_port=None)

--- a/awx/main/migrations/0186_hop_nodes.py
+++ b/awx/main/migrations/0186_hop_nodes.py
@@ -4,7 +4,7 @@ import django.core.validators
 from django.db import migrations, models
 
 
-def set_peers_from_control_nodes_true(apps, schema_editor):
+def automatically_peer_from_control_plane(apps, schema_editor):
     Instance = apps.get_model('main', 'Instance')
     Instance.objects.filter(node_type='execution').update(peers_from_control_nodes=True)
 
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='instance',
-            name='peers_from_control_nodes',
+            name='automatically_peer_from_control_plane',
             field=models.BooleanField(default=False, help_text='If True, control plane cluster nodes should automatically peer to it.'),
         ),
         migrations.AlterField(
@@ -49,5 +49,5 @@ class Migration(migrations.Migration):
                 validators=[django.core.validators.MinValueValidator(1), django.core.validators.MaxValueValidator(65535)],
             ),
         ),
-        migrations.RunPython(set_peers_from_control_nodes_true),
+        migrations.RunPython(automatically_peer_from_control_plane),
     ]

--- a/awx/main/migrations/0186_hop_nodes.py
+++ b/awx/main/migrations/0186_hop_nodes.py
@@ -9,11 +9,7 @@ def automatically_peer_from_control_plane(apps, schema_editor):
     with override_settings(IS_K8S=True):
         Instance = apps.get_model('main', 'Instance')
         Instance.objects.filter(node_type='execution').update(peers_from_control_nodes=True)
-
-
-def set_listener_port_for_control_nodes(apps, schema_editor):
-    Instance = apps.get_model('main', 'Instance')
-    Instance.objects.filter(node_type='control').set(listener_port=None)
+        Instance.objects.filter(node_type='control').update(listener_port=None)
 
 
 class Migration(migrations.Migration):

--- a/awx/main/migrations/0186_hop_nodes.py
+++ b/awx/main/migrations/0186_hop_nodes.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='instance',
-            name='automatically_peer_from_control_plane',
+            name='peers_from_control_nodes',
             field=models.BooleanField(default=False, help_text='If True, control plane cluster nodes should automatically peer to it.'),
         ),
         migrations.AlterField(

--- a/awx/main/migrations/0186_hop_nodes.py
+++ b/awx/main/migrations/0186_hop_nodes.py
@@ -11,6 +11,11 @@ def automatically_peer_from_control_plane(apps, schema_editor):
         Instance.objects.filter(node_type='execution').update(peers_from_control_nodes=True)
 
 
+def set_listener_port_for_control_nodes(apps, schema_editor):
+    Instance = apps.get_model('main', 'Instance')
+    Instance.objects.filter(node_type='control').set(listener_port=None)
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ('main', '0185_move_JSONBlob_to_JSONField'),

--- a/awx/main/migrations/0186_hop_nodes.py
+++ b/awx/main/migrations/0186_hop_nodes.py
@@ -2,11 +2,13 @@
 
 import django.core.validators
 from django.db import migrations, models
+from django.test.utils import override_settings
 
 
 def automatically_peer_from_control_plane(apps, schema_editor):
-    Instance = apps.get_model('main', 'Instance')
-    Instance.objects.filter(node_type='execution').update(peers_from_control_nodes=True)
+    with override_settings(IS_K8S=True):
+        Instance = apps.get_model('main', 'Instance')
+        Instance.objects.filter(node_type='execution').update(peers_from_control_nodes=True)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related issue #14178 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
22.3.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
