### PR TITLE
Collection: Fix using ID for schedule unified_job_template parameter (related #14458)

### DIFF
--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -262,8 +262,7 @@ def main():
         search_fields['organization'] = module.resolve_name_to_id('organizations', organization)
     unified_job_template_id = None
     if unified_job_template:
-        search_fields['name'] = unified_job_template
-        unified_job_template_id = module.get_one('unified_job_templates', **{'data': search_fields})['id']
+        unified_job_template_id = module.get_exactly_one('unified_job_templates', name_or_id=unified_job_template, **{'data': search_fields})['id']
         sched_search_fields['unified_job_template'] = unified_job_template_id
 
     # Attempt to look up an existing item based on the provided data

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -86,7 +86,7 @@ options:
       type: str
     unified_job_template:
       description:
-        - Name of unified job template to run in the workflow.
+        - Name, ID, or named URL of unified job template to run in the workflow.
         - Can be a job template, project, inventory source, etc.
         - Omit if creating an approval node.
         - This parameter is mutually exclusive with C(approval_node).
@@ -340,7 +340,7 @@ def main():
 
     unified_job_template = module.params.get('unified_job_template')
     if unified_job_template:
-        new_fields['unified_job_template'] = module.get_one('unified_job_templates', name_or_id=unified_job_template, **{'data': search_fields})['id']
+        new_fields['unified_job_template'] = module.get_exactly_one('unified_job_templates', name_or_id=unified_job_template, **{'data': search_fields})['id']
     inventory = module.params.get('inventory')
     if inventory:
         new_fields['inventory'] = module.resolve_name_to_id('inventories', inventory)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes using an ID for the `unified_job_template` parameter of the schedule module which was broken by #11135

Also tweaks a prior, similar fix for the workflow_job_template_node module in #11198, changing `get_one()` to `get_exactly_one()` which fails gracefully if the `unified_job_template` value can't be resolved.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
