### PR TITLE
Fix wsrelay KeyboardInteruption not respected

### DIFF
--- a/awx/main/management/commands/run_wsrelay.py
+++ b/awx/main/management/commands/run_wsrelay.py
@@ -171,5 +171,8 @@ class Command(BaseCommand):
             try:
                 asyncio.run(websocket_relay_manager.run())
             except KeyboardInterrupt:
-                logger.info('Restarting Websocket Relayer')
+                logger.info('Shutting down Websocket Relayer')
+                break
+            except Exception as e:
+                logger.exception('Error in Websocket Relayer, exception: {}. Restarting in 10 seconds'.format(e))
                 time.sleep(10)


### PR DESCRIPTION
##### SUMMARY
- stop wsrelay on keyboard interuption
- restart wsrelay for any other failure reason


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
