### PR TITLE
Move the continue-on-error marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,6 @@ jobs:
   collection-integration:
     name: awx_collection integration
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -147,6 +146,7 @@ jobs:
           python3 -m pip install -r awx_collection/requirements.txt
 
       - name: Run integration tests
+        continue-on-error: true
         run: |
           echo "::remove-matcher owner=python::"  # Disable annoying annotations from setup-python
           echo '[general]' > ~/.tower_cli.cfg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,7 @@ jobs:
           path: ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage/
 
       - uses: ./.github/actions/upload_awx_devel_logs
+        if: always()
         with:
           log-filename: collection-integration-${{ matrix.target-regex.name }}.log
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,6 @@ jobs:
           python3 -m pip install -r awx_collection/requirements.txt
 
       - name: Run integration tests
-        continue-on-error: true
         run: |
           echo "::remove-matcher owner=python::"  # Disable annoying annotations from setup-python
           echo '[general]' > ~/.tower_cli.cfg
@@ -160,6 +159,7 @@ jobs:
 
       # Upload coverage report as artifact
       - uses: actions/upload-artifact@v3
+        if: always()
         with:
           name: coverage-${{ matrix.target-regex.name }}
           path: ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage/

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -71,5 +71,6 @@ jobs:
           awx-pf-tests run --project .
 
       - uses: ./.github/actions/upload_awx_devel_logs
+        if: always()
         with:
           log-filename: e2e-${{ matrix.job }}.log


### PR DESCRIPTION
##### SUMMARY
I am trying to read the tea leaves of 

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions

accurately.

My last patch where I added this originally did not work. Artifacts are still not getting saved for failed checks.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

