### PR TITLE
Recover rsyslog from 4xx error

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,7 +22,7 @@ recursive-exclude awx/settings local_settings.py*
 include tools/scripts/request_tower_configuration.sh
 include tools/scripts/request_tower_configuration.ps1
 include tools/scripts/automation-controller-service
-include tools/scripts/failure-event-handler
+include tools/scripts/rsyslog-4xx-recovery
 include tools/scripts/awx-python
 include awx/playbooks/library/mkfifo.py
 include tools/sosreport/*

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -226,15 +226,18 @@ RUN ln -sf /awx_devel/{{ template_dest }}/supervisor_rsyslog.conf /etc/superviso
 ADD tools/ansible/roles/dockerfile/files/launch_awx_web.sh /usr/bin/launch_awx_web.sh
 ADD tools/ansible/roles/dockerfile/files/launch_awx_task.sh /usr/bin/launch_awx_task.sh
 ADD tools/ansible/roles/dockerfile/files/launch_awx_rsyslog.sh /usr/bin/launch_awx_rsyslog.sh
+ADD tools/scripts/rsyslog-4xx-recovery /usr/bin/rsyslog-4xx-recovery
 ADD {{ template_dest }}/supervisor_web.conf /etc/supervisord_web.conf
 ADD {{ template_dest }}/supervisor_task.conf /etc/supervisord_task.conf
 ADD {{ template_dest }}/supervisor_rsyslog.conf /etc/supervisord_rsyslog.conf
+ADD tools/scripts/awx-python /usr/bin/awx-python
 {% endif %}
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
 RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.9/site-packages/awx.egg-link
 ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
-ADD tools/scripts/awx-python /usr/bin/awx-python
+RUN ln -sf /awx_devel/tools/scripts/awx-python /usr/bin/awx-python
+RUN ln -sf /awx_devel/tools/scripts/rsyslog-4xx-recovery /usr/bin/rsyslog-4xx-recovery
 {% endif %}
 
 # Pre-create things we need to access

--- a/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
@@ -15,6 +15,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+stderr_events_enabled = true
 
 [program:awx-rsyslog-configurer]
 {% if kube_dev | bool %}
@@ -65,8 +66,8 @@ buffer_size = 100
 events=PROCESS_LOG_STDERR
 priority=0
 autorestart=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [unix_http_server]
 file=/var/run/supervisor/supervisor.rsyslog.sock

--- a/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
@@ -8,7 +8,7 @@ pidfile = /var/run/supervisor/supervisor.rsyslog.pid
 [program:awx-rsyslogd]
 command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
 autorestart = true
-startsecs = 30
+startsecs = 0
 stopasgroup=true
 killasgroup=true
 stdout_logfile=/dev/stdout
@@ -58,6 +58,15 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[eventlistener:rsyslog-4xx-recovery]
+command=rsyslog-4xx-recovery
+buffer_size = 100
+events=PROCESS_LOG_STDERR
+priority=0
+autorestart=true
+stdout_events_enabled = true
+stderr_events_enabled = true
 
 [unix_http_server]
 file=/var/run/supervisor/supervisor.rsyslog.sock

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -8,16 +8,20 @@ command = awx-manage run_dispatcher
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:awx-receiver]
 command = awx-manage run_callback_receiver
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:awx-wsrelay]
 command = awx-manage run_wsrelay
@@ -25,8 +29,10 @@ autorestart = true
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:awx-ws-heartbeat]
 command = awx-manage run_ws_heartbeat
@@ -34,8 +40,10 @@ autorestart = true
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:awx-rsyslog-configurer]
 command = awx-manage run_rsyslog_configurer
@@ -64,32 +72,40 @@ stopwaitsecs = 1
 stopsignal=KILL
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:awx-daphne]
 command = make daphne
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [program:awx-nginx]
 command = make nginx
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
-
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 [program:awx-rsyslogd]
 command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
 autorestart = true
 startsecs=0
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 stderr_events_enabled = true
 
 [program:awx-receptor]
@@ -97,8 +113,10 @@ command = receptor --config /etc/receptor/receptor.conf
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [group:tower-processes]
 programs=awx-dispatcher,awx-receiver,awx-uwsgi,awx-daphne,awx-nginx,awx-wsrelay,awx-rsyslogd,awx-ws-heartbeat,awx-rsyslog-configurer,awx-cache-clear
@@ -110,8 +128,10 @@ autostart = true
 autorestart = true
 stopasgroup=true
 killasgroup=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [eventlistener:rsyslog-4xx-recovery]
 command=/awx_devel/tools/scripts/rsyslog-4xx-recovery
@@ -119,8 +139,8 @@ buffer_size = 100
 events=PROCESS_LOG_STDERR
 priority=0
 autorestart=true
-stdout_events_enabled = true
-stderr_events_enabled = true
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
 
 [unix_http_server]
 file=/var/run/supervisor/supervisor.sock

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -86,9 +86,9 @@ stderr_events_enabled = true
 [program:awx-rsyslogd]
 command = rsyslogd -n -i /var/run/awx-rsyslog/rsyslog.pid -f /var/lib/awx/rsyslog/rsyslog.conf
 autorestart = true
+startsecs=0
 stopasgroup=true
 killasgroup=true
-redirect_stderr=true
 stdout_events_enabled = true
 stderr_events_enabled = true
 
@@ -110,6 +110,15 @@ autostart = true
 autorestart = true
 stopasgroup=true
 killasgroup=true
+stdout_events_enabled = true
+stderr_events_enabled = true
+
+[eventlistener:rsyslog-4xx-recovery]
+command=/awx_devel/tools/scripts/rsyslog-4xx-recovery
+buffer_size = 100
+events=PROCESS_LOG_STDERR
+priority=0
+autorestart=true
 stdout_events_enabled = true
 stderr_events_enabled = true
 

--- a/tools/scripts/rsyslog-4xx-recovery
+++ b/tools/scripts/rsyslog-4xx-recovery
@@ -11,9 +11,11 @@ def write_stdout(s):
     sys.stdout.write(s)
     sys.stdout.flush()
 
+
 def write_stderr(s):
-    sys.stderr.write(s)
+    sys.stderr.write(f"[rsyslog-4xx-recovery] {s}")
     sys.stderr.flush()
+
 
 def main():
     while 1:
@@ -44,6 +46,15 @@ def main():
                             f"{datetime.datetime.now(timezone.utc)} - sending SIGTERM to proc=[{proc_details['processname']}] with pid=[{int(proc_details['pid'])}] due to log_message=[{log_message}]\n"
                         )
                         os.kill(int(proc_details["pid"]), signal.SIGTERM)
+                    except Exception as e:
+                        write_stderr(str(e))
+
+                if "action-0-omhttp queue: need to do hard cancellation" in log_message:
+                    try:
+                        write_stderr(
+                            f"{datetime.datetime.now(timezone.utc)} - sending SIGKILL to proc=[{proc_details['processname']}] with pid=[{int(proc_details['pid'])}] due to log_message=[{log_message}]\n"
+                        )
+                        os.kill(int(proc_details["pid"]), signal.SIGKILL)
                     except Exception as e:
                         write_stderr(str(e))
 

--- a/tools/scripts/rsyslog-4xx-recovery
+++ b/tools/scripts/rsyslog-4xx-recovery
@@ -11,11 +11,9 @@ def write_stdout(s):
     sys.stdout.write(s)
     sys.stdout.flush()
 
-
 def write_stderr(s):
     sys.stderr.write(s)
     sys.stderr.flush()
-
 
 def main():
     while 1:
@@ -30,23 +28,6 @@ def main():
             data = sys.stdin.read(int(headers["len"]))
         except ValueError as e:
             write_stderr(str(e))
-
-        # now decide what do to based on eventnames
-        if headers["eventname"] == "PROCESS_STATE_FATAL":
-            headers.update(
-                dict(
-                    [x.split(":") for x in sys.stdin.read(int(headers["len"])).split()]
-                )
-            )
-
-            try:
-                # incoming event that produced PROCESS_STATE_FATAL will have a PID. SIGTERM it!
-                write_stderr(
-                    f"{datetime.datetime.now(timezone.utc)} - sending SIGTERM to proc={headers} with data={headers}\n"
-                )
-                os.kill(headers["pid"], signal.SIGTERM)
-            except Exception as e:
-                write_stderr(str(e))
 
         # awx-rsyslog PROCESS_LOG_STDERR handler
         if headers["eventname"] == "PROCESS_LOG_STDERR":


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/7560

Related to https://github.com/rsyslog/rsyslog/issues/4348

'omhttp' module for rsyslog will completely stop forwarding message to external log aggregator after receiving a 4xx error from the external log aggregator

This PR is an "workaround" for this problem by restarting rsyslogd after detecting that rsyslog received a 4xx error

NOTE: this workaround will cause message lost! It's best to resolve the root cause for the 4xx

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.5.2.dev11+g85e9e02a41
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
