### PR TITLE
allow list for example secrets in docs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+[allowlist]
+description = "Documentation contains example secrets and passwords"
+paths = [
+  "docs/docsite/rst/administration/oauth2_token_auth.rst",
+]


### PR DESCRIPTION
##### SUMMARY
InfoSec are reporting lines in the following RST as potential security leaks: docs/docsite/rst/administration/oauth2_token_auth.rst

This PR adds that RST to an allow list so it will be ignored in security scans.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### AWX VERSION
N/A


##### ADDITIONAL INFORMATION
N/A
