### PR TITLE
Debug Web Requests (AWX_REQUEST_PROFILE) Dockerfile support

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -270,6 +270,7 @@ RUN for dir in \
       /var/lib/awx/venv/awx/lib/python3.9/site-packages \
       /var/lib/awx/projects \
       /var/lib/awx/rsyslog \
+      /var/log/tower \
       /var/run/awx-rsyslog \
       /.ansible \
       /var/lib/shared/overlay-images \
@@ -292,6 +293,8 @@ RUN for dir in \
 
 {% if not build_dev|bool %}
 RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stdout /var/log/tower/profile && \
+    ln -sf /dev/stdout /var/log/tower/timing && \
     ln -sf /dev/stderr /var/log/nginx/error.log
 {% endif %}
 


### PR DESCRIPTION
##### SUMMARY

Ensure /var/log/tower gets created in the Dockerfile and symlink 'profile' and 'timing' to stdout

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

AWX throws a HTTP 500 errors when Web Debug (AWX_REQUEST_PROFILE) is enabled and /var/log/tower doesn't exist. See https://github.com/ansible/awx-operator/issues/1485

/var/log/tower was removed from the Dockerfile in 6d11003, however this is still referenced in awx/main/middleware.py and awx/main/utils/profiling.py

After enabling AWX_REQUEST_PROFILE ("Debug Web Requests" in UI) AWX UI and API return HTTP 500 errors, due to /var/log/tower missing and /var/log not being writable by the 'awx' user (see trace below)

##### COMPONENT NAME
- Dockerfile

##### AWX VERSION
[v23.2.0](awx: 0.1.dev33573+g5170105)


##### ADDITIONAL INFORMATION

AWX becomes unusable (HTTP 500) if you enable "Debug Web Requests" in the UI, which is not ideal. 

```
2023-07-05 17:38:48,380 ERROR    [32432794aa9d4d098ec0d6a7e2fdd987] django.request Internal Server Error: / Traceback (most recent call last): File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/core/handlers/exception.py", line 55, in inner response = get_response(request) File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/utils/deprecation.py", line 136, in __call__ response = self.process_response(request, response) File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/middleware.py", line 58, in process_response response['X-API-Profile-File'] = self.prof.stop() File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/profiling.py", line 129, in stop res = self.output_results() File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/profiling.py", line 90, in output_results super().output_results() File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/profiling.py", line 22, in output_results os.makedirs(self.dest) File "/usr/lib64/python3.9/os.py", line 215, in makedirs makedirs(head, exist_ok=exist_ok) File "/usr/lib64/python3.9/os.py", line 225, in makedirs mkdir(name, mode) PermissionError: [Errno 13] Permission denied: '/var/log/tower' 
```