### PR TITLE
Fix #2192 This addition will allow users to pass their Red Hat Satellite Credential values to their playbook

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -826,15 +826,35 @@ ManagedCredentialType(
                 'type': 'string',
                 'help_text': gettext_noop('Enter the URL that corresponds to your Red Hat Satellite 6 server. For example, https://satellite.example.org'),
             },
-            {'id': 'username', 'label': gettext_noop('Username'), 'type': 'string'},
+            {'id': 'username',
+             'label': gettext_noop('Username'),
+             'type': 'string'},
             {
                 'id': 'password',
                 'label': gettext_noop('Password'),
                 'type': 'string',
                 'secret': True,
             },
+            {
+              'id': 'verify_ssl',
+              'label': gettext_noop('Verify SSL'),
+              'type': 'boolean',
+              'default': False,
+            },
         ],
         'required': ['host', 'username', 'password'],
+    },
+   injectors={
+        'env': {
+            'SATELLITE_SERVER_URL':     '{{host}}',
+            'SATELLITE_USERNAME':       '{{username}}',
+            'SATELLITE_PASSWORD':       '{{password}}',
+            'SATELLITE_VALIDATE_CERTS': '{{verify_ssl}}',
+            'FOREMAN_SERVER_URL':       '{{host}}',
+            'FOREMAN_USERNAME':         '{{username}}',
+            'FOREMAN_PASSWORD':         '{{password}}',
+            'FOREMAN_VALIDATE_CERTS':   '{{verify_ssl}}',
+        }
     },
 )
 

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1627,6 +1627,7 @@ class satellite6(PluginFileInjector):
             ret['FOREMAN_SERVER'] = credential.get_input('host', default='')
             ret['FOREMAN_USER'] = credential.get_input('username', default='')
             ret['FOREMAN_PASSWORD'] = credential.get_input('password', default='')
+            ret['FOREMAN_VALIDATE_CERTS'] = credential.get_input('verify_ssl', default=False)
         return ret
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

 It will address this issue that was reported: https://github.com/ansible/awx/issues/2192

This feature will simply allow users to pass the values from the Red Hat Satellite credential to their playbook. A user will be able to run any included role from either redhat.satellite or theforeman.foreman collection with the Red Hat Satellite credential that they assign to their job template without having to worry about the following variables:

```
            'SATELLITE_SERVER_URL':     '{{ host }}',
            'SATELLITE_USERNAME':       '{{ username }}',
            'SATELLITE_PASSWORD':       '{{ password }}',
            'SATELLITE_VALIDATE_CERTS': '{{ verify_ssl }}',
            'FOREMAN__SERVER_URL':      '{{ host }}',
            'FOREMAN_USERNAME':         '{{ username }}',
            'FOREMAN_PASSWORD':         '{{ password }}',
            'FOREMAN_VALIDATE_CERTS':   '{{ verify_ssl }}',
```

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev33661+gb14518c
awx-manage --version 4.4.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
  
The following was tested:

- The following changes worked with credential used as an inventory source. Their source variables would overwrite the environments set from the credential. This was to be expected.
- Each variable was passed to the playbook, as expected. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- hosts: localhost
  tasks: 

  - debug:
      msg:
      - "{{ lookup('env','SATELLITE_SERVER_URL') }}"
      - "{{ lookup('env','SATELLITE_USERNAME') }}"
      - "{{ lookup('env','SATELLITE_PASSWORD') }}"
      - "{{ lookup('env','SATELLITE_VALIDATE_CERTS') }}"
      - "{{ lookup('env','FOREMAN_SERVER_URL') }}"
      - "{{ lookup('env','FOREMAN_USERNAME') }}"
      - "{{ lookup('env','FOREMAN_PASSWORD') }}"
      - "{{ lookup('env','FOREMAN_VALIDATE_CERTS') }}"
```
Before
```
TASK [debug] *******************************************************************
task path: /runner/project/env.yml:4
ok: [localhost] => {
    "msg": [
        "",
        "",
        "",
        "",
        "",
        "",
        "",
        ""
    ]
}
```
After
```
TASK [debug] *******************************************************************
task path: /runner/project/env.yml:4
ok: [localhost] => {
    "msg": [
        "https://satellite.lou.land",
        "admin",
        "redhat",
        false,
        "https://satellite.lou.land",
        "admin",
        "redhat",
        false
    ]
}
```