### PR TITLE
Fix "upgrade in progress" status page not showing up while migration is in progress

### DIFF
--- a/tools/ansible/roles/dockerfile/files/launch_awx_web.sh
+++ b/tools/ansible/roles/dockerfile/files/launch_awx_web.sh
@@ -15,6 +15,4 @@ fi
 
 set -e
 
-wait-for-migrations
-
 exec supervisord -c /etc/supervisord_web.conf


### PR DESCRIPTION
##### SUMMARY
Web container does not need to wait for migration

if the database is running and responsive, but migrations have not finished, it will start serving, and users will get the upgrading page

wait-for-migration prevent nginix and uwsgi from starting up to serve the "upgrade in progress" status page


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.3.1.dev10+g0007872186
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
