### PR TITLE
Remove specific version for receptorctl

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -46,7 +46,7 @@ python-dsv-sdk>=1.0.4
 python-tss-sdk>=1.2.1
 python-ldap
 pyyaml>=6.0.1
-receptorctl==1.3.0
+receptorctl
 social-auth-core[openidconnect]==4.3.0  # see UPGRADE BLOCKERs
 social-auth-app-django==5.0.0  # see UPGRADE BLOCKERs
 sqlparse >= 0.4.4   # Required by django https://github.com/ansible/awx/security/dependabot/96

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -349,7 +349,7 @@ pyyaml==6.0.1
     #   djangorestframework-yaml
     #   kubernetes
     #   receptorctl
-receptorctl==1.3.0
+receptorctl==1.4.2
     # via -r /awx_devel/requirements/requirements.in
 redis==4.3.5
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
Don't know why we specified 1.3.0 receptorctl is now up to 1.4.2

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.3.1.dev19+g4ff32ec5da
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
