### PR TITLE
Add toast and delete modal messaging when removing/adding peers.

### DIFF
--- a/awx/ui/src/screens/Instances/InstancePeers/InstancePeerList.js
+++ b/awx/ui/src/screens/Instances/InstancePeers/InstancePeerList.js
@@ -11,6 +11,7 @@ import DisassociateButton from 'components/DisassociateButton';
 import AssociateModal from 'components/AssociateModal';
 import ErrorDetail from 'components/ErrorDetail';
 import AlertModal from 'components/AlertModal';
+import useToast, { AlertVariant } from 'hooks/useToast';
 import { getQSConfig, parseQueryString, mergeParams } from 'util/qs';
 import { useLocation, useParams } from 'react-router-dom';
 import useRequest, { useDismissableError } from 'hooks/useRequest';
@@ -30,6 +31,7 @@ function InstancePeerList({ setBreadcrumb }) {
   const location = useLocation();
   const { id } = useParams();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { addToast, Toast, toastProps } = useToast();
   const readInstancesOptions = useCallback(
     () => InstancesAPI.readOptions(id),
     [id]
@@ -114,8 +116,14 @@ function InstancePeerList({ setBreadcrumb }) {
         ];
         await InstancesAPI.update(instance.id, { peers: new_peers });
         fetchPeers();
+        addToast({
+          id: instancesPeerToAssociate,
+          title: t`${selected_hostname} added as a peer. Please be sure to run the install bundle for ${instance.hostname} again in order to see changes take effect.`,
+          variant: AlertVariant.success,
+          hasTimeout: true,
+        });
       },
-      [instance, fetchPeers]
+      [instance, fetchPeers, addToast]
     )
   );
 
@@ -134,7 +142,12 @@ function InstancePeerList({ setBreadcrumb }) {
       }
       await InstancesAPI.update(instance.id, { peers: new_peers });
       fetchPeers();
-    }, [instance, selected, fetchPeers])
+      addToast({
+        title: t`${selected_hostname} removed. Please be sure to run the install bundle for ${instance.hostname} again in order to see changes take effect.`,
+        variant: AlertVariant.success,
+        hasTimeout: true,
+      });
+    }, [instance, selected, fetchPeers, addToast])
   );
 
   const { error, dismissError } = useDismissableError(
@@ -239,6 +252,7 @@ function InstancePeerList({ setBreadcrumb }) {
           ]}
         />
       )}
+      <Toast {...toastProps} />
       {error && (
         <AlertModal
           isOpen={error}

--- a/awx/ui/src/screens/Instances/Shared/InstanceForm.js
+++ b/awx/ui/src/screens/Instances/Shared/InstanceForm.js
@@ -154,7 +154,8 @@ function InstanceForm({
         onSubmit={(values) => {
           handleSubmit({
             ...values,
-            listener_port: values.listener_port === '' ? null : values.listener_port,
+            listener_port:
+              values.listener_port === '' ? null : values.listener_port,
             peers: values.peers.map((peer) => peer.hostname || peer),
           });
         }}

--- a/awx/ui/src/screens/Instances/Shared/InstanceForm.test.js
+++ b/awx/ui/src/screens/Instances/Shared/InstanceForm.test.js
@@ -65,7 +65,7 @@ describe('<InstanceForm />', () => {
     expect(handleCancel).toBeCalled();
   });
 
-  test('should call handleSubmit when Cancel button is clicked', async () => {
+  test('should call handleSubmit when Save button is clicked', async () => {
     expect(handleSubmit).not.toHaveBeenCalled();
     await act(async () => {
       wrapper.find('input#hostname').simulate('change', {
@@ -73,9 +73,6 @@ describe('<InstanceForm />', () => {
       });
       wrapper.find('input#instance-description').simulate('change', {
         target: { value: 'This is a repeat song', name: 'description' },
-      });
-      wrapper.find('input#instance-port').simulate('change', {
-        target: { value: 'This is a repeat song', name: 'listener_port' },
       });
     });
     wrapper.update();
@@ -91,10 +88,9 @@ describe('<InstanceForm />', () => {
       enabled: true,
       managed_by_policy: true,
       hostname: 'new Foo',
-      listener_port: 'This is a repeat song',
       node_state: 'installed',
       node_type: 'execution',
-      peers_from_control_nodes: true,
+      peers_from_control_nodes: false,
       peers: [],
     });
   });

--- a/awx/ui/src/screens/Instances/Shared/RemoveInstanceButton.js
+++ b/awx/ui/src/screens/Instances/Shared/RemoveInstanceButton.js
@@ -176,7 +176,7 @@ function RemoveInstanceButton({ itemsToRemove, onRemove, isK8s }) {
             </Button>,
           ]}
         >
-          <div>{t`This action will remove the following instances:`}</div>
+          <div>{t`This action will remove the following instance and you may need to rerun the install bundle for any instance that was previously connected to:`}</div>
           {itemsToRemove.map((item) => (
             <span key={item.id} id={`item-to-be-removed-${item.id}`}>
               <strong>{item.hostname}</strong>

--- a/awx/ui/src/screens/TopologyView/MeshGraph.js
+++ b/awx/ui/src/screens/TopologyView/MeshGraph.js
@@ -178,12 +178,7 @@ function MeshGraph({
       mesh
         .append('defs')
         .selectAll('marker')
-        .data([
-          'end',
-          'end-active',
-          'end-adding',
-          'end-removing',
-        ])
+        .data(['end', 'end-active', 'end-adding', 'end-removing'])
         .join('marker')
         .attr('id', String)
         .attr('viewBox', '0 -5 10 10')

--- a/awx/ui/src/screens/TopologyView/utils/helpers.js
+++ b/awx/ui/src/screens/TopologyView/utils/helpers.js
@@ -110,9 +110,7 @@ export function getRandomInt(min, max) {
 const generateRandomLinks = (n, r) => {
   const links = [];
   function getRandomLinkState() {
-    return ['established', 'adding', 'removing'][
-      getRandomInt(0, 3)
-    ];
+    return ['established', 'adding', 'removing'][getRandomInt(0, 3)];
   }
   for (let i = 0; i < r; i++) {
     const link = {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #14294 

This PR adds a toast notification to notify a use to rerun the install bundle when they associate/disassociate a peer.
![associate-disassociate](https://github.com/ansible/awx/assets/2293210/299f10f2-c5db-4ead-be14-60fd857322ca)

This PR also adds a warning message to notify the user that they may need to re-run install bundles for previously connected instances when a user tries to delete an instance.

![remove-instance](https://github.com/ansible/awx/assets/2293210/388bf82b-626f-4366-bc7b-fd38ce3e5a7d)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI
 
