### PR TITLE
Specify docker network when multiple networks

### DIFF
--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -71,7 +71,7 @@ runs:
       id: data
       shell: bash
       run: |
-        AWX_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' tools_awx_1)
+        AWX_IP=$(docker inspect -f '{{.NetworkSettings.Networks._sources_awx.IPAddress}}' tools_awx_1)
         ADMIN_TOKEN=$(docker exec -i tools_awx_1 awx-manage create_oauth2_token --user admin)
         echo "ip=$AWX_IP" >> $GITHUB_OUTPUT
         echo "admin_token=$ADMIN_TOKEN" >> $GITHUB_OUTPUT


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
We introduced multi networks to our docker env. The code this replaces would return both networks' ip addresses concatinated i.e. '192.168.2.1192.168.2.3'.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.6.1.dev18+g55b24130a3.d20240125
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
