### PR TITLE
Convert swagger release fixture to env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ swagger: reports
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
-	(set -o pipefail && py.test $(PYTEST_ARGS) awx/conf/tests/functional awx/main/tests/functional/api awx/main/tests/docs --release=$(VERSION_TARGET) | tee reports/$@.report)
+	(set -o pipefail && py.test $(PYTEST_ARGS) awx/conf/tests/functional awx/main/tests/functional/api awx/main/tests/docs | tee reports/$@.report)
 
 check: black
 

--- a/awx/main/tests/docs/conftest.py
+++ b/awx/main/tests/docs/conftest.py
@@ -1,13 +1,8 @@
 from awx.main.tests.functional.conftest import *  # noqa
+import os
+import pytest
 
 
-def pytest_addoption(parser):
-    parser.addoption("--release", action="store", help="a release version number, e.g., 3.3.0")
-
-
-def pytest_generate_tests(metafunc):
-    # This is called for every test. Only get/set command line arguments
-    # if the argument is specified in the list of test "fixturenames".
-    option_value = metafunc.config.option.release
-    if 'release' in metafunc.fixturenames and option_value is not None:
-        metafunc.parametrize("release", [option_value])
+@pytest.fixture()
+def release():
+    return os.environ.get('VERSION_TARGET', '')


### PR DESCRIPTION
##### SUMMARY
`pytest awx/main/tests/docs --release=$(VERSION_TARGET)` where --release is required breaks test discovery and running in vscode (from within the container)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.9.1.dev4+gc42ea47876.d20240229
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
