### PR TITLE
Require pyyaml >= 6.0.1

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -44,7 +44,7 @@ pyparsing==2.4.6  # Upgrading to v3 of pyparsing introduce errors on smart host 
 python-dsv-sdk
 python-tss-sdk==1.0.0
 python-ldap
-pyyaml
+pyyaml>=6.0.1
 receptorctl==1.3.0
 schedule==0.6.0
 social-auth-core[openidconnect]==4.3.0  # see UPGRADE BLOCKERs

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -347,7 +347,7 @@ pytz==2022.6
     #   irc
     #   tempora
     #   twilio
-pyyaml==6.0
+pyyaml==6.0.1
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   ansible-runner


### PR DESCRIPTION
##### SUMMARY
Downstream offline rpm build fails processing pyyaml with `AttributeError: cython_sources` error due to Cython 3 being pulled in during build. Updating to 6.0.1 which pins Cython to <3.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API