### PR TITLE
Remove superwatcher from docker-compose dev

### DIFF
--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -113,12 +113,6 @@ killasgroup=true
 stdout_events_enabled = true
 stderr_events_enabled = true
 
-[eventlistener:superwatcher]
-command=stop-supervisor
-events=PROCESS_STATE_FATAL
-autorestart = true
-stderr_logfile=/dev/stdout
-
 [unix_http_server]
 file=/var/run/supervisor/supervisor.sock
 


### PR DESCRIPTION
##### SUMMARY
When making changes to the application sometime you can accidentally cause FATAL state and cause the dev container to crash which will remove any ephemeral changes that you have made and is ANNOYING!

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.5.2.dev7+g09f7fcb888
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
