### PR TITLE
Remove extra scheduler state save that does nothing

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -764,7 +764,6 @@ def awx_periodic_scheduler():
                 new_unified_job.save(update_fields=['status', 'job_explanation'])
                 new_unified_job.websocket_emit_status("failed")
             emit_channel_notification('schedules-changed', dict(id=schedule.id, group_name="schedules"))
-        state.save()
 
 
 def schedule_manager_success_or_error(instance):


### PR DESCRIPTION
##### SUMMARY
While I was looking at https://github.com/ansible/awx/issues/14394 I couldn't figure out what was happening, but I did find this one gigantic red flag.

This save seems to have been introduced in 13c89ab78c081066eecfa145fb51f4e283125bd4 and it didn't make sense then either.

Between the two `state.save()` calls, there is no change made to the `state` object. So what's the point of the save? The timestamp doesn't change from one to the other. The line just re-saves the existing data on the object and seems to be completely pointless.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

