### PR TITLE
Fix websocket relay. Set autocommit so conn.notifies() does not blocks forever

### DIFF
--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -324,6 +324,7 @@ class WebSocketRelayManager(object):
                         port=database_conf['PORT'],
                         **database_conf.get("OPTIONS", {}),
                     )
+                    await async_conn.set_autocommit(True)
 
                     task = event_loop.create_task(self.on_ws_heartbeat(async_conn), name="on_ws_heartbeat")
                     logger.info("Creating `on_ws_heartbeat` task in event loop.")


### PR DESCRIPTION
##### SUMMARY
Fix websocket relay.

Fixes https://github.com/ansible/awx/issues/15038

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
