### PR TITLE
Fix failed jobs when database is not in English

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1156,7 +1156,7 @@ def create_partition(tblname, start=None):
                     f'FOR VALUES FROM (\'{start_timestamp}\') TO (\'{end_timestamp}\');'
                 )
     except (ProgrammingError, IntegrityError) as e:
-        if 'already exists' in str(e):
+        if f'{tblname}_{partition_label}, 2200)' in str(e):
             logger.info(f'Caught known error due to partition creation race: {e}')
         else:
             raise


### PR DESCRIPTION
##### SUMMARY
Job fails if you schedule them at xx:00 with more then 2 slices due to race condition which we caught in Exception, but if database is in different language then english, then if fails.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 - Other

##### AWX VERSION
```
AAP 4.5.1
0.1.dev33808+gb8e17bd
```

##### ADDITIONAL INFORMATION
N/A

Before:
```
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/jobs.py", line 491, in run
    self.pre_run_hook(self.instance, private_data_dir)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/jobs.py", line 1058, in pre_run_hook
    super(RunJob, self).pre_run_hook(job, private_data_dir)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/tasks/jobs.py", line 425, in pre_run_hook
    create_partition(instance.event_class._meta.db_table, start=instance.created)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/awx/main/utils/common.py", line 1175, in create_partition
    cursor.execute(
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/django/db/backends/utils.py", line 87, in _execute
    return self.cursor.execute(sql)
  File "/var/lib/awx/venv/awx/lib64/python3.9/site-packages/psycopg/cursor.py", line 723, in execute
    raise ex.with_traceback(None)
django.db.utils.IntegrityError: doppelter Schlüsselwert verletzt Unique-Constraint »pg_type_typname_nsp_index«
DETAIL:  Schlüssel »(typname, typnamespace)=(main_jobevent_20240215_09, 2200)« existiert bereits.
```

After:
```
2024-02-15 10:00:22,494 INFO     [-] awx.main.utils Caught known error due to partition creation race: doppelter Schlüsselwert verletzt Unique-Constraint »pg_type_typname_nsp_index«
DETAIL:  Schlüssel »(typname, typnamespace)=(main_jobevent_20240215_10, 2200)« existiert bereits.
```