### PR TITLE
Upgrade to postgres:15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -629,9 +629,6 @@ clean-elk:
 	docker rm tools_elasticsearch_1
 	docker rm tools_kibana_1
 
-psql-container:
-	docker run -it --net tools_default --rm postgres:12 sh -c 'exec psql -h "postgres" -p "5432" -U postgres'
-
 VERSION:
 	@echo "awx: $(VERSION)"
 

--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -154,10 +154,11 @@ def manage():
     from django.conf import settings
     from django.core.management import execute_from_command_line
 
-    # enforce the postgres version is equal to 12. if not, then terminate program with exit code of 1
+    # enforce the postgres version is equal to 15. if not, then terminate program with exit code of 1
+    # The return of connection.pg_version is something like 12013
     if not os.getenv('SKIP_PG_VERSION_CHECK', False) and not MODE == 'development':
-        if (connection.pg_version // 10000) < 12:
-            sys.stderr.write("Postgres version 12 is required\n")
+        if (connection.pg_version // 10000) < 15:
+            sys.stderr.write("Postgres version 15 is required\n")
             sys.exit(1)
 
     if len(sys.argv) >= 2 and sys.argv[1] in ('version', '--version'):  # pragma: no cover

--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -154,11 +154,12 @@ def manage():
     from django.conf import settings
     from django.core.management import execute_from_command_line
 
-    # enforce the postgres version is equal to 15. if not, then terminate program with exit code of 1
+    # enforce the postgres version is a minimum of 12 (we need this for partitioning); if not, then terminate program with exit code of 1
+    # In the future if we require a feature of a version of postgres > 12 this should be updated to reflect that.
     # The return of connection.pg_version is something like 12013
     if not os.getenv('SKIP_PG_VERSION_CHECK', False) and not MODE == 'development':
-        if (connection.pg_version // 10000) < 15:
-            sys.stderr.write("Postgres version 15 is required\n")
+        if (connection.pg_version // 10000) < 12:
+            sys.stderr.write("At a minimum, postgres version 12 is required\n")
             sys.exit(1)
 
     if len(sys.argv) >= 2 and sys.argv[1] in ('version', '--version'):  # pragma: no cover

--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -419,7 +419,7 @@ def _events_table(since, full_path, until, tbl, where_column, project_job_create
                           resolved_action,
                           resolved_role,
                           -- '-' operator listed here:
-                          -- https://www.postgresql.org/docs/12/functions-json.html
+                          -- https://www.postgresql.org/docs/15/functions-json.html
                           -- note that operator is only supported by jsonb objects
                           -- https://www.postgresql.org/docs/current/datatype-json.html
                           (CASE WHEN event = 'playbook_on_stats' THEN {event_data} - 'artifact_data' END) as playbook_on_stats,

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -300,7 +300,6 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
 {% endif %}
 
 ENV HOME="/var/lib/awx"
-ENV PATH="/usr/pgsql-12/bin:${PATH}"
 
 {% if build_dev|bool %}
 ENV PATH="/var/lib/awx/venv/awx/bin/:${PATH}"

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -249,7 +249,7 @@ RUN for dir in \
       /var/lib/awx/.local/share/containers/storage \
       /var/run/awx-rsyslog \
       /var/log/nginx \
-      /var/lib/postgresql \
+      /var/lib/pgsql \
       /var/run/supervisor \
       /var/run/awx-receptor \
       /var/lib/nginx ; \

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -207,7 +207,7 @@ services:
   #     context: ../../docker-compose
   #     dockerfile: Dockerfile-logstash
   postgres:
-    image: postgres:12
+    image: postgres:15
     container_name: tools_postgres_1
     # additional logging settings for postgres can be found https://www.postgresql.org/docs/current/runtime-config-logging.html
     command: postgres -c log_destination=stderr -c log_min_messages=info -c log_min_duration_statement={{ pg_log_min_duration_statement|default(1000) }} -c max_connections={{ pg_max_connections|default(1024) }}
@@ -217,7 +217,7 @@ services:
       POSTGRES_DB: {{ pg_database }}
       POSTGRES_PASSWORD: {{ pg_password }}
     volumes:
-      - "awx_db:/var/lib/postgresql/data"
+      - "awx_db_15:/var/lib/postgresql/data"
     networks:
       - awx
     ports:
@@ -305,8 +305,9 @@ services:
 {% endif %}
 
 volumes:
-  awx_db:
-    name: tools_awx_db
+{# For the postgres 15 db upgrade we changed the mount name because 15 can't load a 12 DB #}
+  awx_db_15:
+    name: tools_awx_db_15
 {% for i in range(control_plane_node_count|int) -%}
   {% set container_postfix = loop.index %}
   redis_socket_{{ container_postfix }}:

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -207,17 +207,16 @@ services:
   #     context: ../../docker-compose
   #     dockerfile: Dockerfile-logstash
   postgres:
-    image: postgres:15
+    image: quay.io/sclorg/postgresql-15-c9s
     container_name: tools_postgres_1
     # additional logging settings for postgres can be found https://www.postgresql.org/docs/current/runtime-config-logging.html
-    command: postgres -c log_destination=stderr -c log_min_messages=info -c log_min_duration_statement={{ pg_log_min_duration_statement|default(1000) }} -c max_connections={{ pg_max_connections|default(1024) }}
+    command: run-postgresql -c log_destination=stderr -c log_min_messages=info -c log_min_duration_statement={{ pg_log_min_duration_statement|default(1000) }} -c max_connections={{ pg_max_connections|default(1024) }}
     environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
-      POSTGRES_USER: {{ pg_username }}
-      POSTGRES_DB: {{ pg_database }}
-      POSTGRES_PASSWORD: {{ pg_password }}
+      POSTGRESQL_USER: {{ pg_username }}
+      POSTGRESQL_DATABASE: {{ pg_database }}
+      POSTGRESQL_PASSWORD: {{ pg_password }}
     volumes:
-      - "awx_db_15:/var/lib/postgresql/data"
+      - "awx_db_15:/var/lib/pgsql/data"
     networks:
       - awx
     ports:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Upgrade from using postgres 12 to postgres 15.

Postgres 15 is not able to load a postgres 12 database directly. So we have modified the docker volume name to help distinguish the two version. However, please note that docker-compose will attempt to use the old volume if the `tools_postgres_1` container already exists. If this happens you will see an error in the logs like:
```
tools_postgres_1 | 
tools_postgres_1 | PostgreSQL Database directory appears to contain a database; Skipping initialization
tools_postgres_1 | 
tools_redis_1 | 1:M 12 Jul 2023 13:53:13.739 * monotonic clock: POSIX clock_gettime
tools_postgres_1 | 2023-07-12 13:53:13.919 UTC [1] FATAL:  database files are incompatible with server
tools_postgres_1 | 2023-07-12 13:53:13.919 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 12, which is not compatible with this version 15.3 (Debian 15.3-1.pgdg120+1).
```

First, remove the container with `docker container rm tools_postgres_1`. If you then start the containers again you will get a fresh install of AWX.

If you want to migrate your existing docker-compose development installation do the following:

1. Start with latest current version running via `make docker-compose`.
2. Run `docker exec -it -u postgres tools_postgres_1 pg_dumpall --database awx -U awx > awx_dump.sql`
3. Stop your existing containers.
4. Remove the existing tools_postgres_1 container by running `docker container rm tools_postgres_1`.
5. Checkout the new version of the code.
6. Run `make docker-compose-sources` to upgrade the docker-compose.yml file.
7. Run `docker-compose -f tools/docker-compose/_sources/docker-compose.yml up postgres` to start up the new version of the container.
8. Run `docker cp awx_dump.sql tools_postgres_1:/tmp` to copy the backup file into the new postgres container.
9. Run `docker exec -it tools_postgres_1 /usr/bin/psql -U awx -f /tmp/awx_dump.sql` to restore your old data into the new postgres 15 database.
10. Stop the container being run from `docker-compose up` and start the full environment with `make docker-compose`.

I did simple testing with the keycloak integration (which uses the postgres container) and it works fine. There did not seems to be a compatibility matrix for keycloak and postgres but I did find one doc indicating that it worked with pg 15 (but that was likely intended for the latest version 20 and we are on 15).

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
