### PR TITLE
Clarify that the license module requires fetching subs prior

### DIFF
--- a/awx_collection/plugins/modules/license.py
+++ b/awx_collection/plugins/modules/license.py
@@ -52,7 +52,12 @@ EXAMPLES = '''
   license:
     manifest: "/tmp/my_manifest.zip"
 
-- name: Attach to a pool
+- name: Use the subscriptions module to fetch subscriptions from Red Hat or Red Hat Satellite
+  subscriptions:
+    username: "my_satellite_username"
+    password: "my_satellite_password"
+
+- name: Attach to a pool (requires fetching subscriptions at least once before)
   license:
     pool_id: 123456
 


### PR DESCRIPTION
##### SUMMARY
The `awx.license` module requires accessing a Red Hat Satellite or web-based Red Hat Subscription Management servers. However, the `awx.license` module itself won't use these parameters. Instead, the `awx.subscriptions` module should be used for querying Red Hat Satellite or Red Hat Subscription Management servers for a list of subscriptions at some point prior to `awx.license`.

This PR adds an example to the Examples section to clarify that the `awx.subscriptions` module should be used prior to `awx.license`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection
 - Docs

##### AWX VERSION

Collection version: awx.awx==22.7.0


##### ADDITIONAL INFORMATION
none