### PR TITLE
Fix missing role membership when giving creator permissions

### DIFF
--- a/awx/main/tests/functional/dab_rbac/test_translation_layer.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer.py
@@ -1,6 +1,6 @@
 import pytest
 
-from awx.main.models.rbac import get_role_from_object_role
+from awx.main.models.rbac import get_role_from_object_role, give_creator_permissions
 from awx.main.models import User, Organization, WorkflowJobTemplate, WorkflowJobTemplateNode
 from awx.api.versioning import reverse
 
@@ -74,3 +74,10 @@ def test_workflow_approval_list(get, post, admin_user):
 
     r = get(url=reverse('api:workflow_approval_list'), user=admin_user, expect=200)
     assert r.data['count'] >= 1
+
+
+@pytest.mark.django_db
+def test_creator_permission(rando, admin_user, inventory):
+    give_creator_permissions(rando, inventory)
+    assert rando in inventory.admin_role
+    assert rando in inventory.admin_role.members.all()


### PR DESCRIPTION
##### SUMMARY
Fixes a bug discovered by QE.

We sync role memberships only 1 way, if you use the _old API_ then the _new API_ is changed to reflect the permission setup. However, the same is not true the other way around (and may be un-representable) for memberships... it is for access in a weird nuance.

By using the new `give_creator_permissions` from the DAB library, this did not add the user in question to the memberships of the old role. It is valid to say that this fails to conform to the existing role API contract.

This needs a supporting DAB change https://github.com/ansible/django-ansible-base/pull/253

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
