### PR TITLE
Setting credential_type as required

### DIFF
--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -58,6 +58,7 @@ options:
           Insights, Machine, Microsoft Azure Key Vault, Microsoft Azure Resource Manager, Network, OpenShift or Kubernetes API
           Bearer Token, OpenStack, Red Hat Ansible Automation Platform, Red Hat Satellite 6, Red Hat Virtualization, Source Control,
           Thycotic DevOps Secrets Vault, Thycotic Secret Server, Vault, VMware vCenter, or a custom credential type
+      required: True
       type: str
     inputs:
       description:
@@ -214,7 +215,7 @@ def main():
         copy_from=dict(),
         description=dict(),
         organization=dict(),
-        credential_type=dict(),
+        credential_type=dict(required=True),
         inputs=dict(type='dict', no_log=True),
         update_secrets=dict(type='bool', default=True, no_log=False),
         user=dict(),

--- a/awx_collection/tests/integration/targets/credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential/tasks/main.yml
@@ -81,7 +81,7 @@
 
 - assert:
     that:
-      - "result is changed"
+      - "result is failed"
 
 
 - name: Create an Org-specific credential with an ID with exists

--- a/awx_collection/tests/integration/targets/credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential/tasks/main.yml
@@ -71,6 +71,19 @@
     that:
       - "result is changed"
 
+- name: Delete a credential without credential_type
+  credential:
+    name: "{{ ssh_cred_name1 }}"
+    organization: Default
+    state: absent
+  register: result
+  ignore_errors: true
+
+- assert:
+    that:
+      - "result is changed"
+
+
 - name: Create an Org-specific credential with an ID with exists
   credential:
     name: "{{ ssh_cred_name1 }}"


### PR DESCRIPTION
##### SUMMARY
Fixing an issue where the credential_type is not set, leading to a failure when running the ansible.controller.credential module.
When this value is missing, the cred_type_id lookup returns all credential_types available resulting in a value error instead of treating the parameter as required.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
awx: 23.4.1.dev3+g0312dec44d
```