### PR TITLE
Align Orign and Host header

### DIFF
--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -74,7 +74,6 @@ AWX_CALLBACK_PROFILE = True
 AWX_DISABLE_TASK_MANAGERS = False
 
 # Needed for launching runserver in debug mode
-CSRF_TRUSTED_ORIGINS = []
 # ======================!!!!!!! FOR DEVELOPMENT ONLY !!!!!!!=================================
 
 # Store a snapshot of default settings at this point before loading any

--- a/awx/settings/development.py
+++ b/awx/settings/development.py
@@ -74,7 +74,7 @@ AWX_CALLBACK_PROFILE = True
 AWX_DISABLE_TASK_MANAGERS = False
 
 # Needed for launching runserver in debug mode
-CSRF_TRUSTED_ORIGINS = ["https://localhost:8043"]
+CSRF_TRUSTED_ORIGINS = []
 # ======================!!!!!!! FOR DEVELOPMENT ONLY !!!!!!!=================================
 
 # Store a snapshot of default settings at this point before loading any

--- a/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/nginx.locations.conf.j2
@@ -46,4 +46,5 @@ location @fallback {
     # Add trailing / if missing
     rewrite ^(.*)$http_host(.*[^/])$ $1$http_host$2/ permanent;
     proxy_pass http://runserver;
+    proxy_set_header Host $http_host;
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Before this change the Host: header was runserver. Seems to be set by nginx upstream flow.
* After this change we explicitly set the Host: header
* More about CSRF checks ... CSRF checks that Origin == Host. Think about how the browser works.

  <browser goes to awx.com> "I'm executing javascript that I downloaded from awx.com (ORIGIN) and I'm making an XHR POST request to awx.com (HOST)" Server verifies; Host: header == Origin: header; OK!

  vs. the malicious case.

  <hacker injects javascript code into google.com> <browser goes to google.com> "I'm executing javascript that I downloaded from google.com (ORIGIN) and I'm making an XHR POST request to awx.com (HOST)" Server verifies; Host: header != Origin: header; NOT OK!
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
