### PR TITLE
Remove json serialization for notify validation

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5191,7 +5191,7 @@ class NotificationTemplateSerializer(BaseSerializer):
                         #         _("Webhook body for '{}' should be a json dictionary. Found type '{}'.".format(event, type(potential_body).__name__))
                         #     )
                     except Exception as exc:
-                        error_list.append(_("Webhook body for '{}' is not valid. The following gace an error ({}).".format(event, exc)))
+                        error_list.append(_("Webhook body for '{}' is not valid. The following gave an error ({}).".format(event, exc)))
 
         if error_list:
             raise serializers.ValidationError(error_list)


### PR DESCRIPTION
##### SUMMARY
For the webhook notification, the start body only accepts variables whom transpose to json dict.
E.g : {{job_metadata}} = 
```
{ ..... } 
```
All other variables such as {{job.id}} which are primitives (int, str, float, etc) do not pass the validation.
They are not dict type and the below check does not allow {{job.scm_reivsion}} etc as requested by #14410 

```
if not isinstance(potential_body, dict):
```

This patch loosens up this validation to just check for jinja template exception.

related: #14410 

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
