### PR TITLE
In development environment not auto-reload explicitly STOPPED processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,6 @@ collectstatic:
 	fi; \
 	$(PYTHON) manage.py collectstatic --clear --noinput > /dev/null 2>&1
 
-DEV_RELOAD_COMMAND ?= supervisorctl restart tower-processes:*
-
 uwsgi: collectstatic
 	@if [ "$(VENV_BASE)" ]; then \
 		. $(VENV_BASE)/awx/bin/activate; \
@@ -225,7 +223,7 @@ uwsgi: collectstatic
 	uwsgi /etc/tower/uwsgi.ini
 
 awx-autoreload:
-	@/awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx "$(DEV_RELOAD_COMMAND)"
+	@/awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx
 
 daphne:
 	@if [ "$(VENV_BASE)" ]; then \

--- a/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_rsyslog.conf.j2
@@ -36,7 +36,7 @@ stderr_logfile_maxbytes=0
 
 {% if kube_dev | bool %}
 [program:awx-autoreload]
-command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx 'supervisorctl -c /etc/supervisord_rsyslog.conf restart tower-processes:*'
+command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx
 autostart = true
 autorestart = true
 stopasgroup=true

--- a/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_task.conf.j2
@@ -58,7 +58,7 @@ stderr_logfile_maxbytes=0
 
 {% if kube_dev | bool %}
 [program:awx-autoreload]
-command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx 'supervisorctl -c /etc/supervisord_task.conf restart tower-processes:*'
+command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx
 autostart = true
 autorestart = true
 stopasgroup=true

--- a/tools/ansible/roles/dockerfile/templates/supervisor_web.conf.j2
+++ b/tools/ansible/roles/dockerfile/templates/supervisor_web.conf.j2
@@ -91,7 +91,7 @@ stderr_logfile_maxbytes=0
 
 {% if kube_dev | bool %}
 [program:awx-autoreload]
-command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx 'supervisorctl -c /etc/supervisord_web.conf restart tower-processes:*'
+command = /awx_devel/tools/docker-compose/awx-autoreload /awx_devel/awx
 autostart = true
 autorestart = true
 stopasgroup=true

--- a/tools/docker-compose/awx-autoreload
+++ b/tools/docker-compose/awx-autoreload
@@ -13,8 +13,15 @@ inotifywait -mrq -e create,delete,attrib,close_write,move --exclude '(/awx_devel
    since_last=$((this_reload-last_reload))
    if [[ "$file" =~ ^[^.].*\.py$ ]] && [[ "$since_last" -gt 1 ]]; then
       echo "File changed: $file"
-      echo "Running command: $2"
-      eval $2
+      # if SUPERVISOR_CONFIG_PATH is defined run `supervisorctl -c $SUPERVISOR_CONFIG_PATH` else just run `supervisorctl`
+      if [ -n "$SUPERVISOR_CONFIG_PATH" ]; then
+          supervisorctl_command="supervisorctl -c $SUPERVISOR_CONFIG_PATH"
+      else
+          supervisorctl_command="supervisorctl"
+      fi
+      tower_processes=`$supervisorctl_command status tower-processes:* | grep -v STOPPED | awk '{print $1}' | tr '\n' ' '`
+      echo echo "Running command: $supervisorctl_command restart $tower_processes"
+      eval $supervisorctl_command restart $tower_processes
       last_reload=`date +%s`
    fi
 done


### PR DESCRIPTION
##### SUMMARY
In development/debug workflow sometime we explicitly STOP processes this will make sure auto-reload does not start them back up


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.9.1.dev10+gb2f1895f29.d20240306
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
