### PR TITLE
Add YAML tab for Job Output event modal.

### DIFF
--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.js
@@ -3,6 +3,7 @@ import { Modal, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 import { t } from '@lingui/macro';
 import { encode } from 'html-entities';
+import { jsonToYaml } from 'util/yaml';
 import StatusLabel from '../../../components/StatusLabel';
 import { DetailList, Detail } from '../../../components/DetailList';
 import ContentEmpty from '../../../components/ContentEmpty';
@@ -144,9 +145,28 @@ function HostEventModal({ onClose, hostEvent = {}, isOpen = false }) {
             <ContentEmpty title={t`No JSON Available`} />
           )}
         </Tab>
+        <Tab
+          eventKey={2}
+          title={<TabTitleText>{t`YAML`}</TabTitleText>}
+          aria-label={t`YAML tab`}
+          ouiaId="yaml-tab"
+        >
+          {activeTabKey === 2 && jsonObj ? (
+            <CodeEditor
+              mode="javascript"
+              readOnly
+              value={jsonToYaml(JSON.stringify(jsonObj))}
+              onChange={() => {}}
+              rows={20}
+              hasErrors={false}
+            />
+          ) : (
+            <ContentEmpty title={t`No YAML Available`} />
+          )}
+        </Tab>
         {stdOut?.length ? (
           <Tab
-            eventKey={2}
+            eventKey={3}
             title={<TabTitleText>{t`Output`}</TabTitleText>}
             aria-label={t`Output tab`}
             ouiaId="standard-out-tab"
@@ -163,7 +183,7 @@ function HostEventModal({ onClose, hostEvent = {}, isOpen = false }) {
         ) : null}
         {stdErr?.length ? (
           <Tab
-            eventKey={3}
+            eventKey={4}
             title={<TabTitleText>{t`Standard Error`}</TabTitleText>}
             aria-label={t`Standard error tab`}
             ouiaId="standard-error-tab"

--- a/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
+++ b/awx/ui/src/screens/Job/JobOutput/HostEventModal.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { mountWithContexts } from '../../../../testUtils/enzymeHelpers';
 import HostEventModal from './HostEventModal';
+import { jsonToYaml } from 'util/yaml';
 
 const hostEvent = {
   changed: true,
@@ -167,6 +168,8 @@ const jsonValue = `{
   ]
 }`;
 
+const yamlValue = jsonToYaml(jsonValue);
+
 describe('HostEventModal', () => {
   test('initially renders successfully', () => {
     const wrapper = shallow(
@@ -187,7 +190,7 @@ describe('HostEventModal', () => {
       <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
 
-    expect(wrapper.find('Tabs Tab').length).toEqual(4);
+    expect(wrapper.find('Tabs Tab').length).toEqual(5);
   });
 
   test('should initially show details tab', () => {
@@ -287,7 +290,7 @@ describe('HostEventModal', () => {
     expect(codeEditor.prop('value')).toEqual(jsonValue);
   });
 
-  test('should display Standard Out tab content on tab click', () => {
+  test('should display YAML tab content on tab click', () => {
     const wrapper = shallow(
       <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
     );
@@ -297,6 +300,21 @@ describe('HostEventModal', () => {
     wrapper.update();
 
     const codeEditor = wrapper.find('Tab[eventKey=2] CodeEditor');
+    expect(codeEditor.prop('mode')).toBe('javascript');
+    expect(codeEditor.prop('readOnly')).toBe(true);
+    expect(codeEditor.prop('value')).toEqual(yamlValue);
+  });
+
+  test('should display Standard Out tab content on tab click', () => {
+    const wrapper = shallow(
+      <HostEventModal hostEvent={hostEvent} onClose={() => {}} isOpen />
+    );
+
+    const handleTabClick = wrapper.find('Tabs').prop('onSelect');
+    handleTabClick(null, 3);
+    wrapper.update();
+
+    const codeEditor = wrapper.find('Tab[eventKey=3] CodeEditor');
     expect(codeEditor.prop('mode')).toBe('javascript');
     expect(codeEditor.prop('readOnly')).toBe(true);
     expect(codeEditor.prop('value')).toEqual(hostEvent.event_data.res.stdout);
@@ -316,10 +334,10 @@ describe('HostEventModal', () => {
     );
 
     const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    handleTabClick(null, 3);
+    handleTabClick(null, 4);
     wrapper.update();
 
-    const codeEditor = wrapper.find('Tab[eventKey=3] CodeEditor');
+    const codeEditor = wrapper.find('Tab[eventKey=4] CodeEditor');
     expect(codeEditor.prop('mode')).toBe('javascript');
     expect(codeEditor.prop('readOnly')).toBe(true);
     expect(codeEditor.prop('value')).toEqual('error content');
@@ -351,10 +369,10 @@ describe('HostEventModal', () => {
     );
 
     const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    handleTabClick(null, 2);
+    handleTabClick(null, 3);
     wrapper.update();
 
-    const codeEditor = wrapper.find('Tab[eventKey=2] CodeEditor');
+    const codeEditor = wrapper.find('Tab[eventKey=3] CodeEditor');
     expect(codeEditor.prop('mode')).toBe('javascript');
     expect(codeEditor.prop('readOnly')).toBe(true);
     expect(codeEditor.prop('value')).toEqual('foo bar');
@@ -375,10 +393,10 @@ describe('HostEventModal', () => {
     );
 
     const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    handleTabClick(null, 2);
+    handleTabClick(null, 3);
     wrapper.update();
 
-    const codeEditor = wrapper.find('Tab[eventKey=2] CodeEditor');
+    const codeEditor = wrapper.find('Tab[eventKey=3] CodeEditor');
     expect(codeEditor.prop('mode')).toBe('javascript');
     expect(codeEditor.prop('readOnly')).toBe(true);
     expect(codeEditor.prop('value')).toEqual('baz\nbar');
@@ -394,10 +412,10 @@ describe('HostEventModal', () => {
     );
 
     const handleTabClick = wrapper.find('Tabs').prop('onSelect');
-    handleTabClick(null, 2);
+    handleTabClick(null, 3);
     wrapper.update();
 
-    const codeEditor = wrapper.find('Tab[eventKey=2] CodeEditor');
+    const codeEditor = wrapper.find('Tab[eventKey=3] CodeEditor');
     expect(codeEditor.prop('mode')).toBe('javascript');
     expect(codeEditor.prop('readOnly')).toBe(true);
     expect(codeEditor.prop('value')).toEqual(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add ability to view job result entries as YAML. This addition provides users the ability to view an entry as if it was the YAML stdout callback and is easier to read.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Minor UI update

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.1.1.dev17+ga9336d82b6
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# After
1. View a specific Jobs log.
2. Click on any `task` output.
3. Click the YAML tab and view in YAML format.
```

Below is a screenshot of the YAML tab being selected after clicking on a task result within a job:
<img width="623" alt="image" src="https://github.com/ansible/awx/assets/29315002/b9258b48-5596-4d3b-9006-b34c09bc0cf4">
