### PR TITLE
Format constructed inventory hint example as valid YAML

### DIFF
--- a/awx/ui/src/screens/Inventory/shared/ConstructedInventoryHint.js
+++ b/awx/ui/src/screens/Inventory/shared/ConstructedInventoryHint.js
@@ -302,9 +302,9 @@ function HostsByProcessorTypeExample() {
 
   const hostsByProcessorLimit = `intel_hosts`;
   const hostsByProcessorSourceVars = `plugin: constructed
-  strict: true
-  groups:
-    intel_hosts: "GenuineIntel" in ansible_processor`;
+strict: true
+groups:
+  intel_hosts: "'GenuineIntel' in ansible_processor"`;
 
   return (
     <FormFieldGroupExpandable

--- a/awx/ui/src/screens/Inventory/shared/ConstructedInventoryHint.test.js
+++ b/awx/ui/src/screens/Inventory/shared/ConstructedInventoryHint.test.js
@@ -45,7 +45,7 @@ describe('<ConstructedInventoryHint />', () => {
     );
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
       expect.stringContaining(
-        'intel_hosts: "GenuineIntel" in ansible_processor'
+        `intel_hosts: \"'GenuineIntel' in ansible_processor\"`
       )
     );
   });


### PR DESCRIPTION
##### SUMMARY
Fix invalid YAML in constructed inventory "Hosts by processor type" copy/paste example. 

![hint](https://github.com/ansible/awx/assets/15881645/95555d0b-2d5c-444a-a746-a227492606ed)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

