### PR TITLE
Adjust the awx-manage script to make use of importlib

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -241,7 +241,7 @@ ADD tools/scripts/awx-python /usr/bin/awx-python
 {% endif %}
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
-RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.11/site-packages/awx.egg-link
+RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.11/site-packages/awx.pth
 ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
 RUN ln -sf /awx_devel/tools/scripts/awx-python /usr/bin/awx-python
 RUN ln -sf /awx_devel/tools/scripts/rsyslog-4xx-recovery /usr/bin/rsyslog-4xx-recovery

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -241,8 +241,9 @@ ADD tools/scripts/awx-python /usr/bin/awx-python
 {% endif %}
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
+RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.11/site-packages/awx.egg-link
 RUN echo /awx_devel > /var/lib/awx/venv/awx/lib/python3.11/site-packages/awx.pth
-ADD tools/docker-compose/awx-manage /usr/local/bin/awx-manage
+RUN ln -sf /awx_devel/tools/docker-compose/awx-manage /usr/local/bin/awx-manage
 RUN ln -sf /awx_devel/tools/scripts/awx-python /usr/bin/awx-python
 RUN ln -sf /awx_devel/tools/scripts/rsyslog-4xx-recovery /usr/bin/rsyslog-4xx-recovery
 {% endif %}

--- a/tools/docker-compose/awx-manage
+++ b/tools/docker-compose/awx-manage
@@ -1,8 +1,17 @@
 #!/usr/bin/awx-python
-# EASY-INSTALL-ENTRY-SCRIPT: 'awx','console_scripts','awx-manage'
 import sys
-from pkg_resources import load_entry_point
-__requires__ = 'awx'
+from importlib.metadata import distribution
+
+
+def load_entry_point(dist, group, name):
+    dist_name, _, _ = dist.partition('==')
+    matches = (
+        entry_point
+        for entry_point in distribution(dist_name).entry_points
+        if entry_point.group == group and entry_point.name == name
+    )
+    return next(matches).load()
+
 
 if __name__ == '__main__':
     sys.exit(


### PR DESCRIPTION
##### SUMMARY
removing the deprecation warning.

pkg_resources is now deprecated, so it has been throwing a DeprecationWarning since we've upgraded to Python 3.11.  It's recommended to use importlib instead, which has a couple of functions in importlib.metadata that could be used for this purpose (`distribution` or `entry_points`).

The annoying part of this PR was discovering that `.egg-link` files were not a standardized part of Python, and were only supported by setuptools.  `.pth` files seem to work, though, so I've changed the editable dev environment reference to make use of that instead.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
