### PR TITLE
Allow connecting to websockets via api/websocket/

### DIFF
--- a/awx/main/routing.py
+++ b/awx/main/routing.py
@@ -27,6 +27,7 @@ class AWXProtocolTypeRouter(ProtocolTypeRouter):
 
 
 websocket_urlpatterns = [
+    re_path(r'api/websocket/$', consumers.EventConsumer.as_asgi()),
     re_path(r'websocket/$', consumers.EventConsumer.as_asgi()),
     re_path(r'websocket/relay/$', consumers.RelayConsumer.as_asgi()),
 ]

--- a/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
@@ -10,7 +10,7 @@ location {{ (ingress_path + '/favicon.ico').replace('//', '/') }} {
     alias /awx_devel/awx/public/static/favicon.ico;
 }
 
-location {{ (ingress_path + '/websocket').replace('//', '/') }} {
+location ~ ({{ (ingress_path + '/websocket').replace('//', '/') }}|{{ (ingress_path + '/api/websocket').replace('//', '/') }}) {
     # Pass request to the upstream alias
     proxy_pass http://daphne;
     # Require http version 1.1 to allow for upgrade requests


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Before, we just allowed websockets on <host>/websocket/. With this change, they can now come from <host>/api/websocket/
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.7.1.dev2+gc2e498a5ea
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
