### PR TITLE
Typo in export.py example

### DIFF
--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -115,7 +115,7 @@ EXAMPLES = '''
 - name: Export a job template named "My Template" and all Credentials
   export:
     job_templates: "My Template"
-    credential: 'all'
+    credentials: 'all'
 
 - name: Export a list of inventories
   export:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Typo found in the examples section of the Export module. Changed "Credential" to "Credentials"

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
awx_collection/plugins/modules/export.py

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
