### PR TITLE
Add location for locales in nginx config

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
@@ -2,6 +2,10 @@ location {{ (ingress_path + '/static').replace('//', '/') }} {
     alias /var/lib/awx/public/static/;
 }
 
+location {{ (ingress_path + '/locales').replace('//', '/') }} {
+    alias /var/lib/awx/public/static/awx/locales;
+}
+
 location {{ (ingress_path + '/favicon.ico').replace('//', '/') }} {
     alias /awx_devel/awx/public/static/favicon.ico;
 }


### PR DESCRIPTION
##### SUMMARY
I accidentally botched https://github.com/ansible/awx/pull/14282 so I'm opening a new PR.

After building the static version of awx + the tech preview UI the requests to fetch the translation files from locales are 404'ing:

<img width="1728" alt="image-2023-07-19-15-00-00-448" src="https://github.com/ansible/awx/assets/9889020/085928ca-955a-483f-8480-453e39d6b682">

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other