### PR TITLE
Cleaning SOS report passwords

### DIFF
--- a/tools/sosreport/controller.py
+++ b/tools/sosreport/controller.py
@@ -74,3 +74,24 @@ class Controller(Plugin, RedHatPlugin):
             self.add_forbidden_path(path)
 
         self.add_cmd_output(SOSREPORT_CONTROLLER_COMMANDS)
+
+    def postproc(self):
+        # remove database password
+        jreg = r"(\s*\'PASSWORD\'\s*:(\s))(?:\"){1,}(.+)(?:\"){1,}"
+        repl = r"\1********"
+        self.do_path_regex_sub("/etc/tower/conf.d/postgres.py", jreg, repl)
+
+        # remove email password
+        jreg = r"(EMAIL_HOST_PASSWORD\s*=)\'(.+)\'"
+        repl = r"\1********"
+        self.do_path_regex_sub("/etc/tower/settings.py", jreg, repl)
+
+        # remove email password (if customized)
+        jreg = r"(EMAIL_HOST_PASSWORD\s*=)\'(.+)\'"
+        repl = r"\1********"
+        self.do_path_regex_sub("/etc/tower/conf.d/custom.py", jreg, repl)
+
+        # remove websocket secret
+        jreg = r"(BROADCAST_WEBSOCKET_SECRET\s*=\s*)\"(.+)\""
+        repl = r"\1********"
+        self.do_path_regex_sub("/etc/tower/conf.d/channels.py", jreg, repl)


### PR DESCRIPTION
##### SUMMARY
Clean SOS report passwords:
- database password from `/etc/tower/conf.d/postgres.py`
- e-mail password from `/etc/tower/settings.py` and (if existent) `/etc/tower/conf.d/custom.py`
- broadcast websocket secret from `/etc/tower/conf.d/channels.py`

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
```
[steffen@lab-development-rhel8 awx]$ make VERSION
awx: 0.1.dev33573+g3905f35
```


##### ADDITIONAL INFORMATION
All values will be replaced with `********`, see below example:

```
[root@lab-aap2-controller1 tmp]# grep PASSWORD sosreport-lab-aap2-controller1-2023-10-09-onqntnc/etc/tower/conf.d/postgres.py 
       'PASSWORD': ********,
[root@lab-aap2-controller1 tmp]#
```