### PR TITLE
Fix awx-autoreload in dev environment

### DIFF
--- a/tools/docker-compose/awx-autoreload
+++ b/tools/docker-compose/awx-autoreload
@@ -1,8 +1,8 @@
 #!/bin/env bash
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     echo "Usage:"
-    echo "    autoreload directory command"
+    echo "    autoreload directory"
     exit 1
 fi
 
@@ -13,7 +13,6 @@ inotifywait -mrq -e create,delete,attrib,close_write,move --exclude '(/awx_devel
    since_last=$((this_reload-last_reload))
    if [[ "$file" =~ ^[^.].*\.py$ ]] && [[ "$since_last" -gt 1 ]]; then
       echo "File changed: $file"
-      # if SUPERVISOR_CONFIG_PATH is defined run `supervisorctl -c $SUPERVISOR_CONFIG_PATH` else just run `supervisorctl`
       if [ -n "$SUPERVISOR_CONFIG_PATH" ]; then
           supervisorctl_command="supervisorctl -c $SUPERVISOR_CONFIG_PATH"
       else


### PR DESCRIPTION
##### SUMMARY
recent change made autoreload no longer take the command parameter

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.9.1.dev15+g465d34a7be
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
