### PR TITLE
Support Django logout redirects

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -109,6 +109,9 @@ class LoggedLoginView(auth_views.LoginView):
 
 
 class LoggedLogoutView(auth_views.LogoutView):
+
+    success_url_allowed_hosts = settings.LOGOUT_ALLOWED_HOSTS
+
     def dispatch(self, request, *args, **kwargs):
         original_user = getattr(request, 'user', None)
         ret = super(LoggedLogoutView, self).dispatch(request, *args, **kwargs)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -114,7 +114,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'public', 'media')
 MEDIA_URL = '/media/'
 
 LOGIN_URL = '/api/login/'
-LOGOUT_ALLOWED_HOSTS = os.getenv('LOGOUT_ALLOWED_HOSTS').split(",") if os.getenv('LOGOUT_ALLOWED_HOSTS') else []
+LOGOUT_ALLOWED_HOSTS = []
 
 # Absolute filesystem path to the directory to host projects (with playbooks).
 # This directory should not be web-accessible.

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -114,6 +114,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'public', 'media')
 MEDIA_URL = '/media/'
 
 LOGIN_URL = '/api/login/'
+LOGOUT_ALLOWED_HOSTS = os.getenv('LOGOUT_ALLOWED_HOSTS').split(",") if os.getenv('LOGOUT_ALLOWED_HOSTS') else []
 
 # Absolute filesystem path to the directory to host projects (with playbooks).
 # This directory should not be web-accessible.


### PR DESCRIPTION
##### SUMMARY

This PR allows specification of Django's `auth_views.LogoutView.success_url_allowed_hosts` from `settings`.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 24.3.1.dev9+g4d163c3330
```

##### ADDITIONAL INFORMATION
This has been discussed on `#aap-controller` on Slack.

I managed to step through the code with `sdb` to check the `settings` change has no ill affect.

This PR will need an accompanying PR for `awx-controller` to be able to set the new environment variable from then operator.

This part of the code-base seems sparse of unit tests.. IDK if you require some?