### PR TITLE
Add null value handling in create_partition

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1164,7 +1164,8 @@ def create_partition(tblname, start=None):
     try:
         with transaction.atomic():
             with connection.cursor() as cursor:
-                row = cursor.execute(f"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '{tblname}_{partition_label}');").fetchone()
+                cursor.execute(f"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '{tblname}_{partition_label}');")
+                row = cursor.fetchone()
                 if row is not None:
                     for val in row:  # should only have 1
                         if val is True:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1164,8 +1164,8 @@ def create_partition(tblname, start=None):
     try:
         with transaction.atomic():
             with connection.cursor() as cursor:
-                r_tuples = cursor.execute(f"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '{tblname}_{partition_label}');")
-                for row in r_tuples:  # should only have 1
+                row = cursor.execute(f"SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = '{tblname}_{partition_label}');").fetchone()
+                if row is not None:
                     for val in row:  # should only have 1
                         if val is True:
                             logger.debug(f'Event partition table {tblname}_{partition_label} already exists')


### PR DESCRIPTION
##### SUMMARY
Fix on top of https://github.com/ansible/awx/pull/14433

I believe this may be version-dependent, but I thought I should adopt some of the just-in-case checking I saw in this code:

https://github.com/ansible/awx/blob/9ed527eb26820caa2a8a18e93cf396e345f3c679/awx/sso/migrations/0003_convert_saml_string_to_list.py#L10-L13

And in any case, we rarely directly process the result from `cursor.execute()`, so I don't want this very critical code to be the exception.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 
