### PR TITLE
Fix failure from DAB

### DIFF
--- a/awx/main/tests/unit/utils/test_filters.py
+++ b/awx/main/tests/unit/utils/test_filters.py
@@ -69,7 +69,7 @@ class mockHost:
 @mock.patch('awx.main.utils.filters.get_model', return_value=mockHost())
 class TestSmartFilterQueryFromString:
     @mock.patch(
-        'ansible_base.rest_filters.rest_framework.field_lookup_backend.get_fields_from_path', lambda model, path: ([model], path)
+        'ansible_base.rest_filters.rest_framework.field_lookup_backend.get_fields_from_path', lambda model, path, **kwargs: ([model], path)
     )  # disable field filtering, because a__b isn't a real Host field
     @pytest.mark.parametrize(
         "filter_string,q_expected",


### PR DESCRIPTION
##### SUMMARY
Checks busted due to merge of https://github.com/ansible/django-ansible-base/pull/282

api-tests failed with

```

2024-04-11T15:24:59.1730806Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/ansible_base/rest_filters/rest_framework/field_lookup_backend.py", line 68, in get_fields_from_lookup
2024-04-11T15:24:59.1731193Z     field_list, new_path = get_fields_from_path(model, path, treat_jsonfield_as_text=self.TREAT_JSONFIELD_AS_TEXT)
2024-04-11T15:24:59.1731360Z                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-11T15:24:59.1731857Z TypeError: TestSmartFilterQueryFromString.<lambda>() got an unexpected keyword argument 'treat_jsonfield_as_text'
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

