### PR TITLE
Build the awxkit source distribution bundle to also upload to PyPI

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Build awxkit and upload to pypi
         run: |
           git reset --hard
-          cd awxkit && python3 setup.py bdist_wheel
+          cd awxkit && python3 setup.py sdist bdist_wheel
           twine upload \
             -r ${{ env.pypi_repo }} \
             -u ${{ secrets.PYPI_USERNAME }} \


### PR DESCRIPTION
##### SUMMARY

Our Github Actions release process is currently leaving out the source tarball when building and releasing to PyPI.  This PR adds that back in.

This has been broken since 20.0.1.

related #14744 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other
