### PR TITLE
refactor: remove extra single quote from Skipped status strin

### DIFF
--- a/awx/ui/src/components/StatusLabel/StatusLabel.js
+++ b/awx/ui/src/components/StatusLabel/StatusLabel.js
@@ -47,7 +47,7 @@ export default function StatusLabel({ status, tooltipContent = '', children }) {
     unreachable: t`Unreachable`,
     running: t`Running`,
     pending: t`Pending`,
-    skipped: t`Skipped'`,
+    skipped: t`Skipped`,
     timedOut: t`Timed out`,
     waiting: t`Waiting`,
     disabled: t`Disabled`,

--- a/awx/ui/src/locales/en/messages.po
+++ b/awx/ui/src/locales/en/messages.po
@@ -8722,8 +8722,8 @@ msgid "Skipped"
 msgstr "Skipped"
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
-msgstr "Skipped'"
+msgid "Skipped"
+msgstr "Skipped"
 
 #: components/NotificationList/NotificationList.js:200
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:141

--- a/awx/ui/src/locales/es/messages.po
+++ b/awx/ui/src/locales/es/messages.po
@@ -8190,8 +8190,8 @@ msgid "Skipped"
 msgstr "Omitido"
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
-msgstr "Omitido'"
+msgid "Skipped"
+msgstr "Omitido"
 
 #: components/NotificationList/NotificationList.js:200
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:141

--- a/awx/ui/src/locales/fr/messages.po
+++ b/awx/ui/src/locales/fr/messages.po
@@ -8078,7 +8078,7 @@ msgid "Skipped"
 msgstr "Ignoré"
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
+msgid "Skipped"
 msgstr "Ignoré"
 
 #: components/NotificationList/NotificationList.js:200

--- a/awx/ui/src/locales/ja/messages.po
+++ b/awx/ui/src/locales/ja/messages.po
@@ -8118,8 +8118,8 @@ msgid "Skipped"
 msgstr "スキップ済"
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
-msgstr "スキップ済'"
+msgid "Skipped"
+msgstr "スキップ済"
 
 #: components/NotificationList/NotificationList.js:200
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:141

--- a/awx/ui/src/locales/ko/messages.po
+++ b/awx/ui/src/locales/ko/messages.po
@@ -8072,8 +8072,8 @@ msgid "Skipped"
 msgstr "건너뜀"
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
-msgstr "건너뜀'"
+msgid "Skipped"
+msgstr "건너뜀"
 
 #: components/NotificationList/NotificationList.js:200
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:141

--- a/awx/ui/src/locales/nl/messages.po
+++ b/awx/ui/src/locales/nl/messages.po
@@ -8096,8 +8096,8 @@ msgid "Skipped"
 msgstr "Overgeslagen"
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
-msgstr "Overgeslagen'"
+msgid "Skipped"
+msgstr "Overgeslagen"
 
 #: components/NotificationList/NotificationList.js:200
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:141

--- a/awx/ui/src/locales/zh/messages.po
+++ b/awx/ui/src/locales/zh/messages.po
@@ -8072,8 +8072,8 @@ msgid "Skipped"
 msgstr "跳过"
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
-msgstr "跳过'"
+msgid "Skipped"
+msgstr "跳过"
 
 #: components/NotificationList/NotificationList.js:200
 #: screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js:141

--- a/awx/ui/src/locales/zu/messages.po
+++ b/awx/ui/src/locales/zu/messages.po
@@ -8503,7 +8503,7 @@ msgid "Skipped"
 msgstr ""
 
 #: components/StatusLabel/StatusLabel.js:50
-msgid "Skipped'"
+msgid "Skipped"
 msgstr ""
 
 #: components/NotificationList/NotificationList.js:200


### PR DESCRIPTION
##### SUMMARY
When a task was skipped, the status in the UI had an unnecessary single quote, in this pull request I removed it
before:
![skipped-before](https://github.com/ansible/awx/assets/62117064/c33e8add-7aca-4bfb-b9e0-adc5d39e6051)
after:
![skipped-after](https://github.com/ansible/awx/assets/62117064/9f154e73-e9c7-4db7-a771-3df058c937c5)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI