### PR TITLE
fix: make type conversions work correctly (related #14487)

### DIFF
--- a/awx_collection/plugins/modules/settings.py
+++ b/awx_collection/plugins/modules/settings.py
@@ -89,7 +89,7 @@ def coerce_type(module, value):
         if not HAS_YAML:
             module.fail_json(msg="yaml is not installed, try 'pip install pyyaml'")
         return yaml.safe_load(value)
-    elif value.lower in ('true', 'false', 't', 'f'):
+    elif value.lower() in ('true', 'false', 't', 'f'):
         return {'t': True, 'f': False}[value[0].lower()]
     try:
         return int(value)

--- a/awx_collection/tests/integration/targets/settings/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/settings/tasks/main.yml
@@ -1,4 +1,42 @@
 ---
+- name: Initialize starting project vvv setting to false
+  awx.awx.settings:
+    name: "PROJECT_UPDATE_VVV"
+    value: false
+
+- name: Change project vvv setting to true
+  awx.awx.settings:
+    name: "PROJECT_UPDATE_VVV"
+    value: true
+  register: result
+
+- name: Changing setting to true should have changed the value
+  assert:
+    that:
+      - "result is changed"
+
+- name: Change project vvv setting to true
+  awx.awx.settings:
+    name: "PROJECT_UPDATE_VVV"
+    value: true
+  register: result
+
+- name: Changing setting to true again should not change the value
+  assert:
+    that:
+      - "result is not changed"
+
+- name: Change project vvv setting back to false
+  awx.awx.settings:
+    name: "PROJECT_UPDATE_VVV"
+    value: false
+  register: result
+
+- name: Changing setting back to false should have changed the value
+  assert:
+    that:
+      - "result is changed"
+
 - name: Set the value of AWX_ISOLATION_SHOW_PATHS to a baseline
   settings:
     name: AWX_ISOLATION_SHOW_PATHS


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Closes #14487

Fix the casting issue that string type value to boolean does not work.
In the current implementation, any value that should be determined as boolean do not determined as boolean.

This causes passing `true`/`false` using `value` field breaks idempotency.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.2.1.dev6+gcb62aac217
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The issue came from the method that convert strings to boolean:

https://github.com/ansible/awx/blob/15925f14165aa297f64d799678c457ae17540979/awx_collection/plugins/modules/settings.py#L92-L93

`value.lower in ('true', 'false', 't', 'f')` never be `true` since `.lower` returns method itself. `.lower()` should be used instead.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ python
...
>>> "HOGE".lower
<built-in method lower of str object at 0x7f46df2b8330>

>>> "HOGE".lower()
'hoge'

>>> "TRUE".lower in ('true', 'false', 't', 'f')
False

>>> "TRUE".lower() in ('true', 'false', 't', 'f')
True
```
