### PR TITLE
Simplify RBAC get_roles_on_resource method

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2690,7 +2690,7 @@ class ResourceAccessListElementSerializer(UserSerializer):
             else:
                 # Singleton roles should not be managed from this view, as per copy/edit rework spec
                 role_dict['user_capabilities'] = {'unattach': False}
-            return {'role': role_dict, 'descendant_roles': get_roles_on_resource(obj, role)}
+            return {'role': role_dict, 'descendant_roles': get_roles_on_resource(role)}
 
         def format_team_role_perm(naive_team_role, permissive_role_ids):
             ret = []
@@ -2716,7 +2716,7 @@ class ResourceAccessListElementSerializer(UserSerializer):
                 else:
                     # Singleton roles should not be managed from this view, as per copy/edit rework spec
                     role_dict['user_capabilities'] = {'unattach': False}
-                ret.append({'role': role_dict, 'descendant_roles': get_roles_on_resource(obj, team_role)})
+                ret.append({'role': role_dict, 'descendant_roles': get_roles_on_resource(team_role)})
             return ret
 
         direct_permissive_role_ids = Role.objects.filter(content_type=content_type, object_id=obj.id).values_list('id', flat=True)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2670,7 +2670,7 @@ class ResourceAccessListElementSerializer(UserSerializer):
         def get_roles_on_resource(parent_role):
             "Returns a string list of the roles a parent_role has for current obj."
             return list(
-                RoleAncestorEntry.objects.filter(ancestor=parent_role, content_type_id=content_type, object_id=obj.id)
+                RoleAncestorEntry.objects.filter(ancestor=parent_role, content_type_id=content_type.id, object_id=obj.id)
                 .values_list('role_field', flat=True)
                 .distinct()
             )

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -20,7 +20,6 @@ from django.contrib.auth.models import User  # noqa
 __all__ = [
     'Role',
     'batch_role_ancestor_rebuilding',
-    'get_roles_on_resource',
     'ROLE_SINGLETON_SYSTEM_ADMINISTRATOR',
     'ROLE_SINGLETON_SYSTEM_AUDITOR',
     'role_summary_fields_generator',
@@ -458,31 +457,6 @@ class RoleAncestorEntry(models.Model):
     role_field = models.TextField(null=False)
     content_type_id = models.PositiveIntegerField(null=False)
     object_id = models.PositiveIntegerField(null=False)
-
-
-def get_roles_on_resource(resource, accessor):
-    """
-    Returns a string list of the roles a accessor has for a given resource.
-    An accessor can be either a User, Role, or an arbitrary resource that
-    contains one or more Roles associated with it.
-    """
-
-    if type(accessor) == User:
-        roles = accessor.roles.all()
-    elif type(accessor) == Role:
-        roles = [accessor]
-    else:
-        accessor_type = ContentType.objects.get_for_model(accessor)
-        roles = Role.objects.filter(content_type__pk=accessor_type.id, object_id=accessor.id)
-
-    return [
-        role_field
-        for role_field in RoleAncestorEntry.objects.filter(
-            ancestor__in=roles, content_type_id=ContentType.objects.get_for_model(resource).id, object_id=resource.id
-        )
-        .values_list('role_field', flat=True)
-        .distinct()
-    ]
 
 
 def role_summary_fields_generator(content_object, role_field):

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -95,13 +95,6 @@ The `singleton` class method is a helper method on the `Role` model that helps i
 You may use the `user in some_role` syntax to check and see if the specified
 user is a member of the given role, **or** a member of any ancestor role.
 
-#### `get_roles_on_resource(resource, accessor)`
-
-This is a static method (not bound to a class) that will efficiently return the names
-of all roles that the `accessor` (a user or a team) has on a particular resource.
-The resource is a python object for something like an organization, credential, or job template.
-Return value is a list of strings like `["admin_role", "execute_role"]`.
-
 ### Fields
 
 #### `ImplicitRoleField`


### PR DESCRIPTION
##### SUMMARY
I'm trying to delete more RBAC code that we don't actually need as pre-work for more changes later on.

This method, `get_roles_on_resource` was written very generally and duplicated queryset building logic already in other methods. But we only really needed it to return a very simple set of data in the access list:

```json
            "summary_fields": {
                "direct_access": [],
                "indirect_access": [
                    {
                        "role": {
                            "id": 1,
                            "name": "System Administrator",
                            "description": "Can manage all aspects of the system",
                            "user_capabilities": {
                                "unattach": false
                            }
                        },
                        "descendant_roles": [
                            "admin_role",
                            "execute_role",
                            "read_role"
                        ]
                    }
                ]
            },
```

It's the "descendant_roles" that we generate from this, but we didn't need all we were maintaining from that.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

