### PR TITLE
Disable install_bundle endpoint for ingress node

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5594,7 +5594,7 @@ class InstanceSerializer(BaseSerializer):
         res['jobs'] = self.reverse('api:instance_unified_jobs_list', kwargs={'pk': obj.pk})
         res['peers'] = self.reverse('api:instance_peers_list', kwargs={"pk": obj.pk})
         res['instance_groups'] = self.reverse('api:instance_instance_groups_list', kwargs={'pk': obj.pk})
-        if obj.node_type in [Instance.Types.EXECUTION, Instance.Types.HOP]:
+        if obj.node_type in [Instance.Types.EXECUTION, Instance.Types.HOP] and not obj.managed:
             res['install_bundle'] = self.reverse('api:instance_install_bundle', kwargs={'pk': obj.pk})
         if self.context['request'].user.is_superuser or self.context['request'].user.is_system_auditor:
             if obj.node_type == 'execution':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
install bundle is not used for mesh ingress nodes, so we can just disable the endpoint altogether.

Also properly prevents the install bundle button from showing up on the topology view
![image](https://github.com/ansible/awx/assets/8745776/73f8f2ce-b810-454f-917c-b832ca5f1881)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

```
