### PR TITLE
Execution environment image should not be required

### DIFF
--- a/awx_collection/plugins/modules/execution_environment.py
+++ b/awx_collection/plugins/modules/execution_environment.py
@@ -33,7 +33,6 @@ options:
     image:
       description:
         - The fully qualified url of the container image.
-      required: True
       type: str
     description:
       description:
@@ -79,7 +78,7 @@ def main():
     argument_spec = dict(
         name=dict(required=True),
         new_name=dict(),
-        image=dict(required=True),
+        image=dict(),
         description=dict(),
         organization=dict(),
         credential=dict(),


### PR DESCRIPTION
##### SUMMARY
Remove requirement from image parameter as it's not always needed (e.g. when state is absent or updating an existing execution environment)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 22.1.1.dev353+g6c4c8df3f8
`