### PR TITLE
Make wait-for-migrations wait forever

### DIFF
--- a/tools/ansible/roles/dockerfile/files/wait-for-migrations
+++ b/tools/ansible/roles/dockerfile/files/wait-for-migrations
@@ -7,7 +7,6 @@ readonly CMDNAME=$(basename "$0")
 
 readonly MIN_SLEEP=0.5
 readonly MAX_SLEEP=30
-readonly ATTEMPTS=30
 readonly TIMEOUT=60
 
 log_message() { echo "[${CMDNAME}]" "$@" >&2; }
@@ -25,7 +24,7 @@ wait_for() {
     local check=1
 
     while true; do
-        log_message "Attempt ${attempt} of ${ATTEMPTS}"
+        log_message "Attempt ${attempt}"
 
         timeout "${TIMEOUT}" \
                 /bin/bash -c "awx-manage check" &>/dev/null
@@ -37,8 +36,7 @@ wait_for() {
                 && return || rc=$?
         fi
 
-        (( ++attempt > ATTEMPTS )) && break
-
+        attempt=$((attempt + 1))
         log_message "Waiting ${next_sleep} seconds before next attempt"
         sleep "${next_sleep}"
         next_sleep=$(next_sleep ${next_sleep})


### PR DESCRIPTION
##### SUMMARY
fixes https://github.com/ansible/awx/issues/14314

Removing retry attempt for waiting for db migration to complete 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.3.1.dev6+g1f341c1fb4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
