### PR TITLE
Fix UI peers_from_control_nodes

### DIFF
--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
@@ -209,7 +209,7 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
           <Detail label={t`Node Type`} value={instance.node_type} />
           <Detail label={t`Host`} value={instance.ip_address} />
           <Detail label={t`Listener Port`} value={instance.listener_port} />
-          {(isExecutionNode || isHopNode || !isManaged) && (
+          {!isManaged && (
             <>
               {instance.related?.install_bundle && (
                 <Detail
@@ -231,11 +231,13 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
                   }
                 />
               )}
-              <Detail
+            </>
+          )}
+          {(isExecutionNode || isHopNode) && (
+            <Detail
                 label={t`Peers from control nodes`}
                 value={instance.peers_from_control_nodes ? t`On` : t`Off`}
-              />
-            </>
+            />
           )}
           {!isHopNode && (
             <>
@@ -342,8 +344,7 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
         </DetailList>
         <CardActionsRow>
           {config?.me?.is_superuser &&
-            isK8s &&
-            (isExecutionNode || isHopNode || !isManaged) && (
+            isK8s && !isManaged && (
               <Button
                 ouiaId="instance-detail-edit-button"
                 aria-label={t`edit`}
@@ -354,8 +355,7 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
               </Button>
             )}
           {config?.me?.is_superuser &&
-            isK8s &&
-            (isExecutionNode || isHopNode || !isManaged) && (
+            isK8s && !isManaged && (
               <RemoveInstanceButton
                 dataCy="remove-instance-button"
                 itemsToRemove={[instance]}

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
@@ -209,29 +209,25 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
           <Detail label={t`Node Type`} value={instance.node_type} />
           <Detail label={t`Host`} value={instance.ip_address} />
           <Detail label={t`Listener Port`} value={instance.listener_port} />
-          {!isManaged && (
-            <>
-              {instance.related?.install_bundle && (
-                <Detail
-                  label={t`Install Bundle`}
-                  value={
-                    <Tooltip content={t`Click to download bundle`}>
-                      <Button
-                        component="a"
-                        isSmall
-                        href={`${instance.related?.install_bundle}`}
-                        target="_blank"
-                        variant="secondary"
-                        dataCy="install-bundle-download-button"
-                        rel="noopener noreferrer"
-                      >
-                        <DownloadIcon />
-                      </Button>
-                    </Tooltip>
-                  }
-                />
-              )}
-            </>
+          {!isManaged && instance.related?.install_bundle && (
+            <Detail
+                label={t`Install Bundle`}
+                value={
+                <Tooltip content={t`Click to download bundle`}>
+                    <Button
+                    component="a"
+                    isSmall
+                    href={`${instance.related?.install_bundle}`}
+                    target="_blank"
+                    variant="secondary"
+                    dataCy="install-bundle-download-button"
+                    rel="noopener noreferrer"
+                    >
+                    <DownloadIcon />
+                    </Button>
+                </Tooltip>
+                }
+            />
           )}
           {(isExecutionNode || isHopNode) && (
             <Detail
@@ -344,22 +340,22 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
         </DetailList>
         <CardActionsRow>
           {config?.me?.is_superuser && isK8s && !isManaged && (
-            <Button
-              ouiaId="instance-detail-edit-button"
-              aria-label={t`edit`}
-              component={Link}
-              to={`/instances/${id}/edit`}
-            >
-              {t`Edit`}
-            </Button>
-          )}
-          {config?.me?.is_superuser && isK8s && !isManaged && (
-            <RemoveInstanceButton
-              dataCy="remove-instance-button"
-              itemsToRemove={[instance]}
-              isK8s={isK8s}
-              onRemove={removeInstances}
-            />
+            <>
+                <Button
+                ouiaId="instance-detail-edit-button"
+                aria-label={t`edit`}
+                component={Link}
+                to={`/instances/${id}/edit`}
+                >
+                {t`Edit`}
+                </Button>
+                <RemoveInstanceButton
+                dataCy="remove-instance-button"
+                itemsToRemove={[instance]}
+                isK8s={isK8s}
+                onRemove={removeInstances}
+                />
+            </>
           )}
           {isExecutionNode && (
             <Tooltip content={t`Run a health check on the instance`}>

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
@@ -211,10 +211,10 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
           <Detail label={t`Listener Port`} value={instance.listener_port} />
           {!isManaged && instance.related?.install_bundle && (
             <Detail
-                label={t`Install Bundle`}
-                value={
+              label={t`Install Bundle`}
+              value={
                 <Tooltip content={t`Click to download bundle`}>
-                    <Button
+                  <Button
                     component="a"
                     isSmall
                     href={`${instance.related?.install_bundle}`}
@@ -222,11 +222,11 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
                     variant="secondary"
                     dataCy="install-bundle-download-button"
                     rel="noopener noreferrer"
-                    >
+                  >
                     <DownloadIcon />
-                    </Button>
+                  </Button>
                 </Tooltip>
-                }
+              }
             />
           )}
           {(isExecutionNode || isHopNode) && (
@@ -341,20 +341,20 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
         <CardActionsRow>
           {config?.me?.is_superuser && isK8s && !isManaged && (
             <>
-                <Button
+              <Button
                 ouiaId="instance-detail-edit-button"
                 aria-label={t`edit`}
                 component={Link}
                 to={`/instances/${id}/edit`}
-                >
+              >
                 {t`Edit`}
-                </Button>
-                <RemoveInstanceButton
+              </Button>
+              <RemoveInstanceButton
                 dataCy="remove-instance-button"
                 itemsToRemove={[instance]}
                 isK8s={isK8s}
                 onRemove={removeInstances}
-                />
+              />
             </>
           )}
           {isExecutionNode && (

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
@@ -235,8 +235,8 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
           )}
           {(isExecutionNode || isHopNode) && (
             <Detail
-                label={t`Peers from control nodes`}
-                value={instance.peers_from_control_nodes ? t`On` : t`Off`}
+              label={t`Peers from control nodes`}
+              value={instance.peers_from_control_nodes ? t`On` : t`Off`}
             />
           )}
           {!isHopNode && (
@@ -343,26 +343,24 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
           )}
         </DetailList>
         <CardActionsRow>
-          {config?.me?.is_superuser &&
-            isK8s && !isManaged && (
-              <Button
-                ouiaId="instance-detail-edit-button"
-                aria-label={t`edit`}
-                component={Link}
-                to={`/instances/${id}/edit`}
-              >
-                {t`Edit`}
-              </Button>
-            )}
-          {config?.me?.is_superuser &&
-            isK8s && !isManaged && (
-              <RemoveInstanceButton
-                dataCy="remove-instance-button"
-                itemsToRemove={[instance]}
-                isK8s={isK8s}
-                onRemove={removeInstances}
-              />
-            )}
+          {config?.me?.is_superuser && isK8s && !isManaged && (
+            <Button
+              ouiaId="instance-detail-edit-button"
+              aria-label={t`edit`}
+              component={Link}
+              to={`/instances/${id}/edit`}
+            >
+              {t`Edit`}
+            </Button>
+          )}
+          {config?.me?.is_superuser && isK8s && !isManaged && (
+            <RemoveInstanceButton
+              dataCy="remove-instance-button"
+              itemsToRemove={[instance]}
+              isK8s={isK8s}
+              onRemove={removeInstances}
+            />
+          )}
           {isExecutionNode && (
             <Tooltip content={t`Run a health check on the instance`}>
               <Button

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
@@ -114,7 +114,6 @@ function InstanceListItem({
   );
 
   const isHopNode = instance.node_type === 'hop';
-  const isExecutionNode = instance.node_type === 'execution';
   const isManaged = instance.managed;
 
   return (

--- a/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
+++ b/awx/ui/src/screens/Instances/InstanceList/InstanceListItem.js
@@ -140,7 +140,7 @@ function InstanceListItem({
             rowIndex,
             isSelected,
             onSelect,
-            disable: !(isExecutionNode || isHopNode || isManaged),
+            disable: isManaged,
           }}
           dataLabel={t`Selected`}
         />

--- a/awx/ui/src/screens/Instances/Shared/InstanceForm.js
+++ b/awx/ui/src/screens/Instances/Shared/InstanceForm.js
@@ -98,7 +98,6 @@ function InstanceFormFields({ isEdit, instance }) {
           name="peers_from_control_nodes"
           label={t`Peers from control nodes`}
           tooltip={t`If enabled, control nodes will peer to this instance automatically. If disabled, instance will be connected only to associated peers.`}
-          isDisabled={parseInt(instance.listener_port, 10) < 1024 || true}
         />
       </FormGroup>
     </>

--- a/awx/ui/src/screens/Instances/Shared/InstanceForm.js
+++ b/awx/ui/src/screens/Instances/Shared/InstanceForm.js
@@ -16,7 +16,7 @@ const INSTANCE_TYPES = [
   { id: 'hop', name: t`Hop` },
 ];
 
-function InstanceFormFields({ isEdit, instance }) {
+function InstanceFormFields({ isEdit }) {
   const [instanceTypeField, instanceTypeMeta, instanceTypeHelpers] = useField({
     name: 'node_type',
     validate: required(t`Set a value for this field`),
@@ -138,7 +138,7 @@ function InstanceForm({
         {(formik) => (
           <Form autoComplete="off" onSubmit={formik.handleSubmit}>
             <FormColumnLayout>
-              <InstanceFormFields isEdit={isEdit} instance={instance} />
+              <InstanceFormFields isEdit={isEdit} />
               <FormSubmitError error={submitError} />
               <FormActionGroup
                 onCancel={handleCancel}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes bug where peers_from_control_node was greyed out in UI

Additional changes:
- Make edit instance button only show for instances with managed = False
- Make remove instance button only show for instances with managed = False
- InstanceList selectable only for instances with managed = False

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
![Screenshot from 2024-02-07 18-46-53](https://github.com/ansible/awx/assets/8745776/d1c524e7-225f-4a7a-87e2-74a99f7b72d1)

![Screenshot from 2024-02-07 18-43-36](https://github.com/ansible/awx/assets/8745776/7417ba3d-9258-4863-99b9-0e6b953eeb80)

![Screenshot from 2024-02-07 18-45-59](https://github.com/ansible/awx/assets/8745776/71205989-d86c-4fcc-9b66-36ea51138069)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI