### PR TITLE
Fix swagger generation on rhel (#14317)

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -48,7 +48,7 @@
   vars:
     new_error_page:
       error_code: "{{ item | basename() | regex_replace('custom_(\\d+).html', '\\1') }}"
-      web_path: "{{ item | regex_replace('^.*\/static', '/static') }}"
+      web_path: "{{ item | regex_replace('^.*/static', '/static') }}"
   loop: "{{ lookup('ansible.builtin.fileglob', playbook_dir + '/../../../awx/static/custom_*.html', wantlist=True) }}"
   when: (item | basename()) is regex("custom_\d+\.html")
 


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/14317

Fixed regexp which is used during the swagger generation (see the original issue for more information). Looks like this issue is not related to the Ansible version. I was not able to reproduce it on the Fedora machine with Ansible 2.11, 2.14. 2.15. I was only able to reproduce that problem on RHEL8.

I verified the fix on both Fedora and rhel8. So I think we should be safe here to merge.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
