### PR TITLE
Prevent the user from launching multiple jobs by rapidly clicking on buttons

### DIFF
--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -47,6 +47,9 @@ function LaunchButton({ resource, children }) {
   const [error, setError] = useState(null);
 
   const handleLaunch = async () => {
+    if (isLaunching) {
+      return;
+    }
     setIsLaunching(true);
     const readLaunch =
       resource.type === 'workflow_job_template'
@@ -104,6 +107,10 @@ function LaunchButton({ resource, children }) {
   };
 
   const launchWithParams = async (params) => {
+    if (isLaunching) {
+      return;
+    }
+    setIsLaunching(true);
     try {
       let jobPromise;
 
@@ -141,6 +148,9 @@ function LaunchButton({ resource, children }) {
     let readRelaunch;
     let relaunch;
 
+    if (isLaunching) {
+      return;
+    }
     setIsLaunching(true);
     if (resource.type === 'inventory_update') {
       // We'll need to handle the scenario where the src no longer exists

--- a/awx/ui/src/components/LaunchButton/LaunchButton.js
+++ b/awx/ui/src/components/LaunchButton/LaunchButton.js
@@ -11,6 +11,7 @@ import {
   WorkflowJobsAPI,
   WorkflowJobTemplatesAPI,
 } from 'api';
+import useToast, { AlertVariant } from 'hooks/useToast';
 import AlertModal from '../AlertModal';
 import ErrorDetail from '../ErrorDetail';
 import LaunchPrompt from '../LaunchPrompt';
@@ -45,9 +46,20 @@ function LaunchButton({ resource, children }) {
   const [isLaunching, setIsLaunching] = useState(false);
   const [resourceCredentials, setResourceCredentials] = useState([]);
   const [error, setError] = useState(null);
+  const { addToast, Toast, toastProps } = useToast();
+
+  const showToast = () => {
+    addToast({
+      id: resource.id,
+      title: t`A job has already been launched`,
+      variant: AlertVariant.info,
+      hasTimeout: true,
+    });
+  };
 
   const handleLaunch = async () => {
     if (isLaunching) {
+      showToast();
       return;
     }
     setIsLaunching(true);
@@ -108,6 +120,7 @@ function LaunchButton({ resource, children }) {
 
   const launchWithParams = async (params) => {
     if (isLaunching) {
+      showToast();
       return;
     }
     setIsLaunching(true);
@@ -149,6 +162,7 @@ function LaunchButton({ resource, children }) {
     let relaunch;
 
     if (isLaunching) {
+      showToast();
       return;
     }
     setIsLaunching(true);
@@ -207,6 +221,7 @@ function LaunchButton({ resource, children }) {
         handleRelaunch,
         isLaunching,
       })}
+      <Toast {...toastProps} />
       {error && (
         <AlertModal
           isOpen={error}


### PR DESCRIPTION
##### SUMMARY
link https://github.com/ansible/awx/issues/14187

The easiest way to address this was to go right to the source of the launch/relaunch requests.  We were already keeping track of a launching "state" so I hooked into that at the beginning of each function.  If we detect that we're already launching then we do nothing.

The launch buttons already have logic that disables them while the launch request is firing.  Disabling the launch button inside the prompt wizard (very last step) is much more difficult and would probably require some refactoring.  I decided not to go down that route and figured I'd be more likely to introduce new bugs if I did.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
22.5.0 and earlier

