### PR TITLE
New way to determine hop node health

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -315,12 +315,15 @@ class Instance(HasPolicyEditsMixin, BaseModel):
 
     def save_health_data(self, version=None, cpu=0, memory=0, uuid=None, update_last_seen=False, errors=''):
         update_fields = ['errors']
-        if self.node_type != 'hop':
+        if self.node_type != Instance.Types.HOP:
             self.last_health_check = now()
             update_fields.append('last_health_check')
 
         if update_last_seen:
-            self.last_seen = self.last_health_check
+            if self.node_type == Instance.Types.HOP:
+                self.last_seen = now()
+            else:
+                self.last_seen = self.last_health_check
             update_fields.append('last_seen')
 
         if uuid is not None and self.uuid != uuid:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Old way of detecting health depended on Receptor Service advertisements. However, hop nodes need not run any services, thus they won't show up in the Advertisement lists.

We recently removed work-commands from remote hop node configurations. The presence of work commands also triggered a service Ad. Now hop nodes will stay in Install state indefinitely.

Instead, we can detect health of hop nodes based on whether they show up in the Known Connection Costs list.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
