### PR TITLE
fix nginx append slash to respect proxy

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
@@ -34,7 +34,7 @@ location {{ (ingress_path + '/websocket').replace('//', '/') }} {
 
 location {{ ingress_path }} {
     # Add trailing / if missing
-    rewrite ^(.*[^/])$ $1/ permanent;
+    rewrite ^(.*)$http_host(.*[^/])$ $1$http_host$2/ permanent;
     uwsgi_read_timeout 120s;
     uwsgi_pass uwsgi;
     include /etc/nginx/uwsgi_params;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This is already fixed in awx-operator.
See https://github.com/ansible/awx-operator/blob/a534c856dbebc853191fb2547346007a60f137db/roles/installer/templates/configmaps/config.yaml.j2#L215 This just makes it so a development environment can also work correctly behind a proxy

Fixes problem of
GET to https://$PROXY/something/awx/v2/me
rewritten to https://$AWX/something/awx/v2/me/ (which doesn't exist)

instead path is correctly rewritten as https://$PROXY/something/awx/v2/me/

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```