### PR TITLE
Update DOCKER_COMPOSE command to `docker compose`

### DIFF
--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -71,7 +71,7 @@ runs:
       id: data
       shell: bash
       run: |
-        AWX_IP=$(docker inspect -f '{{.NetworkSettings.Networks._sources_awx.IPAddress}}' tools_awx_1)
+        AWX_IP=$(docker inspect -f '{{.NetworkSettings.Networks.awx.IPAddress}}' tools_awx_1)
         ADMIN_TOKEN=$(docker exec -i tools_awx_1 awx-manage create_oauth2_token --user admin)
         echo "ip=$AWX_IP" >> $GITHUB_OUTPUT
         echo "admin_token=$ADMIN_TOKEN" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 PYTHON := $(notdir $(shell for i in python3.11 python3; do command -v $$i; done|sed 1q))
 SHELL := bash
-DOCKER_COMPOSE ?= docker-compose
+DOCKER_COMPOSE ?= docker compose
 OFFICIAL ?= no
 NODE ?= node
 NPM_BIN ?= npm

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -363,6 +363,7 @@ volumes:
 
 networks:
   awx:
+    name: awx
   service-mesh:
     name: service-mesh
 {% if minikube_container_group|bool %}


### PR DESCRIPTION
##### SUMMARY
docker-compose will stop being supported soon and this is causing CI flake setting DOCKER_COMPOSE default to `docker compose`

example failure https://github.com/ansible/awx/actions/runs/8513225204/job/23358409052?pr=15053
```
make[1]: Entering directory '/home/runner/work/awx/awx'
docker-compose -f tools/docker-compose/_sources/docker-compose.yml  up -d --remove-orphans
bash: line 1: docker-compose: command not found
make[1]: *** [Makefile:550: docker-compose-up] Error 127
make[1]: Leaving directory '/home/runner/work/awx/awx'
make: *** [Makefile:543: docker-compose] Error 2
Error: Process completed with exit code 2.
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
