### PR TITLE
Use AWX base view to make unauth requests 401

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -873,6 +873,7 @@ LOGGING = {
     'loggers': {
         'django': {'handlers': ['console']},
         'django.request': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'WARNING'},
+        'ansible_base': {'handlers': ['console', 'file', 'tower_warnings']},
         'daphne': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'INFO'},
         'rest_framework.request': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'WARNING', 'propagate': False},
         'py.warnings': {'handlers': ['console']},
@@ -1161,3 +1162,6 @@ ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API = False  # Do not allow creating user-def
 
 # system username for django-ansible-base
 SYSTEM_USERNAME = None
+
+# Use AWX base view, to give 401 on unauthenticated requests
+ANSIBLE_BASE_CUSTOM_VIEW_PARENT = 'awx.api.generics.APIView'


### PR DESCRIPTION
##### SUMMARY
This is needed to fix "crawler" test failures, where 403 responses are given to unauthenticated users and 401 is expected.

See AWX `get_authenticate_header` method.

ALSO - note that _without_ that method override

https://github.com/encode/django-rest-framework/blob/09a0c551ca934e486d2765e042a287c15fa85e75/rest_framework/views.py#L190

DRF uses

```python
return authenticators[0].authenticate_header(request)
```

and in my case, this was `AwxJWTAuthentication`, which came from the DRF base class, which gave nothing, which became a 403. This is violently unstable, and will afflict other apps.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
