### PR TITLE
issue #14653 heading does not render correctly

### DIFF
--- a/docs/docsite/rst/userguide/workflow_templates.rst
+++ b/docs/docsite/rst/userguide/workflow_templates.rst
@@ -603,6 +603,8 @@ Extra Variables
    pair: workflow templates; survey extra variables
    pair: surveys; extra variables
 
+.. <- Comment to separate the index and the note to avoid rendering issues.
+
 .. note::
 
     ``extra_vars`` passed to the job launch API are only honored if one of the following is true:


### PR DESCRIPTION
##### SUMMARY

Resolves: https://github.com/ansible/awx/issues/14653

This PR adds a comment between the index and note so that the heading does not overlap the note in the resulting HTML.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### AWX VERSION
N/A


##### ADDITIONAL INFORMATION
N/A
