### PR TITLE
Wrap long line to fit help window (#14597)

### DIFF
--- a/awx/ui/src/components/Workflow/WorkflowHelp.js
+++ b/awx/ui/src/components/Workflow/WorkflowHelp.js
@@ -12,7 +12,7 @@ const Inner = styled.div`
   border-radius: 2px;
   color: white;
   left: 10px;
-  max-width: 300px;
+  max-width: 500px;
   padding: 5px 10px;
   position: absolute;
   top: 10px;

--- a/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
+++ b/awx/ui/src/components/Workflow/WorkflowNodeHelp.js
@@ -12,6 +12,7 @@ const GridDL = styled.dl`
   column-gap: 15px;
   display: grid;
   grid-template-columns: max-content;
+  overflow-wrap: anywhere;
   row-gap: 0px;
   dt {
     grid-column-start: 1;


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
1. Increase help window max-width for better view in case of long resource name.
2. Set "overflow-wrap: anywhere" to wrap long line without wight spaces 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

related #14597

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 23.7.1.dev84+gde7db88e57.d20240506
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Before the change:

<img width="1632" alt="Screenshot 2024-04-19 at 13 50 51" src="https://github.com/ansible/awx/assets/119814380/d8f59f2e-c4fb-4739-b288-21af64265a9d">

After:

<img width="1632" alt="Screenshot 2024-04-22 at 16 27 38" src="https://github.com/ansible/awx/assets/119814380/d17ea117-60a4-4550-9521-5a8dd94676ea">


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
