### PR TITLE
Remove use_role requirement to existing JT.project to make changes to JT

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1629,18 +1629,18 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
             return True
 
         data = dict(data)
-
         if self.changes_are_non_sensitive(obj, data):
             return True
-
         if not self.check_related('execution_environment', ExecutionEnvironment, data, obj=obj, role_field='read_role'):
             return False
-
         for required_field, cls in (('inventory', Inventory), ('project', Project)):
             is_mandatory = True
             if not getattr(obj, '{}_id'.format(required_field)):
                 is_mandatory = False
             if not self.check_related(required_field, cls, data, obj=obj, role_field='use_role', mandatory=is_mandatory):
+                if required_field in data:
+                    new_obj = get_object_from_data(required_field, cls, data)
+                    return self.user in new_obj.use_role and (self.user in obj.inventory.use_role or self.user in obj.project.use_role)
                 return False
         return True
 

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1623,6 +1623,15 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
         return self.user in obj.execute_role
 
     def can_change(self, obj, data):
+        """
+        User can modify any JT setting (like diff_mode) that does not involve related objects
+         - if they have the admin_role to the JT
+
+        If they modify a related project or inventory it becomes more complicated.
+         - they can set the EE if they have read_role to the EE, irrelevant of current
+         - they always need use_role to current and new inventory
+         - they need use_role only to the new project, if changing the project
+        """
         if self.user not in obj.admin_role and not self.user.is_superuser:
             return False
         if data is None:
@@ -1631,18 +1640,12 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
         data = dict(data)
         if self.changes_are_non_sensitive(obj, data):
             return True
-        if not self.check_related('execution_environment', ExecutionEnvironment, data, obj=obj, role_field='read_role'):
-            return False
-        for required_field, cls in (('inventory', Inventory), ('project', Project)):
-            is_mandatory = True
-            if not getattr(obj, '{}_id'.format(required_field)):
-                is_mandatory = False
-            if not self.check_related(required_field, cls, data, obj=obj, role_field='use_role', mandatory=is_mandatory):
-                if required_field in data:
-                    new_obj = get_object_from_data(required_field, cls, data)
-                    return self.user in new_obj.use_role and (self.user in obj.inventory.use_role or self.user in obj.project.use_role)
-                return False
-        return True
+
+        return bool(
+            self.check_related('execution_environment', ExecutionEnvironment, data, obj=obj, role_field='read_role')
+            and self.check_related('inventory', Inventory, data, obj=obj, role_field='use_role', mandatory=True)
+            and self.check_related('project', Project, data, obj=None, role_field='use_role')
+        )
 
     def changes_are_non_sensitive(self, obj, data):
         """

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1554,18 +1554,18 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
             return True
 
         data = dict(data)
-
         if self.changes_are_non_sensitive(obj, data):
             return True
-
         if not self.check_related('execution_environment', ExecutionEnvironment, data, obj=obj, role_field='read_role'):
             return False
-
         for required_field, cls in (('inventory', Inventory), ('project', Project)):
             is_mandatory = True
             if not getattr(obj, '{}_id'.format(required_field)):
                 is_mandatory = False
             if not self.check_related(required_field, cls, data, obj=obj, role_field='use_role', mandatory=is_mandatory):
+                if required_field in data:
+                    new_obj = get_object_from_data(required_field, cls, data)
+                    return self.user in new_obj.use_role and (self.user in obj.inventory.use_role or self.user in obj.project.use_role)
                 return False
         return True
 

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1548,6 +1548,15 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
         return self.user in obj.execute_role
 
     def can_change(self, obj, data):
+        """
+        User can modify any JT setting (like diff_mode) that does not involve related objects
+         - if they have the admin_role to the JT
+
+        If they modify a related project or inventory it becomes more complicated.
+         - they can set the EE if they have read_role to the EE, irrelevant of current
+         - they always need use_role to current and new inventory
+         - they need use_role only to the new project, if changing the project
+        """
         if self.user not in obj.admin_role and not self.user.is_superuser:
             return False
         if data is None:
@@ -1556,18 +1565,12 @@ class JobTemplateAccess(NotificationAttachMixin, UnifiedCredentialsMixin, BaseAc
         data = dict(data)
         if self.changes_are_non_sensitive(obj, data):
             return True
-        if not self.check_related('execution_environment', ExecutionEnvironment, data, obj=obj, role_field='read_role'):
-            return False
-        for required_field, cls in (('inventory', Inventory), ('project', Project)):
-            is_mandatory = True
-            if not getattr(obj, '{}_id'.format(required_field)):
-                is_mandatory = False
-            if not self.check_related(required_field, cls, data, obj=obj, role_field='use_role', mandatory=is_mandatory):
-                if required_field in data:
-                    new_obj = get_object_from_data(required_field, cls, data)
-                    return self.user in new_obj.use_role and (self.user in obj.inventory.use_role or self.user in obj.project.use_role)
-                return False
-        return True
+
+        return bool(
+            self.check_related('execution_environment', ExecutionEnvironment, data, obj=obj, role_field='read_role')
+            and self.check_related('inventory', Inventory, data, obj=obj, role_field='use_role', mandatory=True)
+            and self.check_related('project', Project, data, obj=None, role_field='use_role')
+        )
 
     def changes_are_non_sensitive(self, obj, data):
         """

--- a/awx/main/tests/functional/rbac/test_rbac_job_templates.py
+++ b/awx/main/tests/functional/rbac/test_rbac_job_templates.py
@@ -363,12 +363,15 @@ def test_job_template_mixed_permission(rando, bob, project, inventory):
     # remove use perm on inventory and add use to associated project
     job_template.inventory.use_role.members.remove(rando)
     job_template.project.use_role.members.add(rando)
+
+    assert not access.can_change(job_template, {'project': proj1.pk})  # blocked by inventory
+
     proj1.use_role.members.remove(rando)
     inv1.use_role.members.add(rando)
 
     assert not access.can_change(job_template, {'project': proj2.pk})
-    assert access.can_change(job_template, {'project': project.pk})
-    assert access.can_change(job_template, {'inventory': inv1.pk})
+    assert access.can_change(job_template, {'project': job_template.project.pk})  # no change...
+    assert not access.can_change(job_template, {'inventory': inv1.pk})  # lacks inv1 access
 
     # remove project and inventory permission
     job_template.project.use_role.members.remove(rando)

--- a/awx/main/tests/functional/rbac/test_rbac_job_templates.py
+++ b/awx/main/tests/functional/rbac/test_rbac_job_templates.py
@@ -290,3 +290,95 @@ class TestProjectOrganization:
         assert org_admin not in jt.admin_role
         patch(url=jt.get_absolute_url(), data={'project': project.id}, user=admin_user, expect=200)
         assert org_admin in jt.admin_role
+
+    def test_inventory_read_transfer_direct(self, patch):
+        orgs = []
+        invs = []
+        admins = []
+        for i in range(2):
+            org = Organization.objects.create(name='org{}'.format(i))
+            org_admin = User.objects.create(username='user{}'.format(i))
+            inv = Inventory.objects.create(organization=org, name='inv{}'.format(i))
+            org.auditor_role.members.add(org_admin)
+
+            orgs.append(org)
+            admins.append(org_admin)
+            invs.append(inv)
+
+        jt = JobTemplate.objects.create(name='foo', inventory=invs[0])
+        assert admins[0] in jt.read_role
+        assert admins[1] not in jt.read_role
+
+        jt.inventory = invs[1]
+        jt.save(update_fields=['inventory'])
+        assert admins[0] not in jt.read_role
+        assert admins[1] in jt.read_role
+
+    def test_inventory_read_transfer_indirect(self, patch):
+        orgs = []
+        admins = []
+        for i in range(2):
+            org = Organization.objects.create(name='org{}'.format(i))
+            org_admin = User.objects.create(username='user{}'.format(i))
+            org.auditor_role.members.add(org_admin)
+
+            orgs.append(org)
+            admins.append(org_admin)
+
+        inv = Inventory.objects.create(organization=orgs[0], name='inv{}'.format(i))
+
+        jt = JobTemplate.objects.create(name='foo', inventory=inv)
+        assert admins[0] in jt.read_role
+        assert admins[1] not in jt.read_role
+
+        inv.organization = orgs[1]
+        inv.save(update_fields=['organization'])
+        assert admins[0] not in jt.read_role
+        assert admins[1] in jt.read_role
+
+
+@pytest.mark.django_db
+def test_job_template_mixed_permission(rando, bob, project, inventory):
+    """The job template permissions are a bit tricky when it comes to jt admin and use permissions on related objects
+    This test tries to test different variation of use permissions
+    """
+    # Create new inventory and projects to associate
+    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory, ask_credential_on_launch=True)
+    access = JobTemplateAccess(rando)
+    inv1 = Inventory.objects.create(name='test', organization=project.organization)
+    proj1 = Project.objects.create(name='new_proj', scm_type=project.scm_type, playbook_files=project.playbook_files, organization=project.organization)
+    proj2 = Project.objects.create(name='proj2', scm_type=project.scm_type, playbook_files=project.playbook_files, organization=project.organization)
+
+    assert not access.can_change(job_template, {'project': proj1.pk})
+    assert not access.can_change(job_template, {'inventory': inv1.pk})
+
+    # assign permissions to new project to associate and existing job template admin and inv use
+    proj1.use_role.members.add(rando)
+    job_template.admin_role.members.add(rando)
+    job_template.inventory.use_role.members.add(rando)
+
+    assert not access.can_change(job_template, {'inventory': inv1.pk})
+    assert access.can_change(job_template, {'project': proj1.pk})
+
+    # remove use perm on inventory and add use to associated project
+    job_template.inventory.use_role.members.remove(rando)
+    job_template.project.use_role.members.add(rando)
+    proj1.use_role.members.remove(rando)
+    inv1.use_role.members.add(rando)
+
+    assert not access.can_change(job_template, {'project': proj2.pk})
+    assert access.can_change(job_template, {'project': project.pk})
+    assert access.can_change(job_template, {'inventory': inv1.pk})
+
+    # remove project and inventory permission
+    job_template.project.use_role.members.remove(rando)
+    job_template.update_fields(project=project)
+    job_template.inventory.use_role.members.remove(rando)
+
+    assert not access.can_change(job_template, {'project': proj1.pk})
+    assert not access.can_change(job_template, {'inventory': inv1.pk})
+
+    jt = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory, ask_credential_on_launch=True)
+    jt.admin_role.members.add(bob)
+    assert not access.can_change(jt, {'project': proj1.pk})
+    assert not access.can_change(jt, {'inventory': inv1.pk})

--- a/awx/main/tests/functional/test_rbac_job_templates.py
+++ b/awx/main/tests/functional/test_rbac_job_templates.py
@@ -356,12 +356,15 @@ def test_job_template_mixed_permission(rando, bob, project, inventory):
     # remove use perm on inventory and add use to associated project
     job_template.inventory.use_role.members.remove(rando)
     job_template.project.use_role.members.add(rando)
+
+    assert not access.can_change(job_template, {'project': proj1.pk})  # blocked by inventory
+
     proj1.use_role.members.remove(rando)
     inv1.use_role.members.add(rando)
 
     assert not access.can_change(job_template, {'project': proj2.pk})
-    assert access.can_change(job_template, {'project': project.pk})
-    assert access.can_change(job_template, {'inventory': inv1.pk})
+    assert access.can_change(job_template, {'project': job_template.project.pk})  # no change...
+    assert not access.can_change(job_template, {'inventory': inv1.pk})  # lacks inv1 access
 
     # remove project and inventory permission
     job_template.project.use_role.members.remove(rando)


### PR DESCRIPTION
##### SUMMARY
This is an adjustment to https://github.com/ansible/awx/pull/13818

Unfortunately, I don't see any easy choices here. The "sensitive" change requirements are still suffocating.

This accomplishes the main stated goal of the prior PR and issue - which is to change the project while lacking `use_role` to the _existing_ project. This is accomplished by the subtle `obj=None` in the call to `check_related`. It might be apparent, but I'm _very_ opposed to the solution method in the PR 13818 because it adds more logic to an already out-of-control collection of business logic.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

