### PR TITLE
Option for dev env to enable ssl for postgres

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ VAULT_TLS ?= false
 TACACS ?= false
 # If set to true docker-compose will install editable dependencies
 EDITABLE_DEPENDENCIES ?= false
+# If set to true, use tls for postgres connection
+PG_TLS ?= false
 
 VENV_BASE ?= /var/lib/awx/venv
 
@@ -536,6 +538,7 @@ docker-compose-sources: .git/hooks/pre-commit
 	    -e vault_tls=$(VAULT_TLS) \
 	    -e enable_tacacs=$(TACACS) \
 	    -e install_editable_dependencies=$(EDITABLE_DEPENDENCIES) \
+	    -e pg_tls=$(PG_TLS) \
 	    $(EXTRA_SOURCES_ANSIBLE_OPTS)
 
 docker-compose: awx/projects docker-compose-sources

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -4,6 +4,7 @@ awx_image: 'ghcr.io/ansible/awx_devel'
 pg_port: 5432
 pg_username: 'awx'
 pg_database: 'awx'
+pg_tls: false
 control_plane_node_count: 1
 minikube_container_group: false
 receptor_socket_file: /var/run/awx-receptor/receptor.sock

--- a/tools/docker-compose/ansible/roles/sources/templates/database.py.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/database.py.j2
@@ -5,6 +5,9 @@ DATABASES = {
         'NAME': "{{ pg_database }}",
         'USER': "{{ pg_username }}",
         'PASSWORD': "{{ pg_password }}",
+{% if pg_tls|bool %}
+        'OPTIONS': {'sslmode': 'require'},
+{% endif %}
 {% if enable_pgbouncer|bool %}
         'HOST': "pgbouncer",
         'PORT': "{{ pgbouncer_port }}",

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -237,13 +237,24 @@ services:
     image: quay.io/sclorg/postgresql-15-c9s
     container_name: tools_postgres_1
     # additional logging settings for postgres can be found https://www.postgresql.org/docs/current/runtime-config-logging.html
-    command: run-postgresql -c log_destination=stderr -c log_min_messages=info -c log_min_duration_statement={{ pg_log_min_duration_statement|default(1000) }} -c max_connections={{ pg_max_connections|default(1024) }}
+    command: >
+        bash -c "
+{% if pg_tls|bool %}
+        mkdir -p /opt/app-root/src/certs
+        && openssl genrsa -out /opt/app-root/src/certs/tls.key 2048
+        && openssl req -new -x509 -key /opt/app-root/src/certs/tls.key -out /opt/app-root/src/certs/tls.crt -subj '/CN=postgres'
+        && chmod 600 /opt/app-root/src/certs/tls.crt /opt/app-root/src/certs/tls.key &&
+{% endif %}
+        run-postgresql -c log_destination=stderr -c log_min_messages=info -c log_min_duration_statement={{ pg_log_min_duration_statement|default(1000) }} -c max_connections={{ pg_max_connections|default(1024) }}"
     environment:
       POSTGRESQL_USER: {{ pg_username }}
       POSTGRESQL_DATABASE: {{ pg_database }}
       POSTGRESQL_PASSWORD: {{ pg_password }}
     volumes:
       - "awx_db_15:/var/lib/pgsql/data"
+{% if pg_tls|bool %}
+      - "../../docker-compose/pgssl.conf:/opt/app-root/src/postgresql-cfg/pgssl.conf"
+{% endif %}
     networks:
       - awx
     ports:

--- a/tools/docker-compose/pgssl.conf
+++ b/tools/docker-compose/pgssl.conf
@@ -1,0 +1,5 @@
+ssl = on
+ssl_cert_file = '/opt/app-root/src/certs/tls.crt' # server certificate
+ssl_key_file =  '/opt/app-root/src/certs/tls.key' # server private key
+#ssl_ca_file                                   # trusted certificate authorities
+#ssl_crl_file                                  # certificates revoked by certificate authorities


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`PG_TLS=true make docker-compose`

This will add some extra startup commands for the postgres container to generate a key and
cert to use for postgres connections.

It will also mount in pgssl.conf which has ssl configuration.

**This can be useful for debugging issues that only surface when using ssl postgres connections.**

I'd also be okay with just writing up some docs on how to do this manually if we don't want to add more code to our bloated docker-compose.yml.j2 file

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API