### PR TITLE
fix(sec): upgrade gitpython to 3.1.35

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -155,7 +155,7 @@ frozenlist==1.3.3
     #   aiosignal
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.32
+gitpython==3.1.35
     # via -r /awx_devel/requirements/requirements.in
 google-auth==2.14.1
     # via kubernetes


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in gitpython 3.1.32
- [CVE-2023-41040](https://www.oscs1024.com/hd/CVE-2023-41040)


### What did I do？
Upgrade gitpython from 3.1.32 to 3.1.35 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS