### PR TITLE
Fix: login rerouting only works on the user's current tab (Pull request: #14399)

### DIFF
--- a/awx/ui/src/contexts/Session.js
+++ b/awx/ui/src/contexts/Session.js
@@ -115,8 +115,11 @@ function SessionProvider({ children }) {
   }, [setSessionTimeout, setSessionCountdown]);
 
   useEffect(() => {
+    const isRedirectCondition = (location, histLength) =>
+      location.pathname === '/login' && histLength === 2;
+
     const unlisten = history.listen((location, action) => {
-      if (action === 'POP') {
+      if (action === 'POP' || isRedirectCondition(location, history.length)) {
         setIsRedirectLinkReceived(true);
       }
     });


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes a bug from this [pull request](https://github.com/ansible/awx/pull/14399).
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.1.1.dev74+g71a6d48612.d20231026
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Before this fix, rerouting after user's authentication works only in the browser's tab that user is currently at.
If you open a new tab (or click on the link), fix from [PR](https://github.com/ansible/awx/pull/14399) does not work.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
