### PR TITLE
Re-parent DAB views from AWX base

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1131,3 +1131,6 @@ include(settings_file)
 # example if set to '' API pattern will be /api
 # example if set to 'controller' API pattern will be /api AND /api/controller
 OPTIONAL_API_URLPATTERN_PREFIX = ''
+
+# Use AWX base view, to give 401 on unauthenticated requests
+ANSIBLE_BASE_CUSTOM_VIEW_PARENT = 'awx.api.generics.APIView'


### PR DESCRIPTION
##### SUMMARY
Peeling this off from the RBAC branch, because we got word that other people were experiencing strange 403 errors when a 401 was expected. I ran into that exact thing a while ago and tore my hair out from it for 1/2 of a day. The issue is that DRF has a header-generator for errors, which call back to the authentication plugin. The issue is that we inserted the JWT auth in the _front_ of our authentication plugin list.

This _never mattered_ for AWX because its parent view just went and attached its own darn header to error responses and bypassed that code. But for DAB views, that never applied. Now we will make it so, by using this setting to get DAB to make its own views a subclass of AWX views.

This has been stable enough in the RBAC branch, it should rightfully be peeled off into devel branch.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

