### PR TITLE
Label any changes to requirements folder with dependencies label

### DIFF
--- a/.github/pr_labeler.yml
+++ b/.github/pr_labeler.yml
@@ -15,5 +15,4 @@
 
 "dependencies":
   - any: ["awx/ui/package.json"]
-  - any: ["requirements/*.txt"]
-  - any: ["requirements/requirements.in"]
+  - any: ["requirements/*"]


### PR DESCRIPTION
##### SUMMARY
Minor nit pick - I saw some PRs that didn't have the "dependencies" that I thought should have.

If someone changes git requirements or dev requirements, I think it should still have that label. Even changing the updater script or readme. What is the folder for, if not dependencies?

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

