### PR TITLE
Fix export with system auditor user

### DIFF
--- a/awxkit/awxkit/api/utils.py
+++ b/awxkit/awxkit/api/utils.py
@@ -15,7 +15,12 @@ def freeze(key):
 
 def parse_description(desc):
     options = {}
-    for line in desc.splitlines():
+    desc_lines = []
+    if 'POST' in desc:
+       desc_lines = desc[desc.index('POST') :].splitlines()
+    else:
+        desc_lines = desc.splitlines()
+    for line in desc_lines:
         match = descRE.match(line)
         if not match:
             continue

--- a/awxkit/awxkit/api/utils.py
+++ b/awxkit/awxkit/api/utils.py
@@ -15,7 +15,7 @@ def freeze(key):
 
 def parse_description(desc):
     options = {}
-    for line in desc[desc.index('POST') :].splitlines():
+    for line in desc.splitlines():
         match = descRE.match(line)
         if not match:
             continue

--- a/awxkit/awxkit/api/utils.py
+++ b/awxkit/awxkit/api/utils.py
@@ -17,7 +17,7 @@ def parse_description(desc):
     options = {}
     desc_lines = []
     if 'POST' in desc:
-       desc_lines = desc[desc.index('POST') :].splitlines()
+        desc_lines = desc[desc.index('POST') :].splitlines()
     else:
         desc_lines = desc.splitlines()
     for line in desc_lines:


### PR DESCRIPTION
##### SUMMARY
If we use a system auditor user to export elements like schedules or worklows (that have schedule) we receive a general error from awx.awx.module (because is wrapped and is not clear what is behind).

Going down in the error itself I notice that issue was the `Insufficient privileges on %s, inferring POST fields from description.` and in the `parse_description` function that is called whtn POST action is not visible to "unpriviledge" user.

Inside the `parse_description` i notice that argument passed is referring to `desc[desc.index('POST') :]` but if the description of API not have any POST section (like schedule) extraction go in error.

I think that we can check if `POST` is present in the description and if not use the description itself to extract required data.

Otherwhise is better to return an error to end user (or add the POST descriptio where is missing)

Let me know if i need to modify something
This will fix #14635 

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- API
 - Collection
 - CLI
 
##### AWX VERSION
```
23.3.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
