### PR TITLE
Fix CVE-2023-40267

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -26,7 +26,7 @@ django-split-settings==1.0.0    # We hit a strange issue where the release proce
 djangorestframework
 djangorestframework-yaml
 filelock
-GitPython>=3.1.30  # CVE-2022-24439
+GitPython>=3.1.32  # CVE-2023-40267
 hiredis==2.0.0  # see UPGRADE BLOCKERs
 irc
 jinja2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -155,7 +155,7 @@ frozenlist==1.3.3
     #   aiosignal
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.30
+gitpython==3.1.32
     # via -r /awx_devel/requirements/requirements.in
 google-auth==2.14.1
     # via kubernetes


### PR DESCRIPTION
##### SUMMARY
CVE-2023-40267 GitPython: Insecure non-multi options in clone and clone_from is not blocked https://bugzilla.redhat.com/show_bug.cgi?id=2231474

GitPython before 3.1.32 does not block insecure non-multi options in clone and clone_from. NOTE: this issue exists because of an incomplete fix for CVE-2022-24439.

References:
https://github.com/gitpython-developers/GitPython/commit/ca965ecc81853bca7675261729143f54e5bf4cdd https://github.com/gitpython-developers/GitPython/pull/1609

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.7.1.dev19+g853205a415
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
