### PR TITLE
No longer shall the network be sources_awx

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -363,6 +363,7 @@ volumes:
 
 networks:
   awx:
+    name: awx
   service-mesh:
     name: service-mesh
 {% if minikube_container_group|bool %}


### PR DESCRIPTION
##### SUMMARY
No longer shall the network be `_sources_awx`

Rename `_sources_awx` --> `awx`. This is a more stable and transparent network name than before. Before, `_sources` is chosen because the `docker-compose.yml` file exists in a directory called `sources`. Did anyone know that? If you change that dir name then the network name changes. That's not very stable or transparent.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before

```
docker inspect tools_awx_1 | jq ".[].NetworkSettings.Networks._sources_awx"
{
  "IPAMConfig": {},
  "Links": null,
  "Aliases": [
    "awx_1",
    "0f100a882614"
  ],
  "MacAddress": "02:42:c0:a8:10:04",
  "NetworkID": "9395d178eec443903fda61546eaca2d4c5bf8ce9b46eba5b7f4de5b0cd37d41c",
  "EndpointID": "a32fa3fa1a0b62299742a662d4899d66682a7cc03dddc7e0405bdcbbe4ac7e7f",
  "Gateway": "192.168.16.1",
  "IPAddress": "192.168.16.4",
  "IPPrefixLen": 20,
  "IPv6Gateway": "",
  "GlobalIPv6Address": "",
  "GlobalIPv6PrefixLen": 0,
  "DriverOpts": null,
  "DNSNames": [
    "tools_awx_1",
    "awx_1",
    "0f100a882614"
  ]
}
```

After
```
docker inspect tools_awx_1 | jq ".[].NetworkSettings.Networks.awx"
{
  "IPAMConfig": {},
  "Links": null,
  "Aliases": [
    "awx_1",
    "47ae1ac7d3f9"
  ],
  "MacAddress": "02:42:c0:a8:60:04",
  "NetworkID": "645f1dbe378c75d6cb18b11ce67c159cc167a83dbb9be3ff9f5b7b47e4434387",
  "EndpointID": "59b70c4da806b42f3529ec8b10430628e81ea13c188a53c77c26d7e893a64bf0",
  "Gateway": "192.168.96.1",
  "IPAddress": "192.168.96.4",
  "IPPrefixLen": 20,
  "IPv6Gateway": "",
  "GlobalIPv6Address": "",
  "GlobalIPv6PrefixLen": 0,
  "DriverOpts": null,
  "DNSNames": [
    "tools_awx_1",
    "awx_1",
    "47ae1ac7d3f9"
  ]
}
```
