### PR TITLE
Do not reference cache on init of db wrapper

### DIFF
--- a/awx/main/tests/unit/test_db.py
+++ b/awx/main/tests/unit/test_db.py
@@ -78,11 +78,12 @@ def test_deque_reverse():
     assert len(log) == 1
 
 
-def test_sql_not_recorded_by_default():
+def test_sql_not_recorded_by_default(mocker):
     db = FakeDatabase()
     log = RecordedQueryLog(collections.deque(maxlen=100), db)
     assert log.maxlen == 100
-    assert log.threshold is None
+    # Simulate that profiling is not enabled via the key in Redis
+    mocker.patch('awx.main.db.profiled_pg.base.cache.get', return_value=None)
     log.append(QUERY)
     assert len(log) == 1
     assert [x for x in log] == [QUERY]
@@ -110,11 +111,11 @@ def test_sqlite_failure(tmpdir):
     assert os.listdir(tmpdir) == []
 
 
-def test_sql_above_threshold(tmpdir):
+def test_sql_above_threshold(tmpdir, mocker):
     tmpdir = str(tmpdir)
     db = FakeDatabase()
     log = RecordedQueryLog(collections.deque(maxlen=100), db, dest=tmpdir)
-    log.threshold = 0.00000001
+    mocker.patch('awx.main.db.profiled_pg.base.get_threshold_value', return_value=0.00000001)
 
     for _ in range(5):
         log.append(QUERY)


### PR DESCRIPTION
##### SUMMARY
We have a problem getting a signal 6 when uWSGI workers reach end of their life.

Found out that this doesn't happen if we don't use our custom database wrapper. I would love nothing more than to axe this thing and revert back to `"ENGINE": "django.db.backends.postgresql",`, but feel obligated to make a perfunctory effort to salvage this debugging tool, which is this PR.

We have a string definition of both the cache and database in Django settings. I have no idea what order Django resolves and initializes them in, but one cannot assume the other is initialized in order to work, so this is making the most obvious of obvious fixes to avoid referencing the _redis_ cache in order to create the _postgres_ cursor.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

