### PR TITLE
docs/execution_environments.md: add a link to EE getting started guide

### DIFF
--- a/docs/execution_environments.md
+++ b/docs/execution_environments.md
@@ -3,8 +3,9 @@
 All jobs use container isolation for environment consistency and security.
 Compliant images are referred to as Execution Environments (EE)s.
 
-For more information about the EE technology as well as how to build and test EEs, see the
-[Getting started with Execution Environments guide](https://docs.ansible.com/ansible/devel/getting_started_ee/index.html). 
+For more information about the EE technology as well as how to build and test EEs, see:
+- [Getting started with Execution Environments guide](https://docs.ansible.com/ansible/devel/getting_started_ee/index.html)
+- [Ansible Builder documentation](https://ansible.readthedocs.io/projects/builder/en/latest/)
 
 The Execution Environment model has an `image` field for the image identifier which will be used by jobs.
 The job details view will link to the execution environment that the job uses.

--- a/docs/execution_environments.md
+++ b/docs/execution_environments.md
@@ -2,9 +2,9 @@
 
 All jobs use container isolation for environment consistency and security.
 Compliant images are referred to as Execution Environments (EE)s.
-For more information, see [ansible-runner EE docs](https://ansible-runner.readthedocs.io/en/latest/execution_environments.html)
-for information on how container isolation works, and see [ansible-builder docs](https://ansible-builder.readthedocs.io/en/latest/index.html)
-for instructions on how to build them.
+
+For more information about the EE technology as well as how to build and test EEs, see the
+[Getting started with Execution Environments guide](https://docs.ansible.com/ansible/devel/getting_started_ee/index.html). 
 
 The Execution Environment model has an `image` field for the image identifier which will be used by jobs.
 The job details view will link to the execution environment that the job uses.


### PR DESCRIPTION
##### SUMMARY

Fixes https://github.com/ansible-community/community-team/issues/311

This replaces the EE links with a link to recently created Getting-started with EE guide

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - Docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```
