### PR TITLE
Only block commits if black fails for certain paths

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [ -z $AWX_IGNORE_BLACK ] ; then
-	python_files_changed=$(git diff --cached --name-only --diff-filter=AM | grep -E '\.py$')
+	python_files_changed=$(git diff --cached --name-only --diff-filter=AM awx/ awxkit/ tools/ | grep -E '\.py$')
 	if [ "x$python_files_changed" != "x" ] ; then
         	black --check $python_files_changed || \
 		if [ $? != 0 ] ; then


### PR DESCRIPTION
##### SUMMARY
Connect https://github.com/ansible/awx/issues/13241

This solution isn't "perfect". It doesn't reuse the ignore list in `pyproject.toml`, but this would be very hard to make work with the overall structure we have. I don't want to let the best be the enemy of the good, and this seems pretty good to me. This doesn't change how the checks work, and I don't foresee any problems with it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
