### PR TITLE
Fixing wsrelay connection loop

### DIFF
--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -227,7 +227,7 @@ class WebSocketRelayManager(object):
                 continue
             try:
                 if not notif.payload or notif.channel != "web_ws_heartbeat":
-                    logger.warning(f"Unexpected Channel or Payload. {notif.channel}, {notif.payload}")
+                    logger.warning(f"Unexpected channel or missing payload. {notif.channel}, {notif.payload}")
                     continue
 
                 try:

--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -237,6 +237,8 @@ class WebSocketRelayManager(object):
                     if logger.isEnabledFor(logging.DEBUG):
                         logmsg = "{} {}".format(logmsg, payload)
                         logger.warning(logmsg)
+                    else:
+                        logger.warning("Heartbeat json payload malformed")
                     continue
 
                 # Skip if the message comes from the same host we are running on

--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -227,7 +227,8 @@ class WebSocketRelayManager(object):
                 continue
             try:
                 if not notif.payload or notif.channel != "web_ws_heartbeat":
-                    return
+                    logger.warning(f"Unexpected Channel or Payload. {notif.channel}, {notif.payload}")
+                    continue
 
                 try:
                     payload = json.loads(notif.payload)
@@ -236,12 +237,14 @@ class WebSocketRelayManager(object):
                     if logger.isEnabledFor(logging.DEBUG):
                         logmsg = "{} {}".format(logmsg, payload)
                         logger.warning(logmsg)
-                    return
+                    continue
 
                 # Skip if the message comes from the same host we are running on
                 # In this case, we'll be sharing a redis, no need to relay.
                 if payload.get("hostname") == self.local_hostname:
-                    return
+                    hostname = payload.get("hostname")
+                    logger.debug("Received a heartbeat request for {hostname}. Skipping as we use redis for local host.")
+                    continue
 
                 action = payload.get("action")
 
@@ -250,7 +253,7 @@ class WebSocketRelayManager(object):
                     ip = payload.get("ip") or hostname  # try back to hostname if ip isn't supplied
                     if ip is None:
                         logger.warning(f"Received invalid {action} ws_heartbeat, missing hostname and ip: {payload}")
-                        return
+                        continue
                     logger.debug(f"Web host {hostname} ({ip}) {action} heartbeat received.")
 
                 if action == "online":

--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -236,9 +236,7 @@ class WebSocketRelayManager(object):
                     logmsg = "Failed to decode message from pg_notify channel `web_ws_heartbeat`"
                     if logger.isEnabledFor(logging.DEBUG):
                         logmsg = "{} {}".format(logmsg, payload)
-                        logger.warning(logmsg)
-                    else:
-                        logger.warning("Heartbeat json payload malformed")
+                    logger.warning(logmsg)
                     continue
 
                 # Skip if the message comes from the same host we are running on


### PR DESCRIPTION
##### SUMMARY
* The loop was being interrupted when reaching the return statements, causing a race condition that would make nodes remain disconnected from their web sockets
* Added log messages for the previous return state to improve the logging from this state.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.5.1.dev1+g41ed3782ea
```

##### ADDITIONAL INFORMATION
In a clustered installation, the UI would only be updated on the main control node as the WebSockets would remain disconnected, leading to the UI being "stuck" on the other control nodes unless you refresh the page where the status and job events would be gathered from the database upon API call.