### PR TITLE
Update pip and setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==65.6.3 setuptools_scm[toml]==8.0.4 wheel==0.38.4
+VENV_BOOTSTRAP ?= pip==23.3.1 setuptools==68.2.2 setuptools_scm[toml]==8.0.4 wheel==0.38.4
 
 NAME ?= awx
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -58,8 +58,8 @@ twisted[tls]
 uWSGI
 uwsgitop
 wheel>=0.38.1 # CVE-2022-40898
-pip==21.2.4  # see UPGRADE BLOCKERs
-setuptools  # see UPGRADE BLOCKERs
+pip==23.3.1  # see UPGRADE BLOCKERs
+setuptools==68.2.2  # see UPGRADE BLOCKERs
 setuptools_scm[toml]  # see UPGRADE BLOCKERs, xmlsec build dep
 setuptools-rust >= 0.11.4 # cryptography build dep
 pkgconfig>=1.5.1  # xmlsec build dep - needed for offline build

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -476,9 +476,9 @@ zope-interface==5.5.2
     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==21.2.4
+pip==23.3.1
     # via -r /awx_devel/requirements/requirements.in
-setuptools==65.6.3
+setuptools==68.2.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   asciichartpy


### PR DESCRIPTION
##### SUMMARY
I was experimenting with some newer packaging features and found our version of pip and setuptools was too old.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
23.4.1.dev1+g218a25ef1e.d20231111
```
