### PR TITLE
Fix CVE-2023-43665

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -49,19 +49,6 @@ Make sure to delete the old tarball if it is an upgrade.
 Anything pinned in `*.in` files involves additional manual work in
 order to upgrade. Some information related to that work is outlined here.
 
-### Django
-
-For any upgrade of Django, it must be confirmed that
-we don't regress on FIPS support before merging.
-
-See internal integration test knowledge base article `how_to_test_FIPS`
-for instructions.
-
-If operating in a FIPS environment, `hashlib.md5()` will raise a `ValueError`,
-but will support the `usedforsecurity` keyword on RHEL and Centos systems.
-This used to be a problem with `names_digest` function in Django, but
-was fixed upstream in Django 4.1.
-
 ### django-split-settings
 
 When we attemed to upgrade past 1.0.0 the build process in GitHub failed on the docker build step with the following error:

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -12,7 +12,7 @@ cryptography>=41.0.2  # CVE-2023-38325
 Cython<3 # Since the bump to PyYAML 5.4.1 this is now a mandatory dep
 daphne
 distro
-django==4.2.5  # see UPGRADE BLOCKERs, CVE-2023-41164
+django==4.2.6  # CVE-2023-43665
 django-auth-ldap
 django-cors-headers
 django-crum

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -103,7 +103,7 @@ deprecated==1.2.13
     # via jwcrypto
 distro==1.8.0
     # via -r /awx_devel/requirements/requirements.in
-django==4.2.5
+django==4.2.6
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels


### PR DESCRIPTION
##### SUMMARY
https://access.redhat.com/security/cve/cve-2023-43665

require upgrade testing due to https://github.com/django/django/pull/17295

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.2.1.dev22+gded0783bba
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
