### PR TITLE
host details: increase variables window

### DIFF
--- a/awx/ui/src/screens/Host/HostDetail/HostDetail.js
+++ b/awx/ui/src/screens/Host/HostDetail/HostDetail.js
@@ -91,7 +91,7 @@ function HostDetail({ host }) {
         />
         <VariablesDetail
           label={t`Variables`}
-          rows={4}
+          rows={12}
           value={variables}
           name="variables"
           dataCy="host-detail-variables"


### PR DESCRIPTION
##### SUMMARY

Increase the 'variables' window tallness at host details page.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
```

##### ADDITIONAL INFORMATION
When hosts have variables, they may have lots of them. The current window was only 4 rows tall. By making it taller,
it's easier to read it immediately (also to scroll, etc.) 
I know there is a "fullscreen" button at the top right. This change makes it easier to not have to click it every time, for every host. Attaching screenshot how it looks now with only 2 variables, for comparison

![host_details1](https://github.com/ansible/awx/assets/238607/fccf1763-751c-46ed-a470-8d6359af7371)

ran the below commands
```
npm run prettier
npm run lint
npm run test
```
