### PR TITLE
Add self-check pg_notify messages for silently dropped connections

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -59,9 +59,6 @@ class PubSub(object):
         with self.conn.cursor() as cur:
             cur.execute('SELECT pg_notify(%s, %s);', (channel, payload))
 
-    def ensure_connection(self):
-        self.conn.cursor().execute('SELECT 1')
-
     @staticmethod
     def current_notifies(conn):
         """
@@ -85,7 +82,6 @@ class PubSub(object):
 
         while True:
             if select.select([self.conn], [], [], self.select_timeout) == NOT_READY:
-                self.ensure_connection()  # ping to make sure the connection is alive and prevent hangs
                 if yield_timeouts:
                     yield None
             else:

--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -85,6 +85,7 @@ class PubSub(object):
 
         while True:
             if select.select([self.conn], [], [], self.select_timeout) == NOT_READY:
+                self.ensure_connection()  # ping to make sure the connection is alive and prevent hangs
                 if yield_timeouts:
                     yield None
             else:

--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -59,6 +59,9 @@ class PubSub(object):
         with self.conn.cursor() as cur:
             cur.execute('SELECT pg_notify(%s, %s);', (channel, payload))
 
+    def ensure_connection(self):
+        self.conn.cursor().execute('SELECT 1')
+
     @staticmethod
     def current_notifies(conn):
         """

--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -208,7 +208,7 @@ class AWXConsumerPG(AWXConsumerBase):
             conn.notify(get_task_queuename(), json.dumps({'control': 'alive', 'reply_to': None}))
         logger.debug('Sent alive message for self-assesment of pg_notify queue')
 
-    def run_periodic_tasks(self, conn):
+    def run_periodic_tasks(self):
         """
         Run general periodic logic, and return maximum time in seconds before
         the next requested run
@@ -262,13 +262,13 @@ class AWXConsumerPG(AWXConsumerBase):
                         init = True
                     # run_periodic_tasks run scheduled actions and gives time until next scheduled action
                     # this is saved to the conn (PubSub) object in order to modify read timeout in-loop
-                    conn.select_timeout = self.run_periodic_tasks(conn)
+                    conn.select_timeout = self.run_periodic_tasks()
                     # this is the main operational loop for awx-manage run_dispatcher
                     for e in conn.events(yield_timeouts=True):
                         self.listen_cumulative_time += time.time() - self.listen_start  # for metrics
                         if e is not None:
                             self.process_task(json.loads(e.payload))
-                        conn.select_timeout = self.run_periodic_tasks(conn)
+                        conn.select_timeout = self.run_periodic_tasks()
                     if self.should_stop:
                         return
             except psycopg.InterfaceError:


### PR DESCRIPTION
##### SUMMARY
The problem this addresses is roughly established by this form of testing:

```
awx-manage run_dispatcher --status
strace -f -s 1024 -p 8491
lsof -p 8491 | grep 28
# run as root
iptables -I OUTPUT -p tcp --sport 34586 -j DROP
```

The dropping of the connection is undetected by the dispatcher, which is bad. This leaves the dispatcher in a state where it no longer receives messages. Worse, it doesn't know that it cannot receive messages. I have poked around several options to test the connection outside of this, and they all seem terrible. I think I've concluded I need threading to testing doing `SELECT 1`, because the very scenario I want to diagnose causes that to _hang_ which makes it even less functional than if we had not added that check..

That leads me to the nuclear option - this. This is how it looks from logs:

```
tools_awx_1 | 2024-01-09 15:56:38,547 ERROR    [-] awx.main.dispatch Error consuming new events from postgres, will retry for 40 s
tools_awx_1 | Traceback (most recent call last):
tools_awx_1 |   File "/awx_devel/awx/main/dispatch/worker/base.py", line 267, in run
tools_awx_1 |     conn.select_timeout = self.run_periodic_tasks(conn)
tools_awx_1 |   File "/awx_devel/awx/main/dispatch/worker/base.py", line 237, in run_periodic_tasks
tools_awx_1 |     raise db.DatabaseError(f'pg_notify self-check missing after {delta:.3f}s, did you drop the connection?')
tools_awx_1 | django.db.utils.DatabaseError: pg_notify self-check missing after 26.015s, did you drop the connection?
tools_awx_1 | 2024-01-09 15:56:39,576 INFO     [-] awx.main.dispatch Dispatcher listener connection established
```

Obvious drawback - this is _slow_ to detect problems. I've set this to send every 60 seconds, and then receiving has a tolerance of 20 seconds + whatever task interval we encounter... thus that 26 seconds. This is additive, and we add at least 1 second of delay in retry loop, so call it 87 seconds here to recover. To articulate my feelings:

![recover](https://github.com/ansible/awx/assets/1385596/174d770d-4769-407a-9bcb-8e6d5ca81ec4)

The advantages of this are that it detects this state when nothing else can, and it goes into the error handling loop we want which re-connects but doesn't arbitrarily fail jobs in progress.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

