### PR TITLE
Support for auditors in SAML (Social) Organization Map

### DIFF
--- a/awx/sso/fields.py
+++ b/awx/sso/fields.py
@@ -598,8 +598,10 @@ class SocialMapField(fields.ListField):
 
 class SocialSingleOrganizationMapField(HybridDictField):
     admins = SocialMapField(allow_null=True, required=False)
+    auditors = SocialMapField(allow_null=True, required=False)
     users = SocialMapField(allow_null=True, required=False)
     remove_admins = fields.BooleanField(required=False)
+    remove_auditors = fields.BooleanField(required=False)
     remove_users = fields.BooleanField(required=False)
     organization_alias = SocialMapField(allow_null=True, required=False)
 

--- a/awx/sso/tests/functional/test_saml_pipeline.py
+++ b/awx/sso/tests/functional/test_saml_pipeline.py
@@ -45,6 +45,8 @@ class TestSAMLSimpleMaps:
                         'remove': True,
                         'admins': 'foobar',
                         'remove_admins': True,
+                        "auditors": "bar",
+                        "remove_auditors": True,
                         'users': 'foo',
                         'remove_users': True,
                         'organization_alias': '',
@@ -63,6 +65,7 @@ class TestSAMLSimpleMaps:
 
         # Test user membership logic with regular expressions
         backend.setting('ORGANIZATION_MAP')['Default']['admins'] = re.compile('.*')
+        backend.setting('ORGANIZATION_MAP')['Default']['auditors'] = re.compile('.*')
         backend.setting('ORGANIZATION_MAP')['Default']['users'] = re.compile('.*')
 
         desired_org_state = {}
@@ -71,13 +74,15 @@ class TestSAMLSimpleMaps:
         _update_user_orgs(backend, desired_org_state, orgs_to_create, u2)
         _update_user_orgs(backend, desired_org_state, orgs_to_create, u3)
 
-        assert desired_org_state == {'Default': {'member_role': True, 'admin_role': True, 'auditor_role': False}}
+        assert desired_org_state == {'Default': {'member_role': True, 'admin_role': True, 'auditor_role': True}}
         assert orgs_to_create == ['Default']
 
         # Test remove feature enabled
         backend.setting('ORGANIZATION_MAP')['Default']['admins'] = ''
+        backend.setting('ORGANIZATION_MAP')['Default']['auditors'] = ''
         backend.setting('ORGANIZATION_MAP')['Default']['users'] = ''
         backend.setting('ORGANIZATION_MAP')['Default']['remove_admins'] = True
+        backend.setting('ORGANIZATION_MAP')['Default']['remove_auditors'] = True
         backend.setting('ORGANIZATION_MAP')['Default']['remove_users'] = True
         desired_org_state = {}
         orgs_to_create = []
@@ -87,12 +92,13 @@ class TestSAMLSimpleMaps:
 
         # Test remove feature disabled
         backend.setting('ORGANIZATION_MAP')['Default']['remove_admins'] = False
+        backend.setting('ORGANIZATION_MAP')['Default']['remove_auditors'] = False
         backend.setting('ORGANIZATION_MAP')['Default']['remove_users'] = False
         desired_org_state = {}
         orgs_to_create = []
         _update_user_orgs(backend, desired_org_state, orgs_to_create, u2)
 
-        assert desired_org_state == {'Default': {'member_role': None, 'admin_role': None, 'auditor_role': False}}
+        assert desired_org_state == {'Default': {'member_role': None, 'admin_role': None, 'auditor_role': None}}
         assert orgs_to_create == ['Default']
 
         # Test organization alias feature


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds support for Auditors in SAML (Social) Organization Map field. Based on code at:
- https://github.com/ansible/awx/blob/694d7e98e77c7bd11e57ead6f2ddee43aa34a87c/awx/sso/saml_pipeline.py#L86
- https://github.com/ansible/awx/blob/694d7e98e77c7bd11e57ead6f2ddee43aa34a87c/awx/sso/saml_pipeline.py#L120
the `auditors` and `remove_auditors` are valid attributes for SAML Organization Map (`SOCIAL_AUTH_SAML_ORGANIZATION_MAP`).

I've also updated one of the tests to reflect this change, but unsure if others will need similar changes.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.7.1.dev79+gb3aeb962ce
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

1. Configure SAML SSO (adjust attributes and values in (2) and (3) accordingly)
2. In SAML Organization Attribute Mapping set as following:
```json
{
  "saml_attr": "member-of",
  "saml_admin_attr": "admin-of",
  "saml_auditor_attr": "auditor-of",
  "remove": true,
  "remove_admins": false,
  "remove_auditors": false
}
```
3. In SAML Organization Map set as following:
```json
{
  "org1_group_from_saml": {
    "users": true,
    "admins": true,
    "auditors": true,
    "organization_alias": "org1"  
  }
}
```
4. Saving the form results in `Invalid field` error. Removing the `"auditors": true` allows for saving.

<img width="408" alt="image" src="https://github.com/ansible/awx/assets/243891/1be744b7-3f57-4eb9-bb2b-4b7bc1f5e24d">

