### PR TITLE
Fix and test data migration error from DAB RBAC

### DIFF
--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -140,6 +140,17 @@ def get_permissions_for_role(role_field, children_map, apps):
     return perm_list
 
 
+def model_class(ct, apps):
+    """
+    You can not use model methods in migrations, so this duplicates
+    what ContentType.model_class does, using current apps
+    """
+    try:
+        return apps.get_model(ct.app_label, ct.model)
+    except LookupError:
+        return None
+
+
 def migrate_to_new_rbac(apps, schema_editor):
     """
     This method moves the assigned permissions from the old rbac.py models
@@ -197,7 +208,7 @@ def migrate_to_new_rbac(apps, schema_editor):
             role_definition = managed_definitions[permissions]
         else:
             action = role.role_field.rsplit('_', 1)[0]  # remove the _field ending of the name
-            role_definition_name = f'{role.content_type.model_class().__name__} {action.title()}'
+            role_definition_name = f'{model_class(role.content_type).__name__} {action.title()}'
 
             description = role_descriptions[role.role_field]
             if type(description) == dict:

--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -208,7 +208,7 @@ def migrate_to_new_rbac(apps, schema_editor):
             role_definition = managed_definitions[permissions]
         else:
             action = role.role_field.rsplit('_', 1)[0]  # remove the _field ending of the name
-            role_definition_name = f'{model_class(role.content_type).__name__} {action.title()}'
+            role_definition_name = f'{model_class(role.content_type, apps).__name__} {action.title()}'
 
             description = role_descriptions[role.role_field]
             if type(description) == dict:

--- a/awx/main/tests/functional/test_migrations.py
+++ b/awx/main/tests/functional/test_migrations.py
@@ -68,3 +68,18 @@ class TestMigrationSmoke:
         bar_peers = bar.peers.all()
         assert len(bar_peers) == 1
         assert fooaddr in bar_peers
+
+    def test_migrate_DAB_RBAC(self, migrator):
+        old_state = migrator.apply_initial_migration(('main', '0190_alter_inventorysource_source_and_more'))
+        # Role = old_state.apps.get_model('main', 'Role')
+        Organization = old_state.apps.get_model('main', 'Organization')
+        # ContentType = old_state.apps.get_model('contenttypes', 'ContentType')
+        User = old_state.apps.get_model('auth', 'User')
+
+        org = Organization.objects.create()
+        user = User.objects.create(username='random-user')
+        org.read_role.members.add(user)
+
+        new_state = migrator.apply_tested_migration(
+            ('main', '0192_custom_roles'),
+        )

--- a/awx/main/tests/functional/test_migrations.py
+++ b/awx/main/tests/functional/test_migrations.py
@@ -84,4 +84,4 @@ class TestMigrationSmoke:
         )
 
         RoleUserAssignment = new_state.apps.get_model('dab_rbac', 'RoleUserAssignment')
-        assert RoleUserAssignment.filter(user=user.id, object_id=org.id).exists()
+        assert RoleUserAssignment.objects.filter(user=user.id, object_id=org.id).exists()

--- a/awx/main/tests/functional/test_migrations.py
+++ b/awx/main/tests/functional/test_migrations.py
@@ -1,6 +1,7 @@
 import pytest
 
 from django_test_migrations.plan import all_migrations, nodes_to_tuples
+from django.utils.timezone import now
 
 """
 Most tests that live in here can probably be deleted at some point. They are mainly
@@ -76,7 +77,7 @@ class TestMigrationSmoke:
         # ContentType = old_state.apps.get_model('contenttypes', 'ContentType')
         User = old_state.apps.get_model('auth', 'User')
 
-        org = Organization.objects.create()
+        org = Organization.objects.create(name='arbitrary-org', created=now(), modified=now())
         user = User.objects.create(username='random-user')
         org.read_role.members.add(user)
 

--- a/awx/main/tests/functional/test_migrations.py
+++ b/awx/main/tests/functional/test_migrations.py
@@ -72,9 +72,7 @@ class TestMigrationSmoke:
 
     def test_migrate_DAB_RBAC(self, migrator):
         old_state = migrator.apply_initial_migration(('main', '0190_alter_inventorysource_source_and_more'))
-        # Role = old_state.apps.get_model('main', 'Role')
         Organization = old_state.apps.get_model('main', 'Organization')
-        # ContentType = old_state.apps.get_model('contenttypes', 'ContentType')
         User = old_state.apps.get_model('auth', 'User')
 
         org = Organization.objects.create(name='arbitrary-org', created=now(), modified=now())
@@ -84,3 +82,6 @@ class TestMigrationSmoke:
         new_state = migrator.apply_tested_migration(
             ('main', '0192_custom_roles'),
         )
+
+        RoleUserAssignment = new_state.apps.get_model('dab_rbac', 'RoleUserAssignment')
+        assert RoleUserAssignment.filter(user=user.id, object_id=org.id).exists()


### PR DESCRIPTION
##### SUMMARY
I can explain how this bug was introduced...

One of the latest things done before merging the prior PR that integrated the RBAC app from the DAB library was that the `RoleDefinition` names were changed to a new naming convention. As a part of this, we didn't want to use all-lowercase names like "jobtemplate", so I called `model_class` on the `ContentType` object.

Testing this with the "current" unit tests, you would just pass in the "current" apps, which would have that method. However, with historical migrations, you're using partial models that don't have such methods available.

Thus, https://github.com/ansible/awx/issues/15137

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

