### PR TITLE
Fix edit constructed inventory hanging loading state

### DIFF
--- a/awx/ui/src/api/models/ConstructedInventories.js
+++ b/awx/ui/src/api/models/ConstructedInventories.js
@@ -6,5 +6,20 @@ class ConstructedInventories extends InstanceGroupsMixin(Base) {
     super(http);
     this.baseUrl = 'api/v2/constructed_inventories/';
   }
+
+  async readConstructedInventoryOptions(id, method) {
+    const {
+      data: { actions },
+    } = await this.http.options(`${this.baseUrl}${id}/`);
+
+    if (actions[method]) {
+      return actions[method];
+    }
+
+    throw new Error(
+      `You have insufficient access to this Constructed Inventory. 
+      Please contact your system administrator if there is an issue with your access.`
+    );
+  }
 }
 export default ConstructedInventories;

--- a/awx/ui/src/api/models/ConstructedInventories.test.js
+++ b/awx/ui/src/api/models/ConstructedInventories.test.js
@@ -1,0 +1,51 @@
+import ConstructedInventories from './ConstructedInventories';
+
+describe('ConstructedInventoriesAPI', () => {
+  const constructedInventoryId = 1;
+  const constructedInventoryMethod = 'PUT';
+  let ConstructedInventoriesAPI;
+  let mockHttp;
+
+  beforeEach(() => {
+    const optionsPromise = () =>
+      Promise.resolve({
+        data: {
+          actions: {
+            PUT: {},
+          },
+        },
+      });
+    mockHttp = {
+      options: jest.fn(optionsPromise),
+    };
+    ConstructedInventoriesAPI = new ConstructedInventories(mockHttp);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('readConstructedInventoryOptions calls options with the expected params', async () => {
+    await ConstructedInventoriesAPI.readConstructedInventoryOptions(
+      constructedInventoryId,
+      constructedInventoryMethod
+    );
+    expect(mockHttp.options).toHaveBeenCalledTimes(1);
+    expect(mockHttp.options).toHaveBeenCalledWith(
+      `api/v2/constructed_inventories/${constructedInventoryId}/`
+    );
+  });
+
+  test('readConstructedInventory should throw an error if action method is missing', async () => {
+    try {
+      await ConstructedInventoriesAPI.readConstructedInventoryOptions(
+        constructedInventoryId,
+        'POST'
+      );
+    } catch (error) {
+      expect(error.message).toContain(
+        'You have insufficient access to this Constructed Inventory.'
+      );
+    }
+  });
+});

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryAdd/ConstructedInventoryAdd.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryAdd/ConstructedInventoryAdd.js
@@ -1,13 +1,42 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Card, PageSection } from '@patternfly/react-core';
 import { ConstructedInventoriesAPI, InventoriesAPI } from 'api';
+import useRequest from 'hooks/useRequest';
 import { CardBody } from 'components/Card';
+import ContentError from 'components/ContentError';
+import ContentLoading from 'components/ContentLoading';
 import ConstructedInventoryForm from '../shared/ConstructedInventoryForm';
 
 function ConstructedInventoryAdd() {
   const history = useHistory();
   const [submitError, setSubmitError] = useState(null);
+
+  const {
+    isLoading: isLoadingOptions,
+    error: optionsError,
+    request: fetchOptions,
+    result: options,
+  } = useRequest(
+    useCallback(async () => {
+      const res = await ConstructedInventoriesAPI.readOptions();
+      const { data } = res;
+      return data.actions.POST;
+    }, []),
+    null
+  );
+
+  useEffect(() => {
+    fetchOptions();
+  }, [fetchOptions]);
+
+  if (isLoadingOptions || (!options && !optionsError)) {
+    return <ContentLoading />;
+  }
+
+  if (optionsError) {
+    return <ContentError error={optionsError} />;
+  }
 
   const handleCancel = () => {
     history.push('/inventories');
@@ -48,6 +77,7 @@ function ConstructedInventoryAdd() {
             onCancel={handleCancel}
             onSubmit={handleSubmit}
             submitError={submitError}
+            options={options}
           />
         </CardBody>
       </Card>

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryAdd/ConstructedInventoryAdd.test.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryAdd/ConstructedInventoryAdd.test.js
@@ -55,6 +55,7 @@ describe('<ConstructedInventoryAdd />', () => {
         context: { router: { history } },
       });
     });
+    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
 
   afterEach(() => {

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryEdit/ConstructedInventoryEdit.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryEdit/ConstructedInventoryEdit.js
@@ -21,6 +21,27 @@ function ConstructedInventoryEdit({ inventory }) {
   const constructedInventoryId = inventory.id;
 
   const {
+    isLoading: isLoadingOptions,
+    error: optionsError,
+    request: fetchOptions,
+    result: options,
+  } = useRequest(
+    useCallback(
+      () =>
+        ConstructedInventoriesAPI.readConstructedInventoryOptions(
+          constructedInventoryId,
+          'PUT'
+        ),
+      [constructedInventoryId]
+    ),
+    null
+  );
+
+  useEffect(() => {
+    fetchOptions();
+  }, [fetchOptions]);
+
+  const {
     result: { initialInstanceGroups, initialInputInventories },
     request: fetchedRelatedData,
     error: contentError,
@@ -44,6 +65,7 @@ function ConstructedInventoryEdit({ inventory }) {
       isLoading: true,
     }
   );
+
   useEffect(() => {
     fetchedRelatedData();
   }, [fetchedRelatedData]);
@@ -99,12 +121,12 @@ function ConstructedInventoryEdit({ inventory }) {
 
   const handleCancel = () => history.push(detailsUrl);
 
-  if (isLoading) {
-    return <ContentLoading />;
+  if (contentError || optionsError) {
+    return <ContentError error={contentError || optionsError} />;
   }
 
-  if (contentError) {
-    return <ContentError error={contentError} />;
+  if (isLoading || isLoadingOptions || (!options && !optionsError)) {
+    return <ContentLoading />;
   }
 
   return (
@@ -116,6 +138,7 @@ function ConstructedInventoryEdit({ inventory }) {
         constructedInventory={inventory}
         instanceGroups={initialInstanceGroups}
         inputInventories={initialInputInventories}
+        options={options}
       />
     </CardBody>
   );

--- a/awx/ui/src/screens/Inventory/ConstructedInventoryEdit/ConstructedInventoryEdit.test.js
+++ b/awx/ui/src/screens/Inventory/ConstructedInventoryEdit/ConstructedInventoryEdit.test.js
@@ -51,27 +51,22 @@ describe('<ConstructedInventoryEdit />', () => {
   };
 
   beforeEach(async () => {
-    ConstructedInventoriesAPI.readOptions.mockResolvedValue({
-      data: {
-        related: {},
-        actions: {
-          POST: {
-            limit: {
-              label: 'Limit',
-              help_text: '',
-            },
-            update_cache_timeout: {
-              label: 'Update cache timeout',
-              help_text: 'help',
-            },
-            verbosity: {
-              label: 'Verbosity',
-              help_text: '',
-            },
-          },
+    ConstructedInventoriesAPI.readConstructedInventoryOptions.mockResolvedValue(
+      {
+        limit: {
+          label: 'Limit',
+          help_text: '',
         },
-      },
-    });
+        update_cache_timeout: {
+          label: 'Update cache timeout',
+          help_text: 'help',
+        },
+        verbosity: {
+          label: 'Verbosity',
+          help_text: '',
+        },
+      }
+    );
     InventoriesAPI.readInstanceGroups.mockResolvedValue({
       data: {
         results: associatedInstanceGroups,
@@ -165,6 +160,21 @@ describe('<ConstructedInventoryEdit />', () => {
         <ConstructedInventoryEdit inventory={mockInv} />
       );
     });
+    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
+    expect(wrapper.find('ContentError').length).toBe(1);
+  });
+
+  test('should throw content error if user has insufficient options permissions', async () => {
+    expect(wrapper.find('ContentError').length).toBe(0);
+    ConstructedInventoriesAPI.readConstructedInventoryOptions.mockImplementationOnce(
+      () => Promise.reject(new Error())
+    );
+    await act(async () => {
+      wrapper = mountWithContexts(
+        <ConstructedInventoryEdit inventory={mockInv} />
+      );
+    });
+
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('ContentError').length).toBe(1);
   });

--- a/awx/ui/src/screens/Inventory/shared/ConstructedInventoryForm.js
+++ b/awx/ui/src/screens/Inventory/shared/ConstructedInventoryForm.js
@@ -1,14 +1,10 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { Formik, useField, useFormikContext } from 'formik';
 import { func, shape } from 'prop-types';
 import { t } from '@lingui/macro';
-import { ConstructedInventoriesAPI } from 'api';
 import { minMaxValue, required } from 'util/validators';
-import useRequest from 'hooks/useRequest';
 import { Form, FormGroup } from '@patternfly/react-core';
 import { VariablesField } from 'components/CodeEditor';
-import ContentError from 'components/ContentError';
-import ContentLoading from 'components/ContentLoading';
 import FormActionGroup from 'components/FormActionGroup/FormActionGroup';
 import FormField, { FormSubmitError } from 'components/FormField';
 import { FormFullWidthLayout, FormColumnLayout } from 'components/FormLayout';
@@ -165,6 +161,7 @@ function ConstructedInventoryForm({
   onCancel,
   onSubmit,
   submitError,
+  options,
 }) {
   const initialValues = {
     kind: 'constructed',
@@ -178,32 +175,6 @@ function ConstructedInventoryForm({
     verbosity: constructedInventory?.verbosity || 0,
     source_vars: constructedInventory?.source_vars || '---',
   };
-
-  const {
-    isLoading,
-    error,
-    request: fetchOptions,
-    result: options,
-  } = useRequest(
-    useCallback(async () => {
-      const res = await ConstructedInventoriesAPI.readOptions();
-      const { data } = res;
-      return data.actions.POST;
-    }, []),
-    null
-  );
-
-  useEffect(() => {
-    fetchOptions();
-  }, [fetchOptions]);
-
-  if (isLoading || (!options && !error)) {
-    return <ContentLoading />;
-  }
-
-  if (error) {
-    return <ContentError error={error} />;
-  }
 
   return (
     <Formik initialValues={initialValues} onSubmit={onSubmit}>

--- a/awx/ui/src/screens/Inventory/shared/ConstructedInventoryForm.test.js
+++ b/awx/ui/src/screens/Inventory/shared/ConstructedInventoryForm.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { ConstructedInventoriesAPI } from 'api';
 import {
   mountWithContexts,
   waitForElement,
@@ -19,38 +18,35 @@ const mockFormValues = {
   inputInventories: [{ id: 100, name: 'East' }],
 };
 
+const options = {
+  limit: {
+    label: 'Limit',
+    help_text: '',
+  },
+  update_cache_timeout: {
+    label: 'Update cache timeout',
+    help_text: 'help',
+  },
+  verbosity: {
+    label: 'Verbosity',
+    help_text: '',
+  },
+};
+
 describe('<ConstructedInventoryForm />', () => {
   let wrapper;
   const onSubmit = jest.fn();
 
   beforeEach(async () => {
-    ConstructedInventoriesAPI.readOptions.mockResolvedValue({
-      data: {
-        related: {},
-        actions: {
-          POST: {
-            limit: {
-              label: 'Limit',
-              help_text: '',
-            },
-            update_cache_timeout: {
-              label: 'Update cache timeout',
-              help_text: 'help',
-            },
-            verbosity: {
-              label: 'Verbosity',
-              help_text: '',
-            },
-          },
-        },
-      },
-    });
     await act(async () => {
       wrapper = mountWithContexts(
-        <ConstructedInventoryForm onCancel={() => {}} onSubmit={onSubmit} />
+        <ConstructedInventoryForm
+          onCancel={() => {}}
+          onSubmit={onSubmit}
+          options={options}
+        />
       );
     });
-    await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
   });
 
   afterEach(() => {
@@ -103,21 +99,5 @@ describe('<ConstructedInventoryForm />', () => {
     expect(wrapper.find('VariablesField .pf-m-error').text()).toBe(
       'The plugin parameter is required.'
     );
-  });
-
-  test('should throw content error when option request fails', async () => {
-    let newWrapper;
-    ConstructedInventoriesAPI.readOptions.mockImplementationOnce(() =>
-      Promise.reject(new Error())
-    );
-    await act(async () => {
-      newWrapper = mountWithContexts(
-        <ConstructedInventoryForm onCancel={() => {}} onSubmit={() => {}} />
-      );
-    });
-    expect(newWrapper.find('ContentError').length).toBe(0);
-    newWrapper.update();
-    expect(newWrapper.find('ContentError').length).toBe(1);
-    jest.clearAllMocks();
   });
 });


### PR DESCRIPTION
##### SUMMARY
When clicking on edit for Constructed Inventory, the edit page is loading without any response/return. 

The ConstructedInventoryForm is retrieving an options response from the incorrect endpoint and is checking the wrong actions method. This PR updates the options request to pull information from the correct endpoint and actions method. I also added tests to cover the new constructed inventory  _readConstructedInventoryOptions_ api endpoint and updated existing tests. 

##### Steps to Reproduce
1) Create a new user _test_user_ with user type "Normal User"
2) Create new Constructed Inventory
3) Add access to the new Constructed Inventory :
_Constructed Inventory -> Access tab -> Add role -> Users -> test_user -> Admin role_
4) Log in as _test_user_
5) Navigate to the constructed inventory's edit form
6) See hanging loading state

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
