### PR TITLE
Add a retry to update host facts on deadlocks

### DIFF
--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -62,10 +62,9 @@ def raw_update_hosts(host_list):
     Host.objects.bulk_update(host_list, ['ansible_facts', 'ansible_facts_modified'])
 
 
-def update_hosts(host_list):
+def update_hosts(host_list, max_tries=5):
     if not host_list:
         return
-    max_tries = 5
     for i in range(max_tries):
         try:
             raw_update_hosts(host_list)
@@ -74,7 +73,7 @@ def update_hosts(host_list):
             # inventory updates and updating last_job_host_summary are candidates for conflict
             # but these would resolve easily on a retry
             if i + 1 < max_tries:
-                logger.info(f'OperationalError (suspected deadlock) saving host facts retry {i}, error: {exc}')
+                logger.info(f'OperationalError (suspected deadlock) saving host facts retry {i}, message: {exc}')
                 continue
             else:
                 raise

--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -73,8 +73,8 @@ def update_hosts(host_list):
             # Deadlocks can happen if this runs at the same time as another large query
             # inventory updates and updating last_job_host_summary are candidates for conflict
             # but these would resolve easily on a retry
-            if 'deadlock detected' in str(exc) and i + 1 < max_tries:
-                logger.info(f'Deadlock saving host facts retry {i}')
+            if i + 1 < max_tries:
+                logger.info(f'OperationalError (suspected deadlock) saving host facts retry {i}, error: {exc}')
                 continue
             else:
                 raise

--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -70,6 +70,9 @@ def update_hosts(host_list):
         try:
             raw_update_hosts(host_list)
         except OperationalError as exc:
+            # Deadlocks can happen if this runs at the same time as another large query
+            # inventory updates and updating last_job_host_summary are candidates for conflict
+            # but these would resolve easily on a retry
             if 'deadlock detected' in str(exc) and i + 1 < max_tries:
                 logger.info(f'Deadlock saving host facts retry {i}')
                 continue


### PR DESCRIPTION
##### SUMMARY
If updating facts gives a deadlock error, then retry saving them up to 5 times.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

