### PR TITLE
Fix collection test flake due to successful canceled command

### DIFF
--- a/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
@@ -106,15 +106,11 @@
   register: wait_results
   ignore_errors: true
 
-- name: debug ad hoc command output if failed
-  debug:
-    msg: "{{ lookup('awx.awx.controller_api', 'ad_hoc_commands/' + command.id | string + '/stdout/?format=json') }}"
-  when:
-    - 'wait_results.status not in ["successful", "canceled"]'
-
 - assert:
     that:
       - 'wait_results.status in ["successful", "canceled"]'
+    fail_msg: "Ad hoc command stdout: {{ lookup('awx.awx.controller_api', 'ad_hoc_commands/' + command.id | string + '/stdout/?format=json') }}"
+    success_msg: "Ad hoc command finished with status {{ wait_results.status }}"
 
 - name: Delete the Credential
   credential:

--- a/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
@@ -106,10 +106,15 @@
   register: wait_results
   ignore_errors: true
 
+- name: debug ad hoc command output if failed
+  debug:
+    msg: "{{ lookup('awx.awx.controller_api', 'ad_hoc_commands/' + command.id | string + '/stdout/?format=json') }}"
+  when:
+    - 'wait_results.status not in ["successful", "canceled"]'
+
 - assert:
     that:
-      - wait_results is successful
-      - 'wait_results.status == "successful"'
+      - 'wait_results.status in ["successful", "canceled"]'
 
 - name: Delete the Credential
   credential:


### PR DESCRIPTION
##### SUMMARY
This took some frustration to get to the root of.

```yaml
- name: Wait for the command to exit on cancel
  ad_hoc_command_wait:
    command_id: "{{ command.id }}"
  register: wait_results
  ignore_errors: true

- assert:
    that:
      - wait_results is successful
      - 'wait_results.status == "successful"'
 ```

Think about that for a second. The job (ad hoc command) is canceled, and it's status is successful... how did this _ever_ pass?

It appears to be a race condition where our cancel logic is so slow that the command _completed_ before the cancel took effect. If it ever too too long to dispatch the command (or something like that) the test would fail. Looks extremely hardware-specific.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

