### PR TITLE
AAP-15927 Use ATTACH PARTITION to avoid exclusive table lock for events

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1172,10 +1172,7 @@ def create_partition(tblname, start=None):
                             return
 
                 cursor.execute(
-                    f'CREATE TABLE {tblname}_{partition_label} '
-                    f'(LIKE {tblname} INCLUDING DEFAULTS INCLUDING CONSTRAINTS); '
-                    f'ALTER TABLE {tblname}_{partition_label} ADD CONSTRAINT y{partition_label} '
-                    f'CHECK ( job_created >= TIMESTAMP \'{start_timestamp}\' AND job_created < TIMESTAMP \'{end_timestamp}\' ); '
+                    f'CREATE TABLE {tblname}_{partition_label} (LIKE {tblname} INCLUDING DEFAULTS INCLUDING CONSTRAINTS); '
                     f'ALTER TABLE {tblname} ATTACH PARTITION {tblname}_{partition_label} '
                     f'FOR VALUES FROM (\'{start_timestamp}\') TO (\'{end_timestamp}\'); '
                 )

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -23,7 +23,7 @@ from django.core.exceptions import ObjectDoesNotExist, FieldDoesNotExist
 from django.utils.dateparse import parse_datetime
 from django.utils.translation import gettext_lazy as _
 from django.utils.functional import cached_property
-from django.db import connection, transaction, ProgrammingError
+from django.db import connection, transaction, ProgrammingError, IntegrityError
 from django.db.models.fields.related import ForeignObjectRel, ManyToManyField
 from django.db.models.fields.related_descriptors import ForwardManyToOneDescriptor, ManyToManyDescriptor
 from django.db.models.query import QuerySet
@@ -1176,7 +1176,7 @@ def create_partition(tblname, start=None):
                     f'ALTER TABLE {tblname} ATTACH PARTITION {tblname}_{partition_label} '
                     f'FOR VALUES FROM (\'{start_timestamp}\') TO (\'{end_timestamp}\');'
                 )
-    except ProgrammingError as e:
+    except (ProgrammingError, IntegrityError) as e:
         if 'already exists' in str(e):
             logger.info(f'Caught known error due to partition creation race: {e}')
         else:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1164,10 +1164,20 @@ def create_partition(tblname, start=None):
     try:
         with transaction.atomic():
             with connection.cursor() as cursor:
+                r_tuples = cursor.execute(f"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '{tblname}_{partition_label}');")
+                for row in r_tuples:  # should only have 1
+                    for val in row:  # should only have 1
+                        if val is True:
+                            logger.debug(f'Event partition table {tblname}_{partition_label} already exists')
+                            return
+
                 cursor.execute(
-                    f'CREATE TABLE IF NOT EXISTS {tblname}_{partition_label} '
-                    f'PARTITION OF {tblname} '
-                    f'FOR VALUES FROM (\'{start_timestamp}\') to (\'{end_timestamp}\');'
+                    f'CREATE TABLE {tblname}_{partition_label} '
+                    f'(LIKE {tblname} INCLUDING DEFAULTS INCLUDING CONSTRAINTS); '
+                    f'ALTER TABLE {tblname}_{partition_label} ADD CONSTRAINT y{partition_label} '
+                    f'CHECK ( job_created >= TIMESTAMP \'{start_timestamp}\' AND job_created < TIMESTAMP \'{end_timestamp}\' ); '
+                    f'ALTER TABLE {tblname} ATTACH PARTITION {tblname}_{partition_label} '
+                    f'FOR VALUES FROM (\'{start_timestamp}\') TO (\'{end_timestamp}\'); '
                 )
     except ProgrammingError as e:
         logger.debug(f'Caught known error due to existing partition: {e}')

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1174,7 +1174,7 @@ def create_partition(tblname, start=None):
                 cursor.execute(
                     f'CREATE TABLE {tblname}_{partition_label} (LIKE {tblname} INCLUDING DEFAULTS INCLUDING CONSTRAINTS); '
                     f'ALTER TABLE {tblname} ATTACH PARTITION {tblname}_{partition_label} '
-                    f'FOR VALUES FROM (\'{start_timestamp}\') TO (\'{end_timestamp}\'); '
+                    f'FOR VALUES FROM (\'{start_timestamp}\') TO (\'{end_timestamp}\');'
                 )
     except ProgrammingError as e:
         logger.debug(f'Caught known error due to existing partition: {e}')

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1177,7 +1177,10 @@ def create_partition(tblname, start=None):
                     f'FOR VALUES FROM (\'{start_timestamp}\') TO (\'{end_timestamp}\');'
                 )
     except ProgrammingError as e:
-        logger.debug(f'Caught known error due to existing partition: {e}')
+        if 'already exists' in str(e):
+            logger.info(f'Caught known error due to partition creation race: {e}')
+        else:
+            raise
 
 
 def cleanup_new_process(func):


### PR DESCRIPTION
##### SUMMARY
This parrots the example from postgresql docs

https://www.postgresql.org/docs/current/ddl-partitioning.html

Specifically, see the example:

```sql
CREATE TABLE measurement_y2008m02
  (LIKE measurement INCLUDING DEFAULTS INCLUDING CONSTRAINTS)
  TABLESPACE fasttablespace;

ALTER TABLE measurement_y2008m02 ADD CONSTRAINT y2008m02
   CHECK ( logdate >= DATE '2008-02-01' AND logdate < DATE '2008-03-01' );

\copy measurement_y2008m02 from 'measurement_y2008m02'
-- possibly some other data preparation work

ALTER TABLE measurement ATTACH PARTITION measurement_y2008m02
    FOR VALUES FROM ('2008-02-01') TO ('2008-03-01' );
```

This just replaces our current SQL for creating a partition with this example, editing the details to use the tables names and timestamps that we use.

Right now this is working, in that new jobs will create a partition and that goes fine.

I did add a new bit of code to this to pre-check for existence of the partition. Letting it error in postgres created a lot of log noise that we've found very distracting in the past so I wanted to go ahead and take care of this, particularly since I'm running a new version of our SQL code. I do think we should remove our existing error handling since I added this, so expect a new commit to do that.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
I'm not yet sure if we need this part:

```python
                    f'ALTER TABLE {tblname}_{partition_label} ADD CONSTRAINT y{partition_label} '
                    f'CHECK ( job_created >= TIMESTAMP \'{start_timestamp}\' AND job_created < TIMESTAMP \'{end_timestamp}\' ); '
```

Because historically, the old method did not create this constraint. So I think we could just delete these lines, but including it is more compliant to the docs so I wanted to start with this.
