### PR TITLE
Add python 3.12 dependency

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -90,6 +90,7 @@ setup(
     install_requires=[
         'PyYAML',
         'requests',
+        'setuptools',
     ],
     python_requires=">=3.8",
     extras_require={'formatting': ['jq'], 'websockets': ['websocket-client==0.57.0'], 'crypto': ['cryptography']},


### PR DESCRIPTION
##### SUMMARY
Python 3.12 removes distutils from standard library. While we use some of its function in awxkit, we need to update dependencies in order to have awxkit working with python 3.12

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI
 
##### AWX VERSION
```
23.7.1.dev93+g6235176997
```