### PR TITLE
add granularity to system cleanup job (#14384)

### DIFF
--- a/awx/api/templates/api/system_job_template_launch.md
+++ b/awx/api/templates/api/system_job_template_launch.md
@@ -16,6 +16,21 @@ For `cleanup_activitystream` and `cleanup_jobs` commands, providing
 `"dry_run": true` inside of `extra_vars` will show items that will be
 removed without deleting them.
 
+Specific resources can be optionally listed for `cleanup_jobs` by sending
+an array named "resources" containing the resources to be cleaned.  For
+example.
+
+`{"extra_vars": {"resources":["notifications", "project-updates"]}}`
+
+The resources correspond to the available "awx-manage cleanup" arguments
+and are listed below.
+
+"jobs", "project-updates", "inventory-updates","management-jobs",
+ "ad-hoc-commands", "workflow-jobs", "notifications"
+
+If "resources" is omitted, all resources are cleaned up.
+
+
 Each individual system job task has its own default values, which are
 applicable either when running it from the command line or launching its
 system job template with empty `extra_vars`.

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1886,9 +1886,13 @@ class RunSystemJob(BaseTask):
                 if 'dry_run' in json_vars and json_vars['dry_run']:
                     args.extend(['--dry-run'])
             if system_job.job_type == 'cleanup_jobs':
-                args.extend(
-                    ['--jobs', '--project-updates', '--inventory-updates', '--management-jobs', '--ad-hoc-commands', '--workflow-jobs', '--notifications']
-                )
+                cleanup_job_resources = ['jobs', 'project-updates', 'inventory-updates', 'management-jobs', 'ad-hoc-commands', 'workflow-jobs', 'notifications']
+                if 'resources' in json_vars and any(resource in json_vars['resources'] for resource in cleanup_job_resources):
+                    for resource in cleanup_job_resources:
+                        if resource in json_vars['resources']:
+                            args.extend(['--'+resource])
+                else:
+                    args.extend(['--jobs', '--project-updates', '--inventory-updates', '--management-jobs', '--ad-hoc-commands', '--workflow-jobs', '--notifications'])
         except Exception:
             logger.exception("{} Failed to parse system job".format(system_job.log_format))
         return args


### PR DESCRIPTION
##### SUMMARY
as described here, https://github.com/ansible/awx/issues/14384, this allows the system cleanup jobs to be more specific.

passing a list of resources in extra_vars allows adding specific arguments to the cleanup command.

to remain compatible, omitting the resource types in extra_vars results in the current behavior, all arguments are appended.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.5.1.dev0+g2ac304d289.d20231213
```

