### PR TITLE
Remove conditional paths due to conflict with required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ env:
   COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
 on:
   pull_request:
-    paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
 jobs:
   common-tests:
     name: ${{ matrix.tests.name }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,6 @@
 name: Docsite CI
 on:
   pull_request:
-    paths:
-      - 'docs/**'
-      - '.github/workflows/docs.yml'
 jobs:
   docsite-build:
     name: docsite test build


### PR DESCRIPTION
##### SUMMARY
This can cause checks to not report which is a problem because they're required. This is a known thing with github actions. It looked like a good idea, but it was not.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

