### PR TITLE
Added required epoc time field for Splunk HEC Event Receiver

### DIFF
--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -283,6 +283,7 @@ class LogstashFormatter(LogstashFormatterBase):
             message.update(self.get_debug_fields(record))
 
         if settings.LOG_AGGREGATOR_TYPE == 'splunk':
-            # splunk messages must have a top level "event" key
-            message = {'event': message}
+            # splunk messages must have a top level "event" key when using the /services/collector/event receiver.
+            # The event receiver wont scan an event for a timestamp field therefore a time field must also be supplied containing epoch timestamp
+            message = {'time': record.created, 'event': message}
         return self.serialize(message)


### PR DESCRIPTION
##### SUMMARY
This change adds an epoch time field to the json that will be sent when logging to Splunk.  This time field is required as when sending to the Splunk HEC using the /services/collector/event receiver (which is why the "event" wrapper was added originally) no scanning of the event will occur to find the timestamp of the event.  If a time for the event is required then either the time field needs to be set in the metadata or the parameter "auto_extract_timestamp=true" needs to be passed with the http request.  Adding the itme field is the more efficient option.  If neither of these options are set then Splunk uses the time that the event was received as the alert time, on busy HEC receivers when there is queuing this can distort the event times.

https://docs.splunk.com/Documentation/Splunk/9.1.0/Data/FormateventsforHTTPEventCollector
See event metadata section

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
logging formatters
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev33401+g5def72b
```
##### ADDITIONAL INFORMATION

