### PR TITLE
Fix terraform backend credential issue

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1660,7 +1660,7 @@ class terraform(PluginFileInjector):
         credential = inventory_update.get_cloud_credential()
 
         private_data = {'credentials': {}}
-        gce_cred = credential.get_input('gce_credentials')
+        gce_cred = credential.get_input('gce_credentials', default=None)
         if gce_cred:
             private_data['credentials'][credential] = gce_cred
         return private_data
@@ -1669,7 +1669,7 @@ class terraform(PluginFileInjector):
         env = super(terraform, self).get_plugin_env(inventory_update, private_data_dir, private_data_files)
         credential = inventory_update.get_cloud_credential()
         cred_data = private_data_files['credentials']
-        if cred_data[credential]:
+        if credential in cred_data:
             env['GOOGLE_BACKEND_CREDENTIALS'] = to_container_path(cred_data[credential], private_data_dir)
         return env
 


### PR DESCRIPTION
##### SUMMARY
When trying to sync inventory using terraform backend credentials, the job failed when the credential is not a google credential type. 

```
  File "/awx_devel/awx/main/models/inventory.py", line 1507, in build_private_data
    return self.build_plugin_private_data(inventory_update, private_data_dir)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/models/inventory.py", line 1663, in build_plugin_private_data
    gce_cred = credential.get_input('gce_credentials')
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/models/credential/__init__.py", line 290, in get_input
    raise AttributeError(field_name)
AttributeError: gce_credentials
```

This issue has been introduced by the merge of #15055 
This fix consists in checking whether the user as provided some google credentials.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.3.1.dev7+g2fbbd10b1d
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
