### PR TITLE
Fix linting error in SubscriptionUsageChart

### DIFF
--- a/awx/ui/src/screens/SubscriptionUsage/SubscriptionUsageChart.js
+++ b/awx/ui/src/screens/SubscriptionUsage/SubscriptionUsageChart.js
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
-
 import { t } from '@lingui/macro';
 import {
   Card,
@@ -47,7 +46,7 @@ function SubscriptionUsageChart() {
   const [periodSelection, setPeriodSelection] = useState('year');
   const userProfile = useUserProfile();
 
-  const calculateDateRange = () => {
+  const calculateDateRange = useCallback(() => {
     const today = new Date();
     let date = '';
     switch (periodSelection) {
@@ -77,7 +76,7 @@ function SubscriptionUsageChart() {
         break;
     }
     return date;
-  };
+  }, [periodSelection]);
 
   const {
     isLoading,
@@ -89,7 +88,7 @@ function SubscriptionUsageChart() {
         calculateDateRange()
       );
       return data.data.results;
-    }, [periodSelection]),
+    }, [calculateDateRange]),
     []
   );
 


### PR DESCRIPTION
##### SUMMARY
```
> lint
> eslint --ext .js --ext .jsx .


/Users/mabashian/Desktop/awx/awx/ui/src/screens/SubscriptionUsage/SubscriptionUsageChart.js
  92:8  warning  React Hook useCallback has a missing dependency: 'calculateDateRange'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI
