### PR TITLE
Fix Boolean values defaulting to False in collection

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -980,12 +980,14 @@ class ControllerAPIModule(ControllerModule):
     def create_or_update_if_needed(
         self, existing_item, new_item, endpoint=None, item_type='unknown', on_create=None, on_update=None, auto_exit=True, associations=None
     ):
-        # Remove null values - this assumes there are no nullable fields with non-null defaults
-        # the None value is used to indicate not-provided by Ansible and argparse
+        # Remove boolean values of certain specific types
         # this is needed so that boolean fields will not get a false value when not provided
         for key in list(new_item.keys()):
-            if new_item[key] is None:
-                new_item.pop(key)
+            if key in self.argument_spec:
+                param_spec = self.argument_spec[key]
+                if 'type' in param_spec and param_spec['type'] == 'bool':
+                    if new_item[key] is None:
+                        new_item.pop(key)
 
         if existing_item:
             return self.update_if_needed(existing_item, new_item, on_update=on_update, auto_exit=auto_exit, associations=associations)

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -809,6 +809,13 @@ class ControllerAPIModule(ControllerModule):
             # We will pull the item_name out from the new_item, if it exists
             item_name = self.get_item_name(new_item, allow_unknown=True)
 
+            # Remove null values - this assumes there are no nullable fields with non-null defaults
+            # the None value is used to indicate not-provided by Ansible and argparse
+            # this is needed so that boolean fields will not get a false value when not provided
+            for key in list(new_item.keys()):
+                if new_item[key] is None:
+                    new_item.pop(key)
+
             response = self.post_endpoint(endpoint, **{'data': new_item})
 
             # 200 is response from approval node creation on tower 3.7.3 or awx 15.0.0 or earlier.

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -809,13 +809,6 @@ class ControllerAPIModule(ControllerModule):
             # We will pull the item_name out from the new_item, if it exists
             item_name = self.get_item_name(new_item, allow_unknown=True)
 
-            # Remove null values - this assumes there are no nullable fields with non-null defaults
-            # the None value is used to indicate not-provided by Ansible and argparse
-            # this is needed so that boolean fields will not get a false value when not provided
-            for key in list(new_item.keys()):
-                if new_item[key] is None:
-                    new_item.pop(key)
-
             response = self.post_endpoint(endpoint, **{'data': new_item})
 
             # 200 is response from approval node creation on tower 3.7.3 or awx 15.0.0 or earlier.
@@ -987,6 +980,13 @@ class ControllerAPIModule(ControllerModule):
     def create_or_update_if_needed(
         self, existing_item, new_item, endpoint=None, item_type='unknown', on_create=None, on_update=None, auto_exit=True, associations=None
     ):
+        # Remove null values - this assumes there are no nullable fields with non-null defaults
+        # the None value is used to indicate not-provided by Ansible and argparse
+        # this is needed so that boolean fields will not get a false value when not provided
+        for key in list(new_item.keys()):
+            if new_item[key] is None:
+                new_item.pop(key)
+
         if existing_item:
             return self.update_if_needed(existing_item, new_item, on_update=on_update, auto_exit=auto_exit, associations=associations)
         else:

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -362,7 +362,7 @@ def main():
         'timeout',
     ):
         field_val = module.params.get(field_name)
-        if field_val:
+        if field_val is not None:
             new_fields[field_name] = field_val
 
     association_fields = {}

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -362,7 +362,7 @@ def main():
         'timeout',
     ):
         field_val = module.params.get(field_name)
-        if field_val is not None:
+        if field_val:
             new_fields[field_name] = field_val
 
     association_fields = {}

--- a/awx_collection/tests/integration/targets/host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/host/tasks/main.yml
@@ -68,6 +68,11 @@
     that:
       - "result is changed"
 
+- name: Newly created host should have API default value for enabled
+  assert:
+    that:
+      - "lookup('awx.awx.controller_api', 'hosts/{{result.id}}/').enabled"
+
 - name: Delete a Host
   host:
     name: "{{ result.id }}"

--- a/awx_collection/tests/integration/targets/host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/host/tasks/main.yml
@@ -78,10 +78,14 @@
     that:
       - "result is changed"
 
+- name: Use lookup to check that host was enabled
+  ansible.builtin.set_fact:
+    host_enabled_test: "lookup('awx.awx.controller_api', 'hosts/{{result.id}}/').enabled"
+
 - name: Newly created host should have API default value for enabled
   assert:
     that:
-      - "lookup('awx.awx.controller_api', 'hosts/{{result.id}}/').enabled"
+      - host_enabled_test
 
 - name: Delete a Host
   host:

--- a/awx_collection/tests/integration/targets/host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/host/tasks/main.yml
@@ -42,6 +42,16 @@
     that:
       - "result is not changed"
 
+- name: Modify the host as a no-op
+  host:
+    name: "{{ host_name }}"
+    inventory: "{{ inv_name }}"
+  register: result
+
+- assert:
+    that:
+      - "result is not changed"
+
 - name: Delete a Host
   host:
     name: "{{ host_name }}"

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -76,6 +76,15 @@
         that:
           - result is changed
 
+    - name: Use lookup to check that schedules was enabled
+      ansible.builtin.set_fact:
+        schedules_enabled_test: "lookup('awx.awx.controller_api', 'schedules/{{result.id}}/').enabled"
+
+    - name: Newly created schedules should have API default value for enabled
+      assert:
+        that:
+          - schedules_enabled_test
+
     - name: Build a real schedule with exists
       schedule:
         name: "{{ sched1 }}"


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/14461

Execution of the proposal

> I propose to remove all None values from the data in the method create_if_needed. By modifying the behavior of that method, it will not affect updates, and thus not prevent someone from changing a value from non-null to null. That may be valid in rare cases.

I can confirm the new assertion here fails in devel without this patch.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

