### PR TITLE
Revert "Improve performance for awx cli export  (#13182)"

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -162,7 +162,7 @@ class ApiV2(base.Base):
                 export_key = 'create_approval_template'
                 rel_option_endpoint = _page.related.get('create_approval_template')
 
-            rel_post_fields = self._cache.get_post_fields(rel_option_endpoint)
+            rel_post_fields = utils.get_post_fields(rel_option_endpoint, self._cache)
             if rel_post_fields is None:
                 log.debug("%s is a read-only endpoint.", rel_endpoint)
                 continue
@@ -202,7 +202,7 @@ class ApiV2(base.Base):
         return utils.remove_encrypted(fields)
 
     def _export_list(self, endpoint):
-        post_fields = self._cache.get_post_fields(endpoint)
+        post_fields = utils.get_post_fields(endpoint, self._cache)
         if post_fields is None:
             return None
 
@@ -267,7 +267,7 @@ class ApiV2(base.Base):
 
     def _import_list(self, endpoint, assets):
         log.debug("_import_list -- endpoint: %s, assets: %s", endpoint.endpoint, repr(assets))
-        post_fields = self._cache.get_post_fields(endpoint)
+        post_fields = utils.get_post_fields(endpoint, self._cache)
 
         changed = False
 

--- a/awxkit/awxkit/api/pages/page.py
+++ b/awxkit/awxkit/api/pages/page.py
@@ -495,7 +495,6 @@ class TentativePage(str):
 class PageCache(object):
     def __init__(self):
         self.options = {}
-        self.post_fields = {}
         self.pages_by_url = {}
         self.pages_by_natural_key = {}
 
@@ -516,29 +515,6 @@ class PageCache(object):
             return self.options.setdefault(url, None)
 
         return self.options.setdefault(url, options)
-
-    def get_post_fields(self, page):
-        url = page.endpoint if isinstance(page, Page) else str(page)
-        key = get_registered_page(url)
-        if key in self.post_fields:
-            return self.post_fields[key]
-
-        options_page = self.get_options(page)
-
-        if options_page is None:
-            return None
-
-        if 'POST' not in options_page.r.headers.get('Allow', ''):
-            return None
-
-        if 'POST' in options_page.json['actions']:
-            post_fields = options_page.json['actions']['POST']
-        else:
-            log.warning("Insufficient privileges on %s, inferring POST fields from description.", options_page.endpoint)
-            post_fields = utils.parse_description(options_page.json['description'])
-        self.post_fields[key] = post_fields
-
-        return post_fields
 
     def set_page(self, page):
         log.debug("set_page: %s %s", type(page), page.endpoint)

--- a/awxkit/awxkit/api/utils.py
+++ b/awxkit/awxkit/api/utils.py
@@ -31,3 +31,18 @@ def remove_encrypted(value):
     if isinstance(value, dict):
         return {k: remove_encrypted(v) for k, v in value.items()}
     return value
+
+
+def get_post_fields(page, cache):
+    options_page = cache.get_options(page)
+    if options_page is None:
+        return None
+
+    if 'POST' not in options_page.r.headers.get('Allow', ''):
+        return None
+
+    if 'POST' in options_page.json['actions']:
+        return options_page.json['actions']['POST']
+    else:
+        log.warning("Insufficient privileges on %s, inferring POST fields from description.", options_page.endpoint)
+        return parse_description(options_page.json['description'])


### PR DESCRIPTION
##### SUMMARY

This change reverts #13182, which broke export of workflow nodes (#14292)

The key thing to realize is that multiple url paths can result in the same `Page` subtype but those definitely *do not* share the same options, and correct operation depends on detection of the differences that show up in the options.  This was particularly important for workflow nodes since they are related links off of workflows, _but also off of themselves_ via the `always_nodes`, `success_nodes`, and `failure_nodes` related links, and failure to exercise caution could result in infinite recursion.

cc @ArtsiomMusin 

related #14292 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI
