### PR TITLE
Remove extra data for AoC

### DIFF
--- a/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
+++ b/awx/ui/src/screens/Setting/Subscription/SubscriptionDetail/SubscriptionDetail.js
@@ -89,7 +89,8 @@ function SubscriptionDetail() {
             />
           )}
           {typeof automatedInstancesCount !== 'undefined' &&
-            automatedInstancesCount !== null && (
+            automatedInstancesCount !== null &&
+            systemConfig?.SUBSCRIPTION_USAGE_MODEL !== '' && (
               <Detail
                 dataCy="subscription-hosts-automated"
                 label={t`Hosts automated`}
@@ -105,11 +106,13 @@ function SubscriptionDetail() {
                 }
               />
             )}
-          <Detail
-            dataCy="subscription-hosts-imported"
-            label={t`Hosts imported`}
-            value={license_info.current_instances}
-          />
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL !== '' && (
+            <Detail
+              dataCy="subscription-hosts-imported"
+              label={t`Hosts imported`}
+              value={license_info.current_instances}
+            />
+          )}
           {systemConfig?.SUBSCRIPTION_USAGE_MODEL ===
             'unique_managed_hosts' && (
             <Detail
@@ -134,20 +137,23 @@ function SubscriptionDetail() {
               value={license_info.reactivated_instances}
             />
           )}
-          {license_info.instance_count < 9999999 && (
-            <Detail
-              dataCy="subscription-hosts-available"
-              label={t`Hosts available`}
-              value={license_info.available_instances}
-            />
-          )}
-          {license_info.instance_count >= 9999999 && (
-            <Detail
-              dataCy="subscription-unlimited-hosts-available"
-              label={t`Hosts available`}
-              value={t`Unlimited`}
-            />
-          )}
+
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL !== '' &&
+            license_info.instance_count < 9999999 && (
+              <Detail
+                dataCy="subscription-hosts-available"
+                label={t`Hosts available`}
+                value={license_info.available_instances}
+              />
+            )}
+          {systemConfig?.SUBSCRIPTION_USAGE_MODEL !== '' &&
+            license_info.instance_count >= 9999999 && (
+              <Detail
+                dataCy="subscription-unlimited-hosts-available"
+                label={t`Hosts available`}
+                value={t`Unlimited`}
+              />
+            )}
           <Detail
             dataCy="subscription-type"
             label={t`Subscription type`}


### PR DESCRIPTION
##### SUMMARY
Related to https://issues.redhat.com/browse/AA-1762

Removes Host automated, Host imported and Host available for AoC subscriptions

##### ISSUE TYPE
 - New or Enhanced Feature


##### COMPONENT NAME
 - UI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.3.1.dev57+g0ca8b3c078
```


##### ADDITIONAL INFORMATION
Before:
<img width="1406" alt="Screenshot 2023-07-18 at 11 51 20" src="https://github.com/ansible/awx/assets/9210860/08bc4d03-4826-48c5-aa88-045cc3f23528">

After:
<img width="1393" alt="Screenshot 2023-07-18 at 12 05 15" src="https://github.com/ansible/awx/assets/9210860/5ca4b22d-3ea9-4875-9818-e2429cbaeb87">
