### PR TITLE
Allow using file logging with development settings

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -31,6 +31,12 @@ SHELL_PLUS_PRINT_SQL = False
 COLOR_LOGS = True
 LOGGING['handlers']['console']['()'] = 'awx.main.utils.handlers.ColorHandler'  # noqa
 
+# Normally, we want development to log to stdout, but if someone specifies AWX_LOGGING_MODE=file
+# then we want to avoid /var/log/tower because it probably does not exist
+for name, config in LOGGING['handlers'].items():  # noqa
+    if 'filename' in config and not os.path.exists(LOG_ROOT):
+        config['filename'] = config['filename'].replace(LOG_ROOT, BASE_DIR)  # noqa
+
 ALLOWED_HOSTS = ['*']
 
 mimetypes.add_type("image/svg+xml", ".svg", True)

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -34,7 +34,7 @@ LOGGING['handlers']['console']['()'] = 'awx.main.utils.handlers.ColorHandler'  #
 # Normally, we want development to log to stdout, but if someone specifies AWX_LOGGING_MODE=file
 # then we want to avoid /var/log/tower because it probably does not exist
 for name, config in LOGGING['handlers'].items():  # noqa
-    if 'filename' in config and not os.path.exists(LOG_ROOT):
+    if 'filename' in config and not os.path.exists(LOG_ROOT):  # noqa
         config['filename'] = config['filename'].replace(LOG_ROOT, BASE_DIR)  # noqa
 
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
##### SUMMARY
I had a headache running integration tests. I found that if you do this:

```
AWX_LOGGING_MODE=file awx-manage showmigrations
```

You get a traceback from the logging setup.

```
bash-5.1$ AWX_LOGGING_MODE=file awx-manage showmigrations
Traceback (most recent call last):
  File "/usr/lib64/python3.9/logging/config.py", line 564, in configure
    handler = self.configure_handler(handlers[name])
  File "/usr/lib64/python3.9/logging/config.py", line 745, in configure_handler
    result = factory(**kwargs)
  File "/usr/lib64/python3.9/logging/handlers.py", line 470, in __init__
    logging.FileHandler.__init__(self, filename, mode=mode,
  File "/usr/lib64/python3.9/logging/__init__.py", line 1146, in __init__
    StreamHandler.__init__(self, self._open())
  File "/usr/lib64/python3.9/logging/__init__.py", line 1175, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding,
FileNotFoundError: [Errno 2] No such file or directory: '/var/log/tower/cache_clear.log'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/bin/awx-manage", line 9, in <module>
    load_entry_point('awx', 'console_scripts', 'awx-manage')()
  File "/awx_devel/awx/__init__.py", line 200, in manage
    execute_from_command_line(sys.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/__init__.py", line 19, in setup
    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/utils/log.py", line 76, in configure_logging
    logging_config_func(logging_settings)
  File "/usr/lib64/python3.9/logging/config.py", line 809, in dictConfig
    dictConfigClass(config).configure()
  File "/usr/lib64/python3.9/logging/config.py", line 571, in configure
    raise ValueError('Unable to configure handler '
ValueError: Unable to configure handler 'cache_clear'
```

This is because `/var/log/tower` does not exist. The `Makefile` for this repo (templated) does not pre-create it and the awx user does not have permission to create it.

If you use Ansible to shell into the container and do something, like it's likely that `AWX_LOGGING_MODE` is unset, which gives the same behavior. So you can't run anything without additional hacks.

There's a good chance that whatever management command you run _doesn't write any logs anyway_. This is just something I want to increase resiliency and avoid the need for hacks sprinkled around in testing.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

