### PR TITLE
Address first_found skip bug

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -221,8 +221,10 @@
           vars:
             req_file: "{{ lookup('ansible.builtin.first_found', req_candidates, skip=True) }}"
             req_candidates:
-              - "{{ project_path | quote }}/roles/requirements.yml"
-              - "{{ project_path | quote }}/roles/requirements.yaml"
+              files:
+                - "{{ project_path | quote }}/roles/requirements.yml"
+                - "{{ project_path | quote }}/roles/requirements.yaml"
+              skip: True
           changed_when: "'was installed successfully' in galaxy_result.stdout"
           when:
             - roles_enabled | bool
@@ -237,10 +239,12 @@
           vars:
             req_file: "{{ lookup('ansible.builtin.first_found', req_candidates, skip=True) }}"
             req_candidates:
-              - "{{ project_path | quote }}/collections/requirements.yml"
-              - "{{ project_path | quote }}/collections/requirements.yaml"
-              - "{{ project_path | quote }}/requirements.yml"
-              - "{{ project_path | quote }}/requirements.yaml"
+              files:
+                - "{{ project_path | quote }}/collections/requirements.yml"
+                - "{{ project_path | quote }}/collections/requirements.yaml"
+                - "{{ project_path | quote }}/requirements.yml"
+                - "{{ project_path | quote }}/requirements.yaml"
+              skip: True
           changed_when: "'Nothing to do.' not in galaxy_collection_result.stdout"
           when:
             - "ansible_version.full is version_compare('2.9', '>=')"
@@ -256,8 +260,10 @@
           vars:
             req_file: "{{ lookup('ansible.builtin.first_found', req_candidates, skip=True) }}"
             req_candidates:
-              - "{{ project_path | quote }}/requirements.yaml"
-              - "{{ project_path | quote }}/requirements.yml"
+              files:
+                - "{{ project_path | quote }}/requirements.yaml"
+                - "{{ project_path | quote }}/requirements.yml"
+              skip: True
           changed_when: "'Nothing to do.' not in galaxy_combined_result.stdout"
           when:
             - "ansible_version.full is version_compare('2.10', '>=')"

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -242,8 +242,6 @@
               files:
                 - "{{ project_path | quote }}/collections/requirements.yml"
                 - "{{ project_path | quote }}/collections/requirements.yaml"
-                - "{{ project_path | quote }}/requirements.yml"
-                - "{{ project_path | quote }}/requirements.yaml"
               skip: True
           changed_when: "'Nothing to do.' not in galaxy_collection_result.stdout"
           when:
@@ -253,6 +251,7 @@
           tags:
             - install_collections
 
+        # requirements.yml in project root can be either "old" (roles only) or "new" (collections+roles) format
         - name: Fetch galaxy roles and collections from requirements.(yml/yaml)
           ansible.builtin.command:
             cmd: "ansible-galaxy install -r {{ req_file }} {{ verbosity }}"


### PR DESCRIPTION
##### SUMMARY
In current ansible-core versions, there is a bug where `skip` as a kwarg for `first_found` isn't working properly.  This is being fixed in https://github.com/ansible/ansible/pull/82836 but won't release for around 5 weeks from now.

In the meantime, the bug can be worked around by using the complex/mapping format for `first_found` and including `skip: True` there.

This PR also removes the `<project_path>/requirements.yml` paths from consideration as `collection` requirements that was incorrectly added as part of https://github.com/ansible/awx/commit/4286d411a74024b634cefa49b0c3cbdcd71a7231.  It's not clearly documented what the expectation of this file is, and I'm not going to address that here.  However, the project root `requirements.yml` was originally a v1/old formatted file only including roles, and was [expanded to allow collections](https://github.com/ansible/awx/commit/3624fe2cac7eccf845e46afbb88b6d2d8af7b41a), but this doesn't require it be v2/new formatted, and the agnostic install subcommand works with both, but the `collections install` subcommand does not work with both.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

TASK [Fetch galaxy roles from roles/requirements.(yml/yaml)] *******************
fatal: [localhost]: FAILED! => {"msg": "The conditional check 'req_file' failed. The error was: An unhandled exception occurred while templating '{{ lookup('ansible.builtin.first_found', req_candidates, skip=True) }}'. Error was a <class 'ansible.errors.AnsibleLookupError'>, original message: No file was found when using first_found.\\n\\nThe error appears to be in '/runner/project/project_update.yml': line 217, column 11, but may\\nbe elsewhere in the file depending on the exact syntax problem.\\n\\nThe offending line appears to be:\\n\\n    - block:\\n        - name: Fetch galaxy roles from roles/requirements.(yml/yaml)\\n          ^ here\\n"}
```

-> 

```
TASK [Fetch galaxy roles from roles/requirements.(yml/yaml)] *******************
skipping: [localhost] => {"changed": false, "false_condition": "req_file", "skip_reason": "Conditional result was False"}
```