### PR TITLE
Retries on vault on seal

### DIFF
--- a/tools/docker-compose/ansible/roles/vault/tasks/unseal.yml
+++ b/tools/docker-compose/ansible/roles/vault/tasks/unseal.yml
@@ -16,3 +16,7 @@
     - "{{ Unseal_Key_1 }}"
     - "{{ Unseal_Key_2 }}"
     - "{{ Unseal_Key_3 }}"
+  register: unseal_result
+  until: unseal_result is succeeded or unseal_result is failed and 'Connection refused' not in unseal_result.msg
+  retries: 5
+  delay: 1


### PR DESCRIPTION
##### SUMMARY
Sometime we tried to unseal when vault is not ready yet

after the change
```
TASK [vault : Unseal the vault] *********************************************************************************************************************************************************************************************************************
FAILED - RETRYING: [localhost]: Unseal the vault (3 retries left).
changed: [localhost] => (item=<redacted>)
changed: [localhost] => (item=<redacted>)
changed: [localhost] => (item=<redacted>)
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.7.1.dev100+gaf4dfc1d48.d20240213
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
