### PR TITLE
Persist schedule prompt on launch fields when editing

### DIFF
--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.js
@@ -20,6 +20,7 @@ import UnsupportedScheduleForm from './UnsupportedScheduleForm';
 import parseRuleObj, { UnsupportedRRuleError } from './parseRuleObj';
 import buildRuleObj from './buildRuleObj';
 import buildRuleSet from './buildRuleSet';
+import mergeArraysByCredentialType from './mergeArraysByCredentialType';
 
 const NUM_DAYS_PER_FREQUENCY = {
   week: 7,
@@ -350,8 +351,10 @@ function ScheduleForm({
     startDate: currentDate,
     startTime: time,
     timezone: schedule.timezone || now.zoneName,
-    credentials:
-      credentials.length > 0 ? credentials : resourceDefaultCredentials,
+    credentials: mergeArraysByCredentialType(
+      resourceDefaultCredentials,
+      credentials
+    ),
     labels: originalLabels.current,
     instance_groups: originalInstanceGroups.current,
   };

--- a/awx/ui/src/components/Schedule/shared/ScheduleForm.js
+++ b/awx/ui/src/components/Schedule/shared/ScheduleForm.js
@@ -350,6 +350,10 @@ function ScheduleForm({
     startDate: currentDate,
     startTime: time,
     timezone: schedule.timezone || now.zoneName,
+    credentials:
+      credentials.length > 0 ? credentials : resourceDefaultCredentials,
+    labels: originalLabels.current,
+    instance_groups: originalInstanceGroups.current,
   };
 
   if (hasDaysToKeepField) {

--- a/awx/ui/src/components/Schedule/shared/mergeArraysByCredentialType.js
+++ b/awx/ui/src/components/Schedule/shared/mergeArraysByCredentialType.js
@@ -1,6 +1,6 @@
 export default function mergeArraysByCredentialType(
-  defaultCredentials,
-  overrides
+  defaultCredentials = [],
+  overrides = []
 ) {
   const mergedArray = [...defaultCredentials];
 

--- a/awx/ui/src/components/Schedule/shared/mergeArraysByCredentialType.js
+++ b/awx/ui/src/components/Schedule/shared/mergeArraysByCredentialType.js
@@ -1,0 +1,15 @@
+export default function mergeArraysByCredentialType(array1, array2) {
+  const mergedArray = [...array1];
+
+  array2.forEach((obj2) => {
+    const index = mergedArray.findIndex(
+      (obj1) => obj1.credential_type === obj2.credential_type
+    );
+    if (index !== -1) {
+      mergedArray.splice(index, 1);
+    }
+    mergedArray.push(obj2);
+  });
+
+  return mergedArray;
+}

--- a/awx/ui/src/components/Schedule/shared/mergeArraysByCredentialType.js
+++ b/awx/ui/src/components/Schedule/shared/mergeArraysByCredentialType.js
@@ -1,14 +1,17 @@
-export default function mergeArraysByCredentialType(array1, array2) {
-  const mergedArray = [...array1];
+export default function mergeArraysByCredentialType(
+  defaultCredentials,
+  overrides
+) {
+  const mergedArray = [...defaultCredentials];
 
-  array2.forEach((obj2) => {
+  overrides.forEach((override) => {
     const index = mergedArray.findIndex(
-      (obj1) => obj1.credential_type === obj2.credential_type
+      (defaultCred) => defaultCred.credential_type === override.credential_type
     );
     if (index !== -1) {
       mergedArray.splice(index, 1);
     }
-    mergedArray.push(obj2);
+    mergedArray.push(override);
   });
 
   return mergedArray;


### PR DESCRIPTION
##### SUMMARY
Ensures prompt on launch field remain in place when editing a schedule. Specifically, the credential, labels, and instance groups were getting dropped if the prompt on launch wizard wasn't opened during editing.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
