### PR TITLE
make the default JOB_EVENT_BUFFER_SECONDS 1 seconds

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -210,7 +210,7 @@ JOB_EVENT_WORKERS = 4
 
 # The number of seconds to buffer callback receiver bulk
 # writes in memory before flushing via JobEvent.objects.bulk_create()
-JOB_EVENT_BUFFER_SECONDS = 0.1
+JOB_EVENT_BUFFER_SECONDS = 1
 
 # The interval at which callback receiver statistics should be
 # recorded


### PR DESCRIPTION
This is in conjunction with experiment done for increase the JOB_EVENT_BUFFER_SECONDS from 0.1 second to 1 second. In a high load scenario with loads of event getting generated, with the default 0.1 seconds we end up with loads of small bins, which is not desirable. With 1 second we get bins with bigger sizes. It is clearly visible with following graphs from Grafana:

- With 0.1 seconds:

![0 1sec](https://github.com/ansible/awx/assets/16258763/dfafccd9-1b07-4673-9653-357d91aaa3d7)

- with 1 seconds:

![1sec](https://github.com/ansible/awx/assets/16258763/9242fc7c-dc98-41f8-ba8f-378a7cdbe3ca)

Thus making the default  JOB_EVENT_BUFFER_SECONDS 1 seconds makes sense.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change