### PR TITLE
Fix awx-manage run_wsrelay --status

### DIFF
--- a/awx/main/management/commands/run_wsrelay.py
+++ b/awx/main/management/commands/run_wsrelay.py
@@ -92,8 +92,6 @@ class Command(BaseCommand):
         return host_stats
 
     def handle(self, *arg, **options):
-        WebsocketsMetricsServer().start()
-
         # it's necessary to delay this import in case
         # database migrations are still running
         from awx.main.models.ha import Instance
@@ -165,6 +163,8 @@ class Command(BaseCommand):
             print('\n'.join(lines))
 
             return
+
+        WebsocketsMetricsServer().start()
 
         try:
             websocket_relay_manager = WebSocketRelayManager()


### PR DESCRIPTION
##### SUMMARY
by don't start the metrics server if --status is passed in

example exception
```
sh-5.1# awx-manage run_wsrelay --status
/usr/local/bin/awx-manage:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import load_entry_point
2024-03-14 18:35:12,885 ERROR    [-] awx.main.analytics MetricsServer failed to start for service 'websockets.
Traceback (most recent call last):
  File "/usr/local/bin/awx-manage", line 9, in <module>
    load_entry_point('awx', 'console_scripts', 'awx-manage')()
  File "/awx_devel/awx/__init__.py", line 177, in manage
    execute_from_command_line(sys.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/management/commands/run_wsrelay.py", line 95, in handle
    WebsocketsMetricsServer().start()
  File "/awx_devel/awx/main/analytics/subsystem_metrics.py", line 39, in start
    prometheus_client.start_http_server(self.port(), addr='localhost', registry=self._registry)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/prometheus_client/exposition.py", line 221, in start_wsgi_server
    httpd = make_server(addr, port, app, TmpServer, handler_class=_SilentHandler)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/wsgiref/simple_server.py", line 154, in make_server
    server = server_class((host, port), handler_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/socketserver.py", line 456, in __init__
    self.server_bind()
  File "/usr/lib64/python3.11/wsgiref/simple_server.py", line 50, in server_bind
    HTTPServer.server_bind(self)
  File "/usr/lib64/python3.11/http/server.py", line 136, in server_bind
    socketserver.TCPServer.server_bind(self)
  File "/usr/lib64/python3.11/socketserver.py", line 472, in server_bind
    self.socket.bind(self.server_address)
OSError: [Errno 98] Address already in use
sh-5.1# awx-manage run_wsrelay --status
/usr/local/bin/awx-manage:4: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  from pkg_resources import load_entry_point
2024-03-14 18:38:00,789 ERROR    [-] awx.main.analytics MetricsServer failed to start for service 'websockets.
Traceback (most recent call last):
  File "/usr/local/bin/awx-manage", line 9, in <module>
    load_entry_point('awx', 'console_scripts', 'awx-manage')()
  File "/awx_devel/awx/__init__.py", line 177, in manage
    execute_from_command_line(sys.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/management/commands/run_wsrelay.py", line 95, in handle
    WebsocketsMetricsServer().start()
  File "/awx_devel/awx/main/analytics/subsystem_metrics.py", line 39, in start
    prometheus_client.start_http_server(self.port(), addr='localhost', registry=self._registry)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/prometheus_client/exposition.py", line 221, in start_wsgi_server
    httpd = make_server(addr, port, app, TmpServer, handler_class=_SilentHandler)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/wsgiref/simple_server.py", line 154, in make_server
    server = server_class((host, port), handler_class)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/socketserver.py", line 456, in __init__
    self.server_bind()
  File "/usr/lib64/python3.11/wsgiref/simple_server.py", line 50, in server_bind
    HTTPServer.server_bind(self)
  File "/usr/lib64/python3.11/http/server.py", line 136, in server_bind
    socketserver.TCPServer.server_bind(self)
  File "/usr/lib64/python3.11/socketserver.py", line 472, in server_bind
    self.socket.bind(self.server_address)
OSError: [Errno 98] Address already in use
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
