### PR TITLE
Fix the persistent breakage when cleaning up Github branches

### DIFF
--- a/.github/workflows/feature_branch_deletion.yml
+++ b/.github/workflows/feature_branch_deletion.yml
@@ -2,12 +2,10 @@
 name: Feature branch deletion cleanup
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
-on:
-  delete:
-    branches:
-      - feature_**
+on: delete
 jobs:
-  push:
+  branch_delete:
+    if: ${{ github.event.ref_type == 'branch' && startsWith(github.event.ref, 'feature_') }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -22,6 +20,4 @@ jobs:
         run: |
           ansible localhost -c local, -m command -a "{{ ansible_python_interpreter + ' -m pip install boto3'}}"
           ansible localhost -c local -m aws_s3 \
-            -a "bucket=awx-public-ci-files object=${GITHUB_REF##*/}/schema.json mode=delete permission=public-read"
-
-
+            -a "bucket=awx-public-ci-files object=${GITHUB_REF##*/}/schema.json mode=delobj permission=public-read"


### PR DESCRIPTION
##### SUMMARY
The github workflow that we have set up for branch deletion doesn't work:

- the `on: delete` event does not support the `branches:` filter (https://github.com/orgs/community/discussions/10589)
- the `mode` flag for the aws_s3 module does not have `delete` as one of the options.  The proper option appears to be `delobj`.  (https://docs.ansible.com/ansible/latest/collections/amazon/aws/s3_object_module.html#parameter-mode)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other
