### PR TITLE
Fix wsrelay not retry to establish db connection

### DIFF
--- a/awx/main/management/commands/run_wsrelay.py
+++ b/awx/main/management/commands/run_wsrelay.py
@@ -165,9 +165,11 @@ class Command(BaseCommand):
             return
 
         WebsocketsMetricsServer().start()
+        websocket_relay_manager = WebSocketRelayManager()
 
-        try:
-            websocket_relay_manager = WebSocketRelayManager()
-            asyncio.run(websocket_relay_manager.run())
-        except KeyboardInterrupt:
-            logger.info('Terminating Websocket Relayer')
+        while True:
+            try:
+                asyncio.run(websocket_relay_manager.run())
+            except KeyboardInterrupt:
+                logger.info('Restarting Websocket Relayer')
+                time.sleep(10)


### PR DESCRIPTION
##### SUMMARY
- run_wsrelay retry to run wsrelay forever with 10 second sleep
- wsrelay exist if fail to establish db connection


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
