### PR TITLE
Improve log aggregator host/port validation

### DIFF
--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -75,6 +75,7 @@ LOGGER_BLOCKLIST = (
     'awx.main.utils.formatters',
     'awx.main.utils.filters',
     'awx.main.utils.encryption',
+    'awx.main.utils.external_logging',
     'awx.main.utils.log',
     # loggers that may be called getting logging settings
     'awx.conf',

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -858,7 +858,7 @@ LOGGING = {
         'awx.conf': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.conf.settings': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.main': {'handlers': ['null']},
-        'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver'], 'level': 'INFO'},  # very noisey debug-level logs
+        'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver'], 'level': 'INFO'},  # very noisy debug-level logs
         'awx.main.dispatch': {'handlers': ['dispatcher']},
         'awx.main.consumers': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'INFO'},
         'awx.main.rsyslog_configurer': {'handlers': ['rsyslog_configurer']},
@@ -869,6 +869,7 @@ LOGGING = {
         'awx.main.tasks': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
         'awx.main.analytics': {'handlers': ['task_system', 'external_logger', 'console'], 'level': 'INFO', 'propagate': False},
         'awx.main.scheduler': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
+        'awx.main.utils.external_logging': {'handlers': ['console']},  # force logging to console, if we log while trying to configure logging
         'awx.main.access': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -858,7 +858,7 @@ LOGGING = {
         'awx.conf': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.conf.settings': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.main': {'handlers': ['null']},
-        'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver'], 'level': 'INFO'},  # very noisy debug-level logs
+        'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver'], 'level': 'INFO'},  # very noisey debug-level logs
         'awx.main.dispatch': {'handlers': ['dispatcher']},
         'awx.main.consumers': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'INFO'},
         'awx.main.rsyslog_configurer': {'handlers': ['rsyslog_configurer']},
@@ -869,7 +869,6 @@ LOGGING = {
         'awx.main.tasks': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
         'awx.main.analytics': {'handlers': ['task_system', 'external_logger', 'console'], 'level': 'INFO', 'propagate': False},
         'awx.main.scheduler': {'handlers': ['task_system', 'external_logger', 'console'], 'propagate': False},
-        'awx.main.utils.external_logging': {'handlers': ['console']},  # force logging to console, if we log while trying to configure logging
         'awx.main.access': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.main.signals': {'level': 'INFO'},  # very verbose debug-level logs
         'awx.api.permissions': {'level': 'INFO'},  # very verbose debug-level logs


### PR DESCRIPTION
**Don't merge yet** - I want to add more tests.

##### SUMMARY

- Simplify validation functions for logging settings

- Abstract some host/port parsing logic out in utils.external_logging so the validation function can use it as settings are updated

- Never crash-loop if somehow http logging settings are invalid, just log errors (to the console!) and write a default /dev/null syslog config.

- Add a bunch of new test cases for various scenarios (most of them pass before the changes, but we throw some new errors now when validation fails).

Fixes #13823
Refs #13829

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API