### PR TITLE
Consolidate image and server setup in multiple checks

### DIFF
--- a/.github/actions/awx_ci_setup/action.yml
+++ b/.github/actions/awx_ci_setup/action.yml
@@ -1,0 +1,36 @@
+# This currently *always* uses the "warm build cache" image
+# We should do something to allow forcing a rebuild, probably by looking for
+# some string in the commit message or something.
+
+name: Setup images for AWX
+description: Builds new awx_devel image
+inputs:
+  github-token:
+    description: GitHub Token for registry access
+    required: true
+outputs:
+  ip:
+    description: The IP of the tools_awx_1 container
+    value: ${{ steps.data.outputs.ip }}
+  admin-token:
+    description: OAuth token for admin user
+    value: ${{ steps.data.outputs.admin_token }}
+runs:
+  using: composite
+  steps:
+    - name: Get python version from Makefile
+      shell: bash
+      run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
+
+    - name: Log in to registry
+      shell: bash
+      run: |
+        echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+    - name: Pre-pull latest available devel image and build HEAD on top of it
+      shell: bash
+      run: |
+        docker pull ghcr.io/${{ github.repository_owner }}/awx_devel:${{ github.base_ref }}
+        DEV_DOCKER_TAG_BASE=ghcr.io/${{ github.repository_owner }} \
+        COMPOSE_TAG=${{ github.base_ref }} \
+        make docker-compose-build

--- a/.github/actions/awx_ci_setup/action.yml
+++ b/.github/actions/awx_ci_setup/action.yml
@@ -1,7 +1,3 @@
-# This currently *always* uses the "warm build cache" image
-# We should do something to allow forcing a rebuild, probably by looking for
-# some string in the commit message or something.
-
 name: Setup images for AWX
 description: Builds new awx_devel image
 inputs:
@@ -27,10 +23,13 @@ runs:
       run: |
         echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-    - name: Pre-pull latest available devel image and build HEAD on top of it
+    - name: Pre-pull latest devel image to warm cache
+      shell: bash
+      run: docker pull ghcr.io/${{ github.repository_owner }}/awx_devel:${{ github.base_ref }}
+
+    - name: Build image for current source checkout
       shell: bash
       run: |
-        docker pull ghcr.io/${{ github.repository_owner }}/awx_devel:${{ github.base_ref }}
         DEV_DOCKER_TAG_BASE=ghcr.io/${{ github.repository_owner }} \
         COMPOSE_TAG=${{ github.base_ref }} \
         make docker-compose-build

--- a/.github/actions/awx_devel_image/action.yml
+++ b/.github/actions/awx_devel_image/action.yml
@@ -4,13 +4,6 @@ inputs:
   github-token:
     description: GitHub Token for registry access
     required: true
-outputs:
-  ip:
-    description: The IP of the tools_awx_1 container
-    value: ${{ steps.data.outputs.ip }}
-  admin-token:
-    description: OAuth token for admin user
-    value: ${{ steps.data.outputs.admin_token }}
 runs:
   using: composite
   steps:

--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -1,8 +1,4 @@
-# This currently *always* uses the "warm build cache" image
-# We should do something to allow forcing a rebuild, probably by looking for
-# some string in the commit message or something.
-
-name: Run AWX (devel environment)
+name: Run AWX docker-compose
 description: Runs AWX with `make docker-compose`
 inputs:
   build-ui:

--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -6,6 +6,9 @@ inputs:
     required: false
     default: false
     type: boolean
+  github-token:
+    description: GitHub Token to pass to awx_devel_image
+    required: true
 outputs:
   ip:
     description: The IP of the tools_awx_1 container
@@ -16,6 +19,11 @@ outputs:
 runs:
   using: composite
   steps:
+      - name: Build awx_devel image for running checks
+        uses: ./.github/actions/awx_devel_image
+        with:
+          github-token: ${{ inputs.github-token }}
+
     - name: Upgrade ansible-core
       shell: bash
       run: python3 -m pip install --upgrade ansible-core

--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -19,10 +19,10 @@ outputs:
 runs:
   using: composite
   steps:
-      - name: Build awx_devel image for running checks
-        uses: ./.github/actions/awx_devel_image
-        with:
-          github-token: ${{ inputs.github-token }}
+    - name: Build awx_devel image for running checks
+      uses: ./.github/actions/awx_devel_image
+      with:
+        github-token: ${{ inputs.github-token }}
 
     - name: Upgrade ansible-core
       shell: bash

--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -5,9 +5,6 @@
 name: Run AWX (devel environment)
 description: Runs AWX with `make docker-compose`
 inputs:
-  github-token:
-    description: GitHub Token for registry access
-    required: true
   build-ui:
     description: Should the UI be built?
     required: false
@@ -23,10 +20,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Get python version from Makefile
-      shell: bash
-      run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV
-
     - name: Upgrade ansible-core
       shell: bash
       run: python3 -m pip install --upgrade ansible-core
@@ -34,19 +27,6 @@ runs:
     - name: Install system deps
       shell: bash
       run: sudo apt-get install -y gettext
-
-    - name: Log in to registry
-      shell: bash
-      run: |
-        echo "${{ inputs.github-token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-    - name: Pre-pull latest available devel image and build HEAD on top of it
-      shell: bash
-      run: |
-        docker pull ghcr.io/${{ github.repository_owner }}/awx_devel:${{ github.base_ref }}
-        DEV_DOCKER_TAG_BASE=ghcr.io/${{ github.repository_owner }} \
-        COMPOSE_TAG=${{ github.base_ref }} \
-        make docker-compose-build
 
     - name: Start AWX
       shell: bash

--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -1,14 +1,14 @@
 name: Run AWX docker-compose
 description: Runs AWX with `make docker-compose`
 inputs:
+  github-token:
+    description: GitHub Token to pass to awx_devel_image
+    required: true
   build-ui:
     description: Should the UI be built?
     required: false
     default: false
     type: boolean
-  github-token:
-    description: GitHub Token to pass to awx_devel_image
-    required: true
 outputs:
   ip:
     description: The IP of the tools_awx_1 container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,16 +37,32 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Build awx_devel image for running checks
+        uses: ./.github/actions/awx_ci_setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run check ${{ matrix.tests.name }}
-        run: AWX_DOCKER_CMD='${{ matrix.tests.command }}' make github_ci_runner
+        run: AWX_DOCKER_CMD='${{ matrix.tests.command }}' make docker-runner
 
   dev-env:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
+      - name: Build awx_devel image for running checks
+        uses: ./.github/actions/awx_ci_setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/run_awx_devel
+        id: awx
+        with:
+          build-ui: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run smoke test
-        run: make github_ci_setup && ansible-playbook tools/docker-compose/ansible/smoke-test.yml -v
+        run: ansible-playbook tools/docker-compose/ansible/smoke-test.yml -v
 
   awx-operator:
     runs-on: ubuntu-latest
@@ -130,6 +146,11 @@ jobs:
             regex: ^[r-z0-9]
     steps:
       - uses: actions/checkout@v3
+
+      - name: Build awx_devel image for running checks
+        uses: ./.github/actions/awx_ci_setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: ./.github/actions/run_awx_devel
         id: awx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build awx_devel image for running checks
-        uses: ./.github/actions/awx_ci_setup
+        uses: ./.github/actions/awx_devel_image
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -50,15 +50,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build awx_devel image for running checks
-        uses: ./.github/actions/awx_ci_setup
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: ./.github/actions/run_awx_devel
         id: awx
         with:
           build-ui: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run smoke test
         run: ansible-playbook tools/docker-compose/ansible/smoke-test.yml -v
@@ -146,15 +142,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build awx_devel image for running checks
-        uses: ./.github/actions/awx_ci_setup
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: ./.github/actions/run_awx_devel
         id: awx
         with:
           build-ui: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies for running tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
         id: awx
         with:
           build-ui: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run smoke test
         run: ansible-playbook tools/docker-compose/ansible/smoke-test.yml -v
@@ -156,7 +155,6 @@ jobs:
         id: awx
         with:
           build-ui: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies for running tests
         run: |

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -21,16 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build awx_devel image for running checks
-        uses: ./.github/actions/awx_ci_setup
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: ./.github/actions/run_awx_devel
         id: awx
         with:
           build-ui: true
-          log-filename: e2e-${{ matrix.job }}.log
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Pull awx_cypress_base image
         run: |

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -21,6 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Build awx_devel image for running checks
+        uses: ./.github/actions/awx_ci_setup
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ./.github/actions/run_awx_devel
         id: awx
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -30,7 +30,6 @@ jobs:
         id: awx
         with:
           build-ui: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           log-filename: e2e-${{ matrix.job }}.log
 
       - name: Pull awx_cypress_base image

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ I18N_FLAG_FILE = .i18n_built
 	sdist \
 	ui-release ui-devel \
 	VERSION PYTHON_VERSION docker-compose-sources \
-	.git/hooks/pre-commit github_ci_setup github_ci_runner
+	.git/hooks/pre-commit
 
 clean-tmp:
 	rm -rf tmp/
@@ -324,20 +324,9 @@ test:
 	cd awxkit && $(VENV_BASE)/awx/bin/tox -re py3
 	awx-manage check_migrations --dry-run --check  -n 'missing_migration_file'
 
-## Login to Github container image registry, pull image, then build image.
-github_ci_setup:
-	# GITHUB_ACTOR is automatic github actions env var
-	# CI_GITHUB_TOKEN is defined in .github files
-	echo $(CI_GITHUB_TOKEN) | docker login ghcr.io -u $(GITHUB_ACTOR) --password-stdin
-	docker pull $(DEVEL_IMAGE_NAME) || :  # Pre-pull image to warm build cache
-	$(MAKE) docker-compose-build
-
 ## Runs AWX_DOCKER_CMD inside a new docker container.
 docker-runner:
 	docker run -u $(shell id -u) --rm -v $(shell pwd):/awx_devel/:Z --workdir=/awx_devel $(DEVEL_IMAGE_NAME) $(AWX_DOCKER_CMD)
-
-## Builds image and runs AWX_DOCKER_CMD in it, mainly for .github checks.
-github_ci_runner: github_ci_setup docker-runner
 
 test_collection:
 	rm -f $(shell ls -d $(VENV_BASE)/awx/lib/python* | head -n 1)/no-global-site-packages.txt

--- a/tools/docker-compose/ansible/smoke-test.yml
+++ b/tools/docker-compose/ansible/smoke-test.yml
@@ -11,23 +11,6 @@
 - name: Test that the development environment is able to launch a job
   hosts: localhost
   tasks:
-    - name: Boot the development environment
-      command: |
-        make docker-compose
-      environment:
-        COMPOSE_UP_OPTS: -d
-      args:
-        chdir: "{{ playbook_dir }}/../../../"
-
-    # Takes a while for migrations to finish
-    - name: Wait for the dev environment to be ready
-      uri:
-        url: "http://localhost:8013/api/v2/ping/"
-      register: _result
-      until: _result.status == 200
-      retries: 120
-      delay: 5
-
     - name: Reset admin password
       shell: |
         docker exec -i tools_awx_1 bash <<EOSH


### PR DESCRIPTION
##### SUMMARY
Some time ago, it was me who introduced `make github_ci_setup` and the runner one too. I figure that it is easiest if I am the one to delete it, since we have now seen an independent solution evolve for the same problem, via shared github actions.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

