### PR TITLE
Restore pre-upgrade pg_notify notifcation behavior

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -55,6 +55,23 @@ class PubSub(object):
         with self.conn.cursor() as cur:
             cur.execute('SELECT pg_notify(%s, %s);', (channel, payload))
 
+    @staticmethod
+    def current_notifies(conn):
+        """
+        Altered version of .notifies method from psycopg library
+        This removes the outer while True loop so that we only process
+        queued notifications
+        """
+        with conn.lock:
+            try:
+                ns = conn.wait(psycopg.generators.notifies(conn.pgconn))
+            except psycopg.errors._NO_TRACEBACK as ex:
+                raise ex.with_traceback(None)
+        enc = psycopg._encodings.pgconn_encoding(conn.pgconn)
+        for pgn in ns:
+            n = psycopg.connection.Notify(pgn.relname.decode(enc), pgn.extra.decode(enc), pgn.be_pid)
+            yield n
+
     def events(self, select_timeout=5, yield_timeouts=False):
         if not self.conn.autocommit:
             raise RuntimeError('Listening for events can only be done in autocommit mode')
@@ -64,7 +81,7 @@ class PubSub(object):
                 if yield_timeouts:
                     yield None
             else:
-                notification_generator = self.conn.notifies()
+                notification_generator = self.current_notifies(self.conn)
                 for notification in notification_generator:
                     yield notification
 


### PR DESCRIPTION
##### SUMMARY
This is not the ideal solution. Here's the problem:

With the upgrade to psycopg3 library, done in https://github.com/ansible/awx/pull/14021 by @john-westcott-iv we lost the "old" way of consuming from pg_notify

https://www.psycopg.org/docs/advanced.html

And got "new" ways of doing it

https://www.psycopg.org/psycopg3/docs/advanced/async.html

At issue is the `.notifies()` method, which you can see in both links is implemented substantially differently. In PR 14021 we did adopt the new pattern... sort of. It turned out this didn't have entirely the intended effect. Basically, the dispatcher started up and waited on the `select.select` line, and got a timeout after 5 seconds as expected. This lasts however long it takes for a pg_notify message to come in, and then it goes into the `.notifies()` loop. Unlike before, however, it never exits this loop. So after the first message, no more timeouts are yielded ever.

Why? And does it have to be this way?

Surprisingly, we have the code for the generator we "want" already in the `.notifies` method:

https://github.com/psycopg/psycopg/blob/2ca04b77dbe1ea50a422fcefeda22fa756be754c/psycopg/psycopg/connection.py#L921

It's literally wrapped in a `while True:`, and this PR is re-implementing the method for the sole purpose of removing that outer loop. So let's go back over this:

 - Before: the dispatcher _only_ did anything when it got a pg_notify method, and spent all its time in the `.notifies()` loop
 - After: the dispatcher will do stuff when it gets a pg_notify message _or_ when the 5 second timeout is hit

We should do something about this (even if the answer is to abandon timeouts) because the `select.select` is effectively dead code without it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
