### PR TITLE
Join across the InstanceLink.target to the underlying Instance

### DIFF
--- a/awx/api/views/mesh_visualizer.py
+++ b/awx/api/views/mesh_visualizer.py
@@ -17,7 +17,7 @@ class MeshVisualizer(APIView):
     def get(self, request, format=None):
         data = {
             'nodes': InstanceNodeSerializer(Instance.objects.all(), many=True).data,
-            'links': InstanceLinkSerializer(InstanceLink.objects.select_related('target', 'source'), many=True).data,
+            'links': InstanceLinkSerializer(InstanceLink.objects.select_related('target__instance', 'source'), many=True).data,
         }
 
         return Response(data)


### PR DESCRIPTION
to avoid having to do a lookup for every instance in the list for the mesh visualizer endpoint.
