### PR TITLE
Fix collection module docs for names, IDs, and named URLs

### DIFF
--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -29,12 +29,12 @@ options:
       choices: [ 'run', 'check' ]
     execution_environment:
       description:
-        - Execution Environment name or ID to use for the ad hoc command.
+        - Execution Environment name, ID, or named URL to use for the ad hoc command.
       required: False
       type: str
     inventory:
       description:
-        - Inventory name or ID to use for the ad hoc command.
+        - Inventory name, ID, or named URL to use for the ad hoc command.
       required: True
       type: str
     limit:
@@ -43,7 +43,7 @@ options:
       type: str
     credential:
       description:
-        - Credential name or ID to use for ad hoc command.
+        - Credential name, ID, or named URL to use for ad hoc command.
       required: True
       type: str
     module_name:

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -29,12 +29,12 @@ options:
       choices: [ 'run', 'check' ]
     execution_environment:
       description:
-        - Execution Environment to use for the ad hoc command.
+        - Execution Environment name or ID to use for the ad hoc command.
       required: False
       type: str
     inventory:
       description:
-        - Inventory to use for the ad hoc command.
+        - Inventory name or ID to use for the ad hoc command.
       required: True
       type: str
     limit:
@@ -43,7 +43,7 @@ options:
       type: str
     credential:
       description:
-        - Credential to use for ad hoc command.
+        - Credential name or ID to use for ad hoc command.
       required: True
       type: str
     module_name:

--- a/awx_collection/plugins/modules/application.py
+++ b/awx_collection/plugins/modules/application.py
@@ -48,7 +48,7 @@ options:
       required: False
     organization:
       description:
-        - Name of organization for application.
+        - Name or ID of organization for application.
       type: str
       required: True
     redirect_uris:

--- a/awx_collection/plugins/modules/application.py
+++ b/awx_collection/plugins/modules/application.py
@@ -48,7 +48,7 @@ options:
       required: False
     organization:
       description:
-        - Name or ID of organization for application.
+        - Name, ID, or named URL of organization for application.
       type: str
       required: True
     redirect_uris:

--- a/awx_collection/plugins/modules/bulk_host_create.py
+++ b/awx_collection/plugins/modules/bulk_host_create.py
@@ -48,7 +48,7 @@ options:
           type: str
     inventory:
       description:
-        - Inventory name or ID the hosts should be made a member of.
+        - Inventory name, ID, or named URL the hosts should be made a member of.
       required: True
       type: str
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/bulk_job_launch.py
+++ b/awx_collection/plugins/modules/bulk_job_launch.py
@@ -128,7 +128,7 @@ options:
       type: str
     inventory:
       description:
-        - Inventory name or ID to use for the jobs ran within the bulk job, only used if prompt for inventory is set.
+        - Inventory name, ID, or named URL to use for the jobs ran within the bulk job, only used if prompt for inventory is set.
       type: str
     scm_branch:
       description:

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -45,7 +45,7 @@ options:
       type: str
     organization:
       description:
-        - Organization that should own the credential.
+        - Organization name or ID that should own the credential.
       type: str
     credential_type:
       description:
@@ -92,11 +92,11 @@ options:
       default: true
     user:
       description:
-        - User that should own this credential.
+        - User name or ID that should own this credential.
       type: str
     team:
       description:
-        - Team that should own this credential.
+        - Team name or ID that should own this credential.
       type: str
     state:
       description:

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -45,7 +45,7 @@ options:
       type: str
     organization:
       description:
-        - Organization name or ID that should own the credential.
+        - Organization name, ID, or named URL that should own the credential.
       type: str
     credential_type:
       description:
@@ -92,11 +92,11 @@ options:
       default: true
     user:
       description:
-        - User name or ID that should own this credential.
+        - User name, ID, or named URL that should own this credential.
       type: str
     team:
       description:
-        - Team name or ID that should own this credential.
+        - Team name, ID, or named URL that should own this credential.
       type: str
     state:
       description:

--- a/awx_collection/plugins/modules/credential_input_source.py
+++ b/awx_collection/plugins/modules/credential_input_source.py
@@ -38,12 +38,12 @@ options:
       type: dict
     target_credential:
       description:
-        - The credential name or ID which will have its input defined by this source
+        - The credential name, ID, or named URL which will have its input defined by this source
       required: true
       type: str
     source_credential:
       description:
-        - The credential name or ID which is the source of the credential lookup
+        - The credential name, ID, or named URL which is the source of the credential lookup
       type: str
     state:
       description:

--- a/awx_collection/plugins/modules/credential_input_source.py
+++ b/awx_collection/plugins/modules/credential_input_source.py
@@ -38,12 +38,12 @@ options:
       type: dict
     target_credential:
       description:
-        - The credential which will have its input defined by this source
+        - The credential name or ID which will have its input defined by this source
       required: true
       type: str
     source_credential:
       description:
-        - The credential which is the source of the credential lookup
+        - The credential name or ID which is the source of the credential lookup
       type: str
     state:
       description:

--- a/awx_collection/plugins/modules/execution_environment.py
+++ b/awx_collection/plugins/modules/execution_environment.py
@@ -41,11 +41,11 @@ options:
       type: str
     organization:
       description:
-        - The organization name or ID that the execution environment belongs to.
+        - The organization name, ID, or named URL that the execution environment belongs to.
       type: str
     credential:
       description:
-        - Name or ID of the credential to use for the execution environment.
+        - Name, ID, or named URL of the credential to use for the execution environment.
       type: str
     state:
       description:

--- a/awx_collection/plugins/modules/execution_environment.py
+++ b/awx_collection/plugins/modules/execution_environment.py
@@ -41,11 +41,11 @@ options:
       type: str
     organization:
       description:
-        - The organization the execution environment belongs to.
+        - The organization name or ID that the execution environment belongs to.
       type: str
     credential:
       description:
-        - Name of the credential to use for the execution environment.
+        - Name or ID of the credential to use for the execution environment.
       type: str
     state:
       description:

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -28,72 +28,72 @@ options:
       default: 'False'
     organizations:
       description:
-        - organization names or IDs to export
+        - organization names, IDs, or named URLs to export
       type: list
       elements: str
     users:
       description:
-        - user names or IDs to export
+        - user names, IDs, or named URLs to export
       type: list
       elements: str
     teams:
       description:
-        - team names or IDs to export
+        - team names, IDs, or named URLs to export
       type: list
       elements: str
     credential_types:
       description:
-        - credential type names or IDs to export
+        - credential type names, IDs, or named URLs to export
       type: list
       elements: str
     credentials:
       description:
-        - credential names or IDs to export
+        - credential names, IDs, or named URLs to export
       type: list
       elements: str
     execution_environments:
       description:
-        - execution environment names or IDs to export
+        - execution environment names, IDs, or named URLs to export
       type: list
       elements: str
     notification_templates:
       description:
-        - notification template names or IDs to export
+        - notification template names, IDs, or named URLs to export
       type: list
       elements: str
     inventory_sources:
       description:
-        - inventory source name or IDs to export
+        - inventory source name, ID, or named URLs to export
       type: list
       elements: str
     inventory:
       description:
-        - inventory names or IDs to export
+        - inventory names, IDs, or named URLs to export
       type: list
       elements: str
     projects:
       description:
-        - project names or IDs to export
+        - project names, IDs, or named URLs to export
       type: list
       elements: str
     job_templates:
       description:
-        - job template names or IDs to export
+        - job template names, IDs, or named URLs to export
       type: list
       elements: str
     workflow_job_templates:
       description:
-        - workflow names or IDs to export
+        - workflow names, IDs, or named URLs to export
       type: list
       elements: str
     applications:
       description:
-        - OAuth2 application names or IDs to export
+        - OAuth2 application names, IDs, or named URLs to export
       type: list
       elements: str
     schedules:
       description:
-        - schedule names or IDs to export
+        - schedule names, IDs, or named URLs to export
       type: list
       elements: str
 requirements:
@@ -154,7 +154,7 @@ def main():
 
     # The exporter code currently works like the following:
     #   Empty string == all assets of that type
-    #   Non-Empty string = just a list of assets of that type (by name or ID)
+    #   Non-Empty string = just a list of assets of that type (by name, ID, or named URL)
     #   Asset type not present or None = skip asset type (unless everything is None, then export all)
     # Here we are going to setup a dict of values to export
     export_args = {}

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -28,72 +28,72 @@ options:
       default: 'False'
     organizations:
       description:
-        - organization names to export
+        - organization names or IDs to export
       type: list
       elements: str
     users:
       description:
-        - user names to export
+        - user names or IDs to export
       type: list
       elements: str
     teams:
       description:
-        - team names to export
+        - team names or IDs to export
       type: list
       elements: str
     credential_types:
       description:
-        - credential type names to export
+        - credential type names or IDs to export
       type: list
       elements: str
     credentials:
       description:
-        - credential names to export
+        - credential names or IDs to export
       type: list
       elements: str
     execution_environments:
       description:
-        - execution environment names to export
+        - execution environment names or IDs to export
       type: list
       elements: str
     notification_templates:
       description:
-        - notification template names to export
+        - notification template names or IDs to export
       type: list
       elements: str
     inventory_sources:
       description:
-        - inventory soruces to export
+        - inventory source name or IDs to export
       type: list
       elements: str
     inventory:
       description:
-        - inventory names to export
+        - inventory names or IDs to export
       type: list
       elements: str
     projects:
       description:
-        - project names to export
+        - project names or IDs to export
       type: list
       elements: str
     job_templates:
       description:
-        - job template names to export
+        - job template names or IDs to export
       type: list
       elements: str
     workflow_job_templates:
       description:
-        - workflow names to export
+        - workflow names or IDs to export
       type: list
       elements: str
     applications:
       description:
-        - OAuth2 application names to export
+        - OAuth2 application names or IDs to export
       type: list
       elements: str
     schedules:
       description:
-        - schedule names to export
+        - schedule names or IDs to export
       type: list
       elements: str
 requirements:

--- a/awx_collection/plugins/modules/group.py
+++ b/awx_collection/plugins/modules/group.py
@@ -32,7 +32,7 @@ options:
       type: str
     inventory:
       description:
-        - Inventory the group should be made a member of.
+        - Inventory name or ID that the group should be made a member of.
       required: True
       type: str
     variables:
@@ -41,12 +41,12 @@ options:
       type: dict
     hosts:
       description:
-        - List of hosts that should be put in this group.
+        - List of host names or IDs that should be put in this group.
       type: list
       elements: str
     children:
       description:
-        - List of groups that should be nested inside in this group.
+        - List of groups names or IDs that should be nested inside in this group.
       type: list
       elements: str
       aliases:

--- a/awx_collection/plugins/modules/group.py
+++ b/awx_collection/plugins/modules/group.py
@@ -32,7 +32,7 @@ options:
       type: str
     inventory:
       description:
-        - Inventory name or ID that the group should be made a member of.
+        - Inventory name, ID, or named URL that the group should be made a member of.
       required: True
       type: str
     variables:
@@ -41,12 +41,12 @@ options:
       type: dict
     hosts:
       description:
-        - List of host names or IDs that should be put in this group.
+        - List of host names, IDs, or named URLs that should be put in this group.
       type: list
       elements: str
     children:
       description:
-        - List of groups names or IDs that should be nested inside in this group.
+        - List of groups names, IDs, or named URLs that should be nested inside in this group.
       type: list
       elements: str
       aliases:

--- a/awx_collection/plugins/modules/host.py
+++ b/awx_collection/plugins/modules/host.py
@@ -36,7 +36,7 @@ options:
       type: str
     inventory:
       description:
-        - Inventory the host should be made a member of.
+        - Inventory name or ID the host should be made a member of.
       required: True
       type: str
     enabled:

--- a/awx_collection/plugins/modules/host.py
+++ b/awx_collection/plugins/modules/host.py
@@ -36,7 +36,7 @@ options:
       type: str
     inventory:
       description:
-        - Inventory name or ID the host should be made a member of.
+        - Inventory name, ID, or named URL the host should be made a member of.
       required: True
       type: str
     enabled:

--- a/awx_collection/plugins/modules/instance_group.py
+++ b/awx_collection/plugins/modules/instance_group.py
@@ -33,7 +33,7 @@ options:
       type: str
     credential:
       description:
-        - Credential name or ID to authenticate with Kubernetes or OpenShift.  Must be of type "OpenShift or Kubernetes API Bearer Token".
+        - Credential name, ID, or named URL to authenticate with Kubernetes or OpenShift.  Must be of type "OpenShift or Kubernetes API Bearer Token".
       required: False
       type: str
     is_container_group:
@@ -74,7 +74,7 @@ options:
       type: str
     instances:
       description:
-        - The instance names or IDs associated with this instance_group
+        - The instance names, IDs, or named URLs associated with this instance_group
       required: False
       type: list
       elements: str

--- a/awx_collection/plugins/modules/instance_group.py
+++ b/awx_collection/plugins/modules/instance_group.py
@@ -33,7 +33,7 @@ options:
       type: str
     credential:
       description:
-        - Credential to authenticate with Kubernetes or OpenShift.  Must be of type "OpenShift or Kubernetes API Bearer Token".
+        - Credential name or ID to authenticate with Kubernetes or OpenShift.  Must be of type "OpenShift or Kubernetes API Bearer Token".
       required: False
       type: str
     is_container_group:
@@ -74,7 +74,7 @@ options:
       type: str
     instances:
       description:
-        - The instances associated with this instance_group
+        - The instance names or IDs associated with this instance_group
       required: False
       type: list
       elements: str

--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -44,7 +44,7 @@ options:
       type: str
     organization:
       description:
-        - Organization the inventory belongs to.
+        - Organization name or ID the inventory belongs to.
       required: True
       type: str
     variables:
@@ -62,12 +62,12 @@ options:
       type: str
     instance_groups:
       description:
-        - list of Instance Groups for this Organization to run on.
+        - list of Instance Group names or IDs for this Organization to run on.
       type: list
       elements: str
     input_inventories:
       description:
-        - List of Inventories to use as input for Constructed Inventory.
+        - List of Inventory names or IDs to use as input for Constructed Inventory.
       type: list
       elements: str
     prevent_instance_group_fallback:

--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -44,7 +44,7 @@ options:
       type: str
     organization:
       description:
-        - Organization name or ID the inventory belongs to.
+        - Organization name, ID, or named URL the inventory belongs to.
       required: True
       type: str
     variables:
@@ -62,12 +62,12 @@ options:
       type: str
     instance_groups:
       description:
-        - list of Instance Group names or IDs for this Organization to run on.
+        - list of Instance Group names, IDs, or named URLs for this Organization to run on.
       type: list
       elements: str
     input_inventories:
       description:
-        - List of Inventory names or IDs to use as input for Constructed Inventory.
+        - List of Inventory names, IDs, or named URLs to use as input for Constructed Inventory.
       type: list
       elements: str
     prevent_instance_group_fallback:

--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -36,7 +36,7 @@ options:
       type: str
     inventory:
       description:
-        - Inventory name or ID the group should be made a member of.
+        - Inventory name, ID, or named URL the group should be made a member of.
       required: True
       type: str
     source:
@@ -70,11 +70,11 @@ options:
       type: str
     credential:
       description:
-        - Credential name or ID to use for the source.
+        - Credential name, ID, or named URL to use for the source.
       type: str
     execution_environment:
       description:
-        - Execution Environment name or ID to use for the source.
+        - Execution Environment name, ID, or named URL to use for the source.
       type: str
     custom_virtualenv:
       description:
@@ -107,7 +107,7 @@ options:
       type: int
     source_project:
       description:
-        - Project name or ID to use as source with scm option
+        - Project name, ID, or named URL to use as source with scm option
       type: str
     scm_branch:
       description:

--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -36,7 +36,7 @@ options:
       type: str
     inventory:
       description:
-        - Inventory the group should be made a member of.
+        - Inventory name or ID the group should be made a member of.
       required: True
       type: str
     source:
@@ -70,11 +70,11 @@ options:
       type: str
     credential:
       description:
-        - Credential to use for the source.
+        - Credential name or ID to use for the source.
       type: str
     execution_environment:
       description:
-        - Execution Environment to use for the source.
+        - Execution Environment name or ID to use for the source.
       type: str
     custom_virtualenv:
       description:
@@ -107,7 +107,7 @@ options:
       type: int
     source_project:
       description:
-        - Project to use as source with scm option
+        - Project name or ID to use as source with scm option
       type: str
     scm_branch:
       description:

--- a/awx_collection/plugins/modules/inventory_source_update.py
+++ b/awx_collection/plugins/modules/inventory_source_update.py
@@ -35,7 +35,7 @@ options:
       type: str
     organization:
       description:
-        - Name or ID of the inventory source's inventory's organization.
+        - Name, ID, or named URL of the inventory source's inventory's organization.
       type: str
     wait:
       description:

--- a/awx_collection/plugins/modules/inventory_source_update.py
+++ b/awx_collection/plugins/modules/inventory_source_update.py
@@ -35,7 +35,7 @@ options:
       type: str
     organization:
       description:
-        - Name of the inventory source's inventory's organization.
+        - Name or ID of the inventory source's inventory's organization.
       type: str
     wait:
       description:

--- a/awx_collection/plugins/modules/job_launch.py
+++ b/awx_collection/plugins/modules/job_launch.py
@@ -34,17 +34,17 @@ options:
       type: str
     inventory:
       description:
-        - Inventory to use for the job, only used if prompt for inventory is set.
+        - Inventory name or ID to use for the job, only used if prompt for inventory is set.
       type: str
     organization:
       description:
-        - Organization the job template exists in.
+        - Organization name or ID the job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     credentials:
       description:
-        - Credential to use for job, only used if prompt for credential is set.
+        - Credential names or IDs to use for job, only used if prompt for credential is set.
       type: list
       aliases: ['credential']
       elements: str
@@ -88,7 +88,7 @@ options:
       type: dict
     execution_environment:
       description:
-        - Execution environment to use for the job, only used if prompt for execution environment is set.
+        - Execution environment name or ID to use for the job, only used if prompt for execution environment is set.
       type: str
     forks:
       description:
@@ -96,7 +96,7 @@ options:
       type: int
     instance_groups:
       description:
-        - Instance groups to use for the job, only used if prompt for instance groups is set.
+        - Instance group names or IDs to use for the job, only used if prompt for instance groups is set.
       type: list
       elements: str
     job_slice_count:

--- a/awx_collection/plugins/modules/job_launch.py
+++ b/awx_collection/plugins/modules/job_launch.py
@@ -34,17 +34,17 @@ options:
       type: str
     inventory:
       description:
-        - Inventory name or ID to use for the job, only used if prompt for inventory is set.
+        - Inventory name, ID, or named URL to use for the job, only used if prompt for inventory is set.
       type: str
     organization:
       description:
-        - Organization name or ID the job template exists in.
+        - Organization name, ID, or named URL the job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     credentials:
       description:
-        - Credential names or IDs to use for job, only used if prompt for credential is set.
+        - Credential names, IDs, or named URLs to use for job, only used if prompt for credential is set.
       type: list
       aliases: ['credential']
       elements: str
@@ -88,7 +88,7 @@ options:
       type: dict
     execution_environment:
       description:
-        - Execution environment name or ID to use for the job, only used if prompt for execution environment is set.
+        - Execution environment name, ID, or named URL to use for the job, only used if prompt for execution environment is set.
       type: str
     forks:
       description:
@@ -96,7 +96,7 @@ options:
       type: int
     instance_groups:
       description:
-        - Instance group names or IDs to use for the job, only used if prompt for instance groups is set.
+        - Instance group names, IDs, or named URLs to use for the job, only used if prompt for instance groups is set.
       type: list
       elements: str
     job_slice_count:

--- a/awx_collection/plugins/modules/job_template.py
+++ b/awx_collection/plugins/modules/job_template.py
@@ -49,11 +49,11 @@ options:
       type: str
     inventory:
       description:
-        - Name or ID of the inventory to use for the job template.
+        - Name, ID, or named URL of the inventory to use for the job template.
       type: str
     organization:
       description:
-        - Organization name or ID the job template exists in.
+        - Organization name, ID, or named URL the job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - The Organization is inferred from the associated project
         - If not provided, will lookup by name only, which does not work with duplicates.
@@ -61,7 +61,7 @@ options:
       type: str
     project:
       description:
-        - Name or ID of the project to use for the job template.
+        - Name, ID, or named URL of the project to use for the job template.
       type: str
     playbook:
       description:
@@ -69,22 +69,22 @@ options:
       type: str
     credential:
       description:
-        - Name or ID of the credential to use for the job template.
+        - Name, ID, or named URL of the credential to use for the job template.
         - Deprecated, use 'credentials'.
       type: str
     credentials:
       description:
-        - List of credential names or IDs to use for the job template.
+        - List of credential names, IDs, or named URLs to use for the job template.
       type: list
       elements: str
     vault_credential:
       description:
-        - Name or ID of the vault credential to use for the job template.
+        - Name, ID, or named URL of the vault credential to use for the job template.
         - Deprecated, use 'credentials'.
       type: str
     execution_environment:
       description:
-        - Execution Environment name or ID to use for the job template.
+        - Execution Environment name, ID, or named URL to use for the job template.
       type: str
     custom_virtualenv:
       description:
@@ -94,7 +94,7 @@ options:
       type: str
     instance_groups:
       description:
-        - list of Instance Group names or IDs for this Organization to run on.
+        - list of Instance Group names, IDs, or named URLs for this Organization to run on.
       type: list
       elements: str
     forks:

--- a/awx_collection/plugins/modules/job_template.py
+++ b/awx_collection/plugins/modules/job_template.py
@@ -49,11 +49,11 @@ options:
       type: str
     inventory:
       description:
-        - Name of the inventory to use for the job template.
+        - Name or ID of the inventory to use for the job template.
       type: str
     organization:
       description:
-        - Organization the job template exists in.
+        - Organization name or ID the job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - The Organization is inferred from the associated project
         - If not provided, will lookup by name only, which does not work with duplicates.
@@ -61,7 +61,7 @@ options:
       type: str
     project:
       description:
-        - Name of the project to use for the job template.
+        - Name or ID of the project to use for the job template.
       type: str
     playbook:
       description:
@@ -69,22 +69,22 @@ options:
       type: str
     credential:
       description:
-        - Name of the credential to use for the job template.
+        - Name or ID of the credential to use for the job template.
         - Deprecated, use 'credentials'.
       type: str
     credentials:
       description:
-        - List of credentials to use for the job template.
+        - List of credential names or IDs to use for the job template.
       type: list
       elements: str
     vault_credential:
       description:
-        - Name of the vault credential to use for the job template.
+        - Name or ID of the vault credential to use for the job template.
         - Deprecated, use 'credentials'.
       type: str
     execution_environment:
       description:
-        - Execution Environment to use for the job template.
+        - Execution Environment name or ID to use for the job template.
       type: str
     custom_virtualenv:
       description:
@@ -94,7 +94,7 @@ options:
       type: str
     instance_groups:
       description:
-        - list of Instance Groups for this Organization to run on.
+        - list of Instance Group names or IDs for this Organization to run on.
       type: list
       elements: str
     forks:

--- a/awx_collection/plugins/modules/label.py
+++ b/awx_collection/plugins/modules/label.py
@@ -34,7 +34,7 @@ options:
       type: str
     organization:
       description:
-        - Organization this label belongs to.
+        - Organization name or ID this label belongs to.
       required: True
       type: str
     state:

--- a/awx_collection/plugins/modules/label.py
+++ b/awx_collection/plugins/modules/label.py
@@ -34,7 +34,7 @@ options:
       type: str
     organization:
       description:
-        - Organization name or ID this label belongs to.
+        - Organization name, ID, or named URL this label belongs to.
       required: True
       type: str
     state:

--- a/awx_collection/plugins/modules/notification_template.py
+++ b/awx_collection/plugins/modules/notification_template.py
@@ -44,7 +44,7 @@ options:
       type: str
     organization:
       description:
-        - The organization the notification belongs to.
+        - The organization name or ID the notification belongs to.
       type: str
     notification_type:
       description:

--- a/awx_collection/plugins/modules/notification_template.py
+++ b/awx_collection/plugins/modules/notification_template.py
@@ -44,7 +44,7 @@ options:
       type: str
     organization:
       description:
-        - The organization name or ID the notification belongs to.
+        - The organization name, ID, or named URL the notification belongs to.
       type: str
     notification_type:
       description:

--- a/awx_collection/plugins/modules/organization.py
+++ b/awx_collection/plugins/modules/organization.py
@@ -36,7 +36,7 @@ options:
       type: str
     default_environment:
       description:
-        - Default Execution Environment to use for jobs owned by the Organization.
+        - Default Execution Environment name or ID to use for jobs owned by the Organization.
       type: str
     custom_virtualenv:
       description:
@@ -56,7 +56,7 @@ options:
       type: str
     instance_groups:
       description:
-        - list of Instance Groups for this Organization to run on.
+        - list of Instance Group names or IDs for this Organization to run on.
       type: list
       elements: str
     notification_templates_started:
@@ -81,7 +81,7 @@ options:
       elements: str
     galaxy_credentials:
       description:
-        - list of Ansible Galaxy credentials to associate to the organization
+        - list of Ansible Galaxy credential names or IDs to associate to the organization
       type: list
       elements: str
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/organization.py
+++ b/awx_collection/plugins/modules/organization.py
@@ -36,7 +36,7 @@ options:
       type: str
     default_environment:
       description:
-        - Default Execution Environment name or ID to use for jobs owned by the Organization.
+        - Default Execution Environment name, ID, or named URL to use for jobs owned by the Organization.
       type: str
     custom_virtualenv:
       description:
@@ -56,7 +56,7 @@ options:
       type: str
     instance_groups:
       description:
-        - list of Instance Group names or IDs for this Organization to run on.
+        - list of Instance Group names, IDs, or named URLs for this Organization to run on.
       type: list
       elements: str
     notification_templates_started:
@@ -81,7 +81,7 @@ options:
       elements: str
     galaxy_credentials:
       description:
-        - list of Ansible Galaxy credential names or IDs to associate to the organization
+        - list of Ansible Galaxy credential names, IDs, or named URLs to associate to the organization
       type: list
       elements: str
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -65,7 +65,7 @@ options:
       type: str
     credential:
       description:
-        - Name of the credential to use with this SCM resource.
+        - Name or ID of the credential to use with this SCM resource.
       type: str
       aliases:
         - scm_credential
@@ -106,7 +106,7 @@ options:
         - job_timeout
     default_environment:
       description:
-        - Default Execution Environment to use for jobs relating to the project.
+        - Default Execution Environment name or ID to use for jobs relating to the project.
       type: str
     custom_virtualenv:
       description:
@@ -116,7 +116,7 @@ options:
       type: str
     organization:
       description:
-        - Name of organization for project.
+        - Name or ID of organization for the project.
       type: str
     state:
       description:
@@ -162,7 +162,7 @@ options:
       type: float
     signature_validation_credential:
       description:
-        - Name of the credential to use for signature validation.
+        - Name or ID of the credential to use for signature validation.
         - If signature validation credential is provided, signature validation will be enabled.
       type: str
 

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -65,7 +65,7 @@ options:
       type: str
     credential:
       description:
-        - Name or ID of the credential to use with this SCM resource.
+        - Name, ID, or named URL of the credential to use with this SCM resource.
       type: str
       aliases:
         - scm_credential
@@ -106,7 +106,7 @@ options:
         - job_timeout
     default_environment:
       description:
-        - Default Execution Environment name or ID to use for jobs relating to the project.
+        - Default Execution Environment name, ID, or named URL to use for jobs relating to the project.
       type: str
     custom_virtualenv:
       description:
@@ -116,7 +116,7 @@ options:
       type: str
     organization:
       description:
-        - Name or ID of organization for the project.
+        - Name, ID, or named URL of organization for the project.
       type: str
     state:
       description:
@@ -162,7 +162,7 @@ options:
       type: float
     signature_validation_credential:
       description:
-        - Name or ID of the credential to use for signature validation.
+        - Name, ID, or named URL of the credential to use for signature validation.
         - If signature validation credential is provided, signature validation will be enabled.
       type: str
 

--- a/awx_collection/plugins/modules/project_update.py
+++ b/awx_collection/plugins/modules/project_update.py
@@ -27,7 +27,7 @@ options:
         - project
     organization:
       description:
-        - Organization name or ID the project exists in.
+        - Organization name, ID, or named URL the project exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str

--- a/awx_collection/plugins/modules/project_update.py
+++ b/awx_collection/plugins/modules/project_update.py
@@ -27,7 +27,7 @@ options:
         - project
     organization:
       description:
-        - Organization the project exists in.
+        - Organization name or ID the project exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str

--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -23,22 +23,22 @@ description:
 options:
     user:
       description:
-        - User name or ID that receives the permissions specified by the role.
+        - User name, ID, or named URL that receives the permissions specified by the role.
         - Deprecated, use 'users'.
       type: str
     users:
       description:
-        - User names or IDs that receive the permissions specified by the role.
+        - User names, IDs, or named URLs that receive the permissions specified by the role.
       type: list
       elements: str
     team:
       description:
-        - Team name or ID that receives the permissions specified by the role.
+        - Team name, ID, or named URL that receives the permissions specified by the role.
         - Deprecated, use 'teams'.
       type: str
     teams:
       description:
-        - Team names or IDs that receive the permissions specified by the role.
+        - Team names, IDs, or named URLs that receive the permissions specified by the role.
       type: list
       elements: str
     role:
@@ -50,87 +50,87 @@ options:
       type: str
     target_team:
       description:
-        - Team name or ID that the role acts on.
+        - Team name, ID, or named URL that the role acts on.
         - For example, make someone a member or an admin of a team.
         - Members of a team implicitly receive the permissions that the team has.
         - Deprecated, use 'target_teams'.
       type: str
     target_teams:
       description:
-        - Team names or IDs that the role acts on.
+        - Team names, IDs, or named URLs that the role acts on.
         - For example, make someone a member or an admin of a team.
         - Members of a team implicitly receive the permissions that the team has.
       type: list
       elements: str
     inventory:
       description:
-        - Inventory name or ID the role acts on.
+        - Inventory name, ID, or named URL the role acts on.
         - Deprecated, use 'inventories'.
       type: str
     inventories:
       description:
-        - Inventory names or IDs the role acts on.
+        - Inventory names, IDs, or named URLs the role acts on.
       type: list
       elements: str
     job_template:
       description:
-        - The job template name or ID the role acts on.
+        - The job template name, ID, or named URL the role acts on.
         - Deprecated, use 'job_templates'.
       type: str
     job_templates:
       description:
-        - The job template names or IDs the role acts on.
+        - The job template names, IDs, or named URLs the role acts on.
       type: list
       elements: str
     workflow:
       description:
-        - The workflow job template name or ID the role acts on.
+        - The workflow job template name, ID, or named URL the role acts on.
         - Deprecated, use 'workflows'.
       type: str
     workflows:
       description:
-        - The workflow job template names or IDs the role acts on.
+        - The workflow job template names, IDs, or named URLs the role acts on.
       type: list
       elements: str
     credential:
       description:
-        - Credential name or ID the role acts on.
+        - Credential name, ID, or named URL the role acts on.
         - Deprecated, use 'credentials'.
       type: str
     credentials:
       description:
-        - Credential names or IDs the role acts on.
+        - Credential names, IDs, or named URLs the role acts on.
       type: list
       elements: str
     organization:
       description:
-        - Organization name or ID the role acts on.
+        - Organization name, ID, or named URL the role acts on.
         - Deprecated, use 'organizations'.
       type: str
     organizations:
       description:
-        - Organization names or IDs the role acts on.
+        - Organization names, IDs, or named URLs the role acts on.
       type: list
       elements: str
     lookup_organization:
       description:
-        - Organization name or ID the inventories, job templates, projects, or workflows the items exists in.
+        - Organization name, ID, or named URL the inventories, job templates, projects, or workflows the items exists in.
         - Used to help lookup the object, for organization roles see organization.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     project:
       description:
-        - Project name or ID the role acts on.
+        - Project name, ID, or named URL the role acts on.
         - Deprecated, use 'projects'.
       type: str
     projects:
       description:
-        - Project names or IDs the role acts on.
+        - Project names, IDs, or named URLs the role acts on.
       type: list
       elements: str
     instance_groups:
       description:
-        - Instance Group names or IDs the role acts on.
+        - Instance Group names, IDs, or named URLs the role acts on.
       type: list
       elements: str
     state:
@@ -266,7 +266,7 @@ def main():
     resource_data = {}
     for key, value in resources.items():
         for resource in value:
-            # Attempt to look up project based on the provided name or ID and lookup data
+            # Attempt to look up project based on the provided name, ID, or named URL and lookup data
             lookup_key = key
             if key == 'organizations' or key == 'users':
                 lookup_data_populated = {}

--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -23,22 +23,22 @@ description:
 options:
     user:
       description:
-        - User that receives the permissions specified by the role.
+        - User name or ID that receives the permissions specified by the role.
         - Deprecated, use 'users'.
       type: str
     users:
       description:
-        - Users that receive the permissions specified by the role.
+        - User names or IDs that receive the permissions specified by the role.
       type: list
       elements: str
     team:
       description:
-        - Team that receives the permissions specified by the role.
+        - Team name or ID that receives the permissions specified by the role.
         - Deprecated, use 'teams'.
       type: str
     teams:
       description:
-        - Teams that receive the permissions specified by the role.
+        - Team names or IDs that receive the permissions specified by the role.
       type: list
       elements: str
     role:
@@ -50,87 +50,87 @@ options:
       type: str
     target_team:
       description:
-        - Team that the role acts on.
+        - Team name or ID that the role acts on.
         - For example, make someone a member or an admin of a team.
         - Members of a team implicitly receive the permissions that the team has.
         - Deprecated, use 'target_teams'.
       type: str
     target_teams:
       description:
-        - Team that the role acts on.
+        - Team names or IDs that the role acts on.
         - For example, make someone a member or an admin of a team.
         - Members of a team implicitly receive the permissions that the team has.
       type: list
       elements: str
     inventory:
       description:
-        - Inventory the role acts on.
+        - Inventory name or ID the role acts on.
         - Deprecated, use 'inventories'.
       type: str
     inventories:
       description:
-        - Inventory the role acts on.
+        - Inventory names or IDs the role acts on.
       type: list
       elements: str
     job_template:
       description:
-        - The job template the role acts on.
+        - The job template name or ID the role acts on.
         - Deprecated, use 'job_templates'.
       type: str
     job_templates:
       description:
-        - The job template the role acts on.
+        - The job template names or IDs the role acts on.
       type: list
       elements: str
     workflow:
       description:
-        - The workflow job template the role acts on.
+        - The workflow job template name or ID the role acts on.
         - Deprecated, use 'workflows'.
       type: str
     workflows:
       description:
-        - The workflow job template the role acts on.
+        - The workflow job template names or IDs the role acts on.
       type: list
       elements: str
     credential:
       description:
-        - Credential the role acts on.
+        - Credential name or ID the role acts on.
         - Deprecated, use 'credentials'.
       type: str
     credentials:
       description:
-        - Credential the role acts on.
+        - Credential names or IDs the role acts on.
       type: list
       elements: str
     organization:
       description:
-        - Organization the role acts on.
+        - Organization name or ID the role acts on.
         - Deprecated, use 'organizations'.
       type: str
     organizations:
       description:
-        - Organization the role acts on.
+        - Organization names or IDs the role acts on.
       type: list
       elements: str
     lookup_organization:
       description:
-        - Organization the inventories, job templates, projects, or workflows the items exists in.
+        - Organization name or ID the inventories, job templates, projects, or workflows the items exists in.
         - Used to help lookup the object, for organization roles see organization.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     project:
       description:
-        - Project the role acts on.
+        - Project name or ID the role acts on.
         - Deprecated, use 'projects'.
       type: str
     projects:
       description:
-        - Project the role acts on.
+        - Project names or IDs the role acts on.
       type: list
       elements: str
     instance_groups:
       description:
-        - Instance Group the role acts on.
+        - Instance Group names or IDs the role acts on.
       type: list
       elements: str
     state:

--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -44,7 +44,7 @@ options:
       type: str
     execution_environment:
       description:
-        - Execution Environment name or ID applied as a prompt, assuming job template prompts for execution environment
+        - Execution Environment name, ID, or named URL applied as a prompt, assuming job template prompts for execution environment
       type: str
     extra_data:
       description:
@@ -57,12 +57,12 @@ options:
       type: int
     instance_groups:
       description:
-        - List of Instance Group names or IDs applied as a prompt, assuming job template prompts for instance groups
+        - List of Instance Group names, IDs, or named URLs applied as a prompt, assuming job template prompts for instance groups
       type: list
       elements: str
     inventory:
       description:
-        - Inventory name or ID applied as a prompt, assuming job template prompts for inventory
+        - Inventory name, ID, or named URL applied as a prompt, assuming job template prompts for inventory
       required: False
       type: str
     job_slice_count:
@@ -76,7 +76,7 @@ options:
       elements: str
     credentials:
       description:
-        - List of credential names or IDs applied as a prompt, assuming job template prompts for credentials
+        - List of credential names, IDs, or named URLs applied as a prompt, assuming job template prompts for credentials
       type: list
       elements: str
     scm_branch:
@@ -130,12 +130,12 @@ options:
         - 5
     unified_job_template:
       description:
-        - Name or ID of unified job template to schedule. Used to look up an already existing schedule.
+        - Name, ID, or named URL of unified job template to schedule. Used to look up an already existing schedule.
       required: False
       type: str
     organization:
       description:
-        - The organization name or ID the unified job template exists in.
+        - The organization name, ID, or named URL the unified job template exists in.
         - Used for looking up the unified job template, not a direct model field.
       type: str
     enabled:

--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -44,7 +44,7 @@ options:
       type: str
     execution_environment:
       description:
-        - Execution Environment applied as a prompt, assuming jot template prompts for execution environment
+        - Execution Environment name or ID applied as a prompt, assuming job template prompts for execution environment
       type: str
     extra_data:
       description:
@@ -57,12 +57,12 @@ options:
       type: int
     instance_groups:
       description:
-        - List of Instance Groups applied as a prompt, assuming job template prompts for instance groups
+        - List of Instance Group names or IDs applied as a prompt, assuming job template prompts for instance groups
       type: list
       elements: str
     inventory:
       description:
-        - Inventory applied as a prompt, assuming job template prompts for inventory
+        - Inventory name or ID applied as a prompt, assuming job template prompts for inventory
       required: False
       type: str
     job_slice_count:
@@ -76,7 +76,7 @@ options:
       elements: str
     credentials:
       description:
-        - List of credentials applied as a prompt, assuming job template prompts for credentials
+        - List of credential names or IDs applied as a prompt, assuming job template prompts for credentials
       type: list
       elements: str
     scm_branch:
@@ -130,12 +130,12 @@ options:
         - 5
     unified_job_template:
       description:
-        - Name of unified job template to schedule. Used to look up an already existing schedule.
+        - Name or ID of unified job template to schedule. Used to look up an already existing schedule.
       required: False
       type: str
     organization:
       description:
-        - The organization the unified job template exists in.
+        - The organization name or ID the unified job template exists in.
         - Used for looking up the unified job template, not a direct model field.
       type: str
     enabled:

--- a/awx_collection/plugins/modules/team.py
+++ b/awx_collection/plugins/modules/team.py
@@ -36,7 +36,7 @@ options:
       type: str
     organization:
       description:
-        - Organization name or ID the team should be made a member of.
+        - Organization name, ID, or named URL the team should be made a member of.
       required: True
       type: str
     state:

--- a/awx_collection/plugins/modules/team.py
+++ b/awx_collection/plugins/modules/team.py
@@ -36,7 +36,7 @@ options:
       type: str
     organization:
       description:
-        - Organization the team should be made a member of.
+        - Organization name or ID the team should be made a member of.
       required: True
       type: str
     state:

--- a/awx_collection/plugins/modules/token.py
+++ b/awx_collection/plugins/modules/token.py
@@ -37,7 +37,7 @@ options:
       type: str
     application:
       description:
-        - The application name or ID tied to this token.
+        - The application name, ID, or named URL tied to this token.
       required: False
       type: str
     scope:

--- a/awx_collection/plugins/modules/token.py
+++ b/awx_collection/plugins/modules/token.py
@@ -37,7 +37,7 @@ options:
       type: str
     application:
       description:
-        - The application tied to this token.
+        - The application name or ID tied to this token.
       required: False
       type: str
     scope:

--- a/awx_collection/plugins/modules/user.py
+++ b/awx_collection/plugins/modules/user.py
@@ -44,7 +44,7 @@ options:
       type: str
     organization:
       description:
-        - The user will be created as a member of that organization (needed for organization admins to create new organization users).
+        - The user will be created as a member of that organization name or ID (needed for organization admins to create new organization users).
       type: str
     is_superuser:
       description:

--- a/awx_collection/plugins/modules/user.py
+++ b/awx_collection/plugins/modules/user.py
@@ -44,7 +44,7 @@ options:
       type: str
     organization:
       description:
-        - The user will be created as a member of that organization name or ID (needed for organization admins to create new organization users).
+        - The user will be created as a member of that organization name, ID, or named URL (needed for organization admins to create new organization users).
       type: str
     is_superuser:
       description:

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -58,7 +58,7 @@ options:
         - ask_tags
     organization:
       description:
-        - Organization name or ID the workflow job template exists in.
+        - Organization name, ID, or named URL the workflow job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
@@ -72,7 +72,7 @@ options:
       type: bool
     inventory:
       description:
-        - Name or ID of inventory applied as a prompt, assuming job template prompts for inventory
+        - Name, ID, or named URL of inventory applied as a prompt, assuming job template prompts for inventory
       type: str
     limit:
       description:

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -58,7 +58,7 @@ options:
         - ask_tags
     organization:
       description:
-        - Organization the workflow job template exists in.
+        - Organization name or ID the workflow job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
@@ -72,7 +72,7 @@ options:
       type: bool
     inventory:
       description:
-        - Inventory applied as a prompt, assuming job template prompts for inventory
+        - Name or ID of inventory applied as a prompt, assuming job template prompts for inventory
       type: str
     limit:
       description:

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -31,7 +31,7 @@ options:
       type: dict
     inventory:
       description:
-        - Inventory applied as a prompt, if job template prompts for inventory
+        - Name or ID of the Inventory applied as a prompt, if job template prompts for inventory
       type: str
     scm_branch:
       description:
@@ -73,7 +73,7 @@ options:
         - '5'
     workflow_job_template:
       description:
-        - The workflow job template the node exists in.
+        - The workflow job template name or ID the node exists in.
         - Used for looking up the node, cannot be modified after creation.
       required: True
       type: str
@@ -81,7 +81,7 @@ options:
         - workflow
     organization:
       description:
-        - The organization of the workflow job template the node exists in.
+        - The organization name or ID of the workflow job template the node exists in.
         - Used for looking up the workflow, not a direct model field.
       type: str
     unified_job_template:
@@ -93,7 +93,7 @@ options:
       type: str
     lookup_organization:
       description:
-        - Organization the inventories, job template, project, inventory source the unified_job_template exists in.
+        - Organization name or ID the inventories, job template, project, inventory source the unified_job_template exists in.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     approval_node:
@@ -145,14 +145,14 @@ options:
       elements: str
     credentials:
       description:
-        - Credentials to be applied to job as launch-time prompts.
-        - List of credential names.
+        - Credential names or IDs to be applied to job as launch-time prompts.
+        - List of credential names or IDs.
         - Uniqueness is not handled rigorously.
       type: list
       elements: str
     execution_environment:
       description:
-        - Execution Environment applied as a prompt, assuming jot template prompts for execution environment
+        - Execution Environment name or ID applied as a prompt, assuming job template prompts for execution environment
       type: str
     forks:
       description:
@@ -160,7 +160,7 @@ options:
       type: int
     instance_groups:
       description:
-        - List of Instance Groups applied as a prompt, assuming job template prompts for instance groups
+        - List of Instance Group names or IDs applied as a prompt, assuming job template prompts for instance groups
       type: list
       elements: str
     job_slice_count:

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -31,7 +31,7 @@ options:
       type: dict
     inventory:
       description:
-        - Name or ID of the Inventory applied as a prompt, if job template prompts for inventory
+        - Name, ID, or named URL of the Inventory applied as a prompt, if job template prompts for inventory
       type: str
     scm_branch:
       description:
@@ -73,7 +73,7 @@ options:
         - '5'
     workflow_job_template:
       description:
-        - The workflow job template name or ID the node exists in.
+        - The workflow job template name, ID, or named URL the node exists in.
         - Used for looking up the node, cannot be modified after creation.
       required: True
       type: str
@@ -81,7 +81,7 @@ options:
         - workflow
     organization:
       description:
-        - The organization name or ID of the workflow job template the node exists in.
+        - The organization name, ID, or named URL of the workflow job template the node exists in.
         - Used for looking up the workflow, not a direct model field.
       type: str
     unified_job_template:
@@ -93,7 +93,7 @@ options:
       type: str
     lookup_organization:
       description:
-        - Organization name or ID the inventories, job template, project, inventory source the unified_job_template exists in.
+        - Organization name, ID, or named URL the inventories, job template, project, inventory source the unified_job_template exists in.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     approval_node:
@@ -145,14 +145,14 @@ options:
       elements: str
     credentials:
       description:
-        - Credential names or IDs to be applied to job as launch-time prompts.
-        - List of credential names or IDs.
+        - Credential names, IDs, or named URLs to be applied to job as launch-time prompts.
+        - List of credential names, IDs, or named URLs.
         - Uniqueness is not handled rigorously.
       type: list
       elements: str
     execution_environment:
       description:
-        - Execution Environment name or ID applied as a prompt, assuming job template prompts for execution environment
+        - Execution Environment name, ID, or named URL applied as a prompt, assuming job template prompts for execution environment
       type: str
     forks:
       description:
@@ -160,7 +160,7 @@ options:
       type: int
     instance_groups:
       description:
-        - List of Instance Group names or IDs applied as a prompt, assuming job template prompts for instance groups
+        - List of Instance Group names, IDs, or named URLs applied as a prompt, assuming job template prompts for instance groups
       type: list
       elements: str
     job_slice_count:

--- a/awx_collection/plugins/modules/workflow_launch.py
+++ b/awx_collection/plugins/modules/workflow_launch.py
@@ -27,13 +27,13 @@ options:
         - workflow_template
     organization:
       description:
-        - Organization name or ID the workflow job template exists in.
+        - Organization name, ID, or named URL the workflow job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     inventory:
       description:
-        - Inventory name or ID to use for the job ran with this workflow, only used if prompt for inventory is set.
+        - Inventory name, ID, or named URL to use for the job ran with this workflow, only used if prompt for inventory is set.
       type: str
     limit:
       description:

--- a/awx_collection/plugins/modules/workflow_launch.py
+++ b/awx_collection/plugins/modules/workflow_launch.py
@@ -27,13 +27,13 @@ options:
         - workflow_template
     organization:
       description:
-        - Organization the workflow job template exists in.
+        - Organization name or ID the workflow job template exists in.
         - Used to help lookup the object, cannot be modified using this module.
         - If not provided, will lookup by name only, which does not work with duplicates.
       type: str
     inventory:
       description:
-        - Inventory to use for the job ran with this workflow, only used if prompt for inventory is set.
+        - Inventory name or ID to use for the job ran with this workflow, only used if prompt for inventory is set.
       type: str
     limit:
       description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The collection modules can currently take name, ID, and possibly named URL for related fields. This is an update to the collection documentation to reflect that.

related #14208 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
 - Docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev33410+g72f6d54
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
