### PR TITLE
Tell Makefile and pre-commit.sh that they are bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 -include awx/ui_next/Makefile
 
 PYTHON := $(notdir $(shell for i in python3.9 python3; do command -v $$i; done|sed 1q))
+SHELL := bash
 DOCKER_COMPOSE ?= docker-compose
 OFFICIAL ?= no
 NODE ?= node

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 if [ -z $AWX_IGNORE_BLACK ] ; then
 	python_files_changed=$(git diff --cached --name-only --diff-filter=AM | grep -E '\.py$')
 	if [ "x$python_files_changed" != "x" ] ; then


### PR DESCRIPTION
##### SUMMARY


* set the shell in the Makefile, so that it uses bash (since it is already depending on bash in several targets, even though it is calling it as /bin/sh by default which breaks on systems where points (symlinks) to something other than `/bin/bash`)
* add a shebang to pre-commit.sh for the same reason.


On some systems, /bin/sh is a bash symlink and running it will launch bash in sh compatibility mode. However, bash-specific syntax will still work in this mode (for example using == or pipefail).

However, on systems where /bin/sh is a symlink to another shell (think: Debian-based) they might not have those bashisms available, and so some commands like `make black` fail on those systems.


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other
