### PR TITLE
Add VERSION script to a tox env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ KIND_BIN ?= $(shell which kind)
 CHROMIUM_BIN=/tmp/chrome-linux/chrome
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 MANAGEMENT_COMMAND ?= awx-manage
-VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py)
+VERSION ?= $(shell $(PYTHON) -m tox exec -qqq --skip-pkg-install -e version -- python ./tools/scripts/scm_version.py)
 
 # ansible-test requires semver compatable version, so we allow overrides to hack it
 COLLECTION_VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py | cut -d . -f 1-3)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ KIND_BIN ?= $(shell which kind)
 CHROMIUM_BIN=/tmp/chrome-linux/chrome
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD)
 MANAGEMENT_COMMAND ?= awx-manage
-VERSION ?= $(shell $(PYTHON) -m tox exec -qqq --skip-pkg-install -e version -- python ./tools/scripts/scm_version.py)
+VERSION ?= $(shell $(PYTHON) -m tox -qqq run --skip-pkg-install -e version)
 
 # ansible-test requires semver compatable version, so we allow overrides to hack it
 COLLECTION_VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py | cut -d . -f 1-3)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 isolated_build = True
 
 [testenv:version]
-isolated_build = True
 description = "Retrieve the AWS version from ./tools/scripts/scm_version.py"
 deps =
   setuptools_scm

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,14 @@
 [tox]
 isolated_build = True
 
+[testenv:version]
+isolated_build = True
+description = "Retrieve the AWS version from ./tools/scripts/scm_version.py"
+deps =
+  setuptools_scm
+commands =
+  python3 ./tools/scripts/scm_version.py
+
 [testenv:linters]
 deps =
   black


### PR DESCRIPTION
##### SUMMARY

The problem:
- The `./Makefile` assumes that any given environment is able to invoke the `./tools/scripts/scm_version.py` script but it requires the `setuptools_scm` Python dependency.

Potential solution:
- This PR makes `tox` the only dependency to invoke that version script.
- Another advantage of this approach is its modularity, being easily portable to dev envs or pipelines

##### ISSUE TYPE

 - New or Enhanced Feature

##### COMPONENT NAME

 - Other

##### ADDITIONAL INFORMATION

How to test:

```bash
# Make sure you have tox installed and available on your $PATH
which tox

# Retrieve the version using the following make target
make VERSION
```
