### PR TITLE
Project updates do not run against hosts

### DIFF
--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -124,8 +124,6 @@ class BasePlaybookEvent(CreatedModifiedModel):
         'parent_uuid',
         'start_line',
         'end_line',
-        'host_id',
-        'host_name',
         'verbosity',
     ]
     WRAPUP_EVENT = 'playbook_on_stats'
@@ -473,7 +471,7 @@ class JobEvent(BasePlaybookEvent):
     An event/message logged from the callback when running a job.
     """
 
-    VALID_KEYS = BasePlaybookEvent.VALID_KEYS + ['job_id', 'workflow_job_id', 'job_created']
+    VALID_KEYS = BasePlaybookEvent.VALID_KEYS + ['job_id', 'workflow_job_id', 'job_created', 'host_id', 'host_name']
     JOB_REFERENCE = 'job_id'
 
     objects = DeferJobCreatedManager()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The project update event has no host_id or host_name because they only run on localhost. 

The recent change to `self.host_map` over in the callback caused this failure to surface. https://github.com/ansible/awx/pull/14825

This change also fixes the collection CI failures.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

The bug presents during a project update.

```
tools_awx_1 | 2024-02-01 16:17:17,619 ERROR    [-] awx.main.commands.run_callback_receiver Callback Task Processor Raised Unexpected Exception processing event data:
tools_awx_1 | {'uuid': '9fcb72a1-6302-4795-9692-69d1f772f86d', 'counter': 4, 'stdout': '', 'start_line': 4, 'end_line': 4, 'runner_ident': '18', 'event': 'runner_on_start', 'project_update_id': 18, 'pid': 10, 'created': '2024-02-01T16:17:17.538479+00:00', 'event_data': {'playbook': 'project_update.yml', 'playbook_uuid': '17e040ad-445e-47af-a1f5-1d1444dd32ed', 'play': 'Update source tree if necessary', 'play_uuid': 'b6d7a3cb-c991-261b-23e3-000000000002', 'play_pattern': 'localhost', 'task': 'Update project using git', 'task_uuid': 'b6d7a3cb-c991-261b-23e3-000000000006', 'task_action': 'ansible.builtin.git', 'resolved_action': 'ansible.builtin.git', 'task_args': '', 'task_path': '/runner/project/project_update.yml:41', 'host': 'localhost', 'uuid': '9fcb72a1-6302-4795-9692-69d1f772f86d', 'guid': '98fa4718e4794e94b261ad8e8b797483'}, 'job_created': '2024-02-01 16:17:16.186108+00:00', 'host_name': 'localhost'}
tools_awx_1 | Traceback (most recent call last):
tools_awx_1 |   File "/awx_devel/awx/main/dispatch/worker/callback.py", line 268, in perform_work
tools_awx_1 |     event = cls.create_from_data(**body)
tools_awx_1 |   File "/awx_devel/awx/main/models/events.py", line 454, in create_from_data
tools_awx_1 |     event = cls(**kwargs)
tools_awx_1 |   File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/models/base.py", line 556, in __init__
tools_awx_1 |     _setattr(self, prop, value)
tools_awx_1 | AttributeError: can't set attribute
```
