### PR TITLE
Add  pip>=21.3 to dev requirement to install django-ansible-base in editable mode

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -26,3 +26,4 @@ gprof2dot
 atomicwrites==1.4.0
 flake8
 yamllint
+pip>=21.3 # PEP 660 – Editable installs for pyproject.toml based builds (wheel based)


### PR DESCRIPTION
##### SUMMARY
required for installing django-ansible-base in editable mode

https://peps.python.org/pep-0660/

PEP 660 – Editable installs for pyproject.toml based builds (wheel based)


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.9.1.dev12+gcb15d13c7a.d20240306
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
