### PR TITLE
Fix typo in description of scm_update_on_launch

### DIFF
--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -83,7 +83,7 @@ options:
       type: bool
     scm_update_on_launch:
       description:
-        - Before an update to the local repository before launching a job with this project.
+        - Perform an update to the local repository before launching a job with this project.
       type: bool
     scm_update_cache_timeout:
       description:


### PR DESCRIPTION
##### SUMMARY
This PR fixes what I believe is a typo in the description of a field in the `project` module's documentation. I recently needed to use the `scm_update_on_launch` setting for my job, and I noticed the description is not formatted like the rest, i.e. it contains a typo that makes it confusing and not a sentence. While this might seem like a pedantic PR, I was hoping to use that description to justify using that field in some shared code, and the current state makes it ambiguous.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
The [awx.awx.project](https://docs.ansible.com/ansible/latest/collections/awx/awx/project_module.html) module

##### AWX VERSION
N/A

##### ADDITIONAL INFORMATION
Since this is just a fix to a docstring, I don't have any additional info to provide, but I'd be happy to answer any questions you may have.