### PR TITLE
Removing Podman to use Docker again in the collection ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,6 @@ jobs:
 
       - name: Run sanity tests
         run: make test_collection_sanity
-        env:
-          # needed due to cgroupsv2. This is fixed, but a stable release
-          # with the fix has not been made yet.
-          ANSIBLE_TEST_PREFER_PODMAN: 1
 
   collection-integration:
     name: awx_collection integration


### PR DESCRIPTION
##### SUMMARY
There is an issue with latest Ubuntu image and podman itself, so removing this var to use Docker until the issue is fixed

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

