### PR TITLE
related #14683 Implement podman's --pull=newer policy for execution environments

### DIFF
--- a/awx/main/models/execution_environments.py
+++ b/awx/main/models/execution_environments.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from awx.api.versioning import reverse
@@ -18,6 +19,9 @@ class ExecutionEnvironment(CommonModel):
         ('missing', _("Only pull the image if not present before running.")),
         ('never', _("Never pull container before running.")),
     ]
+    # K8S does not support "newer" pull policy but non-K8S deployments benefit from it.
+    if not settings.IS_K8S:
+        PULL_CHOICES.insert(0, ('newer', _("Pull newer container if available, use local one otherwise."))),
 
     organization = models.ForeignKey(
         'Organization',


### PR DESCRIPTION
##### SUMMARY
(Super trivial)
Implement podman's `--pull=newer` policy for Execution Environments as requested in #14683 .


##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
- Other: base application and Execution Environment model.

##### AWX VERSION
```
awx: 0.1.dev33643+g340710e
```


##### ADDITIONAL INFORMATION
This is super trivial: add a new `PULL_CHOICE` option for the ExecutionEnvironment object's `pull` attribute.

Podman defines these pull policies:
```
   --pull=policy
       Pull image policy. The default is missing.
              · always: Always pull the image and throw an error if the pull fails.
              · missing: Pull the image only if it could not be found in the local containers storage.  Throw an error if no image could be found and the pull fails.
              · never: Never pull the image but use the one from the local containers storage.  Throw an error if no image could be found.
              · newer:  Pull  if  the  image  on  the registry is newer than the one in the local containers storage.  An image is considered to be newer when the digests are different.  Comparing the time stamps is prone to errors.  Pull errors are suppressed if a local image was found.
```

The `newer` policy is the newest one of these and arguably does "The Right Thing" which in my limited experience is what a significant number of awx users expect.

This change merely adds the option to define a pull policy of `newer` for Execution Environment objects.