### PR TITLE
Explicitly turn off autocomplete for API login form

### DIFF
--- a/awx/templates/rest_framework/login.html
+++ b/awx/templates/rest_framework/login.html
@@ -19,7 +19,7 @@
           <input type="text" name="username" maxlength="100"
               autocapitalize="off"
               autocorrect="off" class="form-control textinput textInput"
-              id="id_username" required autofocus
+              id="id_username"  autocomplete="off" required autofocus
               {% if form.username.value %}value="{{ form.username.value }}"{% endif %}>
             {% if form.username.errors %}
             <p class="text-error">{{ form.username.errors|striptags }}</p>
@@ -31,7 +31,8 @@
         <div class="form-group">
           <label for="id_password">Password:</label>
           <input type="password" name="password" maxlength="100" autocapitalize="off"
-              autocorrect="off" class="form-control textinput textInput" id="id_password" required>
+              autocorrect="off" class="form-control textinput textInput" id="id_password"
+              autocomplete="off" required>
             {% if form.password.errors %}
             <p class="text-error">{{ form.password.errors|striptags }}</p>
             {% endif %}


### PR DESCRIPTION
##### SUMMARY

Users have pointed out the the username and password should not be autocompleted for the login form.  That has been corrected for the UI in this PR, but not for the API for the username.  That is what this PR addresses.  

I also explicitly set autocomplete to off for the password field even though that appears to be the default.  

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

