### PR TITLE
Change pytest.ini signature for new version

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = awx.main.tests.settings_for_test
-python_paths = /var/lib/awx/venv/tower/lib/python3.8/site-packages
+pythonpaths = /var/lib/awx/venv/tower/lib/python3.8/site-packages
 site_dirs = /var/lib/awx/venv/tower/lib/python3.8/site-packages
 python_files = *.py
 addopts = --reuse-db --nomigrations --tb=native


### PR DESCRIPTION
##### SUMMARY
https://stackoverflow.com/questions/73749678/what-is-this-pytest-value-error-traceback-telling-me-to-fix

> When running pytest 7.0+, you may need to update your pytest.ini in regard to swapping python_paths by pythonpaths.

Checks failing in other PRs.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

