### PR TITLE
Continue workflow steps to save logs from failed tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ env:
   COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
 jobs:
   common-tests:
     name: ${{ matrix.tests.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ env:
   COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
 jobs:
   common-tests:
     name: ${{ matrix.tests.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,9 @@ jobs:
   collection-integration:
     name: awx_collection integration
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
-      continue-on-error: true
       matrix:
         target-regex:
           - name: a-h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # need to continue-on-error to save docker-compose logs if error happened
+      continue-on-error: true
       matrix:
         target-regex:
           - name: a-h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      # need to continue-on-error to save docker-compose logs if error happened
       continue-on-error: true
       matrix:
         target-regex:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -15,7 +15,6 @@ jobs:
       packages: write
       contents: read
     strategy:
-      # need to continue-on-error to save docker-compose logs if error happened
       continue-on-error: true
       matrix:
         job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -15,7 +15,6 @@ jobs:
       packages: write
       contents: read
     strategy:
-      continue-on-error: true
       matrix:
         job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
 

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -15,6 +15,8 @@ jobs:
       packages: write
       contents: read
     strategy:
+      # need to continue-on-error to save docker-compose logs if error happened
+      continue-on-error: true
       matrix:
         job: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24]
 


### PR DESCRIPTION
##### SUMMARY
I have a concrete example to walk through for this:

https://github.com/ansible/awx/actions/runs/6179711351/job/16775071648?pr=14428

Tests failed for this PR https://github.com/ansible/awx/pull/14428 on the collection tests, even though it kind of obviously didn't change anything about the collection or that could affect the collection.

So we go into the output to debug:

https://pipelinesghubeus4.actions.githubusercontent.com/EHTyFpFf7vgn28ks3aoOdCFaNUumzGeJlLAwUH5fYzJPKOVSD4/_apis/pipelines/1/runs/25476/signedlogcontent/8?urlExpires=2023-09-14T13%3A41%3A50.4005093Z&urlSigningMethod=HMACV1&urlSignature=YAPlPGIzUlo20OdtEcEp0g2mMkmWLKs04Wb8qqGx9BA%3D

We find that it failed on a group create, because related host didn't exist. Okay, check task that created the host, :heavy_check_mark: , but now we have the name of the host. Since it's so hard to explain, we can use the name of this host to get all _requests_ that used it in the query string.

For this we need the docker-compose logs. So go to github artifacts. We have logs for all checks _except the ones that failed_. Why?

Because when it failed a step in the workflow, it cancels all steps after that, which looks like it's due to this continue-on-error option.

So we need to set this so that when the checks failed we can get the logs.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

