### PR TITLE
Fixes #14377 Ensure Conjur Enterprise JWT token is Base64-encoded

### DIFF
--- a/awx/main/credential_plugins/conjur.py
+++ b/awx/main/credential_plugins/conjur.py
@@ -4,6 +4,8 @@ from urllib.parse import urljoin, quote
 
 from django.utils.translation import gettext_lazy as _
 import requests
+import base64
+import binascii
 
 
 conjur_inputs = {
@@ -50,6 +52,13 @@ conjur_inputs = {
 }
 
 
+def _is_base64(s: str) -> bool:
+    try:
+        return base64.b64encode(base64.b64decode(s.encode("utf-8"))) == s.encode("utf-8")
+    except binascii.Error:
+        return False
+
+
 def conjur_backend(**kwargs):
     url = kwargs['url']
     api_key = kwargs['api_key']
@@ -77,7 +86,7 @@ def conjur_backend(**kwargs):
     token = resp.content.decode('utf-8')
 
     lookup_kwargs = {
-        'headers': {'Authorization': 'Token token="{}"'.format(token)},
+        'headers': {'Authorization': 'Token token="{}"'.format(token if _is_base64(token) else base64.b64encode(token.encode('utf-8')).decode('utf-8'))},
         'allow_redirects': False,
     }
 


### PR DESCRIPTION
##### SUMMARY
This change implements a base64 encoding check on the JWT returned from a Conjur Enterprise authentication.  Customers reported sporatic issues of the `Accept-Encoding: base64` header actually encoding the returned JWT.  To prevent issues, the check will handle any failed encoding attempts.

Related #14377 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 0.1.dev33459+g90e28b7
```


##### ADDITIONAL INFORMATION
n/a