### PR TITLE
Fix port conflicts when running other Ansible dev environments

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -61,7 +61,7 @@ services:
 {% if control_plane_node_count|int == 1 %}
       - "6899:6899"
       - "8080:8080"  # unused but mapped for debugging
-      - "8888:8888"  # jupyter notebook
+      - "${AWX_JUPYTER_PORT:-8888}:8888"  # jupyter notebook
       - "8013:8013"  # http
       - "8043:8043"  # https
       - "2222:2222"  # receptor foo node
@@ -201,6 +201,8 @@ services:
       POSTGRES_PASSWORD: {{ pg_password }}
     volumes:
       - "awx_db:/var/lib/postgresql/data"
+    ports:
+       - "${AWX_PG_PORT:-5432}:5432"
 {% if enable_pgbouncer|bool %}
   pgbouncer:
     image: bitnami/pgbouncer:latest


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

There is a docker port conflict with other AAP services:
- 8888:
  - conflicts with Event Driven Automation
  - configurable by ENV `AWX_JUPYTER_PORT`
 
And unlike other AAP repos, Postgres is not exposed:
- 5432:
  - conflicts with Gateway Postgres
  - configurable by ENV `AWX_PG_PORT`
  
To apply ENVs, run 

```shell
AWX_PG_PORT=5431 AWX_JUPYTER_PORT=8887 make docker-compose
```

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change



##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.5.1.dev3+gfeb5562fac
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
