### PR TITLE
Allow saml_admin_attr to work in conjunction with SAML Org Map

### DIFF
--- a/awx/sso/saml_pipeline.py
+++ b/awx/sso/saml_pipeline.py
@@ -87,7 +87,7 @@ def _update_user_orgs(backend, desired_org_state, orgs_to_create, user=None):
             is_member_expression = org_opts.get(user_type, None)
             remove_members = bool(org_opts.get('remove_{}'.format(user_type), remove))
             has_role = _update_m2m_from_expression(user, is_member_expression, remove_members)
-            desired_org_state[organization_name][role_name] = desired_org_state[organization_name].get('role_name', False) or has_role
+            desired_org_state[organization_name][role_name] = desired_org_state[organization_name].get(role_name, False) or has_role
 
 
 def _update_user_teams(backend, desired_team_state, teams_to_create, user=None):

--- a/awx/sso/saml_pipeline.py
+++ b/awx/sso/saml_pipeline.py
@@ -87,7 +87,7 @@ def _update_user_orgs(backend, desired_org_state, orgs_to_create, user=None):
             is_member_expression = org_opts.get(user_type, None)
             remove_members = bool(org_opts.get('remove_{}'.format(user_type), remove))
             has_role = _update_m2m_from_expression(user, is_member_expression, remove_members)
-            desired_org_state[organization_name][role_name] = has_role
+            desired_org_state[organization_name][role_name] = desired_org_state[organization_name].get('role_name', False) or has_role
 
 
 def _update_user_teams(backend, desired_team_state, teams_to_create, user=None):


### PR DESCRIPTION
##### SUMMARY
From the SAML redesign, we found a regression where an admin specified by `saml_admin_attr` property of `SOCIAL_AUTH_SAML_ORGANIZATION_ATTR` setting but the user was not a member of the admin role from the 
`admins` property of the `SOCIAL_AUTH_SAML_ORGANIZATION_MAP` setting the user would not be an admin of the organization. We fixed this by doing an or condition between the existing desired_org_state and the returned values.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
