### PR TITLE
Stop using the bulky test-playbooks in tests where possible

### DIFF
--- a/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
@@ -34,7 +34,7 @@
         name: "{{ project_name }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: true
 
     - name: Create an Inventory

--- a/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
@@ -26,7 +26,7 @@
         name: "{{ project_name }}"
         organization: "{{ org_name }}"
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: true
 
     - name: Create a git project with same name, different org
@@ -34,7 +34,7 @@
         name: "{{ project_name }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/ansible-tower-samples
+        scm_url: https://github.com/ansible/test-playbooks
         wait: true
 
     - name: Create an Inventory

--- a/awx_collection/tests/integration/targets/project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project/tasks/main.yml
@@ -191,13 +191,13 @@
           - "'Non_Existing_Credential' in result.msg"
           - "result.total_results == 0"
 
-    - name: Create a git project without credentials without waiting
+    - name: Create a git project using a branch and allowing branch override
       project:
         name: "{{ project_name3 }}"
         organization: Default
         scm_type: git
         scm_branch: empty_branch
-        scm_url: https://github.com/ansible/ansible-tower-samples
+        scm_url: https://github.com/ansible/test-playbooks
         allow_override: true
       register: result
 
@@ -211,7 +211,7 @@
         organization: Default
         scm_type: git
         scm_branch: empty_branch
-        scm_url: https://github.com/ansible/ansible-tower-samples
+        scm_url: https://github.com/ansible/test-playbooks
         allow_override: true
         wait: true
         update_project: true

--- a/awx_collection/tests/integration/targets/project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project/tasks/main.yml
@@ -31,7 +31,7 @@
         name: "{{ project_name1 }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: true
       register: result
 
@@ -44,7 +44,7 @@
         name: "{{ project_name1 }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: true
         state: exists
       register: result
@@ -58,7 +58,7 @@
         name: "{{ project_name1 }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: true
         state: exists
         request_timeout: .001
@@ -75,7 +75,7 @@
         name: "{{ project_name1 }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: true
         state: absent
       register: result
@@ -89,7 +89,7 @@
         name: "{{ project_name1 }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: true
         state: exists
       register: result
@@ -103,7 +103,7 @@
         name: "{{ project_name1 }}"
         organization: Default
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         wait: false
       register: result
       ignore_errors: true
@@ -137,7 +137,7 @@
         name: "{{ project_name2 }}"
         organization: "{{ org_name }}"
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         scm_credential: "{{ cred_name }}"
       check_mode: true
 
@@ -162,7 +162,7 @@
         name: "{{ project_name2 }}"
         organization: Non_Existing_Org
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         scm_credential: "{{ cred_name }}"
       register: result
       ignore_errors: true
@@ -179,7 +179,7 @@
         name: "{{ project_name2 }}"
         organization: "{{ org_name }}"
         scm_type: git
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         scm_credential: Non_Existing_Credential
       register: result
       ignore_errors: true
@@ -197,7 +197,7 @@
         organization: Default
         scm_type: git
         scm_branch: empty_branch
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         allow_override: true
       register: result
 
@@ -211,7 +211,7 @@
         organization: Default
         scm_type: git
         scm_branch: empty_branch
-        scm_url: https://github.com/ansible/test-playbooks
+        scm_url: https://github.com/ansible/ansible-tower-samples
         allow_override: true
         wait: true
         update_project: true
@@ -264,7 +264,7 @@
         name: "{{ project_name3 }}"
         organization: Default
         scm_type: archive
-        scm_url: https://github.com/ansible/test-playbooks/archive/refs/tags/1.0.0.tar.gz
+        scm_url: https://github.com/ansible/ansible-tower-samples/archive/refs/tags/1.0.0.tar.gz
         wait: true
         update_project: true
       register: result

--- a/awx_collection/tests/integration/targets/project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project/tasks/main.yml
@@ -264,7 +264,7 @@
         name: "{{ project_name3 }}"
         organization: Default
         scm_type: archive
-        scm_url: https://github.com/ansible/ansible-tower-samples/archive/refs/tags/1.0.0.tar.gz
+        scm_url: https://github.com/ansible/test-playbooks/archive/refs/tags/1.0.0.tar.gz
         wait: true
         update_project: true
       register: result

--- a/awx_collection/tests/integration/targets/project_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project_update/tasks/main.yml
@@ -13,7 +13,7 @@
     name: "{{ project_name1 }}"
     organization: Default
     scm_type: git
-    scm_url: https://github.com/ansible/test-playbooks
+    scm_url: https://github.com/ansible/ansible-tower-samples
     wait: false
   register: project_create_result
 


### PR DESCRIPTION
##### SUMMARY
The test-playbooks repo has 40,000 commits by a webhook bot and these are brought over in the standard kind of clone, so this is trying to move us away from reliance on the test-playbooks and instead using the repo for the Demo Project which is relatively quiet

https://github.com/ansible/ansible-tower-samples

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

