### PR TITLE
Leave $encrypted$ on export and remove on import for new object

### DIFF
--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -199,7 +199,7 @@ class ApiV2(base.Base):
                 return None
             fields['natural_key'] = natural_key
 
-        return utils.remove_encrypted(fields)
+        return fields
 
     def _export_list(self, endpoint):
         post_fields = utils.get_post_fields(endpoint, self._cache)
@@ -280,7 +280,7 @@ class ApiV2(base.Base):
                     _page = self._cache.get_by_natural_key(value)
                     post_data[field] = _page['id'] if _page is not None else None
                 else:
-                    post_data[field] = value
+                    post_data[field] = utils.remove_encrypted(value)
 
             _page = self._cache.get_by_natural_key(asset['natural_key'])
             try:


### PR DESCRIPTION
##### SUMMARY
This PR try to address bug 2 of issue #14635 .

I simply remove the function that replace `$encrypted$` value and introduced in import when object not exists (on POST case).
In case of object to be imported exists, PUT will not replace encrypted value (if you not pass it).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
23.3.1
```


##### ADDITIONAL INFORMATION
Refer to issue itself