### PR TITLE
Fix twilio_backend.py to send SMS to multiple destinations.

### DIFF
--- a/awx/main/notifications/twilio_backend.py
+++ b/awx/main/notifications/twilio_backend.py
@@ -39,11 +39,15 @@ class TwilioBackend(AWXBaseEmailBackend, CustomNotificationBase):
             logger.error(smart_str(_("Exception connecting to Twilio: {}").format(e)))
 
         for m in messages:
-            try:
-                connection.messages.create(to=m.to, from_=m.from_email, body=m.subject)
-                sent_messages += 1
-            except Exception as e:
-                logger.error(smart_str(_("Exception sending messages: {}").format(e)))
-                if not self.fail_silently:
-                    raise
+            failed = False
+            for dest in m.to:
+                try:
+                    logger.debug(smart_str(_("FROM: {} / TO: {}").format(m.from_email, dest)))
+                    connection.messages.create(to=dest, from_=m.from_email, body=m.subject)
+                    sent_messages += 1
+                except Exception as e:
+                    logger.error(smart_str(_("Exception sending messages: {}").format(e)))
+                    failed = True
+            if not self.fail_silently and failed:
+                raise
         return sent_messages


### PR DESCRIPTION
Ansible Automation Platform only sends Twilio notifications to one destination with the current version of code, but this is a bug. Fixed this bug for sending SMS to multiple destinations.

Ansible Automation Platform only sends Twilio notifications to one destination with the current version of code, but this is a bug. Fixed this bug for sending SMS to multiple destinations.

##### SUMMARY
To fix the issue #14655 , fixed twilio_backend.py .


##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
```
4.4.7
```

