### PR TITLE
Silence unnecessary setuptools-scm related error messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ KIND_BIN ?= $(shell which kind)
 CHROMIUM_BIN=/tmp/chrome-linux/chrome
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 MANAGEMENT_COMMAND ?= awx-manage
-VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py)
+VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py 2> /dev/null)
 
 # ansible-test requires semver compatable version, so we allow overrides to hack it
 COLLECTION_VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py | cut -d . -f 1-3)


### PR DESCRIPTION
Hopefully silence some setuptools

```
Unable to import setuptools-scm, attempting to install now...
Traceback (most recent call last):
  File "/home/runner/work/awx/awx/tools/scripts/scm_version.py", line 6, in <module>
    from setuptools_scm import get_version
ModuleNotFoundError: No module named 'setuptools_scm'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/awx/awx/tools/scripts/scm_version.py", line 17, in <module>
    raise Exception(f'\nCommand `{" ".join(cmd)}` failed (rc={result.returncode}).\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}')
Exception: 
Command `/usr/bin/python3 -m ensurepip` failed (rc=1).

stdout:
b'ensurepip is disabled in Debian/Ubuntu for the system python.\n\nPython modules for the system python are usually handled by dpkg and apt-get.\n\n    apt install python3-<module name>\n\nInstall the python3-pip package to use pip itself.  Using pip together\nwith the system python might have unexpected results for any system installed\nmodule, so use it on your own risk, or make sure to only use it in virtual\nenvironments.\n\n'

stderr:
b''
Unable to import setuptools-scm, attempting to install now...
Traceback (most recent call last):
  File "/home/runner/work/awx/awx/tools/scripts/scm_version.py", line 6, in <module>
    from setuptools_scm import get_version
ModuleNotFoundError: No module named 'setuptools_scm'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/awx/awx/tools/scripts/scm_version.py", line 17, in <module>
    raise Exception(f'\nCommand `{" ".join(cmd)}` failed (rc={result.returncode}).\n\nstdout:\n{result.stdout}\n\nstderr:\n{result.stderr}')
Exception: 
Command `/usr/bin/python3 -m ensurepip` failed (rc=1).

stdout:
b'ensurepip is disabled in Debian/Ubuntu for the system python.\n\nPython modules for the system python are usually handled by dpkg and apt-get.\n\n    apt install python3-<module name>\n\nInstall the python3-pip package to use pip itself.  Using pip together\nwith the system python might have unexpected results for any system installed\nmodule, so use it on your own risk, or make sure to only use it in virtual\nenvironments.\n\n'

stderr:
b''
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
