### PR TITLE
fixes problems with workflow nodes information section

### DIFF
--- a/awx/ui/src/components/PromptDetail/PromptDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptDetail.js
@@ -257,7 +257,9 @@ function PromptDetail({
                       numChips={5}
                       ouiaId="prompt-job-tag-chips"
                       totalChips={
-                        overrides.job_tags === undefined || overrides.job_tags === null || overrides.job_tags === ''
+                        overrides.job_tags === undefined ||
+                        overrides.job_tags === null ||
+                        overrides.job_tags === ''
                           ? 0
                           : overrides.job_tags.split(',').length
                       }
@@ -287,7 +289,9 @@ function PromptDetail({
                     <ChipGroup
                       numChips={5}
                       totalChips={
-                        overrides.skip_tags === undefined || overrides.skip_tags === null || overrides.skip_tags === ''
+                        overrides.skip_tags === undefined ||
+                        overrides.skip_tags === null ||
+                        overrides.skip_tags === ''
                           ? 0
                           : overrides.skip_tags.split(',').length
                       }

--- a/awx/ui/src/components/PromptDetail/PromptDetail.js
+++ b/awx/ui/src/components/PromptDetail/PromptDetail.js
@@ -257,12 +257,15 @@ function PromptDetail({
                       numChips={5}
                       ouiaId="prompt-job-tag-chips"
                       totalChips={
-                        !overrides.job_tags || overrides.job_tags === ''
+                        overrides.job_tags === undefined || overrides.job_tags === null || overrides.job_tags === ''
                           ? 0
                           : overrides.job_tags.split(',').length
                       }
                     >
-                      {overrides.job_tags.length > 0 &&
+                      {overrides.job_tags !== undefined &&
+                        overrides.job_tags !== null &&
+                        overrides.job_tags !== '' &&
+                        overrides.job_tags.length > 0 &&
                         overrides.job_tags.split(',').map((jobTag) => (
                           <Chip
                             key={jobTag}
@@ -284,13 +287,16 @@ function PromptDetail({
                     <ChipGroup
                       numChips={5}
                       totalChips={
-                        !overrides.skip_tags || overrides.skip_tags === ''
+                        overrides.skip_tags === undefined || overrides.skip_tags === null || overrides.skip_tags === ''
                           ? 0
                           : overrides.skip_tags.split(',').length
                       }
                       ouiaId="prompt-skip-tag-chips"
                     >
-                      {overrides.skip_tags.length > 0 &&
+                      {overrides.skip_tags !== undefined &&
+                        overrides.skip_tags !== null &&
+                        overrides.skip_tags !== '' &&
+                        overrides.skip_tags.length > 0 &&
                         overrides.skip_tags.split(',').map((skipTag) => (
                           <Chip
                             key={skipTag}

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.js
@@ -201,7 +201,10 @@ function NodeViewModal({ readOnly }) {
         overrides.limit = originalNodeObject.limit;
       }
       if (launchConfig.ask_verbosity_on_launch) {
-        overrides.verbosity = originalNodeObject.verbosity.toString();
+        overrides.verbosity = originalNodeObject.verbosity !== undefined &&
+                               originalNodeObject.verbosity !== null
+                              ? originalNodeObject.verbosity.toString()
+                              : '0';
       }
       if (launchConfig.ask_credential_on_launch) {
         overrides.credentials = originalNodeCredentials || [];

--- a/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplateVisualizer/Modals/NodeModals/NodeViewModal.js
@@ -201,10 +201,11 @@ function NodeViewModal({ readOnly }) {
         overrides.limit = originalNodeObject.limit;
       }
       if (launchConfig.ask_verbosity_on_launch) {
-        overrides.verbosity = originalNodeObject.verbosity !== undefined &&
-                               originalNodeObject.verbosity !== null
-                              ? originalNodeObject.verbosity.toString()
-                              : '0';
+        overrides.verbosity =
+          originalNodeObject.verbosity !== undefined &&
+          originalNodeObject.verbosity !== null
+            ? originalNodeObject.verbosity.toString()
+            : '0';
       }
       if (launchConfig.ask_credential_on_launch) {
         overrides.credentials = originalNodeCredentials || [];


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR is fixing a bug with the UI. When clicking on the `i` to the the Workflow node information:
![image](https://github.com/ansible/awx/assets/26822043/5063f90c-9edd-4850-ae16-d79818f2553b)

The following error occurs:
![image](https://github.com/ansible/awx/assets/26822043/74b9f378-e43c-446e-9c0a-b78c189b832e)

This is happening if the Job Template defined at the workflow has checked any of the following options: `ask_verbosity_on_launch`, `ask_tags_on_launch` and `ask_skip_tags_on_launch`

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.6.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This bug was detected at https://github.com/redhat-cop/controller_configuration/issues/746

<!--- Paste verbatim command output below, e.g. before and after your change -->
<!---
```

```
-->