### PR TITLE
Implement optional url prefix the Django way

### DIFF
--- a/awx/api/versioning.py
+++ b/awx/api/versioning.py
@@ -29,9 +29,7 @@ def reverse(viewname, args=None, kwargs=None, request=None, format=None, **extra
             kwargs = {}
         if 'version' not in kwargs:
             kwargs['version'] = settings.REST_FRAMEWORK['DEFAULT_VERSION']
-    url = drf_reverse(viewname, args, kwargs, request, format, **extra)
-
-    return transform_optional_api_urlpattern_prefix_url(request, url)
+    return drf_reverse(viewname, args, kwargs, request, format, **extra)
 
 
 class URLPathVersioning(BaseVersioning):

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
+import functools
 import logging
 import threading
 import time
@@ -23,6 +24,7 @@ from awx.main.utils.named_url_graph import generate_graph, GraphNode
 from awx.conf import fields, register
 from awx.main.utils.profiling import AWXProfiler
 from awx.main.utils.common import memoize
+from awx.urls import get_urlpatterns
 
 
 logger = logging.getLogger('awx.main.middleware')
@@ -220,3 +222,27 @@ class MigrationRanCheckMiddleware(MiddlewareMixin):
     def process_request(self, request):
         if is_migrating() and getattr(resolve(request.path), 'url_name', '') != 'migrations_notran':
             return redirect(reverse("ui:migrations_notran"))
+
+
+class OptionalURLPrefixPath(MiddlewareMixin):
+    @functools.lru_cache
+    def _url_optional(self, prefix):
+        # Relavant Django code path https://github.com/django/django/blob/stable/4.2.x/django/core/handlers/base.py#L300
+        #
+        # resolve_request(request)
+        #   get_resolver(request.urlconf)
+        #     _get_cached_resolver(request.urlconf) <-- cached via @functools.cache
+        #
+        # Django will attempt to cache the value(s) of request.urlconf
+        # Being hashable is a prerequisit for being cachable.
+        # tuple() is hashable list() is not.
+        # Hence the tuple(list()) wrap.
+        return tuple(get_urlpatterns(prefix=prefix))
+
+    def process_request(self, request):
+        prefix = settings.OPTIONAL_API_URLPATTERN_PREFIX
+
+        if request.path.startswith(f"/api/{prefix}"):
+            request.urlconf = self._url_optional(prefix)
+        else:
+            request.urlconf = 'awx.urls'

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1002,6 +1002,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'awx.main.middleware.DisableLocalAuthMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'awx.main.middleware.OptionalURLPrefixPath',
     'awx.sso.middleware.SocialAuthMiddleware',
     'crum.CurrentRequestUserMiddleware',
     'awx.main.middleware.URLModificationMiddleware',

--- a/awx/urls.py
+++ b/awx/urls.py
@@ -9,36 +9,42 @@ from ansible_base.resource_registry.urls import urlpatterns as resource_api_urls
 from awx.main.views import handle_400, handle_403, handle_404, handle_500, handle_csp_violation, handle_login_redirect
 
 
-urlpatterns = [
-    re_path(r'', include('awx.ui.urls', namespace='ui')),
-    re_path(r'^ui_next/.*', include('awx.ui_next.urls', namespace='ui_next')),
-    path('api/', include('awx.api.urls', namespace='api')),
-]
+def get_urlpatterns(prefix=None):
+    if not prefix:
+        prefix = '/'
+    else:
+        prefix = f'/{prefix}/'
 
-if settings.OPTIONAL_API_URLPATTERN_PREFIX:
-    urlpatterns += [
-        path(f'api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}/', include('awx.api.urls')),
+    urlpatterns = [
+        re_path(r'', include('awx.ui.urls', namespace='ui')),
+        re_path(r'^ui_next/.*', include('awx.ui_next.urls', namespace='ui_next')),
+        path(f'api{prefix}', include('awx.api.urls', namespace='api')),
     ]
 
-urlpatterns += [
-    re_path(r'^api/v2/', include(resource_api_urls)),
-    re_path(r'^sso/', include('awx.sso.urls', namespace='sso')),
-    re_path(r'^sso/', include('social_django.urls', namespace='social')),
-    re_path(r'^(?:api/)?400.html$', handle_400),
-    re_path(r'^(?:api/)?403.html$', handle_403),
-    re_path(r'^(?:api/)?404.html$', handle_404),
-    re_path(r'^(?:api/)?500.html$', handle_500),
-    re_path(r'^csp-violation/', handle_csp_violation),
-    re_path(r'^login/', handle_login_redirect),
-]
+    urlpatterns += [
+        path(f'api{prefix}v2/', include(resource_api_urls)),
+        re_path(r'^sso/', include('awx.sso.urls', namespace='sso')),
+        re_path(r'^sso/', include('social_django.urls', namespace='social')),
+        re_path(r'^(?:api/)?400.html$', handle_400),
+        re_path(r'^(?:api/)?403.html$', handle_403),
+        re_path(r'^(?:api/)?404.html$', handle_404),
+        re_path(r'^(?:api/)?500.html$', handle_500),
+        re_path(r'^csp-violation/', handle_csp_violation),
+        re_path(r'^login/', handle_login_redirect),
+    ]
 
-if settings.SETTINGS_MODULE == 'awx.settings.development':
-    try:
-        import debug_toolbar
+    if settings.SETTINGS_MODULE == 'awx.settings.development':
+        try:
+            import debug_toolbar
 
-        urlpatterns += [re_path(r'^__debug__/', include(debug_toolbar.urls))]
-    except ImportError:
-        pass
+            urlpatterns += [re_path(r'^__debug__/', include(debug_toolbar.urls))]
+        except ImportError:
+            pass
+
+    return urlpatterns
+
+
+urlpatterns = get_urlpatterns()
 
 handler400 = 'awx.main.views.handle_400'
 handler403 = 'awx.main.views.handle_403'


### PR DESCRIPTION
##### SUMMARY

Performance investigation notes.
As I suspected, an implementation that constructs the urls patterns foreach request is noticeable. 

The bottom set of `inclusive` times are when visiting `/api/v2/hosts/` vs. the top set are when visiting `/awx/v2/<prefix>/hosts/`. The `exclusive` entry is isolated to just `get_urlpatterns(prefix=settings.OPTIONAL_API_URLPATTERN_PREFIX)`
```
-rw-r--r-- 1 awx  root   55 Apr  9 12:52 0.000253-seconds-exclusive-8d3c0d32-8c04-4f30-b555-1003918494ca.time
-rw-r--r-- 1 awx  root   55 Apr  9 12:53 0.000363-seconds-exclusive-695d75fa-78c6-452a-a75f-635cd3731445.time
-rw-r--r-- 1 awx  root   54 Apr  9 12:53 0.00043-seconds-exclusive-3357476d-9dfb-4e68-a502-7a9536b820d5.time
-rw-r--r-- 1 awx  root   55 Apr  9 12:52 0.000513-seconds-inclusive-3b9e3ba2-f744-4c8f-b2bb-b971398a3db4.time
-rw-r--r-- 1 awx  root   55 Apr  9 12:53 0.000753-seconds-inclusive-9f25b670-b58b-471d-aab5-77f09e5be12a.time
-rw-r--r-- 1 awx  root   55 Apr  9 12:53 0.000863-seconds-inclusive-de8d5fb6-1693-41b2-bdc3-1ed58ff219bb.time
-rw-r--r-- 1 awx  root   54 Apr  9 12:50 1.1e-05-seconds-inclusive-af3f6f83-b2d4-4f52-9ea2-2957357e8a85.time
-rw-r--r-- 1 awx  root   54 Apr  9 12:41 1.2e-05-seconds-inclusive-419adff1-1900-4236-bd13-bcdb16ecddb6.time
-rw-r--r-- 1 awx  root   54 Apr  9 12:41 1.3e-05-seconds-inclusive-a396c7bb-b1cf-4710-be53-adac84f47c08.time
-rw-r--r-- 1 awx  root   54 Apr  9 12:50 1.3e-05-seconds-inclusive-cf462f74-339f-4717-8a80-af892499c1a6.time
-rw-r--r-- 1 awx  root   54 Apr  9 12:41 1.4e-05-seconds-inclusive-1bbe3da6-ff8d-4c0f-a705-e80b28201c47.time
-rw-r--r-- 1 awx  root   54 Apr  9 12:41 1.5e-05-seconds-inclusive-021aa202-2461-4a57-ad92-3fb9cfd0661f.time
```

Done:
* cache `get_urlpatterns(prefix=settings.OPTIONAL_API_URLPATTERN_PREFIX)` results
* <s>_maybe_ call `get_urlpatterns(prefix=settings.OPTIONAL_API_URLPATTERN_PREFIX)` in some sort of init process so we don't pay the penalty on first request. Realistically though, the penalty here isn't that expensive if we _do_ have to pay it 1 time per new uwsgi process.</s> decided this isn't worth it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
