### PR TITLE
Move named url init out of Middleware init

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -1,7 +1,40 @@
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
+from awx.main.utils.named_url_graph import _customize_graph, generate_graph
+from awx.conf import register, fields
 
 
 class MainConfig(AppConfig):
     name = 'awx.main'
     verbose_name = _('Main')
+
+    def load_named_url_feature(self):
+        models = [m for m in self.get_models() if hasattr(m, 'get_absolute_url')]
+        generate_graph(models)
+        _customize_graph()
+        register(
+            'NAMED_URL_FORMATS',
+            field_class=fields.DictField,
+            read_only=True,
+            label=_('Formats of all available named urls'),
+            help_text=_('Read-only list of key-value pairs that shows the standard format of all available named URLs.'),
+            category=_('Named URL'),
+            category_slug='named-url',
+        )
+        register(
+            'NAMED_URL_GRAPH_NODES',
+            field_class=fields.DictField,
+            read_only=True,
+            label=_('List of all named url graph nodes.'),
+            help_text=_(
+                'Read-only list of key-value pairs that exposes named URL graph topology.'
+                ' Use this list to programmatically generate named URLs for resources'
+            ),
+            category=_('Named URL'),
+            category_slug='named-url',
+        )
+
+    def ready(self):
+        super().ready()
+
+        self.load_named_url_feature()

--- a/awx/main/tests/functional/test_named_url.py
+++ b/awx/main/tests/functional/test_named_url.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-from unittest import mock
-
 import pytest
 
-from django.core.exceptions import ImproperlyConfigured
 from django.conf import settings
 
 from awx.api.versioning import reverse
@@ -23,25 +20,6 @@ from awx.main.models import (  # noqa
     User,
     WorkflowJobTemplate,
 )
-from awx.conf import settings_registry
-
-
-def setup_module(module):
-    # In real-world scenario, named url graph structure is populated by __init__
-    # of URLModificationMiddleware. The way Django bootstraps ensures the initialization
-    # will happen *once and only once*, while the number of initialization is uncontrollable
-    # in unit test environment. So it is wrapped by try-except block to mute any
-    # unwanted exceptions.
-    try:
-        URLModificationMiddleware(mock.Mock())
-    except ImproperlyConfigured:
-        pass
-
-
-def teardown_module(module):
-    # settings_registry will be persistent states unless we explicitly clean them up.
-    settings_registry.unregister('NAMED_URL_FORMATS')
-    settings_registry.unregister('NAMED_URL_GRAPH_NODES')
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
* Middleware classes can be instantiated multiple times in testing. To make this a non-issue, move the init code for named urls out of the middleware init and into the app init.
* This makes it easier to use other testing facilities, like LiveServerTestCase, without having to mock the named url middleware init.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
