### PR TITLE
Indicate tower_cli.cfg can also be in current directory

### DIFF
--- a/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
@@ -47,6 +47,7 @@ These can be specified via (from highest to lowest precedence):
  - direct module parameters
  - environment variables (most useful when running against localhost)
  - a config file path specified by the `tower_config_file` parameter
+ - a config file at `./tower_cli.cfg`, i.e. in the current directory
  - a config file at `~/.tower_cli.cfg`
  - a config file at `/etc/tower/tower_cli.cfg`
 
@@ -58,6 +59,15 @@ host = https://localhost:8043
 verify_ssl = true
 username = foo
 password = bar
+```
+
+or like this:
+
+```
+host: https://localhost:8043
+verify_ssl: true
+oauth_token: LEdCpKVKc4znzffcpQL5vLG8oyeku6
+
 ```
 
 ## Release and Upgrade Notes

--- a/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
+++ b/awx_collection/tools/roles/template_galaxy/templates/README.md.j2
@@ -66,7 +66,7 @@ or like this:
 ```
 host: https://localhost:8043
 verify_ssl: true
-oauth_token: LEdCpKVKc4znzffcpQL5vLG8oyeku6
+oauth_token: <token>
 
 ```
 


### PR DESCRIPTION
##### SUMMARY
The `tower_cli.cfg` file is also found in current directory.

##### ISSUE TYPE
 -  Docs Fix

##### COMPONENT NAME
 - Docs

