### PR TITLE
Update a few dev requirements

### DIFF
--- a/awx/conf/tests/unit/test_settings.py
+++ b/awx/conf/tests/unit/test_settings.py
@@ -130,9 +130,9 @@ def test_default_setting(settings, mocker):
     settings.registry.register('AWX_SOME_SETTING', field_class=fields.CharField, category=_('System'), category_slug='system', default='DEFAULT')
 
     settings_to_cache = mocker.Mock(**{'order_by.return_value': []})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=settings_to_cache):
-        assert settings.AWX_SOME_SETTING == 'DEFAULT'
-        assert settings.cache.get('AWX_SOME_SETTING') == 'DEFAULT'
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=settings_to_cache)
+    assert settings.AWX_SOME_SETTING == 'DEFAULT'
+    assert settings.cache.get('AWX_SOME_SETTING') == 'DEFAULT'
 
 
 @pytest.mark.defined_in_file(AWX_SOME_SETTING='DEFAULT')
@@ -146,9 +146,9 @@ def test_setting_is_not_from_setting_file(settings, mocker):
     settings.registry.register('AWX_SOME_SETTING', field_class=fields.CharField, category=_('System'), category_slug='system', default='DEFAULT')
 
     settings_to_cache = mocker.Mock(**{'order_by.return_value': []})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=settings_to_cache):
-        assert settings.AWX_SOME_SETTING == 'DEFAULT'
-        assert settings.registry.get_setting_field('AWX_SOME_SETTING').defined_in_file is False
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=settings_to_cache)
+    assert settings.AWX_SOME_SETTING == 'DEFAULT'
+    assert settings.registry.get_setting_field('AWX_SOME_SETTING').defined_in_file is False
 
 
 def test_empty_setting(settings, mocker):
@@ -156,10 +156,10 @@ def test_empty_setting(settings, mocker):
     settings.registry.register('AWX_SOME_SETTING', field_class=fields.CharField, category=_('System'), category_slug='system')
 
     mocks = mocker.Mock(**{'order_by.return_value': mocker.Mock(**{'__iter__': lambda self: iter([]), 'first.return_value': None})})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=mocks):
-        with pytest.raises(AttributeError):
-            settings.AWX_SOME_SETTING
-        assert settings.cache.get('AWX_SOME_SETTING') == SETTING_CACHE_NOTSET
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=mocks)
+    with pytest.raises(AttributeError):
+        settings.AWX_SOME_SETTING
+    assert settings.cache.get('AWX_SOME_SETTING') == SETTING_CACHE_NOTSET
 
 
 def test_setting_from_db(settings, mocker):
@@ -168,9 +168,9 @@ def test_setting_from_db(settings, mocker):
 
     setting_from_db = mocker.Mock(key='AWX_SOME_SETTING', value='FROM_DB')
     mocks = mocker.Mock(**{'order_by.return_value': mocker.Mock(**{'__iter__': lambda self: iter([setting_from_db]), 'first.return_value': setting_from_db})})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=mocks):
-        assert settings.AWX_SOME_SETTING == 'FROM_DB'
-        assert settings.cache.get('AWX_SOME_SETTING') == 'FROM_DB'
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=mocks)
+    assert settings.AWX_SOME_SETTING == 'FROM_DB'
+    assert settings.cache.get('AWX_SOME_SETTING') == 'FROM_DB'
 
 
 @pytest.mark.defined_in_file(AWX_SOME_SETTING='DEFAULT')
@@ -205,8 +205,8 @@ def test_db_setting_update(settings, mocker):
 
     existing_setting = mocker.Mock(key='AWX_SOME_SETTING', value='FROM_DB')
     setting_list = mocker.Mock(**{'order_by.return_value.first.return_value': existing_setting})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=setting_list):
-        settings.AWX_SOME_SETTING = 'NEW-VALUE'
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=setting_list)
+    settings.AWX_SOME_SETTING = 'NEW-VALUE'
 
     assert existing_setting.value == 'NEW-VALUE'
     existing_setting.save.assert_called_with(update_fields=['value'])
@@ -217,8 +217,8 @@ def test_db_setting_deletion(settings, mocker):
     settings.registry.register('AWX_SOME_SETTING', field_class=fields.CharField, category=_('System'), category_slug='system')
 
     existing_setting = mocker.Mock(key='AWX_SOME_SETTING', value='FROM_DB')
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=[existing_setting]):
-        del settings.AWX_SOME_SETTING
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=[existing_setting])
+    del settings.AWX_SOME_SETTING
 
     assert existing_setting.delete.call_count == 1
 
@@ -283,10 +283,10 @@ def test_sensitive_cache_data_is_encrypted(settings, mocker):
     # use its primary key as part of the encryption key
     setting_from_db = mocker.Mock(pk=123, key='AWX_ENCRYPTED', value='SECRET!')
     mocks = mocker.Mock(**{'order_by.return_value': mocker.Mock(**{'__iter__': lambda self: iter([setting_from_db]), 'first.return_value': setting_from_db})})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=mocks):
-        cache.set('AWX_ENCRYPTED', 'SECRET!')
-        assert cache.get('AWX_ENCRYPTED') == 'SECRET!'
-        assert native_cache.get('AWX_ENCRYPTED') == 'FRPERG!'
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=mocks)
+    cache.set('AWX_ENCRYPTED', 'SECRET!')
+    assert cache.get('AWX_ENCRYPTED') == 'SECRET!'
+    assert native_cache.get('AWX_ENCRYPTED') == 'FRPERG!'
 
 
 def test_readonly_sensitive_cache_data_is_encrypted(settings):

--- a/awx/main/tests/functional/api/test_create_attach_views.py
+++ b/awx/main/tests/functional/api/test_create_attach_views.py
@@ -9,8 +9,8 @@ def test_user_role_view_access(rando, inventory, mocker, post):
     role_pk = inventory.admin_role.pk
     data = {"id": role_pk}
     mock_access = mocker.MagicMock(can_attach=mocker.MagicMock(return_value=False))
-    with mocker.patch('awx.main.access.RoleAccess', return_value=mock_access):
-        post(url=reverse('api:user_roles_list', kwargs={'pk': rando.pk}), data=data, user=rando, expect=403)
+    mocker.patch('awx.main.access.RoleAccess', return_value=mock_access)
+    post(url=reverse('api:user_roles_list', kwargs={'pk': rando.pk}), data=data, user=rando, expect=403)
     mock_access.can_attach.assert_called_once_with(inventory.admin_role, rando, 'members', data, skip_sub_obj_read_check=False)
 
 
@@ -21,8 +21,8 @@ def test_team_role_view_access(rando, team, inventory, mocker, post):
     role_pk = inventory.admin_role.pk
     data = {"id": role_pk}
     mock_access = mocker.MagicMock(can_attach=mocker.MagicMock(return_value=False))
-    with mocker.patch('awx.main.access.RoleAccess', return_value=mock_access):
-        post(url=reverse('api:team_roles_list', kwargs={'pk': team.pk}), data=data, user=rando, expect=403)
+    mocker.patch('awx.main.access.RoleAccess', return_value=mock_access)
+    post(url=reverse('api:team_roles_list', kwargs={'pk': team.pk}), data=data, user=rando, expect=403)
     mock_access.can_attach.assert_called_once_with(inventory.admin_role, team, 'member_role.parents', data, skip_sub_obj_read_check=False)
 
 
@@ -33,8 +33,8 @@ def test_role_team_view_access(rando, team, inventory, mocker, post):
     role_pk = inventory.admin_role.pk
     data = {"id": team.pk}
     mock_access = mocker.MagicMock(return_value=False, __name__='mocked')
-    with mocker.patch('awx.main.access.RoleAccess.can_attach', mock_access):
-        post(url=reverse('api:role_teams_list', kwargs={'pk': role_pk}), data=data, user=rando, expect=403)
+    mocker.patch('awx.main.access.RoleAccess.can_attach', mock_access)
+    post(url=reverse('api:role_teams_list', kwargs={'pk': role_pk}), data=data, user=rando, expect=403)
     mock_access.assert_called_once_with(inventory.admin_role, team, 'member_role.parents', data, skip_sub_obj_read_check=False)
 
 

--- a/awx/main/tests/functional/api/test_job_runtime_params.py
+++ b/awx/main/tests/functional/api/test_job_runtime_params.py
@@ -131,11 +131,11 @@ def test_job_ignore_unprompted_vars(runtime_data, job_template_prompts, post, ad
 
     mock_job = mocker.MagicMock(spec=Job, id=968, **runtime_data)
 
-    with mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job):
-        with mocker.patch('awx.api.serializers.JobSerializer.to_representation'):
-            response = post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), runtime_data, admin_user, expect=201)
-            assert JobTemplate.create_unified_job.called
-            assert JobTemplate.create_unified_job.call_args == ()
+    mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation')
+    response = post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), runtime_data, admin_user, expect=201)
+    assert JobTemplate.create_unified_job.called
+    assert JobTemplate.create_unified_job.call_args == ()
 
     # Check that job is serialized correctly
     job_id = response.data['job']
@@ -167,12 +167,12 @@ def test_job_accept_prompted_vars(runtime_data, job_template_prompts, post, admi
 
     mock_job = mocker.MagicMock(spec=Job, id=968, **runtime_data)
 
-    with mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job):
-        with mocker.patch('awx.api.serializers.JobSerializer.to_representation'):
-            response = post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), runtime_data, admin_user, expect=201)
-            assert JobTemplate.create_unified_job.called
-            called_with = data_to_internal(runtime_data)
-            JobTemplate.create_unified_job.assert_called_with(**called_with)
+    mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation')
+    response = post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), runtime_data, admin_user, expect=201)
+    assert JobTemplate.create_unified_job.called
+    called_with = data_to_internal(runtime_data)
+    JobTemplate.create_unified_job.assert_called_with(**called_with)
 
     job_id = response.data['job']
     assert job_id == 968
@@ -187,11 +187,11 @@ def test_job_accept_empty_tags(job_template_prompts, post, admin_user, mocker):
 
     mock_job = mocker.MagicMock(spec=Job, id=968)
 
-    with mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job):
-        with mocker.patch('awx.api.serializers.JobSerializer.to_representation'):
-            post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), {'job_tags': '', 'skip_tags': ''}, admin_user, expect=201)
-            assert JobTemplate.create_unified_job.called
-            assert JobTemplate.create_unified_job.call_args == ({'job_tags': '', 'skip_tags': ''},)
+    mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation')
+    post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), {'job_tags': '', 'skip_tags': ''}, admin_user, expect=201)
+    assert JobTemplate.create_unified_job.called
+    assert JobTemplate.create_unified_job.call_args == ({'job_tags': '', 'skip_tags': ''},)
 
     mock_job.signal_start.assert_called_once()
 
@@ -203,14 +203,14 @@ def test_slice_timeout_forks_need_int(job_template_prompts, post, admin_user, mo
 
     mock_job = mocker.MagicMock(spec=Job, id=968)
 
-    with mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job):
-        with mocker.patch('awx.api.serializers.JobSerializer.to_representation'):
-            response = post(
-                reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), {'timeout': '', 'job_slice_count': '', 'forks': ''}, admin_user, expect=400
-            )
-            assert 'forks' in response.data and response.data['forks'][0] == 'A valid integer is required.'
-            assert 'job_slice_count' in response.data and response.data['job_slice_count'][0] == 'A valid integer is required.'
-            assert 'timeout' in response.data and response.data['timeout'][0] == 'A valid integer is required.'
+    mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation')
+    response = post(
+        reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), {'timeout': '', 'job_slice_count': '', 'forks': ''}, admin_user, expect=400
+    )
+    assert 'forks' in response.data and response.data['forks'][0] == 'A valid integer is required.'
+    assert 'job_slice_count' in response.data and response.data['job_slice_count'][0] == 'A valid integer is required.'
+    assert 'timeout' in response.data and response.data['timeout'][0] == 'A valid integer is required.'
 
 
 @pytest.mark.django_db
@@ -244,12 +244,12 @@ def test_job_accept_prompted_vars_null(runtime_data, job_template_prompts_null, 
 
     mock_job = mocker.MagicMock(spec=Job, id=968, **runtime_data)
 
-    with mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job):
-        with mocker.patch('awx.api.serializers.JobSerializer.to_representation'):
-            response = post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), runtime_data, rando, expect=201)
-            assert JobTemplate.create_unified_job.called
-            expected_call = data_to_internal(runtime_data)
-            assert JobTemplate.create_unified_job.call_args == (expected_call,)
+    mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation')
+    response = post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), runtime_data, rando, expect=201)
+    assert JobTemplate.create_unified_job.called
+    expected_call = data_to_internal(runtime_data)
+    assert JobTemplate.create_unified_job.call_args == (expected_call,)
 
     job_id = response.data['job']
     assert job_id == 968
@@ -641,18 +641,18 @@ def test_job_launch_unprompted_vars_with_survey(mocker, survey_spec_factory, job
     job_template.survey_spec = survey_spec_factory('survey_var')
     job_template.save()
 
-    with mocker.patch('awx.main.access.BaseAccess.check_license'):
-        mock_job = mocker.MagicMock(spec=Job, id=968, extra_vars={"job_launch_var": 3, "survey_var": 4})
-        with mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job):
-            with mocker.patch('awx.api.serializers.JobSerializer.to_representation', return_value={}):
-                response = post(
-                    reverse('api:job_template_launch', kwargs={'pk': job_template.pk}),
-                    dict(extra_vars={"job_launch_var": 3, "survey_var": 4}),
-                    admin_user,
-                    expect=201,
-                )
-                assert JobTemplate.create_unified_job.called
-                assert JobTemplate.create_unified_job.call_args == ({'extra_vars': {'survey_var': 4}},)
+    mocker.patch('awx.main.access.BaseAccess.check_license')
+    mock_job = mocker.MagicMock(spec=Job, id=968, extra_vars={"job_launch_var": 3, "survey_var": 4})
+    mocker.patch.object(JobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation', return_value={})
+    response = post(
+        reverse('api:job_template_launch', kwargs={'pk': job_template.pk}),
+        dict(extra_vars={"job_launch_var": 3, "survey_var": 4}),
+        admin_user,
+        expect=201,
+    )
+    assert JobTemplate.create_unified_job.called
+    assert JobTemplate.create_unified_job.call_args == ({'extra_vars': {'survey_var': 4}},)
 
     job_id = response.data['job']
     assert job_id == 968
@@ -670,22 +670,22 @@ def test_callback_accept_prompted_extra_var(mocker, survey_spec_factory, job_tem
     job_template.survey_spec = survey_spec_factory('survey_var')
     job_template.save()
 
-    with mocker.patch('awx.main.access.BaseAccess.check_license'):
-        mock_job = mocker.MagicMock(spec=Job, id=968, extra_vars={"job_launch_var": 3, "survey_var": 4})
-        with mocker.patch.object(UnifiedJobTemplate, 'create_unified_job', return_value=mock_job):
-            with mocker.patch('awx.api.serializers.JobSerializer.to_representation', return_value={}):
-                with mocker.patch('awx.api.views.JobTemplateCallback.find_matching_hosts', return_value=[host]):
-                    post(
-                        reverse('api:job_template_callback', kwargs={'pk': job_template.pk}),
-                        dict(extra_vars={"job_launch_var": 3, "survey_var": 4}, host_config_key="foo"),
-                        admin_user,
-                        expect=201,
-                        format='json',
-                    )
-                    assert UnifiedJobTemplate.create_unified_job.called
-                    call_args = UnifiedJobTemplate.create_unified_job.call_args[1]
-                    call_args.pop('_eager_fields', None)  # internal purposes
-                    assert call_args == {'extra_vars': {'survey_var': 4, 'job_launch_var': 3}, 'limit': 'single-host'}
+    mocker.patch('awx.main.access.BaseAccess.check_license')
+    mock_job = mocker.MagicMock(spec=Job, id=968, extra_vars={"job_launch_var": 3, "survey_var": 4})
+    mocker.patch.object(UnifiedJobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation', return_value={})
+    mocker.patch('awx.api.views.JobTemplateCallback.find_matching_hosts', return_value=[host])
+    post(
+        reverse('api:job_template_callback', kwargs={'pk': job_template.pk}),
+        dict(extra_vars={"job_launch_var": 3, "survey_var": 4}, host_config_key="foo"),
+        admin_user,
+        expect=201,
+        format='json',
+    )
+    assert UnifiedJobTemplate.create_unified_job.called
+    call_args = UnifiedJobTemplate.create_unified_job.call_args[1]
+    call_args.pop('_eager_fields', None)  # internal purposes
+    assert call_args == {'extra_vars': {'survey_var': 4, 'job_launch_var': 3}, 'limit': 'single-host'}
 
     mock_job.signal_start.assert_called_once()
 
@@ -697,22 +697,22 @@ def test_callback_ignore_unprompted_extra_var(mocker, survey_spec_factory, job_t
     job_template.host_config_key = "foo"
     job_template.save()
 
-    with mocker.patch('awx.main.access.BaseAccess.check_license'):
-        mock_job = mocker.MagicMock(spec=Job, id=968, extra_vars={"job_launch_var": 3, "survey_var": 4})
-        with mocker.patch.object(UnifiedJobTemplate, 'create_unified_job', return_value=mock_job):
-            with mocker.patch('awx.api.serializers.JobSerializer.to_representation', return_value={}):
-                with mocker.patch('awx.api.views.JobTemplateCallback.find_matching_hosts', return_value=[host]):
-                    post(
-                        reverse('api:job_template_callback', kwargs={'pk': job_template.pk}),
-                        dict(extra_vars={"job_launch_var": 3, "survey_var": 4}, host_config_key="foo"),
-                        admin_user,
-                        expect=201,
-                        format='json',
-                    )
-                    assert UnifiedJobTemplate.create_unified_job.called
-                    call_args = UnifiedJobTemplate.create_unified_job.call_args[1]
-                    call_args.pop('_eager_fields', None)  # internal purposes
-                    assert call_args == {'limit': 'single-host'}
+    mocker.patch('awx.main.access.BaseAccess.check_license')
+    mock_job = mocker.MagicMock(spec=Job, id=968, extra_vars={"job_launch_var": 3, "survey_var": 4})
+    mocker.patch.object(UnifiedJobTemplate, 'create_unified_job', return_value=mock_job)
+    mocker.patch('awx.api.serializers.JobSerializer.to_representation', return_value={})
+    mocker.patch('awx.api.views.JobTemplateCallback.find_matching_hosts', return_value=[host])
+    post(
+        reverse('api:job_template_callback', kwargs={'pk': job_template.pk}),
+        dict(extra_vars={"job_launch_var": 3, "survey_var": 4}, host_config_key="foo"),
+        admin_user,
+        expect=201,
+        format='json',
+    )
+    assert UnifiedJobTemplate.create_unified_job.called
+    call_args = UnifiedJobTemplate.create_unified_job.call_args[1]
+    call_args.pop('_eager_fields', None)  # internal purposes
+    assert call_args == {'limit': 'single-host'}
 
     mock_job.signal_start.assert_called_once()
 
@@ -725,9 +725,9 @@ def test_callback_find_matching_hosts(mocker, get, job_template_prompts, admin_u
     job_template.save()
     host_with_alias = Host(name='localhost', inventory=job_template.inventory)
     host_with_alias.save()
-    with mocker.patch('awx.main.access.BaseAccess.check_license'):
-        r = get(reverse('api:job_template_callback', kwargs={'pk': job_template.pk}), user=admin_user, expect=200)
-        assert tuple(r.data['matching_hosts']) == ('localhost',)
+    mocker.patch('awx.main.access.BaseAccess.check_license')
+    r = get(reverse('api:job_template_callback', kwargs={'pk': job_template.pk}), user=admin_user, expect=200)
+    assert tuple(r.data['matching_hosts']) == ('localhost',)
 
 
 @pytest.mark.django_db
@@ -738,6 +738,6 @@ def test_callback_extra_var_takes_priority_over_host_name(mocker, get, job_templ
     job_template.save()
     host_with_alias = Host(name='localhost', variables={'ansible_host': 'foobar'}, inventory=job_template.inventory)
     host_with_alias.save()
-    with mocker.patch('awx.main.access.BaseAccess.check_license'):
-        r = get(reverse('api:job_template_callback', kwargs={'pk': job_template.pk}), user=admin_user, expect=200)
-        assert not r.data['matching_hosts']
+    mocker.patch('awx.main.access.BaseAccess.check_license')
+    r = get(reverse('api:job_template_callback', kwargs={'pk': job_template.pk}), user=admin_user, expect=200)
+    assert not r.data['matching_hosts']

--- a/awx/main/tests/functional/api/test_rbac_displays.py
+++ b/awx/main/tests/functional/api/test_rbac_displays.py
@@ -165,8 +165,8 @@ class TestAccessListCapabilities:
     def test_access_list_direct_access_capability(self, inventory, rando, get, mocker, mock_access_method):
         inventory.admin_role.members.add(rando)
 
-        with mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method):
-            response = get(reverse('api:inventory_access_list', kwargs={'pk': inventory.id}), rando)
+        mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method)
+        response = get(reverse('api:inventory_access_list', kwargs={'pk': inventory.id}), rando)
 
         mock_access_method.assert_called_once_with(inventory.admin_role, rando, 'members', **self.extra_kwargs)
         self._assert_one_in_list(response.data)
@@ -174,8 +174,8 @@ class TestAccessListCapabilities:
         assert direct_access_list[0]['role']['user_capabilities']['unattach'] == 'foobar'
 
     def test_access_list_indirect_access_capability(self, inventory, organization, org_admin, get, mocker, mock_access_method):
-        with mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method):
-            response = get(reverse('api:inventory_access_list', kwargs={'pk': inventory.id}), org_admin)
+        mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method)
+        response = get(reverse('api:inventory_access_list', kwargs={'pk': inventory.id}), org_admin)
 
         mock_access_method.assert_called_once_with(organization.admin_role, org_admin, 'members', **self.extra_kwargs)
         self._assert_one_in_list(response.data, sublist='indirect_access')
@@ -185,8 +185,8 @@ class TestAccessListCapabilities:
     def test_access_list_team_direct_access_capability(self, inventory, team, team_member, get, mocker, mock_access_method):
         team.member_role.children.add(inventory.admin_role)
 
-        with mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method):
-            response = get(reverse('api:inventory_access_list', kwargs={'pk': inventory.id}), team_member)
+        mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method)
+        response = get(reverse('api:inventory_access_list', kwargs={'pk': inventory.id}), team_member)
 
         mock_access_method.assert_called_once_with(inventory.admin_role, team.member_role, 'parents', **self.extra_kwargs)
         self._assert_one_in_list(response.data)
@@ -198,8 +198,8 @@ class TestAccessListCapabilities:
 def test_team_roles_unattach(mocker, team, team_member, inventory, mock_access_method, get):
     team.member_role.children.add(inventory.admin_role)
 
-    with mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method):
-        response = get(reverse('api:team_roles_list', kwargs={'pk': team.id}), team_member)
+    mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method)
+    response = get(reverse('api:team_roles_list', kwargs={'pk': team.id}), team_member)
 
     # Did we assess whether team_member can remove team's permission to the inventory?
     mock_access_method.assert_called_once_with(inventory.admin_role, team.member_role, 'parents', skip_sub_obj_read_check=True, data={})
@@ -212,8 +212,8 @@ def test_user_roles_unattach(mocker, organization, alice, bob, mock_access_metho
     organization.member_role.members.add(alice)
     organization.member_role.members.add(bob)
 
-    with mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method):
-        response = get(reverse('api:user_roles_list', kwargs={'pk': alice.id}), bob)
+    mocker.patch.object(access_registry[Role], 'can_unattach', mock_access_method)
+    response = get(reverse('api:user_roles_list', kwargs={'pk': alice.id}), bob)
 
     # Did we assess whether bob can remove alice's permission to the inventory?
     mock_access_method.assert_called_once_with(organization.member_role, alice, 'members', skip_sub_obj_read_check=True, data={})

--- a/awx/main/tests/functional/commands/test_commands.py
+++ b/awx/main/tests/functional/commands/test_commands.py
@@ -43,9 +43,9 @@ def run_command(name, *args, **options):
     ],
 )
 def test_update_password_command(mocker, username, password, expected, changed):
-    with mocker.patch.object(UpdatePassword, 'update_password', return_value=changed):
-        result, stdout, stderr = run_command('update_password', username=username, password=password)
-        if result is None:
-            assert stdout == expected
-        else:
-            assert str(result) == expected
+    mocker.patch.object(UpdatePassword, 'update_password', return_value=changed)
+    result, stdout, stderr = run_command('update_password', username=username, password=password)
+    if result is None:
+        assert stdout == expected
+    else:
+        assert str(result) == expected

--- a/awx/main/tests/functional/models/test_context_managers.py
+++ b/awx/main/tests/functional/models/test_context_managers.py
@@ -21,13 +21,13 @@ class TestComputedFields:
     def test_computed_fields_normal_use(self, mocker, inventory):
         job = Job.objects.create(name='fake-job', inventory=inventory)
         with immediate_on_commit():
-            with mocker.patch.object(update_inventory_computed_fields, 'delay'):
-                job.delete()
-                update_inventory_computed_fields.delay.assert_called_once_with(inventory.id)
+            mocker.patch.object(update_inventory_computed_fields, 'delay')
+            job.delete()
+            update_inventory_computed_fields.delay.assert_called_once_with(inventory.id)
 
     def test_disable_computed_fields(self, mocker, inventory):
         job = Job.objects.create(name='fake-job', inventory=inventory)
         with disable_computed_fields():
-            with mocker.patch.object(update_inventory_computed_fields, 'delay'):
-                job.delete()
-                update_inventory_computed_fields.delay.assert_not_called()
+            mocker.patch.object(update_inventory_computed_fields, 'delay')
+            job.delete()
+            update_inventory_computed_fields.delay.assert_not_called()

--- a/awx/main/tests/functional/task_management/test_rampart_groups.py
+++ b/awx/main/tests/functional/task_management/test_rampart_groups.py
@@ -21,13 +21,13 @@ def test_multi_group_basic_job_launch(instance_factory, controlplane_instance_gr
     j2 = create_job(objects2.job_template)
     with mock.patch('awx.main.models.Job.task_impact', new_callable=mock.PropertyMock) as mock_task_impact:
         mock_task_impact.return_value = 500
-        with mocker.patch("awx.main.scheduler.TaskManager.start_task"):
-            TaskManager().schedule()
-            TaskManager.start_task.assert_has_calls([mock.call(j1, ig1, i1), mock.call(j2, ig2, i2)])
+        mocker.patch("awx.main.scheduler.TaskManager.start_task")
+        TaskManager().schedule()
+        TaskManager.start_task.assert_has_calls([mock.call(j1, ig1, i1), mock.call(j2, ig2, i2)])
 
 
 @pytest.mark.django_db
-def test_multi_group_with_shared_dependency(instance_factory, controlplane_instance_group, mocker, instance_group_factory, job_template_factory):
+def test_multi_group_with_shared_dependency(instance_factory, controlplane_instance_group, instance_group_factory, job_template_factory):
     i1 = instance_factory("i1")
     i2 = instance_factory("i2")
     ig1 = instance_group_factory("ig1", instances=[i1])
@@ -50,7 +50,7 @@ def test_multi_group_with_shared_dependency(instance_factory, controlplane_insta
     objects2 = job_template_factory('jt2', organization=objects1.organization, project=p, inventory='inv2', credential='cred2')
     objects2.job_template.instance_groups.add(ig2)
     j2 = create_job(objects2.job_template, dependencies_processed=False)
-    with mocker.patch("awx.main.scheduler.TaskManager.start_task"):
+    with mock.patch("awx.main.scheduler.TaskManager.start_task"):
         DependencyManager().schedule()
         TaskManager().schedule()
         pu = p.project_updates.first()
@@ -73,10 +73,10 @@ def test_workflow_job_no_instancegroup(workflow_job_template_factory, controlpla
     wfj = wfjt.create_unified_job()
     wfj.status = "pending"
     wfj.save()
-    with mocker.patch("awx.main.scheduler.TaskManager.start_task"):
-        TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(wfj, None, None)
-        assert wfj.instance_group is None
+    mocker.patch("awx.main.scheduler.TaskManager.start_task")
+    TaskManager().schedule()
+    TaskManager.start_task.assert_called_once_with(wfj, None, None)
+    assert wfj.instance_group is None
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/task_management/test_scheduler.py
+++ b/awx/main/tests/functional/task_management/test_scheduler.py
@@ -16,9 +16,9 @@ def test_single_job_scheduler_launch(hybrid_instance, controlplane_instance_grou
     instance = controlplane_instance_group.instances.all()[0]
     objects = job_template_factory('jt', organization='org1', project='proj', inventory='inv', credential='cred')
     j = create_job(objects.job_template)
-    with mocker.patch("awx.main.scheduler.TaskManager.start_task"):
-        TaskManager().schedule()
-        TaskManager.start_task.assert_called_once_with(j, controlplane_instance_group, instance)
+    mocker.patch("awx.main.scheduler.TaskManager.start_task")
+    TaskManager().schedule()
+    TaskManager.start_task.assert_called_once_with(j, controlplane_instance_group, instance)
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
@@ -76,15 +76,15 @@ class TestJobTemplateSerializerGetRelated:
 class TestJobTemplateSerializerGetSummaryFields:
     def test_survey_spec_exists(self, test_get_summary_fields, mocker, job_template):
         job_template.survey_spec = {'name': 'blah', 'description': 'blah blah'}
-        with mocker.patch.object(JobTemplateSerializer, '_recent_jobs') as mock_rj:
-            mock_rj.return_value = []
-            test_get_summary_fields(JobTemplateSerializer, job_template, 'survey')
+        mock_rj = mocker.patch.object(JobTemplateSerializer, '_recent_jobs')
+        mock_rj.return_value = []
+        test_get_summary_fields(JobTemplateSerializer, job_template, 'survey')
 
     def test_survey_spec_absent(self, get_summary_fields_mock_and_run, mocker, job_template):
         job_template.survey_spec = None
-        with mocker.patch.object(JobTemplateSerializer, '_recent_jobs') as mock_rj:
-            mock_rj.return_value = []
-            summary = get_summary_fields_mock_and_run(JobTemplateSerializer, job_template)
+        mock_rj = mocker.patch.object(JobTemplateSerializer, '_recent_jobs')
+        mock_rj.return_value = []
+        summary = get_summary_fields_mock_and_run(JobTemplateSerializer, job_template)
         assert 'survey' not in summary
 
     def test_copy_edit_standard(self, mocker, job_template_factory):

--- a/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_job_template_serializers.py
@@ -107,10 +107,10 @@ class TestJobTemplateSerializerGetSummaryFields:
         view.kwargs = {}
         serializer.context['view'] = view
 
-        with mocker.patch("awx.api.serializers.role_summary_fields_generator", return_value='Can eat pie'):
-            with mocker.patch("awx.main.access.JobTemplateAccess.can_change", return_value='foobar'):
-                with mocker.patch("awx.main.access.JobTemplateAccess.can_copy", return_value='foo'):
-                    response = serializer.get_summary_fields(jt_obj)
+        mocker.patch("awx.api.serializers.role_summary_fields_generator", return_value='Can eat pie')
+        mocker.patch("awx.main.access.JobTemplateAccess.can_change", return_value='foobar')
+        mocker.patch("awx.main.access.JobTemplateAccess.can_copy", return_value='foo')
+        response = serializer.get_summary_fields(jt_obj)
 
         assert response['user_capabilities']['copy'] == 'foo'
         assert response['user_capabilities']['edit'] == 'foobar'

--- a/awx/main/tests/unit/api/serializers/test_workflow_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_workflow_serializers.py
@@ -189,8 +189,8 @@ class TestWorkflowJobTemplateNodeSerializerSurveyPasswords:
         serializer = WorkflowJobTemplateNodeSerializer()
         wfjt = WorkflowJobTemplate.objects.create(name='fake-wfjt')
         serializer.instance = WorkflowJobTemplateNode(workflow_job_template=wfjt, unified_job_template=jt, extra_data={'var1': '$encrypted$foooooo'})
-        with mocker.patch('awx.main.models.mixins.decrypt_value', return_value='foo'):
-            attrs = serializer.validate({'unified_job_template': jt, 'workflow_job_template': wfjt, 'extra_data': {'var1': '$encrypted$'}})
+        mocker.patch('awx.main.models.mixins.decrypt_value', return_value='foo')
+        attrs = serializer.validate({'unified_job_template': jt, 'workflow_job_template': wfjt, 'extra_data': {'var1': '$encrypted$'}})
         assert 'survey_passwords' in attrs
         assert 'var1' in attrs['survey_passwords']
         assert attrs['extra_data']['var1'] == '$encrypted$foooooo'

--- a/awx/main/tests/unit/api/test_generics.py
+++ b/awx/main/tests/unit/api/test_generics.py
@@ -191,16 +191,16 @@ class TestResourceAccessList:
 
     def test_parent_access_check_failed(self, mocker, mock_organization):
         mock_access = mocker.MagicMock(__name__='for logger', return_value=False)
-        with mocker.patch('awx.main.access.BaseAccess.can_read', mock_access):
-            with pytest.raises(PermissionDenied):
-                self.mock_view(parent=mock_organization).check_permissions(self.mock_request())
-            mock_access.assert_called_once_with(mock_organization)
+        mocker.patch('awx.main.access.BaseAccess.can_read', mock_access)
+        with pytest.raises(PermissionDenied):
+            self.mock_view(parent=mock_organization).check_permissions(self.mock_request())
+        mock_access.assert_called_once_with(mock_organization)
 
     def test_parent_access_check_worked(self, mocker, mock_organization):
         mock_access = mocker.MagicMock(__name__='for logger', return_value=True)
-        with mocker.patch('awx.main.access.BaseAccess.can_read', mock_access):
-            self.mock_view(parent=mock_organization).check_permissions(self.mock_request())
-            mock_access.assert_called_once_with(mock_organization)
+        mocker.patch('awx.main.access.BaseAccess.can_read', mock_access)
+        self.mock_view(parent=mock_organization).check_permissions(self.mock_request())
+        mock_access.assert_called_once_with(mock_organization)
 
 
 def test_related_search_reverse_FK_field():

--- a/awx/main/tests/unit/api/test_views.py
+++ b/awx/main/tests/unit/api/test_views.py
@@ -66,7 +66,7 @@ class TestJobTemplateLabelList:
             mock_request = mock.MagicMock()
 
             super(JobTemplateLabelList, view).unattach(mock_request, None, None)
-            assert mixin_unattach.called_with(mock_request, None, None)
+            mixin_unattach.assert_called_with(mock_request, None, None)
 
 
 class TestInventoryInventorySourcesUpdate:
@@ -108,15 +108,16 @@ class TestInventoryInventorySourcesUpdate:
         mock_request = mocker.MagicMock()
         mock_request.user.can_access.return_value = can_access
 
-        with mocker.patch.object(InventoryInventorySourcesUpdate, 'get_object', return_value=obj):
-            with mocker.patch.object(InventoryInventorySourcesUpdate, 'get_serializer_context', return_value=None):
-                with mocker.patch('awx.api.serializers.InventoryUpdateDetailSerializer') as serializer_class:
-                    serializer = serializer_class.return_value
-                    serializer.to_representation.return_value = {}
+        mocker.patch.object(InventoryInventorySourcesUpdate, 'get_object', return_value=obj)
+        mocker.patch.object(InventoryInventorySourcesUpdate, 'get_serializer_context', return_value=None)
+        serializer_class = mocker.patch('awx.api.serializers.InventoryUpdateDetailSerializer')
 
-                    view = InventoryInventorySourcesUpdate()
-                    response = view.post(mock_request)
-                    assert response.data == expected
+        serializer = serializer_class.return_value
+        serializer.to_representation.return_value = {}
+
+        view = InventoryInventorySourcesUpdate()
+        response = view.post(mock_request)
+        assert response.data == expected
 
 
 class TestSurveySpecValidation:

--- a/awx/main/tests/unit/models/test_workflow_unit.py
+++ b/awx/main/tests/unit/models/test_workflow_unit.py
@@ -155,35 +155,35 @@ def test_node_getter_and_setters():
 class TestWorkflowJobCreate:
     def test_create_no_prompts(self, wfjt_node_no_prompts, workflow_job_unit, mocker):
         mock_create = mocker.MagicMock()
-        with mocker.patch('awx.main.models.WorkflowJobNode.objects.create', mock_create):
-            wfjt_node_no_prompts.create_workflow_job_node(workflow_job=workflow_job_unit)
-            mock_create.assert_called_once_with(
-                all_parents_must_converge=False,
-                extra_data={},
-                survey_passwords={},
-                char_prompts=wfjt_node_no_prompts.char_prompts,
-                inventory=None,
-                unified_job_template=wfjt_node_no_prompts.unified_job_template,
-                workflow_job=workflow_job_unit,
-                identifier=mocker.ANY,
-                execution_environment=None,
-            )
+        mocker.patch('awx.main.models.WorkflowJobNode.objects.create', mock_create)
+        wfjt_node_no_prompts.create_workflow_job_node(workflow_job=workflow_job_unit)
+        mock_create.assert_called_once_with(
+            all_parents_must_converge=False,
+            extra_data={},
+            survey_passwords={},
+            char_prompts=wfjt_node_no_prompts.char_prompts,
+            inventory=None,
+            unified_job_template=wfjt_node_no_prompts.unified_job_template,
+            workflow_job=workflow_job_unit,
+            identifier=mocker.ANY,
+            execution_environment=None,
+        )
 
     def test_create_with_prompts(self, wfjt_node_with_prompts, workflow_job_unit, credential, mocker):
         mock_create = mocker.MagicMock()
-        with mocker.patch('awx.main.models.WorkflowJobNode.objects.create', mock_create):
-            wfjt_node_with_prompts.create_workflow_job_node(workflow_job=workflow_job_unit)
-            mock_create.assert_called_once_with(
-                all_parents_must_converge=False,
-                extra_data={},
-                survey_passwords={},
-                char_prompts=wfjt_node_with_prompts.char_prompts,
-                inventory=wfjt_node_with_prompts.inventory,
-                unified_job_template=wfjt_node_with_prompts.unified_job_template,
-                workflow_job=workflow_job_unit,
-                identifier=mocker.ANY,
-                execution_environment=None,
-            )
+        mocker.patch('awx.main.models.WorkflowJobNode.objects.create', mock_create)
+        wfjt_node_with_prompts.create_workflow_job_node(workflow_job=workflow_job_unit)
+        mock_create.assert_called_once_with(
+            all_parents_must_converge=False,
+            extra_data={},
+            survey_passwords={},
+            char_prompts=wfjt_node_with_prompts.char_prompts,
+            inventory=wfjt_node_with_prompts.inventory,
+            unified_job_template=wfjt_node_with_prompts.unified_job_template,
+            workflow_job=workflow_job_unit,
+            identifier=mocker.ANY,
+            execution_environment=None,
+        )
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -137,10 +137,10 @@ def test_send_notifications_not_list():
 
 
 def test_send_notifications_job_id(mocker):
-    with mocker.patch('awx.main.models.UnifiedJob.objects.get'):
-        system.send_notifications([], job_id=1)
-        assert UnifiedJob.objects.get.called
-        assert UnifiedJob.objects.get.called_with(id=1)
+    mocker.patch('awx.main.models.UnifiedJob.objects.get')
+    system.send_notifications([], job_id=1)
+    assert UnifiedJob.objects.get.called
+    assert UnifiedJob.objects.get.called_with(id=1)
 
 
 @mock.patch('awx.main.models.UnifiedJob.objects.get')

--- a/awx/main/tests/unit/utils/test_reload.py
+++ b/awx/main/tests/unit/utils/test_reload.py
@@ -7,15 +7,15 @@ def test_produce_supervisor_command(mocker):
     mock_process = mocker.MagicMock()
     mock_process.communicate = communicate_mock
     Popen_mock = mocker.MagicMock(return_value=mock_process)
-    with mocker.patch.object(reload.subprocess, 'Popen', Popen_mock):
-        reload.supervisor_service_command("restart")
-        reload.subprocess.Popen.assert_called_once_with(
-            [
-                'supervisorctl',
-                'restart',
-                'tower-processes:*',
-            ],
-            stderr=-1,
-            stdin=-1,
-            stdout=-1,
-        )
+    mocker.patch.object(reload.subprocess, 'Popen', Popen_mock)
+    reload.supervisor_service_command("restart")
+    reload.subprocess.Popen.assert_called_once_with(
+        [
+            'supervisorctl',
+            'restart',
+            'tower-processes:*',
+        ],
+        stderr=-1,
+        stdin=-1,
+        stdout=-1,
+    )

--- a/awx/sso/tests/unit/test_ldap.py
+++ b/awx/sso/tests/unit/test_ldap.py
@@ -7,18 +7,18 @@ from django.core.cache import cache
 
 def test_ldap_default_settings(mocker):
     from_db = mocker.Mock(**{'order_by.return_value': []})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=from_db):
-        settings = LDAPSettings()
-        assert settings.ORGANIZATION_MAP == {}
-        assert settings.TEAM_MAP == {}
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=from_db)
+    settings = LDAPSettings()
+    assert settings.ORGANIZATION_MAP == {}
+    assert settings.TEAM_MAP == {}
 
 
 def test_ldap_default_network_timeout(mocker):
     cache.clear()  # clearing cache avoids picking up stray default for OPT_REFERRALS
     from_db = mocker.Mock(**{'order_by.return_value': []})
-    with mocker.patch('awx.conf.models.Setting.objects.filter', return_value=from_db):
-        settings = LDAPSettings()
-        assert settings.CONNECTION_OPTIONS[ldap.OPT_NETWORK_TIMEOUT] == 30
+    mocker.patch('awx.conf.models.Setting.objects.filter', return_value=from_db)
+    settings = LDAPSettings()
+    assert settings.CONNECTION_OPTIONS[ldap.OPT_NETWORK_TIMEOUT] == 30
 
 
 def test_ldap_filter_validator():

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -11,9 +11,9 @@ pytest!=7.0.0
 pytest-asyncio
 pytest-cov
 pytest-django
-pytest-mock==1.11.1
+pytest-mock
 pytest-timeout
-pytest-xdist==1.34.0 # 2.0.0 broke zuul for some reason
+pytest-xdist
 tox  # for awxkit
 logutils
 jupyter
@@ -21,7 +21,7 @@ jupyter
 backports.tempfile  # support in unit tests for py32+ tempfile.TemporaryDirectory
 git+https://github.com/artefactual-labs/mockldap.git@master#egg=mockldap
 gprof2dot
-atomicwrites==1.4.0
+atomicwrites
 flake8
 yamllint
 pip>=21.3 # PEP 660 – Editable installs for pyproject.toml based builds (wheel based)


### PR DESCRIPTION
##### SUMMARY
This is intended to address the warnings:

```
/var/lib/awx/venv/awx/lib64/python3.11/site-packages/xdist/dsession.py:70: PytestDeprecationWarning: The hookimpl DSession.pytest_sessionstart uses old-style configuration options (marks or attributes).
Please use the pytest.hookimpl(trylast=True) decorator instead
 to configure the hooks.
```

Because we are pinned to an older version of xdist but using newer pytest, so this doesn't give the library a chance to update plugin style to pytest changes. Also, the stated reason for the pin appears to no longer be applicable.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

