### PR TITLE
Fix undefined property error when task is of type yum/debug and was s…

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
@@ -53,13 +53,9 @@ const getStdOutValue = (hostEvent) => {
   const res = hostEvent?.event_data?.res;
 
   let stdOut;
-  if (taskAction === 'debug' && res.result && res.result.stdout) {
+  if (taskAction === 'debug' && res?.result?.stdout) {
     stdOut = res.result.stdout;
-  } else if (
-    taskAction === 'yum' &&
-    res.results &&
-    Array.isArray(res.results)
-  ) {
+  } else if (taskAction === 'yum' && Array.isArray(res?.results)) {
     stdOut = res.results.join('\n');
   } else if (res?.stdout) {
     stdOut = Array.isArray(res.stdout) ? res.stdout.join(' ') : res.stdout;


### PR DESCRIPTION
##### SUMMARY
When a task was skipped and taskAction is debug or yum, when clicking to see the task details, the error "TypeError: Cannot read properties of undefined (reading 'result')" is thrown on the screen.

Example Task: 
![image](https://github.com/ansible/awx/assets/62117064/e4387d58-ce26-4ea1-b126-04d0f8623ef2)
![image](https://github.com/ansible/awx/assets/62117064/e2773ad1-9988-4610-ac44-8653936bd36f)
before when you click to see the detail:
![image](https://github.com/ansible/awx/assets/62117064/f074ce8c-8c53-48e1-bef5-162ae1133d6b)
after:
![image](https://github.com/ansible/awx/assets/62117064/266e3c95-eea5-481a-8502-2c09d3e4e307)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI