### PR TITLE
[WIP] Adding Host bulk delete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,6 @@ jobs:
   collection-integration:
     name: awx_collection integration
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -160,11 +159,13 @@ jobs:
 
       # Upload coverage report as artifact
       - uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: coverage-${{ matrix.target-regex.name }}
           path: ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage/
 
       - uses: ./.github/actions/upload_awx_devel_logs
+        if: always()
         with:
           log-filename: collection-integration-${{ matrix.target-regex.name }}.log
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ env:
   COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
 jobs:
   common-tests:
     name: ${{ matrix.tests.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,7 @@ jobs:
   collection-integration:
     name: awx_collection integration
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,6 @@
 name: Docsite CI
 on:
   pull_request:
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
 jobs:
   docsite-build:
     name: docsite test build

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -71,5 +71,6 @@ jobs:
           awx-pf-tests run --project .
 
       - uses: ./.github/actions/upload_awx_devel_logs
+        if: always()
         with:
           log-filename: e2e-${{ matrix.job }}.log

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CI](https://github.com/ansible/awx/actions/workflows/ci.yml/badge.svg?branch=devel)](https://github.com/ansible/awx/actions/workflows/ci.yml) [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-yellow.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html) [![Apache v2 License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](https://github.com/ansible/awx/blob/devel/LICENSE.md) [![AWX Mailing List](https://img.shields.io/badge/mailing%20list-AWX-orange.svg)](https://groups.google.com/g/awx-project)
-[![IRC Chat - #ansible-awx](https://img.shields.io/badge/IRC-%23ansible--awx-blueviolet.svg)](https://libera.chat)
+[![Ansible Matrix](https://img.shields.io/badge/matrix-Ansible%20Community-blueviolet.svg?logo=matrix)](https://chat.ansible.im/#/welcome) [![Ansible Discourse](https://img.shields.io/badge/discourse-Ansible%20Community-yellowgreen.svg?logo=discourse)](https://forum.ansible.com)
 
 <img src="https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg?sanitize=true" width=200 alt="AWX" />
 

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2227,14 +2227,14 @@ class BulkHostDeleteSerializer(serializers.Serializer):
                 raise serializers.ValidationError(_(f'Inventory with id {inv.id} not found or lack permissions to add hosts.'))
 
         # Getting list of all host objects in the inventory, filtered by the list of the hosts to delete
-        inventory_hosts = list(x for x in list(Host.objects.get_queryset()) if x.id in attrs['hosts'])
+        attrs['in_inv'] = list(x for x in list(Host.objects.get_queryset()) if x.id in attrs['hosts'])
 
-        if len(inventory_hosts) == 0:
+        if len(attrs['in_inv']) == 0:
             raise serializers.ValidationError(_(f'f"There are no hosts in inventory : {inv}.'))
 
-        if len(inventory_hosts) < len(attrs['hosts']):
+        if len(attrs['in_inv']) < len(attrs['hosts']):
             raise serializers.ValidationError(
-                {"inventory": "Not all hosts are in the inventory", "hosts": list(set(attrs['hosts']).difference(inventory_hosts))}
+                {"inventory": "Not all hosts are in the inventory", "hosts": list(set(attrs['hosts']).difference(attrs['in_inv']))}
             )
         return attrs
 

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2233,7 +2233,7 @@ class BulkHostDeleteSerializer(serializers.Serializer):
         hosts_data = attrs['in_inv'].values()
 
         if len(attrs['in_inv']) == 0:
-            raise serializers.ValidationError({"ERROR": "There are no to delete"})
+            raise serializers.ValidationError({"ERROR": "There are no hosts to delete"})
 
         if len(attrs['in_inv']) < len(attrs['hosts']):
             hosts_exists = [host['id'] for host in hosts_data]

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2224,10 +2224,10 @@ class BulkHostDeleteSerializer(serializers.Serializer):
             raise serializers.ValidationError(_('Number of hosts exceeds system setting BULK_HOST_MAX_DELETE'))
         if request and not request.user.is_superuser:
             if request.user not in inv.admin_role:
-                raise serializers.ValidationError(_(f'Inventory with id {inv.id} not found or lack permissions to add hosts.'))
+                raise serializers.ValidationError(_(f'Inventory with id {inv.id} not found or lack permissions to delete hosts from.'))
 
         # Getting list of all host objects in the inventory, filtered by the list of the hosts to delete
-        attrs['in_inv'] = Host.objects.get_queryset().filter(pk__in=attrs['hosts'])
+        attrs['in_inv'] = Host.objects.get_queryset().filter(pk__in=attrs['hosts'], inventory=inv.id)
         if len(attrs['in_inv']) == 0:
             raise serializers.ValidationError(_(f"There are no hosts in inventory : {inv}. {attrs['in_inv']}"))
 

--- a/awx/api/templates/api/bulk_host_delete_view.md
+++ b/awx/api/templates/api/bulk_host_delete_view.md
@@ -1,0 +1,23 @@
+# Bulk Host Delete
+
+This endpoint allows the client to delete multiple hosts from an inventory. 
+They may do this by providing the inventory ID and a list hosts ID's to be deleted.
+
+Example:
+
+    {
+        "inventory": 1,
+        "hosts": [1, 2, 3, 4, 5]
+    }
+
+Return data:
+
+    {
+        "hosts": {
+            "1": "The host a1 was deleted",
+            "2": "The host a2 was deleted",
+            "3": "The host a3 was deleted",
+            "4": "The host a4 was deleted",
+            "5": "The host a5 was deleted",
+        }
+    }

--- a/awx/api/templates/api/bulk_host_delete_view.md
+++ b/awx/api/templates/api/bulk_host_delete_view.md
@@ -1,12 +1,11 @@
 # Bulk Host Delete
 
-This endpoint allows the client to delete multiple hosts from an inventory. 
-They may do this by providing the inventory ID and a list hosts ID's to be deleted.
+This endpoint allows the client to delete multiple hosts from inventories. 
+They may do this by providing a list hosts ID's to be deleted.
 
 Example:
 
     {
-        "inventory": 1,
         "hosts": [1, 2, 3, 4, 5]
     }
 

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -36,6 +36,7 @@ from awx.api.views import (
 from awx.api.views.bulk import (
     BulkView,
     BulkHostCreateView,
+    BulkHostDeleteView,
     BulkJobLaunchView,
 )
 
@@ -152,6 +153,7 @@ v2_urls = [
     re_path(r'^workflow_approvals/', include(workflow_approval_urls)),
     re_path(r'^bulk/$', BulkView.as_view(), name='bulk'),
     re_path(r'^bulk/host_create/$', BulkHostCreateView.as_view(), name='bulk_host_create'),
+    re_path(r'^bulk/host_delete/$', BulkHostDeleteView.as_view(), name='bulk_host_delete'),
     re_path(r'^bulk/job_launch/$', BulkJobLaunchView.as_view(), name='bulk_job_launch'),
 ]
 

--- a/awx/api/views/bulk.py
+++ b/awx/api/views/bulk.py
@@ -34,6 +34,7 @@ class BulkView(APIView):
         '''List top level resources'''
         data = OrderedDict()
         data['host_create'] = reverse('api:bulk_host_create', request=request)
+        data['host_delete'] = reverse('api:bulk_host_delete', request=request)
         data['job_launch'] = reverse('api:bulk_job_launch', request=request)
         return Response(data)
 
@@ -70,5 +71,22 @@ class BulkHostCreateView(GenericAPIView):
         serializer = serializers.BulkHostCreateSerializer(data=request.data, context={'request': request})
         if serializer.is_valid():
             result = serializer.create(serializer.validated_data)
+            return Response(result, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class BulkHostDeleteView(GenericAPIView):
+    permission_classes = [IsAuthenticated]
+    model = Host
+    serializer_class = serializers.BulkHostDeleteSerializer
+    allowed_methods = ['GET', 'POST', 'OPTIONS']
+
+    def get(self, request):
+        return Response({"detail": "Bulk delete hosts with this endpoint"}, status=status.HTTP_200_OK)
+
+    def post(self, request):
+        serializer = serializers.BulkHostDeleteSerializer(data=request.data, context={'request': request})
+        if serializer.is_valid():
+            result = serializer.delete(serializer.validated_data)
             return Response(result, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -827,6 +827,16 @@ register(
 )
 
 register(
+    'BULK_HOST_MAX_DELETE',
+    field_class=fields.IntegerField,
+    default=250,
+    label=_('Max number of hosts to allow to be deleted in a single bulk action'),
+    help_text=_('Max number of hosts to allow to be deleted in a single bulk action'),
+    category=_('Bulk Actions'),
+    category_slug='bulk',
+)
+
+register(
     'UI_NEXT',
     field_class=fields.BooleanField,
     default=False,

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -8,8 +8,6 @@ from awx.main.models.jobs import JobTemplate
 from awx.main.models import Organization, Inventory, WorkflowJob, ExecutionEnvironment, Host
 from awx.main.scheduler import TaskManager
 
-from django.db import connection
-
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('num_hosts, num_queries', [(1, 15), (10, 15)])

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -340,7 +340,7 @@ def test_bulk_host_delete_num_queries(organization, inventory, post, get, user, 
             bulk_host_create_response = post(reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': hosts}, u, expect=201).data
             assert len(bulk_host_create_response['hosts']) == len(hosts), f"unexpected number of hosts created for user {u}"
             hosts_ids = [host['id'] for host in bulk_host_create_response['hosts']]
-            bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'inventory': inventory.id, 'hosts': hosts_ids}, u, expect=201).data
+            bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'hosts': hosts_ids}, u, expect=201).data
             assert len(bulk_host_delete_response['hosts'].keys()) == len(hosts), f"unexpected number of hosts deleted for user {u}"
 
 
@@ -377,7 +377,7 @@ def test_bulk_host_delete_rbac(organization, inventory, post, get, user):
         assert len(bulk_host_create_response['hosts']) == 1, f"unexpected number of hosts created for user {u}"
         assert Host.objects.filter(inventory__id=inventory.id)[0].name == 'foobar-0'
         hosts_ids = [host['id'] for host in bulk_host_create_response['hosts']]
-        bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'inventory': inventory.id, 'hosts': hosts_ids}, u, expect=201).data
+        bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'hosts': hosts_ids}, u, expect=201).data
         assert len(bulk_host_delete_response['hosts'].keys()) == 1, f"unexpected number of hosts deleted for user {u}"
 
     for indx, u in enumerate([member, auditor, use_inv_member]):
@@ -386,5 +386,5 @@ def test_bulk_host_delete_rbac(organization, inventory, post, get, user):
         ).data
         assert bulk_host_create_response['__all__'][0] == f'Inventory with id {inventory.id} not found or lack permissions to add hosts.'
         hosts_ids = [host['id'] for host in bulk_host_create_response['hosts']]
-        bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'inventory': inventory.id, 'hosts': hosts_ids}, u, expect=201).data
+        bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'hosts': hosts_ids}, u, expect=201).data
         assert len(bulk_host_delete_response['hosts'].keys()) == 1, f"unexpected number of hosts deleted for user {u}"

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -309,3 +309,81 @@ def test_bulk_job_set_all_prompt(job_template, organization, inventory, project,
     assert node[0].limit == 'kansas'
     assert node[0].skip_tags == 'foobar'
     assert node[0].job_tags == 'untagged'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('num_hosts, num_queries', [(1, 40), (10, 40)])
+def test_bulk_host_delete_num_queries(organization, inventory, post, get, user, num_hosts, num_queries, django_assert_max_num_queries):
+    '''
+    If I am a...
+      org admin
+      inventory admin at org level
+      admin of a particular inventory
+      superuser
+
+    Bulk Host delete should take under a certain number of queries
+    '''
+    inventory.organization = organization
+    inventory_admin = user('inventory_admin', False)
+    org_admin = user('org_admin', False)
+    org_inv_admin = user('org_admin', False)
+    superuser = user('admin', True)
+    for u in [org_admin, org_inv_admin, inventory_admin]:
+        organization.member_role.members.add(u)
+    organization.admin_role.members.add(org_admin)
+    organization.inventory_admin_role.members.add(org_inv_admin)
+    inventory.admin_role.members.add(inventory_admin)
+
+    for u in [org_admin, inventory_admin, org_inv_admin, superuser]:
+        hosts = [{'name': uuid4()} for i in range(num_hosts)]
+        bulk_host_create_response = post(reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': hosts}, u, expect=201).data
+        hosts_ids = [host.get('id') for host in bulk_host_create_response['hosts']]
+        with django_assert_max_num_queries(num_queries):
+            bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'inventory': inventory.id, 'hosts': hosts_ids}, u, expect=201).data
+            assert len(bulk_host_delete_response['hosts'].keys()) == len(hosts), f"unexpected number of hosts deleted for user {u}"
+
+
+@pytest.mark.django_db
+def test_bulk_host_delete_rbac(organization, inventory, post, get, user):
+    '''
+    If I am a...
+      org admin
+      inventory admin at org level
+      admin of a particular invenotry
+          ... I can bulk add hosts
+
+    Everyone else cannot
+    '''
+    inventory.organization = organization
+    inventory_admin = user('inventory_admin', False)
+    org_admin = user('org_admin', False)
+    org_inv_admin = user('org_admin', False)
+    auditor = user('auditor', False)
+    member = user('member', False)
+    use_inv_member = user('member', False)
+    for u in [org_admin, org_inv_admin, auditor, member, inventory_admin, use_inv_member]:
+        organization.member_role.members.add(u)
+    organization.admin_role.members.add(org_admin)
+    organization.inventory_admin_role.members.add(org_inv_admin)
+    inventory.admin_role.members.add(inventory_admin)
+    inventory.use_role.members.add(use_inv_member)
+    organization.auditor_role.members.add(auditor)
+
+    for indx, u in enumerate([org_admin, inventory_admin, org_inv_admin]):
+        bulk_host_create_response = post(
+            reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': [{'name': f'foobar-{indx}'}]}, u, expect=201
+        ).data
+        assert len(bulk_host_create_response['hosts']) == 1, f"unexpected number of hosts created for user {u}"
+        assert Host.objects.filter(inventory__id=inventory.id)[0].name == 'foobar-0'
+        hosts_ids = [host.get('id') for host in bulk_host_create_response['hosts']]
+        bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'inventory': inventory.id, 'hosts': hosts_ids}, u, expect=201).data
+        assert len(bulk_host_delete_response['hosts'].keys()) == 1, f"unexpected number of hosts deleted for user {u}"
+
+    for indx, u in enumerate([member, auditor, use_inv_member]):
+        bulk_host_create_response = post(
+            reverse('api:bulk_host_create'), {'inventory': inventory.id, 'hosts': [{'name': f'foobar2-{indx}'}]}, u, expect=400
+        ).data
+        assert bulk_host_create_response['__all__'][0] == f'Inventory with id {inventory.id} not found or lack permissions to add hosts.'
+        hosts_ids = [host.get('id') for host in bulk_host_create_response['hosts']]
+        bulk_host_delete_response = post(reverse('api:bulk_host_delete'), {'inventory': inventory.id, 'hosts': hosts_ids}, u, expect=201).data
+        assert len(bulk_host_delete_response['hosts'].keys()) == 1, f"unexpected number of hosts deleted for user {u}"

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -131,6 +131,9 @@ BULK_JOB_MAX_LAUNCH = 100
 # Maximum number of host that can be created in 1 bulk host create
 BULK_HOST_MAX_CREATE = 100
 
+# Maximum number of host that can be deleted in 1 bulk host delete
+BULK_HOST_MAX_DELETE = 250
+
 SITE_ID = 1
 
 # Make this unique, and don't share it with anybody.

--- a/awx_collection/meta/runtime.yml
+++ b/awx_collection/meta/runtime.yml
@@ -8,6 +8,7 @@ action_groups:
     - application
     - bulk_job_launch
     - bulk_host_create
+    - bulk_host_delete
     - controller_meta
     - credential_input_source
     - credential

--- a/awx_collection/plugins/modules/bulk_host_delete.py
+++ b/awx_collection/plugins/modules/bulk_host_delete.py
@@ -34,7 +34,7 @@ extends_documentation_fragment: awx.awx.auth
 
 EXAMPLES = '''
 - name: Bulk host delete
-  bulk_host_create:
+  bulk_host_delete:
     inventory: 1
     hosts:
       - 1

--- a/awx_collection/plugins/modules/bulk_host_delete.py
+++ b/awx_collection/plugins/modules/bulk_host_delete.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1', 'status': ['preview'], 'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: bulk_host_delete
+author: "Avi Layani (@Avilir)"
+short_description: Bulk host delete in Automation Platform Controller
+description:
+    - Single-request bulk host deletion in Automation Platform Controller.
+    - Provides a way to delete many hosts at once from an inventory in Controller.
+options:
+    hosts:
+      description:
+        - List of hosts id's to delete from inventory.
+      required: True
+      type: list
+      elements: int
+    inventory:
+      description:
+        - Inventory name, ID, or named URL the hosts should be made a member of.
+      required: True
+      type: str
+extends_documentation_fragment: awx.awx.auth
+'''
+
+EXAMPLES = '''
+- name: Bulk host delete
+  bulk_host_create:
+    inventory: 1
+    hosts:
+      - 1
+      - 2
+'''
+
+from ..module_utils.controller_api import ControllerAPIModule
+
+
+def main():
+    # Any additional arguments that are not fields of the item can be added here
+    argument_spec = dict(
+        hosts=dict(required=True, type='list', elements='int'),
+        inventory=dict(required=True, type='str'),
+    )
+
+    # Create a module for ourselves
+    module = ControllerAPIModule(argument_spec=argument_spec)
+
+    # Extract our parameters
+    inv_name = module.params.get('inventory')
+    hosts = module.params.get('hosts')
+
+    inv_id = module.resolve_name_to_id('inventories', inv_name)
+
+    # Launch the jobs
+    result = module.post_endpoint("bulk/host_delete", data={"inventory": inv_id, "hosts": hosts})
+
+    if result['status_code'] != 201:
+        module.fail_json(msg="Failed to delete hosts, see response for details", response=result)
+
+    module.json_output['changed'] = True
+
+    module.exit_json(**module.json_output)
+
+
+if __name__ == '__main__':
+    main()

--- a/awx_collection/plugins/modules/bulk_host_delete.py
+++ b/awx_collection/plugins/modules/bulk_host_delete.py
@@ -16,7 +16,7 @@ author: "Avi Layani (@Avilir)"
 short_description: Bulk host delete in Automation Platform Controller
 description:
     - Single-request bulk host deletion in Automation Platform Controller.
-    - Provides a way to delete many hosts at once from an inventory in Controller.
+    - Provides a way to delete many hosts at once from inventories in Controller.
 options:
     hosts:
       description:
@@ -24,18 +24,12 @@ options:
       required: True
       type: list
       elements: int
-    inventory:
-      description:
-        - Inventory name, ID, or named URL the hosts should be made a member of.
-      required: True
-      type: str
 extends_documentation_fragment: awx.awx.auth
 '''
 
 EXAMPLES = '''
 - name: Bulk host delete
   bulk_host_delete:
-    inventory: 1
     hosts:
       - 1
       - 2
@@ -48,20 +42,16 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         hosts=dict(required=True, type='list', elements='int'),
-        inventory=dict(required=True, type='str'),
     )
 
     # Create a module for ourselves
     module = ControllerAPIModule(argument_spec=argument_spec)
 
     # Extract our parameters
-    inv_name = module.params.get('inventory')
     hosts = module.params.get('hosts')
 
-    inv_id = module.resolve_name_to_id('inventories', inv_name)
-
-    # Launch the jobs
-    result = module.post_endpoint("bulk/host_delete", data={"inventory": inv_id, "hosts": hosts})
+    # Delete the hosts
+    result = module.post_endpoint("bulk/host_delete", data={"hosts": hosts})
 
     if result['status_code'] != 201:
         module.fail_json(msg="Failed to delete hosts, see response for details", response=result)

--- a/awx_collection/test/awx/test_bulk.py
+++ b/awx_collection/test/awx/test_bulk.py
@@ -45,3 +45,29 @@ def test_bulk_host_create(run_module, admin_user, inventory):
     resp_hosts = inventory.hosts.all().values_list('name', flat=True)
     for h in hosts:
         assert h['name'] in resp_hosts
+
+
+@pytest.mark.django_db
+def test_bulk_host_delete(run_module, admin_user, inventory):
+    hosts = [dict(name="127.0.0.1"), dict(name="foo.dns.org")]
+    result = run_module(
+        'bulk_host_create',
+        {
+            'inventory': inventory.name,
+            'hosts': hosts,
+        },
+        admin_user,
+    )
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result
+    resp_hosts_ids = inventory.hosts.all().values_list('id', flat=True)
+    result = run_module(
+        'bulk_host_delete',
+        {
+            'inventory': inventory.id,
+            'hosts': resp_hosts_ids,
+        },
+        admin_user,
+    )
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed'), result

--- a/awx_collection/test/awx/test_bulk.py
+++ b/awx_collection/test/awx/test_bulk.py
@@ -64,7 +64,6 @@ def test_bulk_host_delete(run_module, admin_user, inventory):
     result = run_module(
         'bulk_host_delete',
         {
-            'inventory': inventory.id,
             'hosts': resp_hosts_ids,
         },
         admin_user,

--- a/awx_collection/test/awx/test_bulk.py
+++ b/awx_collection/test/awx/test_bulk.py
@@ -60,7 +60,7 @@ def test_bulk_host_delete(run_module, admin_user, inventory):
     )
     assert not result.get('failed', False), result.get('msg', result)
     assert result.get('changed'), result
-    resp_hosts_ids = inventory.hosts.all().values_list('id', flat=True)
+    resp_hosts_ids = list(inventory.hosts.all().values_list('id', flat=True))
     result = run_module(
         'bulk_host_delete',
         {

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -50,6 +50,7 @@ no_endpoint_for_module = [
 extra_endpoints = {
     'bulk_job_launch': '/api/v2/bulk/job_launch/',
     'bulk_host_create': '/api/v2/bulk/host_create/',
+    'bulk_host_delete': '/api/v2/bulk/host_delete/',
 }
 
 # Global module parameters we can ignore

--- a/awx_collection/tests/integration/targets/bulk_host_delete/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/bulk_host_delete/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+- name: "Generate a random string for test"
+  set_fact:
+    test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
+  when: "test_id is not defined"
+
+- name: "Generate a unique name"
+  set_fact:
+    bulk_inv_name: "AWX-Collection-tests-bulk_host_create-{{ test_id }}"
+
+- name: "Get our collection package"
+  controller_meta:
+  register: "controller_meta"
+
+- name: "Generate the name of our plugin"
+  set_fact:
+    plugin_name: "{{ controller_meta.prefix }}.controller_api"
+
+- name: "Create an inventory"
+  inventory:
+    name: "{{ bulk_inv_name }}"
+    organization: "Default"
+    state: "present"
+  register: "inventory_result"
+
+- name: "Bulk Host Create"
+  bulk_host_create:
+    hosts:
+      - name: "123.456.789.123"
+        description: "myhost1"
+        variables:
+          food: "carrot"
+          color: "orange"
+      - name: "example.dns.gg"
+        description: "myhost2"
+        enabled: "false"
+    inventory: "{{ bulk_inv_name }}"
+  register: "result"
+
+- assert:
+    that:
+      - "result is not failed"
+
+- name: "Get hosts ids from inventory"
+  uri:
+    url: "{{ controller_host }}/api/v2/inventories/{{ bulk_inv_name.id }}/hosts"
+    user: "{{ controller_username|default('admin') }}"
+    password: "{{ controller_password }}"
+    method: "GET"
+    status_code: "200"
+    force_basic_auth: "true"
+    validate_certs: "false"
+    body_format: "json"
+  register: "host_ids"
+
+- name: "Extract host IDs"
+  set_fact:
+    host_id_list: "{{ host_ids.json.results | json_query('[].id') }}"
+
+- name: "Bulk Host Delete"
+  bulk_host_delete:
+    hosts: "{{ host_id_list }}"
+    inventory: "{{ bulk_inv_name }}"
+
+- assert:
+    that:
+      - "result is not failed"
+
+# cleanup
+- name: "Delete inventory"
+  inventory:
+    name: "{{ bulk_inv_name }}"
+    organization: "Default"
+    state: "absent"

--- a/awxkit/awxkit/cli/custom.py
+++ b/awxkit/awxkit/cli/custom.py
@@ -143,6 +143,26 @@ class BulkHostCreate(CustomAction):
         return response
 
 
+class BulkHostDelete(CustomAction):
+    action = 'host_delete'
+    resource = 'bulk'
+
+    @property
+    def options_endpoint(self):
+        return self.page.endpoint + '{}/'.format(self.action)
+
+    def add_arguments(self, parser, resource_options_parser):
+        options = self.page.connection.options(self.options_endpoint)
+        if options.ok:
+            options = options.json()['actions']['POST']
+            resource_options_parser.options['HOSTDELETEPOST'] = options
+            resource_options_parser.build_query_arguments(self.action, 'HOSTDELETEPOST')
+
+    def perform(self, **kwargs):
+        response = self.page.get().host_delete.post(kwargs)
+        return response
+
+
 class ProjectUpdate(Launchable, CustomAction):
     action = 'update'
     resource = 'projects'

--- a/awxkit/awxkit/cli/options.py
+++ b/awxkit/awxkit/cli/options.py
@@ -270,6 +270,12 @@ class ResourceOptionsParser(object):
                     if k == 'hosts':
                         kwargs['type'] = list_of_json_or_yaml
                         kwargs['required'] = required = True
+                if method == "host_delete":
+                    if k == "inventory":
+                        kwargs['required'] = required = True
+                    if k == 'hosts':
+                        kwargs['type'] = 'list_of_ids'
+                        kwargs['required'] = required = True
                 if method == "job_launch":
                     if k == 'jobs':
                         kwargs['type'] = list_of_json_or_yaml

--- a/docs/bulk_api.md
+++ b/docs/bulk_api.md
@@ -3,6 +3,7 @@
 Bulk API endpoints allows to perform bulk operations in single web request. There are currently following bulk api actions:
 - /api/v2/bulk/job_launch
 - /api/v2/bulk/host_create
+- /api/v2/bulk/host_delete
 
 Making individual API calls in rapid succession or at high concurrency can overwhelm AWX's ability to serve web requests. When the application's ability to serve is exausted, clients often receive 504 timeout errors.
 
@@ -85,7 +86,7 @@ Regular users can only see the individual workflow jobs that were launched by th
 
 ## Bulk Host Create
 
-Provides feature in the API that allows a single web request to create multiple hosts in an inventory.  
+Provides feature in the API that allows a single web request to create multiple hosts in an inventory.
 
 Following is an example of a post request at the /api/v2/bulk/host_create:
 
@@ -99,3 +100,20 @@ Following is an example of a post request at the /api/v2/bulk/host_create:
 The above will add 6 hosts in the inventory.
 
 The maximum number of hosts allowed to be added is controlled by the setting `BULK_HOST_MAX_CREATE`. The default is 100 hosts. Additionally, nginx limits the maximum payload size, which is very likely when posting a large number of hosts in one request with variable data associated with them. The maximum payload size is 1MB unless overridden in your nginx config.
+
+## Bulk Host Delete
+
+Provides feature in the API that allows a single web request to delete multiple hosts from an inventory.
+
+Following is an example of a post request at the /api/v2/bulk/host_create:
+
+
+    {
+        "inventory": 1,
+        "hosts": [3, 4, 5, 6, 7 ,8, 9, 10]
+    }
+
+
+The above will delete 8 hosts from the inventory.
+
+The maximum number of hosts allowed to be deleted is controlled by the setting `BULK_HOST_MAX_DELETE`. The default is 250 hosts. Additionally, nginx limits the maximum payload size, which is very likely when posting a large number of hosts in one request with variable data associated with them. The maximum payload size is 1MB unless overridden in your nginx config.

--- a/docs/bulk_api.md
+++ b/docs/bulk_api.md
@@ -105,11 +105,10 @@ The maximum number of hosts allowed to be added is controlled by the setting `BU
 
 Provides feature in the API that allows a single web request to delete multiple hosts from an inventory.
 
-Following is an example of a post request at the /api/v2/bulk/host_create:
+Following is an example of a post request at the /api/v2/bulk/host_delete:
 
 
     {
-        "inventory": 1,
         "hosts": [3, 4, 5, 6, 7 ,8, 9, 10]
     }
 

--- a/docs/docsite/rst/administration/index.rst
+++ b/docs/docsite/rst/administration/index.rst
@@ -1,10 +1,22 @@
 .. _ag_start:
 
-==================
-AWX Administration
-==================
+=============================
+Administering AWX Deployments
+=============================
 
-AWX Administration
+Learn how to administer AWX deployments through custom scripts, management jobs, and DevOps workflows.
+This guide assumes at least basic understanding of the systems that you manage and maintain with AWX.
+
+This guide applies to the latest version of AWX only.
+The content in this guide is updated frequently and might contain functionality that is not available in previous versions.
+Likewise content in this guide can be removed or replaced if it applies to functionality that is no longer available in the latest version.
+
+**Join us online**
+
+We talk about AWX documentation on Matrix at `#docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ and on libera IRC at ``#ansible-docs`` if you ever want to join us and chat about the docs!
+
+You can also find lots of AWX discussion and get answers to questions at `forum.ansible.com <https://forum.ansible.com/>`_.
+
 
 .. toctree::
   :maxdepth: 2

--- a/docs/docsite/rst/contributor/index.rst
+++ b/docs/docsite/rst/contributor/index.rst
@@ -1,0 +1,23 @@
+.. _contributor_guide:
+
+=======================
+AWX Contributor's Guide
+=======================
+
+Want to get involved with the AWX community?
+Great!
+There are so many ways you can contribute to AWX.
+
+**Join us online**
+
+You can chat with us and ask questions on Matrix at `#awx:ansible.com <https://matrix.to/#/#awx:ansible.com>`_.
+Also visit the `forum.ansible.com <https://forum.ansible.com/>`_ to find contributor resources.
+
+.. toctree::
+   :maxdepth: 2
+   :numbered:
+
+   intro
+   setting_up
+   work_items
+   report_issues

--- a/docs/docsite/rst/contributor/intro.rst
+++ b/docs/docsite/rst/contributor/intro.rst
@@ -1,0 +1,7 @@
+
+Introduction
+=============
+
+Hi there! We're excited to have you as a contributor.
+
+Have questions about this document or anything not covered here? Come chat with us at `#ansible-awx` on irc.libera.chat, or submit your question to the `mailing list <https://groups.google.com/forum/#!forum/awx-project>`_.

--- a/docs/docsite/rst/contributor/report_issues.rst
+++ b/docs/docsite/rst/contributor/report_issues.rst
@@ -1,0 +1,22 @@
+
+.. _docs_report_issues:
+
+Reporting Issues
+================
+
+To report issues you find in the AWX documentation, use the GitHub [issue tracker](https://github.com/ansible/awx/issues) for filing bugs. In order to save time, and help us respond to issues quickly, make sure to fill out as much of the issue template
+as possible. Version information, and an accurate reproducing scenario are critical to helping us identify the problem.
+
+Be sure to attach the ``component:docs`` label to your issue. These labels are determined by the template data. Please use the template and fill it out as accurately as possible.
+
+Please don't use the issue tracker as a way to ask how to do something. Instead, use the `mailing list <https://groups.google.com/forum/#!forum/awx-project>`_, and the ``#ansible-awx`` channel on irc.libera.chat to get help.
+
+Before opening a new issue, please use the issue search feature to see if what you're experiencing has already been reported. If you have any extra detail to provide, please comment. Otherwise, rather than posting a "me too" comment, please consider giving it a `"thumbs up" <https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comment>`_ to give us an indication of the severity of the problem.
+
+See `How issues are resolved <https://github.com/ansible/awx/blob/devel/ISSUES.md#how-issues-are-resolved>`_ for more information about the triaging and resolution process.
+
+
+Getting help
+-------------
+
+If you require additional assistance, please reach out to us at ``#ansible-awx`` on irc.libera.chat, or submit your question or concern on the `mailing list <https://groups.google.com/forum/#!forum/awx-project>`_, or `Discourse <https://forum.ansible.com/tag/documentation>`_.

--- a/docs/docsite/rst/contributor/setting_up.rst
+++ b/docs/docsite/rst/contributor/setting_up.rst
@@ -1,0 +1,76 @@
+
+Setting up your development environment
+========================================
+
+The AWX docs are developed using the Python toolchain. The content itself is authored in ReStructuredText (rst).
+
+Prerequisites
+---------------
+
+.. contents::
+    :local:
+
+
+Fork and clone the AWX repo
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you have not done so already, you'll need to fork the AWX repo on GitHub. For more on how to do this, see `Fork a Repo <https://help.github.com/articles/fork-a-repo/>`_.
+
+
+Install python and setuptools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Install the setuptools package on Linux using pip:
+
+
+1. If not already installed, `download the latest version of Python3 <https://www.geeksforgeeks.org/how-to-download-and-install-python-latest-version-on-linux/>`_ on your machine.
+
+2. Check if pip3 and python3 are correctly installed in your system using the following command:
+
+::
+
+	python3 --version
+	pip3 --version
+
+3. Upgrade pip3 to the latest version to prevent installation issues:
+
+::
+
+	pip3 install --upgrade pip
+
+4. Install Setuptools:
+
+::
+
+	pip3 install setuptools
+
+5. Verify whether the Setuptools has been properly installed: 
+
+::
+
+	import setuptools
+
+If no errors are returned, then the package was installed properly.
+
+6. Install the tox package so you can build the docs locally:
+
+::
+
+	pip3 install tox
+
+
+
+Run local build of the docs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To build the docs on your local machine, use the tox utility. In your forked branch of your AWX repo, run: 
+
+::
+
+	tox -e docs  
+
+
+Access the AWX user interface
+------------------------------
+
+To access an instance of the AWX interface, refer to `Build and run the development environment <https://github.com/ansible/awx/blob/devel/CONTRIBUTING.md#setting-up-your-development-environment>`_ for detail. Once you have your environment setup, you can access the AWX UI by logging into it at `https://localhost:8043 <https://localhost:8043>`_, and access the API directly at `https://localhost:8043/api/ <https://localhost:8043/api/>`_.

--- a/docs/docsite/rst/contributor/work_items.rst
+++ b/docs/docsite/rst/contributor/work_items.rst
@@ -1,0 +1,46 @@
+
+What should I work on?
+=======================
+
+Good first issue
+-----------------
+
+We have a `"good first issue" label` <https://github.com/ansible/awx/issues?q=is%3Aopen+label%3A%22good+first+issue%22+label%3Acomponent%3Adocs+) we put on some doc issues that might be a good starting point for new contributors with the following filter:
+
+::
+
+	is:open label:"good first issue" label:component:docs 
+
+
+Fixing and updating the documentation are always appreciated, so reviewing the backlog of issues is always a good place to start.
+
+
+Things to know prior to submitting revisions
+----------------------------------------------
+
+- All doc revisions or additions are done through pull requests against the ``devel`` branch.
+- You must use ``git commit --signoff`` for any commit to be merged, and agree that usage of ``--signoff`` constitutes agreement with the terms of `DCO 1.1 <https://github.com/ansible/awx/blob/devel/DCO_1_1.md>`_.
+- Take care to make sure no merge commits are in the submission, and use ``git rebase`` vs ``git merge`` for this reason.
+  - If collaborating with someone else on the same branch, consider using ``--force-with-lease`` instead of ``--force``. This will prevent you from accidentally overwriting commits pushed by someone else. For more information, see `git push docs <https://git-scm.com/docs/git-push#git-push---force-with-leaseltrefnamegt>`_.
+- If submitting a large doc change, it's a good idea to join the ``#ansible-docs`` channel on irc.libera.chat or `Discourse <https://forum.ansible.com/tag/documentation>`_, and talk about what you would like to do or add first. This not only helps everyone know what's going on, it also helps save time and effort, if the community decides some changes are needed.
+- We ask all of our community members and contributors to adhere to the `Ansible code of conduct <http://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_. If you have questions, or need assistance, please reach out to our community team at `codeofconduct@ansible.com <mailto:codeofconduct@ansible.com>`_.
+
+
+**NOTES**
+
+> Issue assignment will only be done for maintainers of the project. If you decide to work on an issue, please feel free to add a comment in the issue to let others know that you are working on it; but know that we will accept the first pull request from whomever is able to fix an issue. Once your PR is accepted we can add you as an assignee to an issue upon request. 
+
+
+> If you work in a part of the docs that is going through active development, your changes may be rejected, or you may be asked to `rebase`. A good idea before starting work is to have a discussion with us in the ``#ansible-awx`` channel on irc.libera.chat, or on the `mailing list <https://groups.google.com/forum/#!forum/awx-project>`_, or `Discourse <https://forum.ansible.com/tag/documentation>`_.
+
+> If you find an issue with the functions of the UI or API, please see the `Reporting Issues <https://github.com/ansible/awx/blob/devel/CONTRIBUTING.md#reporting-issues>`_ section to open an issue. 
+
+> If you find an issue with the docs themselves, refer to :ref:`docs_report_issues`.
+
+
+Translations
+-------------
+
+At this time we do not accept PRs for adding additional language translations as we have an automated process for generating our translations. This is because translations require constant care as new strings are added and changed in the code base. Because of this the .po files are overwritten during every translation release cycle. We also can't support a lot of translations on AWX as its an open source project and each language adds time and cost to maintain. If you would like to see AWX translated into a new language please create an issue and ask others you know to upvote the issue. Our translation team will review the needs of the community and see what they can do around supporting additional language.
+
+If you find an issue with an existing translation, please see the `Reporting Issues <https://github.com/ansible/awx/blob/devel/CONTRIBUTING.md#reporting-issues>`_ section to open an issue and our translation team will work with you on a resolution. 

--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -5,36 +5,37 @@ Ansible AWX helps teams manage complex multi-tier deployments by adding control,
 
 .. toctree::
    :maxdepth: 2
-   :caption: AWX Quickstart
+   :caption: Get started
 
    quickstart/index
 
 .. toctree::
    :maxdepth: 2
-   :caption: User Guide
+   :caption: Community
+
+   contributor/index
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Users
 
    userguide/index
 
 .. toctree::
    :maxdepth: 2
-   :caption: AWX Administration
-
-   administration/index
-
-.. toctree::
-   :maxdepth: 2
-   :caption: AWX REST API
+   :caption: Developers
 
    rest_api/index
 
 .. toctree::
    :maxdepth: 2
-   :caption: Upgrades and Migrations
+   :caption: Administrators
 
+   administration/index
    upgrade_migration/index
 
 .. toctree::
    :maxdepth: 2
-   :caption: Release Notes
+   :caption: Release notes
 
    release_notes/index

--- a/docs/docsite/rst/quickstart/index.rst
+++ b/docs/docsite/rst/quickstart/index.rst
@@ -4,7 +4,17 @@
 AWX Quickstart
 ==============
 
-AWX Quickstart
+Complete the basic steps for using AWX and running your first playbook.
+
+This guide applies to the latest version of AWX only.
+The content in this guide is updated frequently and might contain functionality that is not available in previous versions.
+Likewise content in this guide can be removed or replaced if it applies to functionality that is no longer available in the latest version.
+
+**Join us online**
+
+We talk about AWX documentation on Matrix at `#docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ and on libera IRC at ``#ansible-docs`` if you ever want to join us and chat about the docs!
+
+You can also find lots of AWX discussion and get answers to questions at `forum.ansible.com <https://forum.ansible.com/>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/release_notes/index.rst
+++ b/docs/docsite/rst/release_notes/index.rst
@@ -1,10 +1,20 @@
 .. _releasenotes_start:
 
-=================
-AWX Release Notes
-=================
+=============
+Release Notes
+=============
 
-AWX Release Notes
+AWX release notes, known issues, and related reference materials.
+
+This guide applies to the latest version of AWX only.
+The content in this guide is updated frequently and might contain functionality that is not available in previous versions.
+Likewise content in this guide can be removed or replaced if it applies to functionality that is no longer available in the latest version.
+
+**Join us online**
+
+We talk about AWX documentation on Matrix at `#docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ and on libera IRC at ``#ansible-docs`` if you ever want to join us and chat about the docs!
+
+You can also find lots of AWX discussion and get answers to questions at `forum.ansible.com <https://forum.ansible.com/>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/rest_api/index.rst
+++ b/docs/docsite/rst/rest_api/index.rst
@@ -1,10 +1,20 @@
 .. _api_start:
 
-============
-AWX REST API
-============
+=================
+AWX API Reference
+=================
 
-AWX REST API
+Developer reference for the AWX API.
+
+This guide applies to the latest version of AWX only.
+The content in this guide is updated frequently and might contain functionality that is not available in previous versions.
+Likewise content in this guide can be removed or replaced if it applies to functionality that is no longer available in the latest version.
+
+**Join us online**
+
+We talk about AWX documentation on Matrix at `#docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ and on libera IRC at ``#ansible-docs`` if you ever want to join us and chat about the docs!
+
+You can also find lots of AWX discussion and get answers to questions at `forum.ansible.com <https://forum.ansible.com/>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/upgrade_migration/index.rst
+++ b/docs/docsite/rst/upgrade_migration/index.rst
@@ -1,10 +1,20 @@
 .. _upgrade_migration_start:
 
-=======================================
-Upgrading and Migrating AWX Deployments
-=======================================
+=======================
+Upgrades and Migrations
+=======================
 
-Upgrading and Migrating AWX Deployments
+Review important information before upgrading or migrating AWX deployments.
+
+This guide applies to the latest version of AWX only.
+The content in this guide is updated frequently and might contain functionality that is not available in previous versions.
+Likewise content in this guide can be removed or replaced if it applies to functionality that is no longer available in the latest version.
+
+**Join us online**
+
+We talk about AWX documentation on Matrix at `#docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ and on libera IRC at ``#ansible-docs`` if you ever want to join us and chat about the docs!
+
+You can also find lots of AWX discussion and get answers to questions at `forum.ansible.com <https://forum.ansible.com/>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/docsite/rst/userguide/execution_environments.rst
+++ b/docs/docsite/rst/userguide/execution_environments.rst
@@ -16,88 +16,14 @@ Execution Environments
 Building an Execution Environment
 ---------------------------------
 
-.. index::
-    single: execution environment
-    pair: build; execution environment
-
-
-Using Ansible content that depends on non-default dependencies (custom virtual environments) can be tricky. Packages must be installed on each node, play nicely with other software installed on the host system, and be kept in sync. Previously, jobs ran inside of a virtual environment at ``/var/lib/awx/venv/ansible`` by default, which was pre-loaded with dependencies for ansible-runner and certain types of Ansible content used by the Ansible control machine. 
-
-To help simplify this process, container images can be built that serve as Ansible `control nodes <https://docs.ansible.com/ansible/latest/network/getting_started/basic_concepts.html#control-node>`_. These container images are referred to as automation |ees|, which you can create with ansible-builder and then ansible-runner can make use of those images. 
-
-Install ansible-builder
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-In order to build images, either installations of podman or docker is required along with the ansible-builder Python package. The ``--container-runtime`` option needs to correspond to the Podman/Docker executable you intend to use.
-
-Refer to the latest `Quickstart for Ansible Builder <https://ansible.readthedocs.io/projects/builder/en/latest/#quickstart-for-ansible-builder>`_ for detail.
-
-.. _build_ee:
-
-Build an execution environment
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Ansible-builder is used to create an |ee|. 
-
-An |ee| is expected to contain:
-
-- Ansible
-- Ansible Runner
-- Ansible Collections
-- Python and/or system dependencies of:
-
-  - modules/plugins in collections
-  - content in ansible-base
-  - custom user needs
-
-Building a new |ee| involves a definition (a ``.yml`` file) that specifies which content you would like to include in your |ee|, such as collections, Python requirements, and system-level packages. The content from the output generated from migrating to |ees| has some of the required data that can be piped to a file or pasted into this definition file.
-
-
-Run the builder
-~~~~~~~~~~~~~~~~
-
-Once you created a definition, use this procedure to build your |ee|.
-
-The ``ansible-builder build`` command takes an |ee| definition as an input. It outputs the build context necessary for building an |ee| image, and proceeds with building that image. The image can be re-built with the build context elsewhere, and produces the same result. By default, it looks for a file named ``execution-environment.yml`` in the current directory.
-
-For the illustration purposes, the following example ``execution-environment.yml`` file is used as a starting point:
-
-::
-
-	---
-	version: 3
-	dependencies:
-	  galaxy: requirements.yml
-
-The content of ``requirements.yml``:
-
-::
-
-	---
-	collections:
-	  - name: awx.awx
-
-To build an |ee| using the files above, run:
-
-::	
-
-	$ ansible-builder build
-	...
-	STEP 7: COMMIT my-awx-ee
-	--> 09c930f5f6a
-	09c930f5f6ac329b7ddb321b144a029dbbfcc83bdfc77103968b7f6cdfc7bea2
-	Complete! The build context can be found at: context
-
-In addition to producing a ready-to-use container image, the build context is preserved, which can be rebuilt at a different time and/or location with the tooling of your choice, such as ``docker build`` or ``podman build``.
-
-For additional information about the ``ansible-builder build`` command, refer to Ansible's `CLI Usage <https://ansible.readthedocs.io/projects/builder/en/latest/usage/#cli-usage>`_ documentation.
+The `Getting started with Execution Environments guide` will give you a brief technology overview and show you how to build and test your first |ee| in a few easy steps.
 
 Use an execution environment in jobs
 ------------------------------------
 
 In order to use an |ee| in a job, a few components are required:
 
-- An |ee| must have been created using |ab|. See :ref:`build_ee` for detail. Once an |ee| is created, you can use it to run jobs. Use the AWX user interface to specify the |ee| to use in your job templates.
+- Use the AWX user interface to specify the |ee| you :ref:`build<ug_build_ees>` to use in your job templates.
 
 - Depending on whether an |ee| is made available for global use or tied to an organization, you must have the appropriate level of administrator privileges in order to use an |ee| in a job. |Ees| tied to an organization require Organization administrators to be able to run jobs with those |ees|.
 

--- a/docs/docsite/rst/userguide/index.rst
+++ b/docs/docsite/rst/userguide/index.rst
@@ -1,10 +1,21 @@
 .. _ug_start:
 
-==========
-User Guide
-==========
+===================
+Automating with AWX
+===================
 
-User Guide
+Learn how to use AWX functionality to scale and manage your automation.
+This guide assumes moderate familiarity with Ansible, including concepts such as **Playbooks**, **Variables**, and **Tags**.
+
+This guide applies to the latest version of AWX only.
+The content in this guide is updated frequently and might contain functionality that is not available in previous versions.
+Likewise content in this guide can be removed or replaced if it applies to functionality that is no longer available in the latest version.
+
+**Join us online**
+
+We talk about AWX documentation on Matrix at `#docs:ansible.im <https://matrix.to/#/#docs:ansible.im>`_ and on libera IRC at ``#ansible-docs`` if you ever want to join us and chat about the docs!
+
+You can also find lots of AWX discussion and get answers to questions at `forum.ansible.com <https://forum.ansible.com/>`_.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -169,7 +169,7 @@ Operator hub PRs are generated via an Ansible Playbook. See someone on the AWX t
   * [kustomize](https://kustomize.io/)
   * [opm](https://docs.openshift.com/container-platform/4.9/cli_reference/opm/cli-opm-install.html)
 
-3. Download the script from https://gist.github.com/rooftopcellist/0e232f26666dee45be1d8a69270d63c2 into your awx-operator repo as release_operator_hub.sh
+3. Download the script from https://github.com/ansible/awx-operator/blob/devel/hack/publish-to-operator-hub.sh into your awx-operator repo as release_operator_hub.sh
 
 4. Make sure you are logged into quay.io with `docker login quay.io`
 


### PR DESCRIPTION
##### SUMMARY

This PR present new capability to the API, deleting host from inventory as bulk in one API call instead of deleting them one by one

##### ISSUE TYPE

 - New or Enhanced Feature

##### COMPONENT NAME

 - API

##### ADDITIONAL INFORMATION

- With this change you could delete a bulk of hosts as following:

Post to `/api/v2/bulk/host_delete`
```
{
    "inventory": 1,
    "hosts": [1, 2, 3, 4]
}
```
The above will delete the 4 hosts with id's : 1, 2, 3, 4 from inventory ID 1