### PR TITLE
Fix extra_vars bug in ansible.controller.ad_hoc_command

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3763,10 +3763,6 @@ class AdHocCommandList(ListCreateAPIView):
                 data = dict(passwords_needed_to_start=needed)
                 return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
-        # Convert OrderedDict to JSON string
-        if request.data.get('extra_vars'):
-            request.data['extra_vars'] = json.dumps(request.data['extra_vars'])
-
         response = super(AdHocCommandList, self).create(request, *args, **kwargs)
         if response.status_code != status.HTTP_201_CREATED:
             return response

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -12,7 +12,6 @@ import requests
 import socket
 import sys
 import time
-import json
 from base64 import b64encode
 from collections import OrderedDict
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3765,6 +3765,8 @@ class AdHocCommandList(ListCreateAPIView):
 
         # Convert OrderedDict to JSON string
         request.data['extra_vars'] = json.dumps(request.data['extra_vars'])
+        if request.data.get('extra_vars'):
+            request.data['extra_vars'] = json.dumps(request.data['extra_vars'])
 
         response = super(AdHocCommandList, self).create(request, *args, **kwargs)
         if response.status_code != status.HTTP_201_CREATED:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -3764,7 +3764,6 @@ class AdHocCommandList(ListCreateAPIView):
                 return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
         # Convert OrderedDict to JSON string
-        request.data['extra_vars'] = json.dumps(request.data['extra_vars'])
         if request.data.get('extra_vars'):
             request.data['extra_vars'] = json.dumps(request.data['extra_vars'])
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -12,6 +12,7 @@ import requests
 import socket
 import sys
 import time
+import json
 from base64 import b64encode
 from collections import OrderedDict
 
@@ -3761,6 +3762,9 @@ class AdHocCommandList(ListCreateAPIView):
             if not all(provided.values()):
                 data = dict(passwords_needed_to_start=needed)
                 return Response(data, status=status.HTTP_400_BAD_REQUEST)
+
+        # Convert OrderedDict to JSON string
+        request.data['extra_vars'] = json.dumps(request.data['extra_vars'])
 
         response = super(AdHocCommandList, self).create(request, *args, **kwargs)
         if response.status_code != status.HTTP_201_CREATED:

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -6,6 +6,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+import json
 
 __metaclass__ = type
 
@@ -161,7 +162,11 @@ def main():
     }
     for arg in ['job_type', 'limit', 'forks', 'verbosity', 'extra_vars', 'become_enabled', 'diff_mode']:
         if module.params.get(arg):
-            post_data[arg] = module.params.get(arg)
+            # extra_var can receive a dict or a string, if a dict covert it to a string
+            if arg == 'extra_vars' and type(module.params.get(arg)) is not str:
+                post_data[arg] = json.dumps(module.params.get(arg))
+            else:
+                post_data[arg] = module.params.get(arg)
 
     # Attempt to look up the related items the user specified (these will fail the module if not found)
     post_data['inventory'] = module.resolve_name_to_id('inventories', inventory)

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -6,7 +6,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-import json
 
 __metaclass__ = type
 
@@ -119,6 +118,7 @@ status:
 '''
 
 from ..module_utils.controller_api import ControllerAPIModule
+import json
 
 
 def main():

--- a/awx_collection/tests/integration/targets/ad_hoc_command/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/ad_hoc_command/tasks/main.yml
@@ -72,6 +72,21 @@
       - "result is changed"
       - "result.status == 'successful'"
 
+- name: Launch an Ad Hoc Command with extra_vars
+  ad_hoc_command:
+    inventory: "Demo Inventory"
+    credential: "{{ ssh_cred_name }}"
+    module_name: "ping"
+    extra_vars:
+      var1: "test var"
+    wait: true
+  register: result
+
+- assert:
+    that:
+      - "result is changed"
+      - "result.status == 'successful'"
+
 - name: Launch an Ad Hoc Command with Execution Environment specified
   ad_hoc_command:
     inventory: "Demo Inventory"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related #14481 
We're currently submitting an OrderedDict to a CharField which is throwing a validation error on the serializer.
This PR converts the OrderedDict to a JSON string before submitting it.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.2.1.dev20+gcec6e1e93a.d20231018
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
PLAY [all] ************************************************************************************************************
TASK [Launch an ad hoc command] ***************************************************************************************
[WARNING]: You are running collection version 22.7.0 but connecting to AWX version 23.1.1.dev1+g8feeb5f1fa
fatal: [localhost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "msg": "Failed to launch command, see response for details", "response": {"json": {"extra_vars": ["Not a valid string."]}, "status_code": 400}}
PLAY RECAP ************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0 
```
After
```
PLAY [all] ************************************************************************************************************
TASK [Launch an ad hoc command] ***************************************************************************************
[WARNING]: You are running collection version 22.7.0 but connecting to AWX version 23.1.1.dev1+g8feeb5f1fa
changed: [localhost] => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": true, "id": 76, "status": "new"}
PLAY RECAP ************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0    
```
