### PR TITLE
Add link to service-index URL

### DIFF
--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -13,6 +13,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
+from django.urls import reverse as django_reverse
 
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -130,6 +131,7 @@ class ApiVersionRootView(APIView):
         data['mesh_visualizer'] = reverse('api:mesh_visualizer_view', request=request)
         data['bulk'] = reverse('api:bulk', request=request)
         data['analytics'] = reverse('api:analytics_root_view', request=request)
+        data['service_index'] = django_reverse('service-index-root')
         return Response(data)
 
 


### PR DESCRIPTION
##### SUMMARY
A goal of the AWX API is to be navigable, so in https://github.com/ansible/django-ansible-base/pull/188 DAB added a "splash" page for the resource registry URLs.

This links the AWX root navigation to that. I selfishly want this because we have crawler tests that keep finding issues with new URLs, and I believe it is missing issues with the resource registry URLs because it is unexpectedly not navigable by links. These problems are shared by the new RBAC endpoints.

Connect https://github.com/ansible/awx/issues/14951

Tested manually that it works. We have to use a special thing for doing the `reverse`.

Also, I hate the name of this, because it doesn't help understand what it does. @newswangerd if you have any other suggestions for the dictionary key (as opposed to "service_index"), we could change that.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

