### PR TITLE
Fix cancel bug - WorkflowManager cancel in transaction

### DIFF
--- a/awx/main/dispatch/control.py
+++ b/awx/main/dispatch/control.py
@@ -37,8 +37,11 @@ class Control(object):
     def running(self, *args, **kwargs):
         return self.control_with_reply('running', *args, **kwargs)
 
-    def cancel(self, task_ids, *args, **kwargs):
-        return self.control_with_reply('cancel', *args, extra_data={'task_ids': task_ids}, **kwargs)
+    def cancel(self, task_ids, with_reply=True):
+        if with_reply:
+            return self.control_with_reply('cancel', extra_data={'task_ids': task_ids})
+        else:
+            self.control({'control': 'cancel', 'task_ids': task_ids, 'reply_to': None}, extra_data={'task_ids': task_ids})
 
     def schedule(self, *args, **kwargs):
         return self.control_with_reply('schedule', *args, **kwargs)

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -89,8 +89,9 @@ class AWXConsumerBase(object):
                 if task_ids and not msg:
                     logger.info(f'Could not locate running tasks to cancel with ids={task_ids}')
 
-            with pg_bus_conn() as conn:
-                conn.notify(reply_queue, json.dumps(msg))
+            if reply_queue is not None:
+                with pg_bus_conn() as conn:
+                    conn.notify(reply_queue, json.dumps(msg))
         elif control == 'reload':
             for worker in self.pool.workers:
                 worker.quit()

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1439,6 +1439,11 @@ class UnifiedJob(
         if not self.celery_task_id:
             return
         canceled = []
+        if not connection.get_autocommit():
+            # this condition is purpose-written for the task manager, when it cancels jobs in workflows
+            ControlDispatcher('dispatcher', self.controller_node).cancel([self.celery_task_id], with_reply=False)
+            return True  # task manager itself needs to act under assumption that cancel was received
+
         try:
             # Use control and reply mechanism to cancel and obtain confirmation
             timeout = 5


### PR DESCRIPTION
##### SUMMARY
Describing the bug here, I have not seen it in the issue queue:

```
2023-10-26 05:36:07,011 WARNING  [d80bf2f3b13145809117ed4d9a705278] awx.main.dispatch checking dispatcher cancel for automationcontroller-0
2023-10-26 05:36:07,011 ERROR    [d80bf2f3b13145809117ed4d9a705278] awx.main.models.unified_jobs error encountered when checking task status
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/models/unified_jobs.py", line 1445, in cancel_dispatcher_process
    canceled = ControlDispatcher('dispatcher', self.controller_node).cancel([self.celery_task_id])
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/dispatch/control.py", line 41, in cancel
    return self.control_with_reply('cancel', *args, extra_data={'task_ids': task_ids}, **kwargs)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/dispatch/control.py", line 56, in control_with_reply
    raise RuntimeError('Control-with-reply messages can only be done in autocommit mode')
RuntimeError: Control-with-reply messages can only be done in autocommit mode 
```

I was able to see the real bug with manual testing:
 - create a JT that runs a sleep task and has a host
 - create a WFJT with that JT in it
 - launch the WFJT
 - wait for first events to come in the JT
 - cancel the WFJT

Expectation is that JT will be canceled. It _temporarily_ gets the "canceled" status (which is incorrect) and then it goes into "successful" status. This is a bug, where workflows run out the clock on jobs running inside that workflow.

I can verify this fixes it. This change makes the cancel message fire as part of the task manager transaction - similar to the messages that tell the dispatcher to start a new job.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
