### PR TITLE
Add secure flag option for userLoggedIn cookie if SESSION_COOKIE_SECU…

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -91,7 +91,7 @@ class LoggedLoginView(auth_views.LoginView):
         ret = super(LoggedLoginView, self).post(request, *args, **kwargs)
         if request.user.is_authenticated:
             logger.info(smart_str(u"User {} logged in from {}".format(self.request.user.username, request.META.get('REMOTE_ADDR', None))))
-            ret.set_cookie('userLoggedIn', 'true')
+            ret.set_cookie('userLoggedIn', 'true', secure=getattr(settings, 'SESSION_COOKIE_SECURE', False))
             ret.setdefault('X-API-Session-Cookie-Name', getattr(settings, 'SESSION_COOKIE_NAME', 'awx_sessionid'))
 
             return ret
@@ -107,7 +107,7 @@ class LoggedLogoutView(auth_views.LogoutView):
         original_user = getattr(request, 'user', None)
         ret = super(LoggedLogoutView, self).dispatch(request, *args, **kwargs)
         current_user = getattr(request, 'user', None)
-        ret.set_cookie('userLoggedIn', 'false')
+        ret.set_cookie('userLoggedIn', 'false', secure=getattr(settings, 'SESSION_COOKIE_SECURE', False))
         if (not current_user or not getattr(current_user, 'pk', True)) and current_user != original_user:
             logger.info("User {} logged out.".format(original_user.username))
         return ret

--- a/awx/sso/views.py
+++ b/awx/sso/views.py
@@ -38,7 +38,7 @@ class CompleteView(BaseRedirectView):
         response = super(CompleteView, self).dispatch(request, *args, **kwargs)
         if self.request.user and self.request.user.is_authenticated:
             logger.info(smart_str(u"User {} logged in".format(self.request.user.username)))
-            response.set_cookie('userLoggedIn', 'true')
+            response.set_cookie('userLoggedIn', 'true', secure=getattr(settings, 'SESSION_COOKIE_SECURE', False))
             response.setdefault('X-API-Session-Cookie-Name', getattr(settings, 'SESSION_COOKIE_NAME', 'awx_sessionid'))
         return response
 


### PR DESCRIPTION
##### SUMMARY
When setting SESSION_COOKIE_SECURE to True, the userLoggedIn cookie would not pick up the secure flag. These changes will allow users to set the SESSION_COOKIE_SECURE to True and the userLoggedIn cookie would have its secure flag set correctly. 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### AWX VERSION
```
awx: 0.1.dev33675+g34cc56f
```


##### ADDITIONAL INFORMATION
You can test this by setting SESSION_COOKIE_SECURE and CSRF_COOKIE_SECURE to true in the extra settings and confirm that with the current version the userLoggedIn cookie does not have the secure option flagged in your browser developer tools. With this change, the secure flag is set correctly.
```
  extra_settings:
  - setting: SESSION_COOKIE_SECURE
    value: true
  - setting: CSRF_COOKIE_SECURE
    value: true
```
