### PR TITLE
Unbreak the pip-compile command when multiple files are passed in

### DIFF
--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -23,7 +23,7 @@ generate_requirements() {
   # FIXME: https://github.com/jazzband/pip-tools/issues/1558
   ${venv}/bin/python3 -m pip install -U 'pip<22.0' pip-tools
 
-  ${pip_compile} "$1" --output-file requirements.txt
+  ${pip_compile} $1 --output-file requirements.txt
   # consider the git requirements for purposes of resolving deps
   # Then remove any git+ lines from requirements.txt
   if [[ "$sanitize_git" == "1" ]] ; then


### PR DESCRIPTION
##### SUMMARY
Unbreak the pip-compile command when multiple files are passed in

Currently if you try to do `./updater.sh run`, you get

```
Usage: pip-compile [OPTIONS] [SRC_FILES]...
Try 'pip-compile -h' for help.

Error: Invalid value for '[SRC_FILES]...': Path '/awx_devel/requirements/requirements.in /awx_devel/requirements/requirements_git.txt' does not exist.
```

This is because it is pretending that the paths to requirements.in and requirements_git.txt are one long path with a space character in it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other
