### PR TITLE
Update location of logstash build context

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -187,7 +187,7 @@ services:
   # helpful for testing awx/tower logging
   # logstash:
   #   build:
-  #     context: ./docker-compose
+  #     context: ../../docker-compose
   #     dockerfile: Dockerfile-logstash
   postgres:
     image: postgres:12


### PR DESCRIPTION
##### SUMMARY
A long time ago I would use this logstash container, and I found it to be reliable and helpful. I would have sworn that we had enabling via env var `LOGSTASH=true`, but there seems to be no trace of that now.

Now we can still attempt to enable by removing these comments, but the docker-compose file has moved since the comments were added.

I used this, and yes it did actually work. At least it worked with TCP, something with the http option didn't work.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

