### PR TITLE
Fix bug that prevented dispatcher exit with downed DB

### DIFF
--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -16,7 +16,9 @@ class SignalExit(Exception):
 class SignalState:
     def reset(self):
         self.sigterm_flag = False
-        self.is_active = False
+        self.sigint_flag = False
+
+        self.is_active = False  # for nested context managers
         self.original_sigterm = None
         self.original_sigint = None
         self.raise_exception = False
@@ -24,30 +26,36 @@ class SignalState:
     def __init__(self):
         self.reset()
 
-    def set_flag(self, *args):
-        """Method to pass into the python signal.signal method to receive signals"""
-        self.sigterm_flag = True
+    def raise_if_needed(self):
         if self.raise_exception:
             self.raise_exception = False  # so it is not raised a second time in error handling
             raise SignalExit()
 
+    def set_sigterm_flag(self, *args):
+        self.sigterm_flag = True
+        self.raise_if_needed()
+
+    def set_sigint_flag(self, *args):
+        self.sigint_flag = True
+        self.raise_if_needed()
+
     def connect_signals(self):
         self.original_sigterm = signal.getsignal(signal.SIGTERM)
         self.original_sigint = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGTERM, self.set_flag)
-        signal.signal(signal.SIGINT, self.set_flag)
+        signal.signal(signal.SIGTERM, self.set_sigterm_flag)
+        signal.signal(signal.SIGINT, self.set_sigint_flag)
         self.is_active = True
 
     def restore_signals(self):
         signal.signal(signal.SIGTERM, self.original_sigterm)
         signal.signal(signal.SIGINT, self.original_sigint)
-        # if we got a SIGTERM while our signal handling was active, call parent methods.
+        # if we got a signal while context manager was active, call parent methods.
         if self.sigterm_flag:
             if callable(self.original_sigterm):
                 self.original_sigterm()
-            if self.original_sigterm is not self.original_sigint:
-                if callable(self.original_sigint):
-                    self.original_sigint()
+        if self.sigint_flag:
+            if callable(self.original_sigint):
+                self.original_sigint()
         self.reset()
 
 
@@ -55,7 +63,7 @@ signal_state = SignalState()
 
 
 def signal_callback():
-    return signal_state.sigterm_flag
+    return bool(signal_state.sigterm_flag or signal_state.sigint_flag)
 
 
 def with_signal_handling(f):

--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -41,6 +41,13 @@ class SignalState:
     def restore_signals(self):
         signal.signal(signal.SIGTERM, self.original_sigterm)
         signal.signal(signal.SIGINT, self.original_sigint)
+        # if we got a SIGTERM while our signal handling was active, call parent methods.
+        if self.sigterm_flag:
+            if callable(self.original_sigterm):
+                self.original_sigterm()
+            if self.original_sigterm is not self.original_sigint:
+                if callable(self.original_sigint):
+                    self.original_sigint()
         self.reset()
 
 

--- a/awx/main/tests/unit/tasks/test_signals.py
+++ b/awx/main/tests/unit/tasks/test_signals.py
@@ -1,14 +1,17 @@
 import signal
-from contextlib import contextmanager
+import functools
 
 from awx.main.tasks.signals import signal_state, signal_callback, with_signal_handling
 
 
-def do_nothing():
-    do_nothing.called_count += 1
+def pytest_sigint():
+    pytest_sigint.called_count += 1
 
 
-@contextmanager
+def pytest_sigterm():
+    pytest_sigterm.called_count += 1
+
+
 def tmp_signals_for_test(func):
     """
     When we run our internal signal handlers, it will call the original signal
@@ -19,12 +22,14 @@ def tmp_signals_for_test(func):
     with new signal handlers that do nothing so that tests do not crash.
     """
 
+    @functools.wraps(func)
     def wrapper():
         original_sigterm = signal.getsignal(signal.SIGTERM)
         original_sigint = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGTERM, do_nothing)
-        signal.signal(signal.SIGINT, do_nothing)
-        do_nothing.called_count = 0
+        signal.signal(signal.SIGTERM, pytest_sigterm)
+        signal.signal(signal.SIGINT, pytest_sigint)
+        pytest_sigterm.called_count = 0
+        pytest_sigint.called_count = 0
         func()
         signal.signal(signal.SIGTERM, original_sigterm)
         signal.signal(signal.SIGINT, original_sigint)
@@ -45,17 +50,19 @@ def test_outer_inner_signal_handling():
     @with_signal_handling
     def f1():
         assert signal_callback() is False
-        signal_state.set_flag()
+        signal_state.set_sigterm_flag()
         assert signal_callback()
         f2()
 
     original_sigterm = signal.getsignal(signal.SIGTERM)
     assert signal_callback() is False
-    assert do_nothing.called_count == 0
+    assert pytest_sigterm.called_count == 0
+    assert pytest_sigint.called_count == 0
     f1()
     assert signal_callback() is False
     assert signal.getsignal(signal.SIGTERM) is original_sigterm
-    assert do_nothing.called_count == 1
+    assert pytest_sigterm.called_count == 1
+    assert pytest_sigint.called_count == 0
 
 
 @tmp_signals_for_test
@@ -67,7 +74,7 @@ def test_inner_outer_signal_handling():
     @with_signal_handling
     def f2():
         assert signal_callback() is False
-        signal_state.set_flag()
+        signal_state.set_sigint_flag()
         assert signal_callback()
 
     @with_signal_handling
@@ -78,8 +85,10 @@ def test_inner_outer_signal_handling():
 
     original_sigterm = signal.getsignal(signal.SIGTERM)
     assert signal_callback() is False
-    assert do_nothing.called_count == 0
+    assert pytest_sigterm.called_count == 0
+    assert pytest_sigint.called_count == 0
     f1()
     assert signal_callback() is False
     assert signal.getsignal(signal.SIGTERM) is original_sigterm
-    assert do_nothing.called_count == 1
+    assert pytest_sigterm.called_count == 0
+    assert pytest_sigint.called_count == 1

--- a/awx/main/tests/unit/tasks/test_signals.py
+++ b/awx/main/tests/unit/tasks/test_signals.py
@@ -1,8 +1,38 @@
 import signal
+from contextlib import contextmanager
 
 from awx.main.tasks.signals import signal_state, signal_callback, with_signal_handling
 
 
+def do_nothing():
+    do_nothing.called_count += 1
+
+
+@contextmanager
+def tmp_signals_for_test(func):
+    """
+    When we run our internal signal handlers, it will call the original signal
+    handlers when its own work is finished.
+    This would crash the test runners normally, because those methods will
+    shut down the process.
+    So this is a decorator to safely replace existing signal handlers
+    with new signal handlers that do nothing so that tests do not crash.
+    """
+
+    def wrapper():
+        original_sigterm = signal.getsignal(signal.SIGTERM)
+        original_sigint = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGTERM, do_nothing)
+        signal.signal(signal.SIGINT, do_nothing)
+        do_nothing.called_count = 0
+        func()
+        signal.signal(signal.SIGTERM, original_sigterm)
+        signal.signal(signal.SIGINT, original_sigint)
+
+    return wrapper
+
+
+@tmp_signals_for_test
 def test_outer_inner_signal_handling():
     """
     Even if the flag is set in the outer context, its value should persist in the inner context
@@ -21,11 +51,14 @@ def test_outer_inner_signal_handling():
 
     original_sigterm = signal.getsignal(signal.SIGTERM)
     assert signal_callback() is False
+    assert do_nothing.called_count == 0
     f1()
     assert signal_callback() is False
     assert signal.getsignal(signal.SIGTERM) is original_sigterm
+    assert do_nothing.called_count == 1
 
 
+@tmp_signals_for_test
 def test_inner_outer_signal_handling():
     """
     Even if the flag is set in the inner context, its value should persist in the outer context
@@ -45,6 +78,8 @@ def test_inner_outer_signal_handling():
 
     original_sigterm = signal.getsignal(signal.SIGTERM)
     assert signal_callback() is False
+    assert do_nothing.called_count == 0
     f1()
     assert signal_callback() is False
     assert signal.getsignal(signal.SIGTERM) is original_sigterm
+    assert do_nothing.called_count == 1


### PR DESCRIPTION
##### SUMMARY
We have an issue where we the dispatcher would go down during the middle of the job, and this left the entire service in a deadlock in the end.

Previously, we did a bunch of stuff to prevent the dispatcher service from exiting if the database went out temporarily (default tolerance set to 40). We also moved to a new job canceling system which would tell it to cancel via a SIGTERM signal.

The problem is what happens when we _exceed_ that 40 second threshold while a job is running. In that case:
 - the parent process correctly measures that it has been >40 seconds since the database went away, and... not being able to read anything from `pg_notify`, decides it will exit
 - the multiprocessing library correctly forwards the exit signal onto child processes, including the control process which is still active for a running job
 - the control process correctly processes the signal and terminates the job over receptor
 - the _problem_ comes after the job finishes, since the control process over-rides the signal handler of the normal worker loop, the kill flag got set **for the control process** but not **for the worker main read loop** and because of that the worker continues to read for new work from its parent forever, which then deadlocks, because the parent is waiting for the worker to exit.

So in summary, we have 2 layers of signal processing, and the inner layer was misbehaving in that it did not call that parent process signal handling method. This adds calls to do that.

Testing, I was able to see the dispatcher exit with this patch applied.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

