### PR TITLE
Set subscription type as developer for developer subscriptions.

### DIFF
--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -324,7 +324,9 @@ class Licenser(object):
     def generate_license_options_from_entitlements(self, json):
         from dateutil.parser import parse
 
-        ValidSub = collections.namedtuple('ValidSub', 'sku name support_level end_date trial developer_license quantity pool_id satellite subscription_id account_number usage')
+        ValidSub = collections.namedtuple(
+            'ValidSub', 'sku name support_level end_date trial developer_license quantity pool_id satellite subscription_id account_number usage'
+        )
         valid_subs = []
         for sub in json:
             satellite = sub.get('satellite')
@@ -371,7 +373,20 @@ class Licenser(object):
                             developer_license = True
 
                 valid_subs.append(
-                    ValidSub(sku, sub['productName'], support_level, end_date, trial, developer_license, quantity, pool_id, satellite, subscription_id, account_number, usage)
+                    ValidSub(
+                        sku,
+                        sub['productName'],
+                        support_level,
+                        end_date,
+                        trial,
+                        developer_license,
+                        quantity,
+                        pool_id,
+                        satellite,
+                        subscription_id,
+                        account_number,
+                        usage,
+                    )
                 )
 
         if valid_subs:

--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -199,6 +199,8 @@ class Licenser(object):
                     license['support_level'] = attr.get('value')
                 elif attr.get('name') == 'usage':
                     license['usage'] = attr.get('value')
+                elif attr.get('name') == 'ph_product_name' and attr.get('value') == 'RHEL Developer':
+                    license['license_type'] == 'developer'
 
         if not license:
             logger.error("No valid subscriptions found in manifest")

--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -200,7 +200,7 @@ class Licenser(object):
                 elif attr.get('name') == 'usage':
                     license['usage'] = attr.get('value')
                 elif attr.get('name') == 'ph_product_name' and attr.get('value') == 'RHEL Developer':
-                    license['license_type'] == 'developer'
+                    license['license_type'] = 'developer'
 
         if not license:
             logger.error("No valid subscriptions found in manifest")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The subscription type in AAP controller is enterprise by default except trial SKUs. It seems not that appropriate to show enterprise for developer subscriptions.
This PR aims to set subscription type as developer for developer subscriptions.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
23.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Active subscriptions that match this criteria: RH00798, RH2262474, RH2262474F3.
As per current aggregation rules, these subscriptions could not be aggregated with any other applicable subscriptions, so no need to consider which subscription type to set when someone upload a manifest with both the aforementioned developer subscriptions and other Ansible subscriptions.

<!--- Paste verbatim command output below, e.g. before and after your change -->

