### PR TITLE
Fix failing bulk launch job due to create partition race

### DIFF
--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1160,14 +1160,13 @@ def create_partition(tblname, start=None):
     except (ProgrammingError, IntegrityError) as e:
         cause = e.__cause__
         if cause and hasattr(cause, 'sqlstate'):
-            # 42P07 = DuplicateTable
             sqlstate = cause.sqlstate
-            sqlstate_str = psycopg.errors.lookup(sqlstate)
+            sqlstate_cls = psycopg.errors.lookup(sqlstate)
 
-            if psycopg.errors.DuplicateTable == sqlstate:
+            if psycopg.errors.DuplicateTable == sqlstate_cls or psycopg.errors.UniqueViolation == sqlstate_cls:
                 logger.info(f'Caught known error due to partition creation race: {e}')
             else:
-                logger.error('SQL Error state: {} - {}'.format(sqlstate, sqlstate_str))
+                logger.error('SQL Error state: {} - {}'.format(sqlstate, sqlstate_cls))
                 raise
     except DatabaseError as e:
         cause = e.__cause__


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/pull/14910/files

introduced a bug where we no longer accept the right exceptions

when 2 job launch at the sametime and try to create jobevent table partition 1 of the job will fail

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
