### PR TITLE
Fix default redis url to pass check in redis-py>4.4

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -476,7 +476,7 @@ CELERYBEAT_SCHEDULE = {
 
 # Django Caching Configuration
 DJANGO_REDIS_IGNORE_EXCEPTIONS = True
-CACHES = {'default': {'BACKEND': 'awx.main.cache.AWXRedisCache', 'LOCATION': 'unix:/var/run/redis/redis.sock?db=1'}}
+CACHES = {'default': {'BACKEND': 'awx.main.cache.AWXRedisCache', 'LOCATION': 'unix:///var/run/redis/redis.sock?db=1'}}
 
 # Social Auth configuration.
 SOCIAL_AUTH_STRATEGY = 'social_django.strategy.DjangoStrategy'


### PR DESCRIPTION
The redis-py library allows `redis://`, `rediss://`, and `unix://` URLs. Ansible uses a `unix://` URL, but didn't include the slashes in the default config (the default config used `unix:/var/...` instead).

https://github.com/redis/redis-py/blob/3.1.0/CHANGES#L2

https://github.com/redis/redis-py/commit/5a2e26d2b0b554bfcd6875a968bcd8090b7f9b03

As of redis-py 4.4.0, there is now a stricter check to enforce that the slashes are present:

https://github.com/redis/redis-py/commit/b5ebada842c715e9ee74ea638a7e6d11afcddae1

The error that comes up when the slashes are missing manifests in a somewhat non-obvious way: When starting up the containers, the wait-for-migrations script loops, appearing to wait on migrations, but actually failing on the `awx-manage check`. To verify this, one can `kubectl exec` into the pod that AWX is running in and run `awx-manage check`, which gave the relevant redis error.

We're specifically interested in this change because the redis-py<4.3.6 has a known exploit that we're required to upgrade to mitigate (though I'm fairly convinced it's not applicable in this situation!), and while 4.3.6 does mitigate the error _without_ triggering the issue fixed here, we're aiming to be upgraded to a current version of this package.

https://github.com/redis/redis-py/releases/tag/v4.3.6

AWX currently uses redis-py 4.3.5:

https://github.com/ansible/awx/blob/22.7.0/requirements/requirements.txt#L356C13-L356C13

redis-py 5.0.0 was released this morning:

https://github.com/redis/redis-py/releases/tag/v5.0.0

This change has been tested to work with 4.3.5 (the version that AWX currently uses), 4.6.0 (the latest as of yesterday), and 5.0.0 (the latest as of this morning).

Edited to add: This is a "Bug, Docs Fix or other nominal change"