### PR TITLE
fix broken link to upgrade docs. related #11313

### DIFF
--- a/DATA_MIGRATION.md
+++ b/DATA_MIGRATION.md
@@ -4,6 +4,6 @@
 
 Early versions of AWX did not support seamless upgrades between major versions and required the use of a backup and restore tool to perform upgrades.
 
-Users who wish to upgrade modern AWX installations should follow the instructions at:
+As of version 18.0, `awx-operator` is the preferred install/upgrade method. Users who wish to upgrade modern AWX installations should follow the instructions at:
 
-https://github.com/ansible/awx/blob/devel/INSTALL.md#upgrading-from-previous-versions
+https://github.com/ansible/awx-operator/blob/devel/docs/upgrade/upgrading.md


### PR DESCRIPTION
Fixed broken link to upgrade docs by linking to awx-operator repo

##### SUMMARY
The existing link referred to a doc section that had been removed. As install documentation in `awx` is generally handled in `awx-operator`, we'll link to `awx-operator` to reflect that. 

Language is based on [existing](https://github.com/ansible/awx/blob/devel/INSTALL.md#the-awx-operator) `INSTALL.md`.

Related issue #11313 

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - Docs


