### PR TITLE
Fix success_url_allowed_hosts set instantiation

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -110,7 +110,7 @@ class LoggedLoginView(auth_views.LoginView):
 
 class LoggedLogoutView(auth_views.LogoutView):
 
-    success_url_allowed_hosts = settings.LOGOUT_ALLOWED_HOSTS
+    success_url_allowed_hosts = set(settings.LOGOUT_ALLOWED_HOSTS.split(",")) if settings.LOGOUT_ALLOWED_HOSTS else set()
 
     def dispatch(self, request, *args, **kwargs):
         original_user = getattr(request, 'user', None)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -114,7 +114,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'public', 'media')
 MEDIA_URL = '/media/'
 
 LOGIN_URL = '/api/login/'
-LOGOUT_ALLOWED_HOSTS = []
+LOGOUT_ALLOWED_HOSTS = None
 
 # Absolute filesystem path to the directory to host projects (with playbooks).
 # This directory should not be web-accessible.


### PR DESCRIPTION
##### SUMMARY
Further to https://github.com/ansible/awx/pull/15148

This PR fixes parsing of the _injected_ setting value.

I've tested with a locally built AWX image deployed to OpenShift and verified various scenarios now work correctly.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
```
awx: 24.3.2.dev9+g0649fe7e8d
```


##### ADDITIONAL INFORMATION
The injection of `spec.extra_settings` into Django's `settings` was adding the value as a set of characters.

This PR corrects handling of the setting to use a set of parsed, comma separated, values.