### PR TITLE
dependabot for docsite requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "docs/docsite/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 2
+    labels:
+      - "docs"
+      - "dependencies"


### PR DESCRIPTION
##### SUMMARY
This PR follows up on https://github.com/ansible/awx/pull/14669 by adding a dependabot configuration to keep docsite requirements updated.

Note that this PR requires a change to the repository settings to enable dependabot (if not already).

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### AWX VERSION
N/A


##### ADDITIONAL INFORMATION
N/A
