### PR TITLE
Use view-level rest_filter exclusion list from DAB

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1677,6 +1677,9 @@ class HostList(HostRelatedSearchMixin, ListCreateAPIView):
     always_allow_superuser = False
     model = models.Host
     serializer_class = serializers.HostSerializer
+    rest_filters_reserved_names = [
+        'host_filter',
+    ]
 
     def get_queryset(self):
         qs = super(HostList, self).get_queryset()

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1933,6 +1933,9 @@ class HostList(HostRelatedSearchMixin, ListCreateAPIView):
     model = models.Host
     serializer_class = serializers.HostSerializer
     resource_purpose = 'hosts'
+    rest_filters_reserved_names = [
+        'host_filter',
+    ]
 
     @extend_schema_if_available(extensions={"x-ai-description": "A list of hosts."})
     def get(self, request, *args, **kwargs):

--- a/awx/api/views/mixin.py
+++ b/awx/api/views/mixin.py
@@ -191,6 +191,10 @@ class OrganizationCountsMixin(object):
 
 
 class NoTruncateMixin(object):
+    rest_filters_reserved_names = [
+        'no_truncate',
+    ]
+
     def get_serializer_context(self):
         context = super().get_serializer_context()
         if self.request.query_params.get('no_truncate'):

--- a/awx/api/views/mixin.py
+++ b/awx/api/views/mixin.py
@@ -207,6 +207,10 @@ class OrganizationCountsMixin(object):
 
 
 class NoTruncateMixin(object):
+    rest_filters_reserved_names = [
+        'no_truncate',
+    ]
+
     def get_serializer_context(self):
         context = super().get_serializer_context()
         if self.request.query_params.get('no_truncate'):


### PR DESCRIPTION
##### SUMMARY
Adopts https://github.com/ansible/django-ansible-base/pull/384 so that we can have a more targeted default list.

We are on DAB devel so this is expected to take effect right away... or at least when the image rebuilds.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds `rest_filters_reserved_names` metadata to prevent specific query params from being interpreted by the REST filtering backend; no business logic or data handling changes.
> 
> **Overview**
> Adopts django-ansible-base’s view-level REST filter exclusion mechanism by adding `rest_filters_reserved_names` declarations.
> 
> `HostList` now reserves `host_filter`, and `NoTruncateMixin` reserves `no_truncate`, reducing the chance these custom query params are treated as generic rest-filter inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4e6c6c13292ab58a2fdee014d2b357c4f635294. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API query parameter handling to properly reserve specific parameter names. This ensures `host_filter` and `no_truncate` query parameters function correctly in API requests without being treated as generic filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->