### PR TITLE
Allow empty values for source_project in inventory_source

### DIFF
--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -279,11 +279,15 @@ def main():
         inventory_source_fields['credential'] = module.resolve_name_to_id('credentials', credential)
     if ee is not None:
         inventory_source_fields['execution_environment'] = module.resolve_name_to_id('execution_environments', ee)
+
     if source_project is not None:
+      if source_project != '' and source_project != 'None' and source_project != '{}':
         source_project_object = module.get_one('projects', name_or_id=source_project, data=lookup_data)
         if not source_project_object:
             module.fail_json(msg='The specified source project, {0}, was not found.'.format(lookup_data))
         inventory_source_fields['source_project'] = source_project_object['id']
+      else:
+        inventory_source_fields['source_project'] = None
 
     OPTIONAL_VARS = (
         'description',


### PR DESCRIPTION
##### SUMMARY
Added an ability to specify empty value for source_project in ansible.controller.inventory_source module.

related #14921 

##### ISSUE TYPE
Bug, Docs Fix or other nominal change

##### COMPONENT NAME
Collection

##### ADDITIONAL INFORMATION
Suggested testing:
```
    - ansible.controller.inventory_source:
        name: "A"
        inventory: "Dynamic A"
      ignore_errors: true

    - ansible.controller.inventory_source:
        name: "A"
        inventory: "Dynamic A"
        source: scm
        source_project: "Creds A"
      ignore_errors: true

    - ansible.controller.inventory_source:
        name: "A"
        inventory: "Dynamic A"
        source: ec2
        source_project: ""
      ignore_errors: true

    - ansible.controller.inventory_source:
        name: "A"
        inventory: "Dynamic A"
        source: ec2
        source_project: {}
      ignore_errors: true

    - ansible.controller.inventory_source:
        name: "A"
        inventory: "Dynamic A"
        source: ec2
        source_project: None
      ignore_errors: true
```
