### PR TITLE
Add try/except on release of work Unit and add force to workunit reaper

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -196,6 +196,7 @@ def administrative_workunit_reaper(work_list=None):
      - worker_cleanup
     These should ordinarily be released when the method finishes, but this is a
     cleanup of last-resort, in case something went awry
+    Release will be forced to be sure that everything will be relased.
     """
     receptor_ctl = get_receptor_ctl()
     if work_list is None:
@@ -219,7 +220,7 @@ def administrative_workunit_reaper(work_list=None):
             if work_data.get('StateName') in RECEPTOR_ACTIVE_STATES:
                 continue  # do not want to touch active work units
             logger.info(f'Reaping orphaned work unit {unit_id} with params {params}')
-        receptor_ctl.simple_command(f"work release {unit_id}")
+        receptor_ctl.simple_command(f"work force-release {unit_id}")
 
 
 class RemoteJobError(RuntimeError):

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -196,7 +196,6 @@ def administrative_workunit_reaper(work_list=None):
      - worker_cleanup
     These should ordinarily be released when the method finishes, but this is a
     cleanup of last-resort, in case something went awry
-    Release will be forced to be sure that everything will be relased.
     """
     receptor_ctl = get_receptor_ctl()
     if work_list is None:
@@ -220,7 +219,7 @@ def administrative_workunit_reaper(work_list=None):
             if work_data.get('StateName') in RECEPTOR_ACTIVE_STATES:
                 continue  # do not want to touch active work units
             logger.info(f'Reaping orphaned work unit {unit_id} with params {params}')
-        receptor_ctl.simple_command(f"work force-release {unit_id}")
+        receptor_ctl.simple_command(f"work release {unit_id}")
 
 
 class RemoteJobError(RuntimeError):

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -688,9 +688,14 @@ def awx_receptor_workunit_reaper():
             receptor_ctl.simple_command(f"work cancel {job.work_unit_id}")
             receptor_ctl.simple_command(f"work release {job.work_unit_id}")
         except Exception as e:
-            # force release of work unit
-            logger.error(f"Error on cancel or release {job.work_unit_id} with error {str(e)}.")
-            receptor_ctl.simple_command(f"work force-release {job.work_unit_id}")
+            # force release of work unit. Try/except is required becasue force-release
+            # try to release the job one time and thne delete it from worklist 
+            logger.error(f"Error on cancel or release {job.work_unit_id} with error {str(e)}.Try Force it...")
+            try:
+                receptor_ctl.simple_command(f"work force-release {job.work_unit_id}")
+                logger.debug(f"{job.log_format} is now released")
+            except Exception as e:
+                logger.error(f"Error on force-release {job.work_unit_id} with error {str(e)}. Skip It")
 
     administrative_workunit_reaper(receptor_work_list)
 

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -688,9 +688,9 @@ def awx_receptor_workunit_reaper():
             receptor_ctl.simple_command(f"work cancel {job.work_unit_id}")
             receptor_ctl.simple_command(f"work release {job.work_unit_id}")
         except Exception as e:
-            # leave the cleaning of work unit to administrative_workunit_reaper
-            # show only an error on log side to track it
+            # force release of work unit
             logger.error(f"Error on cancel or release {job.work_unit_id} with error {str(e)}.")
+            receptor_ctl.simple_command(f"work force-release {job.work_unit_id}")
 
     administrative_workunit_reaper(receptor_work_list)
 

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -684,8 +684,13 @@ def awx_receptor_workunit_reaper():
     jobs_with_unreleased_receptor_units = UnifiedJob.objects.filter(work_unit_id__in=unit_ids).exclude(status__in=ACTIVE_STATES)
     for job in jobs_with_unreleased_receptor_units:
         logger.debug(f"{job.log_format} is not active, reaping receptor work unit {job.work_unit_id}")
-        receptor_ctl.simple_command(f"work cancel {job.work_unit_id}")
-        receptor_ctl.simple_command(f"work release {job.work_unit_id}")
+        try:
+            receptor_ctl.simple_command(f"work cancel {job.work_unit_id}")
+            receptor_ctl.simple_command(f"work release {job.work_unit_id}")
+        except Exception as e:
+            # leave the cleaning of work unit to administrative_workunit_reaper
+            # show only an error on log side to track it
+            logger.error(f"Error on cancel or release {job.work_unit_id} with error {str(e)}.")
 
     administrative_workunit_reaper(receptor_work_list)
 


### PR DESCRIPTION
##### SUMMARY
In case we have some issue beetween execution node and AWX, and AWX will not catch that execution node is not working well or nor reachave or simply delete workunit (I don't identify exactly the use case but appen to me in 24.2.0 with execution node and ansible runne 1.4.3), workflow still wait the running state.
if we try to cancel the job/workflow via UI, we receive error below on awx-task pod and job never cancelled/stopped.

```
2024-04-23T09:11:30.367001675+02:00   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/dispatch/worker/task.py", line 103, in perform_work
    result = self.run_callable(body)
             ^^^^^^^^^^^^^^^^^^^^^^^
2024-04-23T09:11:30.367012067+02:00   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/dispatch/worker/task.py", line 78, in run_callable
2024-04-23T09:11:30.367015375+02:00     return _call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
2024-04-23T09:11:30.367023213+02:00   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/system.py", line 687, in awx_receptor_workunit_reaper
    receptor_ctl.simple_command(f"work cancel {job.work_unit_id}")
2024-04-23T09:11:30.367031453+02:00   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/receptorctl/socket_interface.py", line 83, in simple_command
2024-04-23T09:11:30.367035057+02:00     return self.read_and_parse_json()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-04-23T09:11:30.367042158+02:00   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/receptorctl/socket_interface.py", line 60, in read_and_parse_json
    raise RuntimeError(text[7:])
RuntimeError: error cancelling remote unit:  unknown work unit wwXpmxdB
```

In thi PR i simply try/except the for cycle and demand the release to workunit reaper, where I put the `force-release` command instead of simple `release`.

I think that we need to force the release inside the for-cycle, because administrative_workunit_reaper check a lot of things on work unit side, that to me is not much sense because we already filter by ACTIVE_STATES on UnifiedJob filter.

If this is true, i can change it adding a force-relase command on exception in that way we are shure that works will be relased when cancel will be clicked on UI.


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Receptor

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
