### PR TITLE
Fix black pre-commit hook

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,5 +1,5 @@
 if [ -z $AWX_IGNORE_BLACK ] ; then
-	python_files_changed=$(git diff --cached --name-only --diff-filter=AM | grep -E '\.py')
+	python_files_changed=$(git diff --cached --name-only --diff-filter=AM | grep -E '\.py$')
 	if [ "x$python_files_changed" != "x" ] ; then
         	black --check $python_files_changed || \
 		if [ $? != 0 ] ; then


### PR DESCRIPTION
If you had a templated file like tools/docker-compose/ansible/roles/sources/templates/database.py.j2 the filter would catch it and attempt to run back on it.
This change should prevent that.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
