### PR TITLE
Change docker buildx to not push by default

### DIFF
--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -75,3 +75,5 @@ jobs:
       - name: Build and push AWX devel images
         run: |
           make ${{ matrix.build-targets.make-target }}
+        env:
+          DOCKER_BUILDX_PUSH: true

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -113,6 +113,8 @@ jobs:
               --build-arg OPERATOR_VERSION=${{ github.event.inputs.operator_version }}" \
           IMG=ghcr.io/${{ github.repository_owner }}/awx-operator:${{ github.event.inputs.operator_version }} \
           make docker-buildx
+        env:
+          DOCKER_BUILDX_PUSH: "true"
 
       - name: Run test deployment with awx-operator
         working-directory: awx-operator

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,11 @@ SDIST_TAR_FILE ?= $(SDIST_TAR_NAME).tar.gz
 
 I18N_FLAG_FILE = .i18n_built
 
-## PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
+# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 PLATFORMS ?= linux/amd64,linux/arm64  # linux/ppc64le,linux/s390x
+
+# Set DOCKER_BUILDX_PUSH to "true" to push the image, set to any other value to skip pushing
+DOCKER_BUILDX_PUSH ?= false
 
 .PHONY: awx-link clean clean-tmp clean-venv requirements requirements_dev \
 	develop refresh adduser migrate dbchange \
@@ -603,7 +606,7 @@ docker-compose-buildx: Dockerfile.dev
 	- docker buildx create --name docker-compose-buildx
 	docker buildx use docker-compose-buildx
 	- docker buildx build \
-		--push \
+		$(if $(filter true,$(DOCKER_BUILDX_PUSH)),--push,--load) \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--cache-from=$(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG) \
 		--platform=$(PLATFORMS) \
@@ -675,7 +678,7 @@ awx-kube-buildx: Dockerfile
 	- docker buildx create --name awx-kube-buildx
 	docker buildx use awx-kube-buildx
 	- docker buildx build \
-		--push \
+		$(if $(filter true,$(DOCKER_BUILDX_PUSH)),--push,--load) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg SETUPTOOLS_SCM_PRETEND_VERSION=$(VERSION) \
 		--build-arg HEADLESS=$(HEADLESS) \
@@ -706,7 +709,7 @@ awx-kube-dev-buildx: Dockerfile.kube-dev
 	- docker buildx create --name awx-kube-dev-buildx
 	docker buildx use awx-kube-dev-buildx
 	- docker buildx build \
-		--push \
+		$(if $(filter true,$(DOCKER_BUILDX_PUSH)),--push,--load) \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		--cache-from=$(DEV_DOCKER_TAG_BASE)/awx_kube_devel:$(COMPOSE_TAG) \
 		--platform=$(PLATFORMS) \

--- a/tools/ansible/roles/image_build/tasks/main.yml
+++ b/tools/ansible/roles/image_build/tasks/main.yml
@@ -12,19 +12,12 @@
     dest: "../../awx/ui/public/static/media/"
   when: awx_official|default(false)|bool
 
-- set_fact:
-    command_to_run: |
-      docker build -t {{ awx_image }}:{{ awx_image_tag }} \
-        -f {{ dockerfile_name }} \
-        --build-arg VERSION={{ awx_version }} \
-        --build-arg SETUPTOOLS_SCM_PRETEND_VERSION={{ awx_version }} \
-        --build-arg HEADLESS={{ headless }} \
-        .
-
-# Calling Docker directly because docker-py doesnt support BuildKit
 - name: Build AWX image
-  shell: "{{ command_to_run }}"
+  shell: "make awx-kube-build"
   environment:
-    DOCKER_BUILDKIT: 1
+    VERSION: "{{ awx_version }}"
+    HEADLESS: "{{ headless }}"
+    COMPOSE_TAG: "{{ awx_image_tag }}"
+
   args:
     chdir: "{{ playbook_dir }}/../../"


### PR DESCRIPTION
##### SUMMARY
Enable push via `DOCKER_BUILDX_PUSH = true`

prevent accidental push to default image registry

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
