### PR TITLE
Use ldap container hostname for LDAP config

### DIFF
--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -442,13 +442,11 @@ Now we are ready to configure and plumb OpenLDAP with AWX. To do this we have pr
 
 Note: The default configuration will utilize the non-tls connection. If you want to use the tls configuration you will need to work through TLS negotiation issues because the LDAP server is using a self signed certificate.
 
-Before we can run the playbook we need to understand that LDAP will be communicated to from within the AWX container. Because of this, we have to tell AWX how to route traffic to the LDAP container through the `LDAP Server URI` settings. The playbook requires a variable called container_reference to be set. The container_reference variable needs to be how your AWX container will be able to talk to the LDAP container. See the SAML section for some examples for how to select a `container_reference`.
-
-Once you have your container reference you can run the playbook like:
+You can run the playbook like:
 ```bash
 export CONTROLLER_USERNAME=<your username>
 export CONTROLLER_PASSWORD=<your password>
-ansible-playbook tools/docker-compose/ansible/plumb_ldap.yml -e container_reference=<your container_reference here>
+ansible-playbook tools/docker-compose/ansible/plumb_ldap.yml
 ```
 
 

--- a/tools/docker-compose/ansible/templates/ldap_settings.json.j2
+++ b/tools/docker-compose/ansible/templates/ldap_settings.json.j2
@@ -1,5 +1,5 @@
 {
-    "AUTH_LDAP_1_SERVER_URI": "ldap://{{ container_reference }}:389",
+    "AUTH_LDAP_1_SERVER_URI": "ldap://ldap:1389",
     "AUTH_LDAP_1_BIND_DN": "cn=admin,dc=example,dc=org",
     "AUTH_LDAP_1_BIND_PASSWORD": "admin",
     "AUTH_LDAP_1_START_TLS": false,


### PR DESCRIPTION
##### SUMMARY
Since the tools_awx_1 and tools_ldap_1 is in the same network with hostname configured they can address each other by hostname

NOTE: port changed from host port 389 to ldap container port 1389

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.1.1.dev13+g851899de85.d20230920
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
