### PR TITLE
Remove uneeded drf_reverse overwrite

### DIFF
--- a/awx/main/tests/functional/api/test_auth.py
+++ b/awx/main/tests/functional/api/test_auth.py
@@ -6,7 +6,7 @@ from django.test import Client
 from rest_framework.test import APIRequestFactory
 
 from awx.api.generics import LoggedLoginView
-from awx.api.versioning import drf_reverse
+from rest_framework.reverse import reverse as drf_reverse
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/api/test_oauth.py
+++ b/awx/main/tests/functional/api/test_oauth.py
@@ -8,8 +8,10 @@ from django.db import connection
 from django.test.utils import override_settings
 from django.utils.encoding import smart_str, smart_bytes
 
+from rest_framework.reverse import reverse as drf_reverse
+
 from awx.main.utils.encryption import decrypt_value, get_encryption_key
-from awx.api.versioning import reverse, drf_reverse
+from awx.api.versioning import reverse
 from awx.main.models.oauth import OAuth2Application as Application, OAuth2AccessToken as AccessToken
 from awx.main.tests.functional import immediate_on_commit
 from awx.sso.models import UserEnterpriseAuth


### PR DESCRIPTION
##### SUMMARY
* `drf_reverse()` was introduced here https://github.com/ansible/awx/commit/1a75b1836e3416260961e72e17c7736d6b43e0b3
* There is a comment about monkey patching. I can't find the monkey patch it is referencing.
* AWX `drf_reverse()` is a copy paste of this https://github.com/encode/django-rest-framework/blob/master/rest_framework/reverse.py#L32
  * The only difference is DRF's version calls `preserve_builtin_query_params()` * `preserve_builtin_query_params()` only does something if `api_settings.URL_FORMAT_OVERRIDE` is defined. * We don't use `REST_FRAMEWORK.URL_FORMAT_OVERRIDE`

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
