### PR TITLE
Replace REMOTE_ADDR with ansible_base.lib.utils.requests.get_remote_host

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -33,6 +33,7 @@ from rest_framework.negotiation import DefaultContentNegotiation
 # django-ansible-base
 from ansible_base.rest_filters.rest_framework.field_lookup_backend import FieldLookupBackend
 from ansible_base.lib.utils.models import get_all_field_names
+from ansible_base.lib.utils.requests import get_remote_host
 from ansible_base.rbac.models import RoleEvaluation, RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
 
@@ -93,8 +94,9 @@ class LoggedLoginView(auth_views.LoginView):
 
     def post(self, request, *args, **kwargs):
         ret = super(LoggedLoginView, self).post(request, *args, **kwargs)
+        ip = get_remote_host(request)  # request.META.get('REMOTE_ADDR', None)
         if request.user.is_authenticated:
-            logger.info(smart_str(u"User {} logged in from {}".format(self.request.user.username, request.META.get('REMOTE_ADDR', None))))
+            logger.info(smart_str(u"User {} logged in from {}".format(self.request.user.username, ip)))
             ret.set_cookie(
                 'userLoggedIn', 'true', secure=getattr(settings, 'SESSION_COOKIE_SECURE', False), samesite=getattr(settings, 'USER_COOKIE_SAMESITE', 'Lax')
             )
@@ -103,7 +105,7 @@ class LoggedLoginView(auth_views.LoginView):
             return ret
         else:
             if 'username' in self.request.POST:
-                logger.warning(smart_str(u"Login failed for user {} from {}".format(self.request.POST.get('username'), request.META.get('REMOTE_ADDR', None))))
+                logger.warning(smart_str(u"Login failed for user {} from {}".format(self.request.POST.get('username'), ip)))
             ret.status_code = 401
             return ret
 
@@ -208,11 +210,12 @@ class APIView(views.APIView):
             return response
 
         if response.status_code >= 400:
+            ip = get_remote_host(request)  # request.META.get('REMOTE_ADDR', None)
             msg_data = {
                 'status_code': response.status_code,
                 'user_name': request.user,
                 'url_path': request.path,
-                'remote_addr': request.META.get('REMOTE_ADDR', None),
+                'remote_addr': ip,
             }
 
             if type(response.data) is dict:


### PR DESCRIPTION
##### SUMMARY
Replace request.META.get('REMOTE_ADDR') with django-ansible-base get_remote_host

for environments with proxies and other intermediates where callbacks are broken because the remote_addr is the proxy.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 
##### AWX VERSION
all
