### PR TITLE
Fix environment-specific rough edges of logging setup

### DIFF
--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -4,6 +4,7 @@
 # Python
 import base64
 import logging
+import logging.handlers
 import sys
 import traceback
 import os
@@ -25,6 +26,9 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from opentelemetry.sdk.resources import Resource
+
+
+__all__ = ['RSysLogHandler', 'SpecialInventoryHandler', 'ColorHandler']
 
 
 class RSysLogHandler(logging.handlers.SysLogHandler):
@@ -109,39 +113,35 @@ class SpecialInventoryHandler(logging.Handler):
 
 
 if settings.COLOR_LOGS is True:
-    try:
-        from logutils.colorize import ColorizingStreamHandler
-        import colorama
+    from logutils.colorize import ColorizingStreamHandler
+    import colorama
 
-        colorama.deinit()
-        colorama.init(wrap=False, convert=False, strip=False)
+    colorama.deinit()
+    colorama.init(wrap=False, convert=False, strip=False)
 
-        class ColorHandler(ColorizingStreamHandler):
-            def colorize(self, line, record):
-                # comment out this method if you don't like the job_lifecycle
-                # logs rendered with cyan text
-                previous_level_map = self.level_map.copy()
-                if record.name == "awx.analytics.job_lifecycle":
-                    self.level_map[logging.INFO] = (None, 'cyan', True)
-                msg = super(ColorHandler, self).colorize(line, record)
-                self.level_map = previous_level_map
-                return msg
+    class ColorHandler(ColorizingStreamHandler):
+        def colorize(self, line, record):
+            # comment out this method if you don't like the job_lifecycle
+            # logs rendered with cyan text
+            previous_level_map = self.level_map.copy()
+            if record.name == "awx.analytics.job_lifecycle":
+                self.level_map[logging.INFO] = (None, 'cyan', True)
+            msg = super(ColorHandler, self).colorize(line, record)
+            self.level_map = previous_level_map
+            return msg
 
-            def format(self, record):
-                message = logging.StreamHandler.format(self, record)
-                return '\n'.join([self.colorize(line, record) for line in message.splitlines()])
+        def format(self, record):
+            message = logging.StreamHandler.format(self, record)
+            return '\n'.join([self.colorize(line, record) for line in message.splitlines()])
 
-            level_map = {
-                logging.DEBUG: (None, 'green', True),
-                logging.INFO: (None, None, True),
-                logging.WARNING: (None, 'yellow', True),
-                logging.ERROR: (None, 'red', True),
-                logging.CRITICAL: (None, 'red', True),
-            }
+        level_map = {
+            logging.DEBUG: (None, 'green', True),
+            logging.INFO: (None, None, True),
+            logging.WARNING: (None, 'yellow', True),
+            logging.ERROR: (None, 'red', True),
+            logging.CRITICAL: (None, 'red', True),
+        }
 
-    except ImportError:
-        # logutils is only used for colored logs in the dev environment
-        pass
 else:
     ColorHandler = logging.StreamHandler
 


### PR DESCRIPTION
##### SUMMARY

Two separate random things here. Firstly, I have no expectation that this would work:

```python
import logging

logging.handlers.SysLogHandler
```

You didn't import the `logging.handlers` module... so why should python have loaded that module? You get `SysLogHandler` if you load that module. Newer versions of python will fail with this syntax, but there's no reason we shouldn't do it generally.

Next, the blanket `ImportError` will (logically) often error on not having `colorama` or whatever. But what happens then? It passes. But... if you were _in this block_ that means that the `COLOR_LOGS` is True in settings. If that setting is true, _that means you're using color logs_, which means that the class `ColorHandler` will be referenced in the logging dict config. But the `pass` means that it won't be defined. So the error you'll get is just simply that it can't import `awx.main.utils.handlers.ColorHandler`


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
