### PR TITLE
[CI] Include a lint check for the Ansible tasks/roles/playbooks in AWX

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,0 +1,34 @@
+exclude_paths:
+  - .github
+  - .tox
+
+# Failed: 1348 failure(s), 97 warning(s) on 4230 files.
+skip_list:
+  - 'command-instead-of-module'
+  - 'command-instead-of-shell'
+  - 'deprecated-local-action'
+  - 'key-order[task]'
+  - 'jinja[invalid]'
+  - 'jinja[spacing]'
+  - 'schema[tasks]'
+  - 'name[missing]'
+  - 'name[play]'
+  - 'var-naming[no-reserved]'
+  - 'var-naming[pattern]'
+  - 'yaml[document-start]'
+  - 'yaml[empty-lines]'
+  - 'name[template]'
+  - 'name[casing]'
+  - 'risky-file-permissions'
+  - 'risky-shell-pipe'
+  - 'galaxy[no-changelog]'
+  - 'galaxy[version-incorrect]'
+  - 'ignore-errors'
+  - 'no-changed-when'
+  - 'no-handler'
+  - 'sanity[cannot-ignore]'
+  - 'fqcn[action-core]'
+  - 'fqcn[action]'
+  - 'fqcn[canonical]'
+  - 'fqcn[keyword]'
+  - 'args[module]'

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,0 +1,50 @@
+name: Run ansible-lint
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 */8 * * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get remove ansible -y
+        python3 -m pip uninstall ansible ansible-base ansible-core -y
+        python3 -m pip install --upgrade ansible
+        python3 -m pip install --upgrade --ignore-installed PyYAML
+        python3 -m pip install --upgrade pip
+        python3 -m pip install --upgrade virtualenv
+        python3 -m pip install --upgrade setuptools
+        python3 -m pip install --upgrade shyaml
+
+    - name: Build the AWX collection and resolve dependencies
+      run: |
+        cd awx_collection
+        rm -rf awx_collection/releases
+        mkdir -p awx_collection/releases
+
+        # Build and install the collection
+        rm -rf ~/.ansible/collections/ansible_collections/awx/awx
+        ansible-galaxy collection build -vvvvv --force --output-path releases/
+        ansible-galaxy collection install -vvvvv --force --force-with-deps releases/awx-awx-`cat galaxy.yml | shyaml get-value version`.tar.gz
+
+        ansible-galaxy collection install -vvv --force --force-with-deps community.docker:*
+        ansible-galaxy collection install -vvv --force --force-with-deps community.kubernetes:*
+        ansible-galaxy collection install -vvv --force --force-with-deps splunk.es:*
+
+    - name: Set collection paths env
+      run: echo "ANSIBLE_COLLECTIONS_PATHS=$ANSIBLE_COLLECTIONS_PATHS:/home/runner/.ansible/collections/ansible_collections" >> $GITHUB_ENV
+
+    - name: Lint Ansible Playbook
+      uses: ansible/ansible-lint@main
+      with:
+        targets: |
+          playbooks
+          roles
+        args: "-v -c .ansible-lint.yml"

--- a/awx/main/tests/data/ansible_utils/playbooks/valid/foo.yml
+++ b/awx/main/tests/data/ansible_utils/playbooks/valid/foo.yml
@@ -1,0 +1,3 @@
+- name: Foo
+  ansible.builtin.debug:
+    msg: Do nothing

--- a/awx/main/tests/data/ansible_utils/playbooks/valid/import.yml
+++ b/awx/main/tests/data/ansible_utils/playbooks/valid/import.yml
@@ -1,2 +1,2 @@
 ---
-- import_playbook: foo
+- import_playbook: hello_world.yml

--- a/awx/main/tests/data/ansible_utils/playbooks/valid/import_fqcn.yml
+++ b/awx/main/tests/data/ansible_utils/playbooks/valid/import_fqcn.yml
@@ -1,2 +1,2 @@
 ---
-- ansible.builtin.import_playbook: foo
+- ansible.builtin.import_playbook: hello_world.yml

--- a/awx/main/tests/data/ansible_utils/playbooks/valid/include.yml
+++ b/awx/main/tests/data/ansible_utils/playbooks/valid/include.yml
@@ -1,2 +1,2 @@
 ---
-- include: foo
+- include: foo.yml

--- a/awx/main/tests/data/ansible_utils/playbooks/valid/include_fqcn.yml
+++ b/awx/main/tests/data/ansible_utils/playbooks/valid/include_fqcn.yml
@@ -1,2 +1,2 @@
 ---
-- ansible.builtin.include: foo
+- ansible.builtin.include: foo.yml


### PR DESCRIPTION
##### SUMMARY

This commit includes a GitHub actions lint check for the Ansible automation that resides in this repo.

The idea of this commit is to save some time in any e2e job that might fail because an issue that can be prevented with a lint check.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other (Ansible playbooks/roles/tasks)

##### AWX VERSION
NA