### PR TITLE
Fix bug, None was used instead of empty for DB outage

### DIFF
--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -418,6 +418,10 @@ class SettingsWrapper(UserSettingsHolder):
         """Get value while accepting the in-memory cache if key is available"""
         with _ctit_db_wrapper(trans_safe=True):
             return self._get_local(name)
+        # If the last line did not return, that means we hit a database error
+        # in that case, we should not have a local cache value
+        # thus, return empty as a signal to use the default
+        return empty
 
     def __getattr__(self, name):
         value = empty


### PR DESCRIPTION
##### SUMMARY
It looks like something changed with the Django upgrade such that they do more referencing of settings in the startup order (probably because Django settings are canonically cached now)

This resulted in a list-valued setting with a default of `[]` returning `None` due to a surprising oversight in our error-catching wrapper.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

