### PR TITLE
Don't use English for string comparisons

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -6,6 +6,7 @@ import itertools
 import json
 import logging
 import os
+import psycopg
 from io import StringIO
 from contextlib import redirect_stdout
 import shutil
@@ -630,10 +631,18 @@ def cluster_node_heartbeat(dispatch_time=None, worker_tasks=None):
                 logger.error("Host {} last checked in at {}, marked as lost.".format(other_inst.hostname, other_inst.last_seen))
 
         except DatabaseError as e:
-            if 'did not affect any rows' in str(e):
-                logger.debug('Another instance has marked {} as lost'.format(other_inst.hostname))
+            cause = e.__cause__
+            if cause and hasattr(cause, 'sqlstate'):
+                sqlstate = cause.sqlstate
+                sqlstate_str = psycopg.errors.lookup(sqlstate)
+                logger.debug('SQL Error state: {} - {}'.format(sqlstate, sqlstate_str))
+
+                if sqlstate == psycopg.errors.NoData:
+                    logger.debug('Another instance has marked {} as lost'.format(other_inst.hostname))
+                else:
+                    logger.exception("Error marking {} as lost.".format(other_inst.hostname))
             else:
-                logger.exception('Error marking {} as lost'.format(other_inst.hostname))
+                logger.exception('No SQL state available.  Error marking {} as lost'.format(other_inst.hostname))
 
     # Run local reaper
     if worker_tasks is not None:
@@ -788,10 +797,19 @@ def update_inventory_computed_fields(inventory_id):
     try:
         i.update_computed_fields()
     except DatabaseError as e:
-        if 'did not affect any rows' in str(e):
-            logger.debug('Exiting duplicate update_inventory_computed_fields task.')
-            return
-        raise
+        # https://github.com/django/django/blob/eff21d8e7a1cb297aedf1c702668b590a1b618f3/django/db/models/base.py#L1105
+        # django raises DatabaseError("Forced update did not affect any rows.")
+
+        # if sqlstate is set then there was a database error and otherwise will re-raise that error
+        cause = e.__cause__
+        if cause and hasattr(cause, 'sqlstate'):
+            sqlstate = cause.sqlstate
+            sqlstate_str = psycopg.errors.lookup(sqlstate)
+            logger.error('SQL Error state: {} - {}'.format(sqlstate, sqlstate_str))
+            raise
+
+        # otherwise
+        logger.debug('Exiting duplicate update_inventory_computed_fields task.')
 
 
 def update_smart_memberships_for_inventory(smart_inventory):

--- a/awx/main/tests/unit/tasks/test_system.py
+++ b/awx/main/tests/unit/tasks/test_system.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from awx.main.tasks.system import update_inventory_computed_fields
+from awx.main.models import Inventory
+from django.db import DatabaseError
+
+
+@pytest.fixture
+def mock_logger():
+    with patch("awx.main.tasks.system.logger") as logger:
+        yield logger
+
+
+@pytest.fixture
+def mock_inventory():
+    return MagicMock(spec=Inventory)
+
+
+def test_update_inventory_computed_fields_existing_inventory(mock_logger, mock_inventory):
+    # Mocking the Inventory.objects.filter method to return a non-empty queryset
+    with patch("awx.main.tasks.system.Inventory.objects.filter") as mock_filter:
+        mock_filter.return_value.exists.return_value = True
+        mock_filter.return_value.__getitem__.return_value = mock_inventory
+
+        # Mocking the update_computed_fields method
+        with patch.object(mock_inventory, "update_computed_fields") as mock_update_computed_fields:
+            update_inventory_computed_fields(1)
+
+            # Assertions
+            mock_filter.assert_called_once_with(id=1)
+            mock_update_computed_fields.assert_called_once()
+
+            # You can add more assertions based on your specific requirements
+
+
+def test_update_inventory_computed_fields_missing_inventory(mock_logger):
+    # Mocking the Inventory.objects.filter method to return an empty queryset
+    with patch("awx.main.tasks.system.Inventory.objects.filter") as mock_filter:
+        mock_filter.return_value.exists.return_value = False
+
+        update_inventory_computed_fields(1)
+
+        # Assertions
+        mock_filter.assert_called_once_with(id=1)
+        mock_logger.error.assert_called_once_with("Update Inventory Computed Fields failed due to missing inventory: 1")
+
+
+def test_update_inventory_computed_fields_database_error_nosqlstate(mock_logger, mock_inventory):
+    # Mocking the Inventory.objects.filter method to return a non-empty queryset
+    with patch("awx.main.tasks.system.Inventory.objects.filter") as mock_filter:
+        mock_filter.return_value.exists.return_value = True
+        mock_filter.return_value.__getitem__.return_value = mock_inventory
+
+        # Mocking the update_computed_fields method
+        with patch.object(mock_inventory, "update_computed_fields") as mock_update_computed_fields:
+            # Simulating the update_computed_fields method to explicitly raise a DatabaseError
+            mock_update_computed_fields.side_effect = DatabaseError("Some error")
+
+            update_inventory_computed_fields(1)
+
+            # Assertions
+            mock_filter.assert_called_once_with(id=1)
+            mock_update_computed_fields.assert_called_once()
+            mock_inventory.update_computed_fields.assert_called_once()


### PR DESCRIPTION
##### SUMMARY
This work is to remove string validation using comparisons of English literals for comparison.
This replaces validation with error/op codes as a universal approach to validation and comparison


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
```
all
```

