### PR TITLE
Changes "approval" role in module to "approve" align with controller API

### DIFF
--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -45,7 +45,7 @@ options:
       description:
         - The role type to grant/revoke.
       required: True
-      choices: ["admin", "read", "member", "execute", "adhoc", "update", "use", "approval", "auditor", "project_admin", "inventory_admin", "credential_admin",
+      choices: ["admin", "read", "member", "execute", "adhoc", "update", "use", "approve", "auditor", "project_admin", "inventory_admin", "credential_admin",
                 "workflow_admin", "notification_admin", "job_template_admin", "execution_environment_admin"]
       type: str
     target_team:
@@ -185,7 +185,7 @@ def main():
                 "adhoc",
                 "update",
                 "use",
-                "approval",
+                "approve",
                 "auditor",
                 "project_admin",
                 "inventory_admin",

--- a/awx_collection/test/awx/test_role.py
+++ b/awx_collection/test/awx/test_role.py
@@ -63,19 +63,19 @@ def test_grant_workflow_list_permission(run_module, admin_user, organization, st
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('state', ('present', 'absent'))
-def test_grant_workflow_approval_permission(run_module, admin_user, organization, state):
+def test_grant_workflow_approve_permission(run_module, admin_user, organization, state):
     wfjt = WorkflowJobTemplate.objects.create(organization=organization, name='foo-workflow')
     rando = User.objects.create(username='rando')
     if state == 'absent':
         wfjt.execute_role.members.add(rando)
 
-    result = run_module('role', {'user': rando.username, 'workflow': wfjt.name, 'role': 'approval', 'state': state}, admin_user)
+    result = run_module('role', {'user': rando.username, 'workflow': wfjt.name, 'role': 'approve', 'state': state}, admin_user)
     assert not result.get('failed', False), result.get('msg', result)
 
     if state == 'present':
-        assert rando in wfjt.approval_role
+        assert rando in wfjt.approve_role
     else:
-        assert rando not in wfjt.approval_role
+        assert rando not in wfjt.approve_role
 
 
 @pytest.mark.django_db

--- a/awx_collection/test/awx/test_role.py
+++ b/awx_collection/test/awx/test_role.py
@@ -73,9 +73,9 @@ def test_grant_workflow_approve_permission(run_module, admin_user, organization,
     assert not result.get('failed', False), result.get('msg', result)
 
     if state == 'present':
-        assert rando in wfjt.approve_role
+        assert rando in wfjt.approval_role
     else:
-        assert rando not in wfjt.approve_role
+        assert rando not in wfjt.approval_role
 
 
 @pytest.mark.django_db

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -200,7 +200,7 @@
       role:
         users:
           - "{{ username }}2"
-        role: approval
+        role: approve
         workflow: test-role-workflow
         state: present
       register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Controller API has the named role "approve" for workflow approval access. The collection has this role named "approval" which fails due to the mismatch.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - Collection


##### AWX VERSION
controller 4.5.1


