### PR TITLE
Replace view reverse URLs with header value

### DIFF
--- a/awx/api/versioning.py
+++ b/awx/api/versioning.py
@@ -24,6 +24,11 @@ def drf_reverse(viewname, args=None, kwargs=None, request=None, format=None, **e
     else:
         url = _reverse(viewname, args, kwargs, request, format, **extra)
 
+    if settings.URL_REPLACE_FROM_HEADER:
+        header_string = request.headers.get(settings.URL_REPLACE_FROM_HEADER['header'], None)
+        if header_string:
+            url = url.replace(settings.URL_REPLACE_FROM_HEADER['to_replace'], header_string)
+
     return url
 
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -165,6 +165,11 @@ ALLOWED_HOSTS = []
 # reverse proxy.
 REMOTE_HOST_HEADERS = ['REMOTE_ADDR', 'REMOTE_HOST']
 
+URL_REPLACE_FROM_HEADER = {
+    'header': 'Aap-Prefix',  # e.g. api/controller/v2
+    'to_replace': 'api/v2',  # the header string will replace this substring in the URL
+}
+
 # If we are behind a reverse proxy/load balancer, use this setting to
 # allow the proxy IP addresses from which Tower should trust custom
 # REMOTE_HOST_HEADERS header values


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Enables replacing part of the URLs that appear on the API page with a request header.

If a special header is present in the HTTP request, the substring will be replaced with the header value provided.

for example,

in settings.py

```
URL_REPLACE_FROM_HEADER = {
    'header': 'Aap-Prefix',
    'to_replace': 'api/v2',
}
```

This will replace

    api/v2/instances/3

with

    api/controller/v2/instances/3

if 'Aap-Prefix' is defined in the request header.

This feature is added to allow consistent URLs when controller is deployed alongside aap-gateway.

- [ ] should the setting be turned off be default
- [ ] there are few places where we import `reverse` from restframework and django.urls instead of our custom defined `reverse`. So we may need to tweak those imports

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API