### PR TITLE
Temporarily downgrade openssl

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -36,6 +36,7 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
 {% endif %}
     nss \
     openldap-devel \
+    openssl-3.0.7 \
     patch \
     postgresql \
     postgresql-devel \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
openssl 3.2.0 has incompatiblity issues with the libpq version we are using, and causes some C runtime errors:
"double free or corruption (out)"

see awx issue #15136

also this issue

https://github.com/conan-io/conan-center-index/pull/22615
https://github.com/Homebrew/homebrew-core/issues/155651

once the libpq libraries on centos stream9 are updated with the patch, we can unpin openssl

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.3.1.dev2+ga1e3859ed0
```
