### PR TITLE
Fixed missing fstring from wsrelay logging

### DIFF
--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -242,7 +242,7 @@ class WebSocketRelayManager(object):
                 # In this case, we'll be sharing a redis, no need to relay.
                 if payload.get("hostname") == self.local_hostname:
                     hostname = payload.get("hostname")
-                    logger.debug("Received a heartbeat request for {hostname}. Skipping as we use redis for local host.")
+                    logger.debug(f"Received a heartbeat request for {hostname}. Skipping as we use redis for local host.")
                     continue
 
                 action = payload.get("action")


### PR DESCRIPTION
##### SUMMARY
Fixed missing fstring from wsrelay logging

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.2.1.dev3+g7f2c1ca512
```

##### ADDITIONAL INFORMATION
The original PR missed and fstring leading to an incorrect log output.
```
2024-04-10 15:38:09,496 DEBUG    [-] awx.main.wsrelay Received a heartbeat request for {hostname}. Skipping as we use redis for local host.
```
