### PR TITLE
Replace ANSIBLE_COLLECTIONS_PATHS with ANSIBLE_COLLECTIONS_PATH in preparation for deprecation in Ansible Version 2.19

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -925,7 +925,7 @@ class RunJob(SourceControlMixin, BaseTask):
                 env['ANSIBLE_NET_AUTH_PASS'] = network_cred.get_input('authorize_password', default='')
 
         path_vars = (
-            ('ANSIBLE_COLLECTIONS_PATHS', 'collections_paths', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
+            ('ANSIBLE_COLLECTIONS_PATH', 'collections_paths', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
             ('ANSIBLE_ROLES_PATH', 'roles_path', 'requirements_roles', '~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles'),
             ('ANSIBLE_COLLECTIONS_PATH', 'collections_path', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
         )
@@ -942,7 +942,10 @@ class RunJob(SourceControlMixin, BaseTask):
                 for path in config_values[config_setting].split(':'):
                     if path not in paths:
                         paths = [config_values[config_setting]] + paths
-            paths = [os.path.join(CONTAINER_ROOT, folder)] + paths
+            folder_path = os.path.join(CONTAINER_ROOT, folder)
+            if folder_path in path
+                paths.pop(paths.index(folder_path))
+            paths = [folder_path] + paths
             env[env_key] = os.pathsep.join(paths)
 
         return env
@@ -1504,30 +1507,35 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
             raise NotImplementedError('Cannot update file sources through the task system.')
 
         if inventory_update.source == 'scm' and inventory_update.source_project_update:
-            env_key = 'ANSIBLE_COLLECTIONS_PATHS'
-            config_setting = 'collections_paths'
-            folder = 'requirements_collections'
-            default = '~/.ansible/collections:/usr/share/ansible/collections'
+            path_vars = (
+                ('ANSIBLE_COLLECTIONS_PATH', 'collections_paths', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
+                ('ANSIBLE_COLLECTIONS_PATH', 'collections_path', 'requirements_collections', '~/.ansible/collections:/usr/share/ansible/collections'),
+            )
 
-            config_values = read_ansible_config(os.path.join(private_data_dir, 'project'), [config_setting])
+            config_values = read_ansible_config(os.path.join(private_data_dir, 'project'), list(map(lambda x: x[1], path_vars)))
 
-            paths = default.split(':')
-            if env_key in env:
-                for path in env[env_key].split(':'):
-                    if path not in paths:
-                        paths = [env[env_key]] + paths
-            elif config_setting in config_values:
-                for path in config_values[config_setting].split(':'):
-                    if path not in paths:
-                        paths = [config_values[config_setting]] + paths
-            paths = [os.path.join(CONTAINER_ROOT, folder)] + paths
-            env[env_key] = os.pathsep.join(paths)
-        if 'ANSIBLE_COLLECTIONS_PATHS' in env:
-            paths = env['ANSIBLE_COLLECTIONS_PATHS'].split(':')
+            for env_key, config_setting, folder, default in path_vars:
+                paths = default.split(':')
+                if env_key in env:
+                    for path in env[env_key].split(':'):
+                        if path not in paths:
+                            paths = [env[env_key]] + paths
+                elif config_setting in config_values:
+                    for path in config_values[config_setting].split(':'):
+                        if path not in paths:
+                            paths = [config_values[config_setting]] + paths
+                folder_path = os.path.join(CONTAINER_ROOT, folder)
+                if folder_path in path
+                    paths.pop(paths.index(folder_path))
+                paths = [folder_path] + paths
+                env[env_key] = os.pathsep.join(paths)
+            
+        if 'ANSIBLE_COLLECTIONS_PATH' in env:
+            paths = env['ANSIBLE_COLLECTIONS_PATH'].split(':')
         else:
             paths = ['~/.ansible/collections', '/usr/share/ansible/collections']
         paths.append('/usr/share/automation-controller/collections')
-        env['ANSIBLE_COLLECTIONS_PATHS'] = os.pathsep.join(paths)
+        env['ANSIBLE_COLLECTIONS_PATH'] = os.pathsep.join(paths)
 
         return env
 

--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -228,7 +228,7 @@ def test_inventory_update_injected_content(this_kind, inventory, fake_credential
             len([True for k in content.keys() if k.endswith(inventory_filename)]) > 0
         ), f"'{inventory_filename}' file not found in inventory update runtime files {content.keys()}"
 
-        env.pop('ANSIBLE_COLLECTIONS_PATHS', None)  # collection paths not relevant to this test
+        env.pop('ANSIBLE_COLLECTIONS_PATH', None)  # collection paths not relevant to this test
         base_dir = os.path.join(DATA, 'plugins')
         if not os.path.exists(base_dir):
             os.mkdir(base_dir)

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -214,7 +214,7 @@
     # additional_galaxy_env contains environment variables are used for installing roles and collections and will take precedence over items in galaxy_task_env
     additional_galaxy_env:
       # These paths control where ansible-galaxy installs collections and roles on top the filesystem
-      ANSIBLE_COLLECTIONS_PATHS: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_collections"
+      ANSIBLE_COLLECTIONS_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_collections"
       ANSIBLE_ROLES_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_roles"
       # Put the local tmp directory in same volume as collection destination
       # otherwise, files cannot be moved accross volumes and will cause error

--- a/awx/ui/src/screens/Host/data.hostFacts.json
+++ b/awx/ui/src/screens/Host/data.hostFacts.json
@@ -118,7 +118,7 @@
       "ANSIBLE_STDOUT_CALLBACK": "awx_display",
       "SUPERVISOR_PROCESS_NAME": "awx-dispatcher",
       "ANSIBLE_CALLBACK_PLUGINS": "/awx_devel/awx/plugins/callback:/var/lib/awx/venv/awx/lib/python3.6/site-packages/ansible_runner/callbacks",
-      "ANSIBLE_COLLECTIONS_PATHS": "/tmp/awx_13_r1ffeqze/requirements_collections:~/.ansible/collections:/usr/share/ansible/collections",
+      "ANSIBLE_COLLECTIONS_PATH": "/tmp/awx_13_r1ffeqze/requirements_collections:~/.ansible/collections:/usr/share/ansible/collections",
       "ANSIBLE_HOST_KEY_CHECKING": "False",
       "RUNNER_ONLY_FAILED_EVENTS": "False",
       "ANSIBLE_RETRY_FILES_ENABLED": "False",

--- a/awx/ui/src/screens/Inventory/shared/data.hostFacts.json
+++ b/awx/ui/src/screens/Inventory/shared/data.hostFacts.json
@@ -118,7 +118,7 @@
       "ANSIBLE_STDOUT_CALLBACK": "awx_display",
       "SUPERVISOR_PROCESS_NAME": "awx-dispatcher",
       "ANSIBLE_CALLBACK_PLUGINS": "/awx_devel/awx/plugins/callback:/var/lib/awx/venv/awx/lib/python3.6/site-packages/ansible_runner/callbacks",
-      "ANSIBLE_COLLECTIONS_PATHS": "/tmp/awx_13_r1ffeqze/requirements_collections:~/.ansible/collections:/usr/share/ansible/collections",
+      "ANSIBLE_COLLECTIONS_PATH": "/tmp/awx_13_r1ffeqze/requirements_collections:~/.ansible/collections:/usr/share/ansible/collections",
       "ANSIBLE_HOST_KEY_CHECKING": "False",
       "RUNNER_ONLY_FAILED_EVENTS": "False",
       "ANSIBLE_RETRY_FILES_ENABLED": "False",

--- a/awx/ui/src/screens/Job/shared/data.job.json
+++ b/awx/ui/src/screens/Job/shared/data.job.json
@@ -156,7 +156,7 @@
       "ANSIBLE_PARAMIKO_RECORD_HOST_KEYS": "False",
       "ANSIBLE_VENV_PATH": "/var/lib/awx/venv/ansible",
       "AWX_PRIVATE_DATA_DIR": "/tmp/awx_2_a4b1afiw",
-      "ANSIBLE_COLLECTIONS_PATHS": "/tmp/collections",
+      "ANSIBLE_COLLECTIONS_PATH": "/tmp/collections",
       "PYTHONPATH": "/var/lib/awx/venv/ansible/lib/python2.7/site-packages:/awx_devel/awx/lib:",
       "JOB_ID": "2",
       "INVENTORY_ID": "1",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`ANSIBLE_COLLECTIONS_PATH` has a higher precedence than `ANSIBLE_COLLECTIONS_PATHS`. Therefore, the configuration 
```
# ansible.cfg
[defaults]
collections_paths=./collections/
```
was overwritten, if any collection was defined in `collections/requirements.yml`

This PR adds a logic to add the configuration for `collections_path` and `collections_paths` to `ANSIBLE_COLLECTIONS_PATH` and don't consider the environment variable `ANSIBLE_COLLECTIONS_PATHS` anymore. 

---

For the parameter for `collection_path` was not considered for inventory source update.
This PR adds same logic from above to the inventory source update

---

All occurrences of `ANSIBLE_COLLECTIONS_PATHS` were replaced with `ANSIBLE_COLLECTIONS_PATH`, due to the fact that the variable `ANSIBLE_COLLECTIONS_PATHS` will deprecated in Ansible 2.19

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related #14364 
related #14800

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
>= 21.4.0
```
