### PR TITLE
Update setting_up.rst

### DIFF
--- a/docs/docsite/rst/contributor/setting_up.rst
+++ b/docs/docsite/rst/contributor/setting_up.rst
@@ -48,7 +48,7 @@ Install the setuptools package on Linux using pip:
 
 ::
 
-	import setuptools
+	python3 -c 'import setuptools'
 
 If no errors are returned, then the package was installed properly.
 


### PR DESCRIPTION
Just running through the dev setup docs like a monkey banging on the keyboard and thought the user might not know to run `python3` before checking if setuptools is importable.

Bug, Docs Fix or other nominal change