### PR TITLE
Fix test that fail on rerun due to expecting exact IDs

### DIFF
--- a/awx/main/tests/functional/test_projects.py
+++ b/awx/main/tests/functional/test_projects.py
@@ -411,14 +411,14 @@ def test_project_delete(delete, organization, admin_user):
 
 
 @pytest.mark.parametrize(
-    'order_by, expected_names, expected_ids',
+    'order_by, expected_names',
     [
-        ('name', ['alice project', 'bob project', 'shared project'], [1, 2, 3]),
-        ('-name', ['shared project', 'bob project', 'alice project'], [3, 2, 1]),
+        ('name', ['alice project', 'bob project', 'shared project']),
+        ('-name', ['shared project', 'bob project', 'alice project']),
     ],
 )
 @pytest.mark.django_db
-def test_project_list_ordering_by_name(get, order_by, expected_names, expected_ids, organization_factory):
+def test_project_list_ordering_by_name(get, order_by, expected_names, organization_factory):
     'ensure sorted order of project list is maintained correctly when the requested order is invalid or not applicable'
     objects = organization_factory(
         'org1',
@@ -426,13 +426,11 @@ def test_project_list_ordering_by_name(get, order_by, expected_names, expected_i
         superusers=['admin'],
     )
     project_names = []
-    project_ids = []
     # TODO: ask for an order by here that doesn't apply
     results = get(reverse('api:project_list'), objects.superusers.admin, QUERY_STRING='order_by=%s' % order_by).data['results']
     for x in range(len(results)):
         project_names.append(results[x]['name'])
-        project_ids.append(results[x]['id'])
-    assert project_names == expected_names and project_ids == expected_ids
+    assert project_names == expected_names
 
 
 @pytest.mark.parametrize('order_by', ('name', '-name'))
@@ -450,7 +448,8 @@ def test_project_list_ordering_with_duplicate_names(get, order_by, organization_
     for x in range(3):
         results = get(reverse('api:project_list'), objects.superusers.admin, QUERY_STRING='order_by=%s' % order_by).data['results']
         project_ids[x] = [proj['id'] for proj in results]
-    assert project_ids[0] == project_ids[1] == project_ids[2] == [1, 2, 3, 4, 5]
+    assert project_ids[0] == project_ids[1] == project_ids[2]
+    assert project_ids[0] == sorted(project_ids[0])
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
example failure for `test_project_list_ordering_with_duplicate_names` on rerun
```
    assert project_ids[0] == project_ids[1] == project_ids[2] == [1, 2, 3, 4, 5]
AssertionError: assert [16, 17, 18, 19, 20] == [1, 2, 3, 4, 5]
```
example failure for `test_project_list_ordering_by_name` on rerun
```
    assert project_names == expected_names and project_ids == expected_ids
AssertionError: assert (['shared proj...lice project'] == ['shared proj...lice project']
  
  Use -v to get more diff and [18, 17, 16] == [3, 2, 1]
```

 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.9.1.dev9+g8cf2861491
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
