### PR TITLE
Incorrect capacity for remote execution nodes 14051

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -310,7 +310,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.mem_capacity = 0  # formula has a non-zero offset, so we make sure it is 0 for hop nodes
         else:
             self.cpu_capacity = get_cpu_effective_capacity(self.cpu, self.node_type)
-            self.mem_capacity = get_mem_effective_capacity(self.memory)
+            self.mem_capacity = get_mem_effective_capacity(self.memory, self.node_type)
         self.set_capacity_value()
 
     def save_health_data(self, version=None, cpu=0, memory=0, uuid=None, update_last_seen=False, errors=''):

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -309,8 +309,8 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.cpu_capacity = 0
             self.mem_capacity = 0  # formula has a non-zero offset, so we make sure it is 0 for hop nodes
         else:
-            self.cpu_capacity = get_cpu_effective_capacity(self.cpu, is_control_plane=bool(self.node_type in (Instance.Types.EXECUTION,)))
-            self.mem_capacity = get_mem_effective_capacity(self.memory, is_control_plane=bool(self.node_type in (Instance.Types.EXECUTION,)))
+            self.cpu_capacity = get_cpu_effective_capacity(self.cpu, is_execution_node=bool(self.node_type in (Instance.Types.EXECUTION,)))
+            self.mem_capacity = get_mem_effective_capacity(self.memory, is_execution_node=bool(self.node_type in (Instance.Types.EXECUTION,)))
         self.set_capacity_value()
 
     def save_health_data(self, version=None, cpu=0, memory=0, uuid=None, update_last_seen=False, errors=''):

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -309,8 +309,8 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.cpu_capacity = 0
             self.mem_capacity = 0  # formula has a non-zero offset, so we make sure it is 0 for hop nodes
         else:
-            self.cpu_capacity = get_cpu_effective_capacity(self.cpu, self.node_type)
-            self.mem_capacity = get_mem_effective_capacity(self.memory, self.node_type)
+            self.cpu_capacity = get_cpu_effective_capacity(self.cpu, is_control_plane=bool(self.node_type in (Instance.Types.EXECUTION,)))
+            self.mem_capacity = get_mem_effective_capacity(self.memory, is_control_plane=bool(self.node_type in (Instance.Types.EXECUTION,)))
         self.set_capacity_value()
 
     def save_health_data(self, version=None, cpu=0, memory=0, uuid=None, update_last_seen=False, errors=''):
@@ -333,12 +333,16 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.version = version
             update_fields.append('version')
 
-        new_cpu = get_corrected_cpu(cpu, self.node_type)
+        if self.node_type == Instance.Types.EXECUTION:
+            new_cpu = cpu
+            new_memory = memory
+        else:
+            new_cpu = get_corrected_cpu(cpu)
+            new_memory = get_corrected_memory(memory)
         if new_cpu != self.cpu:
             self.cpu = new_cpu
             update_fields.append('cpu')
 
-        new_memory = get_corrected_memory(memory, self.node_type)
         if new_memory != self.memory:
             self.memory = new_memory
             update_fields.append('memory')

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -233,7 +233,6 @@ class Instance(HasPolicyEditsMixin, BaseModel):
 
     @property
     def health_check_pending(self):
-        return False
         if self.health_check_started is None:
             return False
         if self.last_health_check is None:
@@ -339,7 +338,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.cpu = new_cpu
             update_fields.append('cpu')
 
-        new_memory = get_corrected_memory(memory)
+        new_memory = get_corrected_memory(memory, self.node_type)
         if new_memory != self.memory:
             self.memory = new_memory
             update_fields.append('memory')

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -233,6 +233,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
 
     @property
     def health_check_pending(self):
+        return False
         if self.health_check_started is None:
             return False
         if self.last_health_check is None:
@@ -309,7 +310,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.cpu_capacity = 0
             self.mem_capacity = 0  # formula has a non-zero offset, so we make sure it is 0 for hop nodes
         else:
-            self.cpu_capacity = get_cpu_effective_capacity(self.cpu)
+            self.cpu_capacity = get_cpu_effective_capacity(self.cpu, self.node_type)
             self.mem_capacity = get_mem_effective_capacity(self.memory)
         self.set_capacity_value()
 
@@ -333,7 +334,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.version = version
             update_fields.append('version')
 
-        new_cpu = get_corrected_cpu(cpu)
+        new_cpu = get_corrected_cpu(cpu, self.node_type)
         if new_cpu != self.cpu:
             self.cpu = new_cpu
             update_fields.append('cpu')

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -309,8 +309,8 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.cpu_capacity = 0
             self.mem_capacity = 0  # formula has a non-zero offset, so we make sure it is 0 for hop nodes
         else:
-            self.cpu_capacity = get_cpu_effective_capacity(self.cpu, is_execution_node=bool(self.node_type in (Instance.Types.EXECUTION,)))
-            self.mem_capacity = get_mem_effective_capacity(self.memory, is_execution_node=bool(self.node_type in (Instance.Types.EXECUTION,)))
+            self.cpu_capacity = get_cpu_effective_capacity(self.cpu, is_control_node=bool(self.node_type in (Instance.Types.CONTROL, Instance.Types.HYBRID)))
+            self.mem_capacity = get_mem_effective_capacity(self.memory, is_control_node=bool(self.node_type in (Instance.Types.CONTROL, Instance.Types.HYBRID)))
         self.set_capacity_value()
 
     def save_health_data(self, version=None, cpu=0, memory=0, uuid=None, update_last_seen=False, errors=''):
@@ -339,6 +339,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         else:
             new_cpu = get_corrected_cpu(cpu)
             new_memory = get_corrected_memory(memory)
+
         if new_cpu != self.cpu:
             self.cpu = new_cpu
             update_fields.append('cpu')

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -466,7 +466,6 @@ def execution_node_health_check(node):
     data = worker_info(node)
 
     prior_capacity = instance.capacity
-
     instance.save_health_data(
         version='ansible-runner-' + data.get('runner_version', '???'),
         cpu=data.get('cpu_count', 0),

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -42,7 +42,7 @@ def test_orphan_unified_job_creation(instance, inventory):
 @mock.patch('awx.main.models.ha.get_mem_effective_capacity', lambda mem: 62)
 def test_job_capacity_and_with_inactive_node():
     i = Instance.objects.create(hostname='test-1')
-    i.save_health_data('18.0.1', 2, 8000)
+    i.save_health_data('18.0.1', 2, 8000, is_control_node=True)
     assert i.enabled is True
     assert i.capacity_adjustment == 1.0
     assert i.capacity == 62

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -37,12 +37,12 @@ def test_orphan_unified_job_creation(instance, inventory):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.main.tasks.system.inspect_execution_and_hop_nodes', lambda *args, **kwargs: None)
-@mock.patch('awx.main.models.ha.get_cpu_effective_capacity', lambda cpu: 8)
-@mock.patch('awx.main.models.ha.get_mem_effective_capacity', lambda mem: 62)
+@mock.patch('awx.main.tasks.system.inspect_execution_nodes', lambda *args, **kwargs: None)
+@mock.patch('awx.main.models.ha.get_cpu_effective_capacity', lambda cpu, is_control_node: 8)
+@mock.patch('awx.main.models.ha.get_mem_effective_capacity', lambda mem, is_control_node: 62)
 def test_job_capacity_and_with_inactive_node():
     i = Instance.objects.create(hostname='test-1')
-    i.save_health_data('18.0.1', 2, 8000, is_control_node=True)
+    i.save_health_data('18.0.1', 2, 8000)
     assert i.enabled is True
     assert i.capacity_adjustment == 1.0
     assert i.capacity == 62

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -37,7 +37,7 @@ def test_orphan_unified_job_creation(instance, inventory):
 
 
 @pytest.mark.django_db
-@mock.patch('awx.main.tasks.system.inspect_execution_nodes', lambda *args, **kwargs: None)
+@mock.patch('awx.main.tasks.system.inspect_execution_and_hop_nodes', lambda *args, **kwargs: None)
 @mock.patch('awx.main.models.ha.get_cpu_effective_capacity', lambda cpu, is_control_node: 8)
 @mock.patch('awx.main.models.ha.get_mem_effective_capacity', lambda mem, is_control_node: 62)
 def test_job_capacity_and_with_inactive_node():

--- a/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
+++ b/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
@@ -38,8 +38,7 @@ def test_SYSTEM_TASK_ABS_MEM_conversion(value, converted_value, mem_capacity):
         assert get_corrected_memory(-1) == converted_value
         assert get_mem_effective_capacity(-1) == mem_capacity
         # SYSTEM_TASK_ABS_MEM should not effect memory and capacity for execution nodes
-        assert get_corrected_memory(2147483648, 'execution') == 2147483648
-        assert get_mem_effective_capacity(2147483648, 'execution') == 20
+        assert get_mem_effective_capacity(2147483648, is_control_node=False) == 20
 
 
 @pytest.mark.parametrize(
@@ -60,8 +59,7 @@ def test_SYSTEM_TASK_ABS_CPU_conversion(value, converted_value, cpu_capacity):
         mock_settings.SYSTEM_TASK_ABS_CPU = value
         mock_settings.SYSTEM_TASK_FORKS_CPU = 4
         assert convert_cpu_str_to_decimal_cpu(value) == converted_value
-        assert get_corrected_cpu(8) == converted_value
+        assert get_corrected_cpu(-1) == converted_value
         assert get_cpu_effective_capacity(-1) == cpu_capacity
         # SYSTEM_TASK_ABS_CPU should not effect cpu count and capacity for execution nodes
-        assert get_corrected_cpu(2.0, 'execution') == 2.0
-        assert get_cpu_effective_capacity(2.0, 'execution') == 8
+        assert get_cpu_effective_capacity(2.0, is_control_node=False) == 8

--- a/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
+++ b/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
@@ -78,13 +78,15 @@ def test_SYSTEM_TASK_ABS_CPU_conversion(value, converted_value, cpu_capacity):
         ('64Garbage', 1, 1),
     ],
 )
-def test_execution_node_mem_capacity(get_mem_effective_capacity, value, mem_capacity):
+def test_execution_node_mem_capacity(value, converted_value, mem_capacity):
     with mock.patch('django.conf.settings') as mock_settings:
         mock_settings.SYSTEM_TASK_ABS_MEM = value
         mock_settings.SYSTEM_TASK_FORKS_MEM = 100
         mock_settings.IS_K8S = True
         mock_settings.node_type == 'execution'
-        assert get_mem_effective_capacity(value) == mem_capacity
+        assert convert_mem_str_to_bytes(value) == converted_value
+        assert get_corrected_memory(-1) == converted_value
+        assert get_mem_effective_capacity(-1) == mem_capacity
 
 
 @pytest.mark.parametrize(

--- a/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
+++ b/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
@@ -59,3 +59,12 @@ def test_SYSTEM_TASK_ABS_CPU_conversion(value, converted_value, cpu_capacity):
         assert convert_cpu_str_to_decimal_cpu(value) == converted_value
         assert get_corrected_cpu(-1) == converted_value
         assert get_cpu_effective_capacity(-1) == cpu_capacity
+
+
+def test_execution_node_mem_capacity(value, get_mem_effective_capacity, get_corrected_memory):
+    with mock.patch('django.conf.settings') as mock_settings:
+        mock_settings.SYSTEM_TASK_ABS_MEM = value
+        mock_settings.SYSTEM_TASK_FORKS_MEM = 100
+        mock_settings.IS_K8S = True
+        assert get_mem_effective_capacity(value)
+        assert get_corrected_memory(value)

--- a/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
+++ b/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
@@ -36,7 +36,7 @@ def test_SYSTEM_TASK_ABS_MEM_conversion(value, converted_value, mem_capacity):
         mock_settings.IS_K8S = True
         assert convert_mem_str_to_bytes(value) == converted_value
         assert get_corrected_memory(-1) == converted_value
-        assert get_mem_effective_capacity(-1) == mem_capacity
+        assert get_mem_effective_capacity(1, is_control_node=True) == mem_capacity
         # SYSTEM_TASK_ABS_MEM should not effect memory and capacity for execution nodes
         assert get_mem_effective_capacity(2147483648, is_control_node=False) == 20
 
@@ -60,6 +60,6 @@ def test_SYSTEM_TASK_ABS_CPU_conversion(value, converted_value, cpu_capacity):
         mock_settings.SYSTEM_TASK_FORKS_CPU = 4
         assert convert_cpu_str_to_decimal_cpu(value) == converted_value
         assert get_corrected_cpu(-1) == converted_value
-        assert get_cpu_effective_capacity(-1) == cpu_capacity
+        assert get_cpu_effective_capacity(-1, is_control_node=True) == cpu_capacity
         # SYSTEM_TASK_ABS_CPU should not effect cpu count and capacity for execution nodes
         assert get_cpu_effective_capacity(2.0, is_control_node=False) == 8

--- a/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
+++ b/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
@@ -37,6 +37,9 @@ def test_SYSTEM_TASK_ABS_MEM_conversion(value, converted_value, mem_capacity):
         assert convert_mem_str_to_bytes(value) == converted_value
         assert get_corrected_memory(-1) == converted_value
         assert get_mem_effective_capacity(-1) == mem_capacity
+        # SYSTEM_TASK_ABS_MEM should not effect memory and capacity for execution nodes
+        assert get_corrected_memory(2147483648, 'execution') == 2147483648
+        assert get_mem_effective_capacity(2147483648, 'execution') == 20
 
 
 @pytest.mark.parametrize(
@@ -57,57 +60,8 @@ def test_SYSTEM_TASK_ABS_CPU_conversion(value, converted_value, cpu_capacity):
         mock_settings.SYSTEM_TASK_ABS_CPU = value
         mock_settings.SYSTEM_TASK_FORKS_CPU = 4
         assert convert_cpu_str_to_decimal_cpu(value) == converted_value
-        assert get_corrected_cpu(-1) == converted_value
+        assert get_corrected_cpu(8) == converted_value
         assert get_cpu_effective_capacity(-1) == cpu_capacity
-
-
-@pytest.mark.parametrize(
-    "value,converted_value,mem_capacity",
-    [
-        ('2G', 2000000000, 19),
-        ('4G', 4000000000, 38),
-        ('2Gi', 2147483648, 20),
-        ('2.1G', 1, 1),  # expressing memory with non-integers is not supported, and we'll fall back to 1 fork for memory capacity.
-        ('4Gi', 4294967296, 40),
-        ('2M', 2000000, 1),
-        ('3M', 3000000, 1),
-        ('2Mi', 2097152, 1),
-        ('2048Mi', 2147483648, 20),
-        ('4096Mi', 4294967296, 40),
-        ('64G', 64000000000, 610),
-        ('64Garbage', 1, 1),
-    ],
-)
-def test_execution_node_mem_capacity(value, converted_value, mem_capacity):
-    with mock.patch('django.conf.settings') as mock_settings:
-        mock_settings.SYSTEM_TASK_ABS_MEM = value
-        mock_settings.SYSTEM_TASK_FORKS_MEM = 100
-        mock_settings.IS_K8S = True
-        mock_settings.node_type == 'execution'
-        assert convert_mem_str_to_bytes(value) == converted_value
-        assert get_corrected_memory(-1) == converted_value
-        assert get_mem_effective_capacity(-1) == mem_capacity
-
-
-@pytest.mark.parametrize(
-    "value,converted_value,cpu_capacity",
-    [
-        ('2', 2.0, 8),
-        ('1.5', 1.5, 6),
-        ('100m', 0.1, 1),
-        ('2000m', 2.0, 8),
-        ('4MillionCPUm', 1.0, 4),  # Any suffix other than 'm' is not supported, we fall back to 1 CPU
-        ('Random', 1.0, 4),  # Any setting value other than integers, floats millicores (e.g 1, 1.0, or 1000m) is not supported, fall back to 1 CPU
-        ('2505m', 2.5, 10),
-        ('1.55', 1.6, 6),
-    ],
-)
-def test_execution_node_CPU_capacity(value, converted_value, cpu_capacity):
-    with mock.patch('django.conf.settings') as mock_settings:
-        mock_settings.SYSTEM_TASK_ABS_CPU = value
-        mock_settings.SYSTEM_TASK_FORKS_CPU = 4
-        mock_settings.IS_K8S = True
-        mock_settings.node_type == 'execution'
-        assert convert_cpu_str_to_decimal_cpu(value) == converted_value
-        assert get_corrected_cpu(-1) == converted_value
-        assert get_cpu_effective_capacity(-1) == cpu_capacity
+        # SYSTEM_TASK_ABS_CPU should not effect cpu count and capacity for execution nodes
+        assert get_corrected_cpu(2.0, 'execution') == 2.0
+        assert get_cpu_effective_capacity(2.0, 'execution') == 8

--- a/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
+++ b/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
@@ -61,10 +61,26 @@ def test_SYSTEM_TASK_ABS_CPU_conversion(value, converted_value, cpu_capacity):
         assert get_cpu_effective_capacity(-1) == cpu_capacity
 
 
-def test_execution_node_mem_capacity(value, get_mem_effective_capacity, get_corrected_memory):
+@pytest.mark.parametrize(
+    "value, mem_capacity",
+    [
+        ('2G', 19),
+        ('4G', 38),
+        ('2Gi', 20),
+        ('2.1G', 1),  # expressing memory with non-integers is not supported, and we'll fall back to 1 fork for memory capacity.
+        ('4Gi', 40),
+        ('2M', 1),
+        ('3M', 1),
+        ('2Mi', 1),
+        ('2048Mi', 20),
+        ('4096Mi', 40),
+        ('64G', 610),
+        ('64Garbage', 1),
+    ],
+)
+def test_execution_node_mem_capacity(get_mem_effective_capacity, value, mem_capacity):
     with mock.patch('django.conf.settings') as mock_settings:
-        mock_settings.SYSTEM_TASK_ABS_MEM = value
+        mock_settings.SYSTEM_TASK_ABS_MEM = "1G"
         mock_settings.SYSTEM_TASK_FORKS_MEM = 100
         mock_settings.IS_K8S = True
-        assert get_mem_effective_capacity(value)
-        assert get_corrected_memory(value)
+        assert get_mem_effective_capacity(value) == mem_capacity

--- a/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
+++ b/awx/main/tests/unit/settings/test_k8s_resource_setttings.py
@@ -62,25 +62,50 @@ def test_SYSTEM_TASK_ABS_CPU_conversion(value, converted_value, cpu_capacity):
 
 
 @pytest.mark.parametrize(
-    "value, mem_capacity",
+    "value,converted_value,mem_capacity",
     [
-        ('2G', 19),
-        ('4G', 38),
-        ('2Gi', 20),
-        ('2.1G', 1),  # expressing memory with non-integers is not supported, and we'll fall back to 1 fork for memory capacity.
-        ('4Gi', 40),
-        ('2M', 1),
-        ('3M', 1),
-        ('2Mi', 1),
-        ('2048Mi', 20),
-        ('4096Mi', 40),
-        ('64G', 610),
-        ('64Garbage', 1),
+        ('2G', 2000000000, 19),
+        ('4G', 4000000000, 38),
+        ('2Gi', 2147483648, 20),
+        ('2.1G', 1, 1),  # expressing memory with non-integers is not supported, and we'll fall back to 1 fork for memory capacity.
+        ('4Gi', 4294967296, 40),
+        ('2M', 2000000, 1),
+        ('3M', 3000000, 1),
+        ('2Mi', 2097152, 1),
+        ('2048Mi', 2147483648, 20),
+        ('4096Mi', 4294967296, 40),
+        ('64G', 64000000000, 610),
+        ('64Garbage', 1, 1),
     ],
 )
 def test_execution_node_mem_capacity(get_mem_effective_capacity, value, mem_capacity):
     with mock.patch('django.conf.settings') as mock_settings:
-        mock_settings.SYSTEM_TASK_ABS_MEM = "1G"
+        mock_settings.SYSTEM_TASK_ABS_MEM = value
         mock_settings.SYSTEM_TASK_FORKS_MEM = 100
         mock_settings.IS_K8S = True
+        mock_settings.node_type == 'execution'
         assert get_mem_effective_capacity(value) == mem_capacity
+
+
+@pytest.mark.parametrize(
+    "value,converted_value,cpu_capacity",
+    [
+        ('2', 2.0, 8),
+        ('1.5', 1.5, 6),
+        ('100m', 0.1, 1),
+        ('2000m', 2.0, 8),
+        ('4MillionCPUm', 1.0, 4),  # Any suffix other than 'm' is not supported, we fall back to 1 CPU
+        ('Random', 1.0, 4),  # Any setting value other than integers, floats millicores (e.g 1, 1.0, or 1000m) is not supported, fall back to 1 CPU
+        ('2505m', 2.5, 10),
+        ('1.55', 1.6, 6),
+    ],
+)
+def test_execution_node_CPU_capacity(value, converted_value, cpu_capacity):
+    with mock.patch('django.conf.settings') as mock_settings:
+        mock_settings.SYSTEM_TASK_ABS_CPU = value
+        mock_settings.SYSTEM_TASK_FORKS_CPU = 4
+        mock_settings.IS_K8S = True
+        mock_settings.node_type == 'execution'
+        assert convert_cpu_str_to_decimal_cpu(value) == converted_value
+        assert get_corrected_cpu(-1) == converted_value
+        assert get_cpu_effective_capacity(-1) == cpu_capacity

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -751,17 +751,15 @@ def convert_cpu_str_to_decimal_cpu(cpu_str):
     return max(0.1, round(cpu, 1))
 
 
-def get_corrected_cpu(cpu_count, node_type=None):  # formerlly get_cpu_capacity
+def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
     """Some environments will do a correction to the reported CPU number
     because the given OpenShift value is a lie
     """
     from django.conf import settings
-    from awx.main.models.ha import Instance
 
     settings_abscpu = getattr(settings, 'SYSTEM_TASK_ABS_CPU', None)
     env_abscpu = os.getenv('SYSTEM_TASK_ABS_CPU', None)
-    if node_type == Instance.Types.EXECUTION:
-        return cpu_count
+
     if env_abscpu is not None:
         return convert_cpu_str_to_decimal_cpu(env_abscpu)
     elif settings_abscpu is not None:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -827,7 +827,7 @@ def convert_mem_str_to_bytes(mem_str):
     return max(1, conversions[mem_unit](mem))
 
 
-def get_corrected_memory(memory):
+def get_corrected_memory(memory, node_type=None):
     from django.conf import settings
 
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
@@ -835,6 +835,8 @@ def get_corrected_memory(memory):
 
     # Runner returns memory in bytes
     # so we convert memory from settings to bytes as well.
+    if node_type == 'execution':
+        return memory
     if env_absmem is not None:
         return convert_mem_str_to_bytes(env_absmem)
     elif settings_absmem is not None:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -768,10 +768,10 @@ def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
     return cpu_count  # no correction
 
 
-def get_cpu_effective_capacity(cpu_count, is_control_plane=False):
+def get_cpu_effective_capacity(cpu_count, is_execution_node=False):
     from django.conf import settings
 
-    if is_control_plane:
+    if is_execution_node:
         cpu_count = get_corrected_cpu(cpu_count)
 
     settings_forkcpu = getattr(settings, 'SYSTEM_TASK_FORKS_CPU', None)
@@ -844,10 +844,10 @@ def get_corrected_memory(memory):
     return memory
 
 
-def get_mem_effective_capacity(mem_bytes, is_control_plane=False):
+def get_mem_effective_capacity(mem_bytes, is_execution_node=False):
     from django.conf import settings
 
-    if is_control_plane:
+    if is_execution_node:
         mem_bytes = get_corrected_memory(mem_bytes)
 
     settings_mem_mb_per_fork = getattr(settings, 'SYSTEM_TASK_FORKS_MEM', None)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -756,10 +756,11 @@ def get_corrected_cpu(cpu_count, node_type=None):  # formerlly get_cpu_capacity
     because the given OpenShift value is a lie
     """
     from django.conf import settings
+    from awx.main.models.ha import Instance
 
     settings_abscpu = getattr(settings, 'SYSTEM_TASK_ABS_CPU', None)
     env_abscpu = os.getenv('SYSTEM_TASK_ABS_CPU', None)
-    if node_type == 'execution':
+    if node_type == Instance.Types.EXECUTION:
         return cpu_count
     if env_abscpu is not None:
         return convert_cpu_str_to_decimal_cpu(env_abscpu)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -768,12 +768,12 @@ def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
     return cpu_count  # no correction
 
 
-def get_cpu_effective_capacity(cpu_count, is_execution_node=False):
+def get_cpu_effective_capacity(cpu_count, is_control_node=False):
     from django.conf import settings
 
     settings_forkcpu = getattr(settings, 'SYSTEM_TASK_FORKS_CPU', None)
     env_forkcpu = os.getenv('SYSTEM_TASK_FORKS_CPU', None)
-    if is_execution_node:
+    if is_control_node:
         cpu_count = get_corrected_cpu(cpu_count)
     if env_forkcpu:
         forkcpu = int(env_forkcpu)
@@ -825,7 +825,7 @@ def convert_mem_str_to_bytes(mem_str):
     return max(1, conversions[mem_unit](mem))
 
 
-def get_corrected_memory(memory, node_type=None):
+def get_corrected_memory(memory):
     from django.conf import settings
 
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
@@ -833,8 +833,7 @@ def get_corrected_memory(memory, node_type=None):
 
     # Runner returns memory in bytes
     # so we convert memory from settings to bytes as well.
-    if node_type == 'execution':
-        return memory
+
     if env_absmem is not None:
         return convert_mem_str_to_bytes(env_absmem)
     elif settings_absmem is not None:
@@ -843,13 +842,13 @@ def get_corrected_memory(memory, node_type=None):
     return memory
 
 
-def get_mem_effective_capacity(mem_bytes, node_type=None, is_execution_node=False):
+def get_mem_effective_capacity(mem_bytes, is_control_node=False):
     from django.conf import settings
 
     settings_mem_mb_per_fork = getattr(settings, 'SYSTEM_TASK_FORKS_MEM', None)
     env_mem_mb_per_fork = os.getenv('SYSTEM_TASK_FORKS_MEM', None)
-    if is_execution_node:
-        mem_bytes = get_corrected_memory(mem_bytes, node_type)
+    if is_control_node:
+        mem_bytes = get_corrected_memory(mem_bytes)
     if env_mem_mb_per_fork:
         mem_mb_per_fork = int(env_mem_mb_per_fork)
     elif settings_mem_mb_per_fork:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -830,13 +830,15 @@ def convert_mem_str_to_bytes(mem_str):
 
 def get_corrected_memory(memory, node_type=None):
     from django.conf import settings
+    from awx.main.models.ha import Instance
 
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
     env_absmem = os.getenv('SYSTEM_TASK_ABS_MEM', None)
 
     # Runner returns memory in bytes
     # so we convert memory from settings to bytes as well.
-    if node_type == 'execution':
+
+    if node_type == Instance.Types.EXECUTION:
         return memory
     if env_absmem is not None:
         return convert_mem_str_to_bytes(env_absmem)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -825,7 +825,7 @@ def convert_mem_str_to_bytes(mem_str):
     return max(1, conversions[mem_unit](mem))
 
 
-def get_corrected_memory(memory):
+def get_corrected_memory(memory, node_type=None):
     from django.conf import settings
 
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
@@ -833,7 +833,8 @@ def get_corrected_memory(memory):
 
     # Runner returns memory in bytes
     # so we convert memory from settings to bytes as well.
-
+    if node_type == 'execution':
+        return memory
     if env_absmem is not None:
         return convert_mem_str_to_bytes(env_absmem)
     elif settings_absmem is not None:
@@ -842,13 +843,13 @@ def get_corrected_memory(memory):
     return memory
 
 
-def get_mem_effective_capacity(mem_bytes, is_execution_node=False):
+def get_mem_effective_capacity(mem_bytes, node_type=None, is_execution_node=False):
     from django.conf import settings
 
     settings_mem_mb_per_fork = getattr(settings, 'SYSTEM_TASK_FORKS_MEM', None)
     env_mem_mb_per_fork = os.getenv('SYSTEM_TASK_FORKS_MEM', None)
     if is_execution_node:
-        mem_bytes = get_corrected_memory(mem_bytes)
+        mem_bytes = get_corrected_memory(mem_bytes, node_type)
     if env_mem_mb_per_fork:
         mem_mb_per_fork = int(env_mem_mb_per_fork)
     elif settings_mem_mb_per_fork:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -829,7 +829,6 @@ def convert_mem_str_to_bytes(mem_str):
 
 def get_corrected_memory(memory, node_type=None):
     from django.conf import settings
-    from awx.main.models.ha import Instance
 
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)
     env_absmem = os.getenv('SYSTEM_TASK_ABS_MEM', None)
@@ -837,8 +836,6 @@ def get_corrected_memory(memory, node_type=None):
     # Runner returns memory in bytes
     # so we convert memory from settings to bytes as well.
 
-    if node_type == Instance.Types.EXECUTION:
-        return memory
     if env_absmem is not None:
         return convert_mem_str_to_bytes(env_absmem)
     elif settings_absmem is not None:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -827,7 +827,7 @@ def convert_mem_str_to_bytes(mem_str):
     return max(1, conversions[mem_unit](mem))
 
 
-def get_corrected_memory(memory, node_type=None):
+def get_corrected_memory(memory):
     from django.conf import settings
 
     settings_absmem = getattr(settings, 'SYSTEM_TASK_ABS_MEM', None)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -845,10 +845,10 @@ def get_corrected_memory(memory, node_type=None):
     return memory
 
 
-def get_mem_effective_capacity(mem_bytes):
+def get_mem_effective_capacity(mem_bytes, node_type=None):
     from django.conf import settings
 
-    mem_bytes = get_corrected_memory(mem_bytes)
+    mem_bytes = get_corrected_memory(mem_bytes, node_type)
 
     settings_mem_mb_per_fork = getattr(settings, 'SYSTEM_TASK_FORKS_MEM', None)
     env_mem_mb_per_fork = os.getenv('SYSTEM_TASK_FORKS_MEM', None)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -770,10 +770,11 @@ def get_corrected_cpu(cpu_count, node_type=None):  # formerlly get_cpu_capacity
     return cpu_count  # no correction
 
 
-def get_cpu_effective_capacity(cpu_count, node_type=None):
+def get_cpu_effective_capacity(cpu_count, is_control_plane=False):
     from django.conf import settings
 
-    cpu_count = get_corrected_cpu(cpu_count, node_type)
+    if is_control_plane:
+        cpu_count = get_corrected_cpu(cpu_count)
 
     settings_forkcpu = getattr(settings, 'SYSTEM_TASK_FORKS_CPU', None)
     env_forkcpu = os.getenv('SYSTEM_TASK_FORKS_CPU', None)
@@ -848,10 +849,11 @@ def get_corrected_memory(memory, node_type=None):
     return memory
 
 
-def get_mem_effective_capacity(mem_bytes, node_type=None):
+def get_mem_effective_capacity(mem_bytes, is_control_plane=False):
     from django.conf import settings
 
-    mem_bytes = get_corrected_memory(mem_bytes, node_type)
+    if is_control_plane:
+        mem_bytes = get_corrected_memory(mem_bytes)
 
     settings_mem_mb_per_fork = getattr(settings, 'SYSTEM_TASK_FORKS_MEM', None)
     env_mem_mb_per_fork = os.getenv('SYSTEM_TASK_FORKS_MEM', None)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -771,12 +771,10 @@ def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
 def get_cpu_effective_capacity(cpu_count, is_execution_node=False):
     from django.conf import settings
 
-    if is_execution_node:
-        cpu_count = get_corrected_cpu(cpu_count)
-
     settings_forkcpu = getattr(settings, 'SYSTEM_TASK_FORKS_CPU', None)
     env_forkcpu = os.getenv('SYSTEM_TASK_FORKS_CPU', None)
-
+    if is_execution_node:
+        cpu_count = get_corrected_cpu(cpu_count)
     if env_forkcpu:
         forkcpu = int(env_forkcpu)
     elif settings_forkcpu:
@@ -847,12 +845,10 @@ def get_corrected_memory(memory):
 def get_mem_effective_capacity(mem_bytes, is_execution_node=False):
     from django.conf import settings
 
-    if is_execution_node:
-        mem_bytes = get_corrected_memory(mem_bytes)
-
     settings_mem_mb_per_fork = getattr(settings, 'SYSTEM_TASK_FORKS_MEM', None)
     env_mem_mb_per_fork = os.getenv('SYSTEM_TASK_FORKS_MEM', None)
-
+    if is_execution_node:
+        mem_bytes = get_corrected_memory(mem_bytes)
     if env_mem_mb_per_fork:
         mem_mb_per_fork = int(env_mem_mb_per_fork)
     elif settings_mem_mb_per_fork:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -751,7 +751,7 @@ def convert_cpu_str_to_decimal_cpu(cpu_str):
     return max(0.1, round(cpu, 1))
 
 
-def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
+def get_corrected_cpu(cpu_count, node_type=None):  # formerlly get_cpu_capacity
     """Some environments will do a correction to the reported CPU number
     because the given OpenShift value is a lie
     """
@@ -759,7 +759,8 @@ def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
 
     settings_abscpu = getattr(settings, 'SYSTEM_TASK_ABS_CPU', None)
     env_abscpu = os.getenv('SYSTEM_TASK_ABS_CPU', None)
-
+    if node_type == 'execution':
+        return cpu_count
     if env_abscpu is not None:
         return convert_cpu_str_to_decimal_cpu(env_abscpu)
     elif settings_abscpu is not None:
@@ -768,10 +769,10 @@ def get_corrected_cpu(cpu_count):  # formerlly get_cpu_capacity
     return cpu_count  # no correction
 
 
-def get_cpu_effective_capacity(cpu_count):
+def get_cpu_effective_capacity(cpu_count, node_type=None):
     from django.conf import settings
 
-    cpu_count = get_corrected_cpu(cpu_count)
+    cpu_count = get_corrected_cpu(cpu_count, node_type)
 
     settings_forkcpu = getattr(settings, 'SYSTEM_TASK_FORKS_CPU', None)
     env_forkcpu = os.getenv('SYSTEM_TASK_FORKS_CPU', None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes issue https://github.com/ansible/awx/issues/14051
Correct reporting for task container resource limits set (in k8s), revising the handling of execution nodes specifically.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
22.5.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
