### PR TITLE
Allow importing licenses with a missing "usage" attribute

### DIFF
--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -292,7 +292,7 @@ class Licenser(object):
                     license['productId'] = sub['product_id']
                     license['quantity'] = int(sub['quantity'])
                     license['support_level'] = sub['support_level']
-                    license['usage'] = sub['usage']
+                    license['usage'] = sub.get('usage')
                     license['subscription_name'] = sub['name']
                     license['subscriptionId'] = sub['subscription_id']
                     license['accountNumber'] = sub['account_number']


### PR DESCRIPTION
##### SUMMARY
This trivial change fixes AAP-14614.
The original issue happens when AAP is pulling a subscription from Red Hat Satellite, and the subscription is missing a "usage" attribute.
Many subscriptions lack a "usage" attribute, so this shouldn't cause AAP to fail with an error 400.

The error on AAP is a KeyError thrown by `sub['usage']`.
The fix here is to allow this lookup to return a blank value with `sub.get('usage')` so the KeyError is never raised and the subscription import occurs just fine.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
No make installed in this lab AAP, so here is the RPM version.
```
automation-controller-venv-tower-4.4.1-1.el9ap.x86_64
```


##### ADDITIONAL INFORMATION

Logged in `tower.log` before this fix:
```
2023-08-08 18:32:14,015 ERROR    [db1442fb0fc440bdba589c6a90bd10f5] awx.api.views.root Invalid subscription submitted.
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/api/views/root.py", line 194, in post
    validated = get_licenser().validate_rh(user, pw)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/licensing.py", line 231, in validate_rh
    json = self.get_satellite_subs(host, user, pw)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/licensing.py", line 290, in get_satellite_subs
    license['usage'] = sub['usage']
KeyError: 'usage'
2023-08-08 18:32:14,016 WARNING  [db1442fb0fc440bdba589c6a90bd10f5] awx.api.generics status 400 received by user admin attempting to access /api/v2/config/subscriptions/ from 10.2.69.13
2023-08-08 18:32:14,023 WARNING  [db1442fb0fc440bdba589c6a90bd10f5] django.request Bad Request: /api/v2/config/subscriptions/
```

Logged after the fix:
Nothing logged at INFO level or worse.