### PR TITLE
Make vault init more idempotent

### DIFF
--- a/tools/docker-compose/ansible/roles/vault/tasks/initialize.yml
+++ b/tools/docker-compose/ansible/roles/vault/tasks/initialize.yml
@@ -1,15 +1,11 @@
 ---
-- name: See if vault has been initialized
-  ansible.builtin.stat:
-    path: "{{ vault_file }}"
-  register: vault_secret_file_info
-
 - block:
     - name: Start the vault
       community.docker.docker_compose:
         state: present
         services: vault
         project_src: "{{ sources_dest }}"
+      register: vault_start
 
     - name: Run the initialization
       community.docker.docker_container_exec:
@@ -18,6 +14,7 @@
         env:
           VAULT_ADDR: "http://127.0.0.1:1234"
       register: vault_initialization
+      ignore_errors: true
 
     - name: Write out initialization file
       copy:
@@ -30,6 +27,7 @@
           {{ vault_initialization.stdout_lines[4] | regex_replace('Unseal Key ', 'Unseal_Key_') }}
           {{ vault_initialization.stdout_lines[6] | regex_replace('Initial Root Token', 'Initial_Root_Token') }}
         dest: "{{ vault_file }}"
+      when: (vault_initialization.stdout_lines | length) > 0
 
     - name: Unlock the vault
       include_role:
@@ -58,5 +56,4 @@
       community.docker.docker_compose:
         state: absent
         project_src: "{{ sources_dest }}"
-
-  when: not vault_secret_file_info.stat.exists
+      when: vault_start is defined and vault_start.changed


### PR DESCRIPTION
##### SUMMARY
Currently if you cleanup docker volume for vault and bring docker-compose development back up with vault enabled we will not initialize vault because the secret files still exist.

This change will attempt to initialize vault reguardless and update the secret file if vault is initialized

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.4.1.dev7+g3a01ccf137
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
