### PR TITLE
[RBAC] Tweaks to reflect what endpoints are deprecated

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -800,6 +800,7 @@ class RetrieveUpdateDestroyAPIView(RetrieveUpdateAPIView, DestroyAPIView):
 
 
 class ResourceAccessList(ParentMixin, ListAPIView):
+    deprecated = True
     serializer_class = ResourceAccessListElementSerializer
     ordering = ('username',)
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -545,7 +545,6 @@ class InstanceGroupObjectRolesList(SubListAPIView):
     serializer_class = serializers.RoleSerializer
     parent_model = models.InstanceGroup
     search_fields = ('role_field', 'content_type__model')
-    deprecated = True
 
     def get_queryset(self):
         po = self.get_parent_object()


### PR DESCRIPTION
##### SUMMARY
In one endpoint, I wrote `deprecated` twice, and in the case of access_list it was intended to deprecate it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
