### PR TITLE
Add setting for configuring optional URL prefix for /api

### DIFF
--- a/awx/api/versioning.py
+++ b/awx/api/versioning.py
@@ -24,6 +24,10 @@ def drf_reverse(viewname, args=None, kwargs=None, request=None, format=None, **e
     else:
         url = _reverse(viewname, args, kwargs, request, format, **extra)
 
+    if settings.OPTIONAL_API_URLPATTERN_PREFIX and request:
+        if request._request.path.startswith(f"/api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}"):
+            url = url.replace('/api', f"/api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}")
+
     return url
 
 

--- a/awx/api/versioning.py
+++ b/awx/api/versioning.py
@@ -25,7 +25,7 @@ def drf_reverse(viewname, args=None, kwargs=None, request=None, format=None, **e
         url = _reverse(viewname, args, kwargs, request, format, **extra)
 
     if settings.OPTIONAL_API_URLPATTERN_PREFIX and request:
-        if request._request.path.startswith(f"/api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}"):
+        if request.path.startswith(f"/api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}"):
             url = url.replace('/api', f"/api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}")
 
     return url

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1126,3 +1126,8 @@ from ansible_base.lib import dynamic_config  # noqa: E402
 
 settings_file = os.path.join(os.path.dirname(dynamic_config.__file__), 'dynamic_settings.py')
 include(settings_file)
+
+# Add a postfix to the API URL patterns
+# example if set to '' API pattern will be /api
+# example if set to 'controller' API pattern will be /api AND /api/controller
+OPTIONAL_API_URLPATTERN_PREFIX = ''

--- a/awx/urls.py
+++ b/awx/urls.py
@@ -2,7 +2,7 @@
 # All Rights Reserved.
 
 from django.conf import settings
-from django.urls import re_path, include
+from django.urls import path, re_path, include
 
 from ansible_base.resource_registry.urls import urlpatterns as resource_api_urls
 
@@ -12,7 +12,15 @@ from awx.main.views import handle_400, handle_403, handle_404, handle_500, handl
 urlpatterns = [
     re_path(r'', include('awx.ui.urls', namespace='ui')),
     re_path(r'^ui_next/.*', include('awx.ui_next.urls', namespace='ui_next')),
-    re_path(r'^api/', include('awx.api.urls', namespace='api')),
+    path('api/', include('awx.api.urls', namespace='api')),
+]
+
+if settings.OPTIONAL_API_URLPATTERN_PREFIX:
+    urlpatterns += [
+        path(f'api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}/', include('awx.api.urls')),
+    ]
+
+urlpatterns += [
     re_path(r'^api/v2/', include(resource_api_urls)),
     re_path(r'^sso/', include('awx.sso.urls', namespace='sso')),
     re_path(r'^sso/', include('social_django.urls', namespace='social')),


### PR DESCRIPTION
##### SUMMARY
Add OPTIONAL_API_URLPATTERN_PREFIX setting

examples:
- if set to `''` (empty string) API pattern will be `/api`
- if set to 'controller' API pattern will be `/api` AND `/api/controller`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.9.1.dev4+gec1a556ba0.d20240228
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
