### PR TITLE
awx-manage: Add enable_instance command

### DIFF
--- a/awx/main/management/commands/enable_instance.py
+++ b/awx/main/management/commands/enable_instance.py
@@ -1,0 +1,78 @@
+from urllib.parse import urljoin
+
+from argparse import ArgumentTypeError
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import Q
+
+from awx.main.models import Instance, UnifiedJob
+
+
+class AWXInstance:
+    def __init__(self, **filter):
+        self.filter = filter
+        self.get_instance()
+
+    def get_instance(self):
+        filter = self.filter if self.filter is not None else dict(hostname=settings.CLUSTER_HOST_ID)
+        qs = Instance.objects.filter(**filter)
+        if not qs.exists():
+            raise ValueError(f"No AWX instance found with {filter} parameters")
+        self.instance = qs.first()
+
+    def disable(self):
+        if self.instance.enabled:
+            self.instance.enabled = False
+            self.instance.save()
+            return True
+
+    def enable(self):
+        if not self.instance.enabled:
+            self.instance.enabled = True
+            self.instance.save()
+            return True
+
+    def instance_pretty(self):
+        instance = (
+            self.instance.hostname,
+            urljoin(settings.TOWER_URL_BASE, f"/#/instances/{self.instance.pk}/details"),
+        )
+        return f"[\"{instance[0]}\"]({instance[1]})"
+
+
+class Command(BaseCommand):
+    help = "Enable instance."
+
+    @staticmethod
+    def ge_1(arg):
+        if arg == "inf":
+            return float("inf")
+
+        int_arg = int(arg)
+        if int_arg < 1:
+            raise ArgumentTypeError(f"The value must be a positive number >= 1. Provided: \"{arg}\"")
+        return int_arg
+
+    def add_arguments(self, parser):
+        filter_group = parser.add_mutually_exclusive_group()
+
+        filter_group.add_argument(
+            "--hostname",
+            type=str,
+            default=settings.CLUSTER_HOST_ID,
+            help=f"{Instance.hostname.field.help_text} Defaults to the hostname of the machine where the Python interpreter is currently executing".strip(),
+        )
+        filter_group.add_argument("--id", type=self.ge_1, help=Instance.id.field.help_text)
+
+    def handle(self, *args, **options):
+        try:
+            filter = dict(id=options["id"]) if options["id"] is not None else dict(hostname=options["hostname"])
+            instance = AWXInstance(**filter)
+        except ValueError as e:
+            raise CommandError(e)
+
+        if instance.enable():
+            self.stdout.write(self.style.SUCCESS(f"Instance {instance.instance_pretty()} has been enabled"))
+        else:
+            self.stdout.write(f"Instance {instance.instance_pretty()} has already been enabled")


### PR DESCRIPTION
Taken from:
https://github.com/ansible/awx/pull/13445

Adds the ability to enable an AWX instance via `awx-manage`.

##### SUMMARY
Gives `awx-manage` another command called `enable_instance` which allows an admin to use `awx-manage` to enable a given instance in addition to disabling an instance.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI
 - `awx-manage`

##### AWX VERSION
```
awx: 0.1.dev33458+gee1022b
```

##### ADDITIONAL INFORMATION
This feature completes the idea of being able to disable a queue (instance) within AWX via `awx-manage`, draining jobs, and re-enabling the queue when patching/maintenance/work is completed on a given instance node.

A benefit of using `awx-manage` vs the AWX API is it gives a way to run commands via automation service accounts to perform maintenance without having to be a user or admin of AWX.

For example:

```
# Docker environment
$ docker exec -ti awx_task awx-manage enable_instance --hostname <instance_node>

# K8s environment
$ kubectl -n awx exec -ti pod/awx-task-<hash>-<hash> -c awx-task -- awx-manage enable_instance --hostname awx-task-<hash>-<hash>
```
