### PR TITLE
fix python_paths error

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = awx.main.tests.settings_for_test
-python_paths = /var/lib/awx/venv/tower/lib/python3.8/site-packages
-site_dirs = /var/lib/awx/venv/tower/lib/python3.8/site-packages
 python_files = *.py
 addopts = --reuse-db --nomigrations --tb=native
 markers =


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
not sure what changed, but recently seeing this in api-test CI check

```
 PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider -n auto awx/main/tests/unit awx/main/tests/functional awx/conf/tests awx/sso/tests
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/_pytest/config/__init__.py", line 1495, in getini
    return self._inicache[name]
KeyError: 'python_paths'
```

appears there is some old config lines, as I don't think `awx/venv/tower` exists at all.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
