### PR TITLE
Return back chdir to project sync to support project-local roles/coll…

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -255,6 +255,9 @@
           tags:
             - install_collections
             - install_roles
+      module_defaults:
+        ansible.builtin.command:
+          chdir: "{{ project_path | quote }}"
 
       # We combine our additional_galaxy_env into galaxy_task_env so that our values are preferred over anything a user would set
       environment: "{{ galaxy_task_env | combine(additional_galaxy_env) }}"


### PR DESCRIPTION
…ections

##### SUMMARY
PR https://github.com/ansible/awx/pull/14081 added support for 3 requirements.yml paths, however it removed the `chdir` argument to `ansible.builtin.command`.

When a requirements.yml contains a project-relative source, this causes the following error(s) from `ansible-galaxy` during project sync:
```
ERROR! Neither the collection requirement entry key 'name', nor 'source' point to a concrete resolvable collection artifact. Also 'name' is not an FQCN. A valid collection name must be in the format <namespace>.<collection>. Please make sure that the namespace and the collection name contain characters from [a-zA-Z0-9_] only.

Could not find ./collections/ansible-netcommon-4.1.0.tar.gz.
```
This was discovered after recently updating from AWX 22.2.0 to 22.5.0, and has brought all related AWX jobs to a halt because the project sync itself is now failing.

Besides not being confident of where the EE is executing this command within the container/pod(as an admin), this also breaks support for project-local sources, and/or requirements files generated by `ansible-galaxy collection download --download-path <path> -r requirements.reference.yml`. ex:
```
collections:
  - name: ./collections/ansible-netcommon-4.1.0.tar.gz
    version: 4.1.0
  - source: ./collections/arbitrarycollection
    type: dir
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
1. Create `./requirements.galaxy.yml` file with `collections: [{name: 'ansible.netcommon', version: '4.1.0'}]` as yaml
2. Run `ansible-galaxy collection download -r requirements.galaxy.yml`
3. Revise `./collections/requirements.yml` to include `./collections/` prefix for all collections
4. Commit all changes
5. Perform project sync with role/collection installation enabled
6. Sync fails

Running `ansible-galaxy collection install -r ./collections/requirements.yml` directly by hand from the root of the project directory locally is successful, same as it was prior to AWX 22.5.0
```
