### PR TITLE
[RBAC] Fix server error from delete capability of approvals

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2935,6 +2935,9 @@ class WorkflowApprovalAccess(BaseAccess):
         if (obj.workflow_job_template and self.user in obj.workflow_job_template.approval_role) or self.user.is_superuser:
             return True
 
+    def can_delete(self, obj):
+        return self.user.is_superuser  # Not really supposed to be done
+
 
 class WorkflowApprovalTemplateAccess(BaseAccess):
     """


### PR DESCRIPTION
##### SUMMARY
Now _this_ is a skeleton that adding validation managed to dig up. Look at `WorkflowApprovalAccess`, it never wrote CRUD access logic... and this model doesn't have roles either.

So it deferred to BaseAccess. What does that mean? Edit / other stuff is restricted to superuser. Okay, but the view probably doesn't allow this anyway, right? Nope, it does. Didn't make sense then, still doesn't make sense. I'm just trying to fix the server error.

```
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/api/views/__init__.py", line 4419, in get
    return super(WorkflowApprovalList, self).get(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/generics.py", line 199, in get
    return self.list(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/mixins.py", line 43, in list
    return self.get_paginated_response(serializer.data)
                                       ^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/serializers.py", line 768, in data
    ret = super().data
          ^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/serializers.py", line 253, in data
    self._data = self.to_representation(self.instance)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/serializers.py", line 686, in to_representation
    return [
           ^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/serializers.py", line 687, in <listcomp>
    self.child.to_representation(item) for item in iterable
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/api/serializers.py", line 941, in to_representation
    ret = super(UnifiedJobListSerializer, self).to_representation(obj)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/api/serializers.py", line 883, in to_representation
    ret = super(UnifiedJobSerializer, self).to_representation(obj)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/serializers.py", line 522, in to_representation
    ret[field.field_name] = field.to_representation(attribute)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/fields.py", line 1838, in to_representation
    return method(value)
           ^^^^^^^^^^^^^
  File "/awx_devel/awx/api/serializers.py", line 426, in _get_summary_fields
    return {} if obj is None else self.get_summary_fields(obj)
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/api/serializers.py", line 828, in get_summary_fields
    summary_fields = super(UnifiedJobSerializer, self).get_summary_fields(obj)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/api/serializers.py", line 484, in get_summary_fields
    user_capabilities = self._obj_capability_dict(obj)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/api/serializers.py", line 515, in _obj_capability_dict
    return get_user_capabilities(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/access.py", line 184, in get_user_capabilities
    return access_class(user).get_user_capabilities(instance, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/access.py", line 485, in get_user_capabilities
    user_capabilities[display_method] = self.get_method_capability(method, obj, parent_obj)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/access.py", line 495, in get_method_capability
    return access_method(obj)
           ^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/access.py", line 267, in can_delete
    return self.user.has_obj_perm(obj, 'delete')
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/testing/django-ansible-base/ansible_base/rbac/evaluations.py", line 82, in bound_has_obj_perm
    raise RuntimeError(f'Object of {obj._meta.model_name} type is not registered with DAB RBAC')
RuntimeError: Object of workflowapproval type is not registered with DAB RBAC

```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

