### PR TITLE
Get rid of names_digest hack no longer needed

### DIFF
--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -53,7 +53,12 @@ except ImportError:  # pragma: no cover
     MODE = 'production'
 
 
-from django.db import connection
+try:
+    import django  # noqa: F401
+except ImportError:
+    pass
+else:
+    from django.db import connection
 
 
 def find_commands(management_dir):

--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -52,38 +52,8 @@ try:
 except ImportError:  # pragma: no cover
     MODE = 'production'
 
-import hashlib
 
-try:
-    import django  # noqa: F401
-
-    HAS_DJANGO = True
-except ImportError:
-    HAS_DJANGO = False
-else:
-    from django.db.backends.base import schema
-    from django.db.models import indexes
-    from django.db.backends.utils import names_digest
-    from django.db import connection
-
-if HAS_DJANGO is True:
-    # See upgrade blocker note in requirements/README.md
-    try:
-        names_digest('foo', 'bar', 'baz', length=8)
-    except ValueError:
-
-        def names_digest(*args, length):
-            """
-            Generate a 32-bit digest of a set of arguments that can be used to shorten
-            identifying names.  Support for use in FIPS environments.
-            """
-            h = hashlib.md5(usedforsecurity=False)
-            for arg in args:
-                h.update(arg.encode())
-            return h.hexdigest()[:length]
-
-        schema.names_digest = names_digest
-        indexes.names_digest = names_digest
+from django.db import connection
 
 
 def find_commands(management_dir):

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -59,13 +59,8 @@ for instructions.
 
 If operating in a FIPS environment, `hashlib.md5()` will raise a `ValueError`,
 but will support the `usedforsecurity` keyword on RHEL and Centos systems.
-
-Keep an eye on https://code.djangoproject.com/ticket/28401
-
-The override of `names_digest` could easily be broken in a future version.
-Check that the import remains the same in the desired version.
-
-https://github.com/django/django/blob/af5ec222ccd24e81f9fec6c34836a4e503e7ccf7/django/db/backends/base/schema.py#L7
+This used to be a problem with `names_digest` function in Django, but
+was fixed upstream in Django 4.1.
 
 ### django-split-settings
 
@@ -172,4 +167,3 @@ available on PyPi with source distribution.
 
 Version 4.8 makes us a little bit nervous with changes to `searchwindowsize` https://github.com/pexpect/pexpect/pull/579/files
 Pin to `pexpect==4.7.x` until we have more time to move to `4.8` and test.
-


### PR DESCRIPTION
##### SUMMARY
We were waiting for upstream to handle this, and they did!

https://github.com/django/django/commit/d10c7bfe56f025ccc690721c9f13e7029b777b9c

Needs FIPS testing.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

