### PR TITLE
awx modules wait on event processing finished

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -1038,7 +1038,7 @@ class ControllerAPIModule(ControllerModule):
         # Grab our start time to compare against for the timeout
         start = time.time()
         result = self.get_endpoint(url)
-        while not result['json']['finished']:
+        while not result['json']['event_processing_finished']:
             # If we are past our time out fail with a message
             if timeout and timeout < time.time() - start:
                 # Account for Legacy messages

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -1038,7 +1038,10 @@ class ControllerAPIModule(ControllerModule):
         # Grab our start time to compare against for the timeout
         start = time.time()
         result = self.get_endpoint(url)
-        while not result['json']['event_processing_finished']:
+        wait_on_field = 'event_processing_finished'
+        if wait_on_field not in result['json']:
+            wait_on_field = 'finished'
+        while not result['json'][wait_on_field]:
             # If we are past our time out fail with a message
             if timeout and timeout < time.time() - start:
                 # Account for Legacy messages


### PR DESCRIPTION
##### SUMMARY
related https://github.com/ansible/awx/issues/15063

<!--- Describe the change, including rationale and design decisions -->
This change makes "wait: true" for jobs and syncs look at the event_processing_finished instead of finished field.

Right now there is a race condition where a module might try to delete an inventory, but the events for an inventory sync have not yet finished. We have a RelatedJobsPreventDeleteMixin that checks for this condition.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
