### PR TITLE
Fix UI_NEXT build process broken by https://github.com/ansible/ansible-ui/pull/766

### DIFF
--- a/awx/ui_next/Makefile
+++ b/awx/ui_next/Makefile
@@ -22,7 +22,7 @@ $(UI_NEXT_DIR)/build:
 	@$(MAKE) $(UI_NEXT_DIR)/src/build/awx
 	@echo "=== Copying $(UI_NEXT_DIR)/src/build to $(UI_NEXT_DIR)/build ==="
 	@rm -rf $(UI_NEXT_DIR)/build
-	@cp -r $(UI_NEXT_DIR)/src/build $(UI_NEXT_DIR)
+	@cp -r $(UI_NEXT_DIR)/src/build $(UI_NEXT_DIR) && mv build/awx/index.html build/awx/index_awx.html
 	@echo "=== Done building $(UI_NEXT_DIR)/build ==="
 
 .PHONY: ui-next/src/build

--- a/awx/ui_next/Makefile
+++ b/awx/ui_next/Makefile
@@ -5,9 +5,12 @@ UI_NEXT_DIR := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 #  NOTE: you will not be able to build within the docker-compose development environment if you use this option
 UI_NEXT_LOCAL ?=
 
-# Git repo and branch to the UI_NEXT repo
+## Git repo and branch to the UI_NEXT repo
 UI_NEXT_GIT_REPO ?= https://github.com/ansible/ansible-ui.git
 UI_NEXT_GIT_BRANCH ?= main
+
+## Product name to display on the UI used in UI_NEXT build process
+PRODUCT ?= AWX
 
 .PHONY: ui-next
 ## Default build target of ui-next Makefile, builds ui-next/build
@@ -32,7 +35,7 @@ ui-next/src/build: $(UI_NEXT_DIR)/src/build/awx
 ## True target for ui-next/src/build. Build ui_next from source.
 $(UI_NEXT_DIR)/src/build/awx: $(UI_NEXT_DIR)/src $(UI_NEXT_DIR)/src/node_modules/webpack
 	@echo "=== Building ui_next ==="
-	@cd $(UI_NEXT_DIR)/src && npm run build:awx
+	@cd $(UI_NEXT_DIR)/src && PRODUCT=$(PRODUCT) PUBLIC_PATH=/static/awx npm run build:awx
 
 .PHONY: ui-next/src
 ## Clone or link src of UI_NEXT to ui-next/src, will re-clone/link/update if necessary.


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/14345

Due to change made in https://github.com/ansible/ansible-ui/pull/766/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R18 
awx/ui_next/build/awx/index_awx.html was renamed to awx/ui_next/build/awx/index.html

This PR fixes the problem by renaming the file back

https://github.com/ansible/ansible-ui/pull/792 added configurable public path (which was change to '/' in https://github.com/ansible/ansible-ui/pull/766/files#diff-2606df06d89b38ff979770f810c3c269083e7c0fbafb27aba7f9ea0297179828L128-R157)

This PR added the variable when building ui-next

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.7.1.dev4+g5454b30a6f
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
