### PR TITLE
Adding add_fields and remove_fields on api

### DIFF
--- a/awx/api/filters.py
+++ b/awx/api/filters.py
@@ -133,7 +133,7 @@ class FieldLookupBackend(BaseFilterBackend):
     Filter using field lookups provided via query string parameters.
     """
 
-    RESERVED_NAMES = ('page', 'page_size', 'format', 'order', 'order_by', 'search', 'type', 'host_filter', 'count_disabled', 'no_truncate', 'limit')
+    RESERVED_NAMES = ('page', 'page_size', 'format', 'order', 'order_by', 'search', 'type', 'host_filter', 'count_disabled', 'no_truncate', 'limit', 'add_fields', 'remove_fields')
 
     SUPPORTED_LOOKUPS = (
         'exact',

--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -345,6 +345,12 @@ class GenericAPIView(generics.GenericAPIView, APIView):
     #   serializer_class = SerializerClass
 
     def get_serializer(self, *args, **kwargs):
+        add_fields = self.request.query_params.get('add_fields', None)
+        remove_fields = self.request.query_params.get('remove_fields', None)
+        if add_fields:
+            kwargs.update({'add_fields': add_fields.split(',')})
+        if remove_fields:
+            kwargs.update({'remove_fields': remove_fields.split(',')})
         serializer = super(GenericAPIView, self).get_serializer(*args, **kwargs)
         # Override when called from browsable API to generate raw data form;
         # update serializer "validated" data to be displayed by the raw data


### PR DESCRIPTION
##### SUMMARY
This PR is to allow us the possibility to add and/remove fields from API query, simpli adding new query parameters called `add_fields` and `remove_fields`.

This is related discussion with @AlanCoding on #14199 ,  the idea is to have a way to add (or remove) one or more fileds in a api view.
My approach is to allow adding and removing fields via query params, separated by comma for all API, not only for single endpoint. 

In case of `add_fields` we need to evaluate fields, retrieve him models and then create field based on model, so in that way we can extend current field defined in serializer, with all fields present in the model itself.

In all cases (add/remove), if fields requested not exists in the model, we simply skip it.

Some example:
- Add ansible_facts to host view
`http://localhost:8013/api/v2/hosts/?add_fields=ansible_facts`
- Remove related and summary_fields from api view
`http://localhost:8013/api/v2/hosts/?remove_fields=related,summary_fields`
- A combination of add/remove
`http://localhost:8013/api/v2/hosts/?remove_fields=related,summary_fields&add_fields=ansible_facts`


##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
N/A
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
