### PR TITLE
fixes docs link for controller versions >= 4.3

### DIFF
--- a/awx/ui/src/util/getDocsBaseUrl.js
+++ b/awx/ui/src/util/getDocsBaseUrl.js
@@ -1,8 +1,17 @@
 export default function getDocsBaseUrl(config) {
   let version = 'latest';
   const licenseType = config?.license_info?.license_type;
+
   if (licenseType && licenseType !== 'open') {
-    version = config?.version ? config.version.split('-')[0] : 'latest';
+    if (config?.version) {
+      if (parseFloat(config?.version.split('-')[0]) >= 4.3) {
+        version = parseFloat(config?.version.split('-')[0]);
+      } else {
+        version = config?.version.split('-')[0];
+      }
+    }
+  } else {
+    version = 'latest';
   }
   return `https://docs.ansible.com/automation-controller/${version}`;
 }


### PR DESCRIPTION
##### SUMMARY
We have broken docs links for users that are on versions >= 4.3 because at that version we stopped using z stream releases.  
This work resolves that.  

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
