### PR TITLE
Address the 404 errors in swagger checks

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -378,24 +378,6 @@ class GenericAPIView(generics.GenericAPIView, APIView):
         else:
             return super(GenericAPIView, self).get_queryset()
 
-    def get_object_or_404(self, model=None, lookup_field=None):
-        """Shortcut as a view-level get_object_or_404
-
-        This can also give a guess in the event it is called for schema generation
-        """
-        if model is None:
-            model = self.model
-        if lookup_field is None:
-            lookup_field = self.lookup_field
-
-        if lookup_field not in self.kwargs and getattr(self, 'swagger_fake_view', False):
-            # here is where we return a best-effort guess for schema generation
-            example_obj = model.objects.first()
-            if example_obj:
-                return example_obj
-        parent_filter = {lookup_field: self.kwargs[lookup_field]}
-        return get_object_or_404(model, **parent_filter)
-
     def get_description_context(self):
         # Set instance attributes needed to get serializer metadata.
         if not hasattr(self, 'request'):
@@ -508,6 +490,24 @@ class ListCreateAPIView(ListAPIView, generics.ListCreateAPIView):
 
 class ParentMixin(object):
     parent_object = None
+
+    def get_object_or_404(self, model=None, lookup_field=None):
+        """Shortcut as a view-level get_object_or_404
+
+        This can also give a guess in the event it is called for schema generation
+        """
+        if model is None:
+            model = self.model
+        if lookup_field is None:
+            lookup_field = self.lookup_field
+
+        if lookup_field not in self.kwargs and getattr(self, 'swagger_fake_view', False):
+            # here is where we return a best-effort guess for schema generation
+            example_obj = model.objects.first()
+            if example_obj:
+                return example_obj
+        parent_filter = {lookup_field: self.kwargs[lookup_field]}
+        return get_object_or_404(model, **parent_filter)
 
     def get_parent_object(self):
         if self.parent_object is not None:

--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -378,6 +378,24 @@ class GenericAPIView(generics.GenericAPIView, APIView):
         else:
             return super(GenericAPIView, self).get_queryset()
 
+    def get_object_or_404(self, model=None, lookup_field=None):
+        """Shortcut as a view-level get_object_or_404
+
+        This can also give a guess in the event it is called for schema generation
+        """
+        if model is None:
+            model = self.model
+        if lookup_field is None:
+            lookup_field = self.lookup_field
+
+        if lookup_field not in self.kwargs and getattr(self, 'swagger_fake_view', False):
+            # here is where we return a best-effort guess for schema generation
+            example_obj = model.objects.first()
+            if example_obj:
+                return example_obj
+        parent_filter = {lookup_field: self.kwargs[lookup_field]}
+        return get_object_or_404(model, **parent_filter)
+
     def get_description_context(self):
         # Set instance attributes needed to get serializer metadata.
         if not hasattr(self, 'request'):
@@ -494,9 +512,7 @@ class ParentMixin(object):
     def get_parent_object(self):
         if self.parent_object is not None:
             return self.parent_object
-        parent_filter = {self.lookup_field: self.kwargs.get(self.lookup_field, None)}
-        self.parent_object = get_object_or_404(self.parent_model, **parent_filter)
-        return self.parent_object
+        return self.get_object_or_404(self.parent_model)
 
     def check_parent_access(self, parent=None):
         parent = parent or self.get_parent_object()

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -68,6 +68,7 @@ from awx.main.tasks.system import send_notifications, update_inventory_computed_
 from awx.main.access import get_user_queryset
 from awx.api.generics import (
     APIView,
+    ParentMixin,
     BaseUsersList,
     CopyAPIView,
     GenericCancelView,
@@ -3711,7 +3712,7 @@ class JobJobEventsList(BaseJobEventsList):
         return job.get_event_queryset().prefetch_related('job__job_template', 'host').order_by('start_line')
 
 
-class JobJobEventsChildrenSummary(APIView):
+class JobJobEventsChildrenSummary(ParentMixin, APIView):
     renderer_classes = [JSONRenderer]
     meta_events = ('debug', 'verbose', 'warning', 'error', 'system_warning', 'deprecated')
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -738,7 +738,7 @@ class TeamRolesList(SubListAttachDetachAPIView):
     search_fields = ('role_field', 'content_type__model')
 
     def get_queryset(self):
-        team = get_object_or_404(models.Team, pk=self.kwargs['pk'])
+        team = self.get_object_or_404(self.parent_model, lookup_field='pk')
         if not self.request.user.can_access(models.Team, 'read', team):
             raise PermissionDenied()
         return models.Role.filter_visible_roles(self.request.user, team.member_role.children.all().exclude(pk=team.read_role.pk))
@@ -758,7 +758,7 @@ class TeamRolesList(SubListAttachDetachAPIView):
             data = dict(msg=_("You cannot grant system-level permissions to a team."))
             return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
-        team = get_object_or_404(models.Team, pk=self.kwargs['pk'])
+        team = self.get_object_or_404(self.parent_model, lookup_field='pk')
         credential_content_type = ContentType.objects.get_for_model(models.Credential)
         if role.content_type == credential_content_type:
             if not role.content_object.organization or role.content_object.organization.id != team.organization.id:
@@ -915,7 +915,7 @@ class ProjectTeamsList(ListAPIView):
     serializer_class = serializers.TeamSerializer
 
     def get_queryset(self):
-        p = get_object_or_404(models.Project, pk=self.kwargs['pk'])
+        p = self.get_object_or_404(models.Project, lookup_field='pk')
         if not self.request.user.can_access(models.Project, 'read', p):
             raise PermissionDenied()
         project_ct = ContentType.objects.get_for_model(models.Project)
@@ -1239,7 +1239,7 @@ class UserTeamsList(SubListAPIView):
     parent_model = models.User
 
     def get_queryset(self):
-        u = get_object_or_404(models.User, pk=self.kwargs['pk'])
+        u = self.get_object_or_404(models.User, lookup_field='pk')
         if not self.request.user.can_access(models.User, 'read', u):
             raise PermissionDenied()
         return models.Team.accessible_objects(self.request.user, 'read_role').filter(Q(member_role__members=u) | Q(admin_role__members=u)).distinct()
@@ -1256,7 +1256,7 @@ class UserRolesList(SubListAttachDetachAPIView):
     search_fields = ('role_field', 'content_type__model')
 
     def get_queryset(self):
-        u = get_object_or_404(models.User, pk=self.kwargs['pk'])
+        u = self.get_object_or_404(self.parent_model, lookup_field='pk')
         if not self.request.user.can_access(models.User, 'read', u):
             raise PermissionDenied()
         content_type = ContentType.objects.get_for_model(models.User)
@@ -1437,7 +1437,7 @@ class CredentialOwnerTeamsList(SubListAPIView):
     parent_model = models.Credential
 
     def get_queryset(self):
-        credential = get_object_or_404(self.parent_model, pk=self.kwargs['pk'])
+        credential = self.get_object_or_404(self.parent_model, lookup_field='pk')
         if not self.request.user.can_access(models.Credential, 'read', credential):
             raise PermissionDenied()
 
@@ -3717,7 +3717,7 @@ class JobJobEventsChildrenSummary(APIView):
 
     def get(self, request, **kwargs):
         resp = dict(children_summary={}, meta_event_nested_uuid={}, event_processing_finished=False, is_tree=True)
-        job = get_object_or_404(models.Job, pk=kwargs['pk'])
+        job = self.get_object_or_404(models.Job, lookup_field='pk')
         if not job.event_processing_finished:
             return Response(resp)
         else:
@@ -4368,7 +4368,7 @@ class RoleParentsList(SubListAPIView):
     search_fields = ('role_field', 'content_type__model')
 
     def get_queryset(self):
-        role = models.Role.objects.get(pk=self.kwargs['pk'])
+        role = self.get_object_or_404(self.model, lookup_field='pk')
         return models.Role.filter_visible_roles(self.request.user, role.parents.all())
 
 
@@ -4382,7 +4382,7 @@ class RoleChildrenList(SubListAPIView):
     search_fields = ('role_field', 'content_type__model')
 
     def get_queryset(self):
-        role = models.Role.objects.get(pk=self.kwargs['pk'])
+        role = self.get_object_or_404(self.model, lookup_field='pk')
         return models.Role.filter_visible_roles(self.request.user, role.children.all())
 
 

--- a/awx/api/views/webhooks.py
+++ b/awx/api/views/webhooks.py
@@ -27,7 +27,10 @@ class WebhookKeyView(GenericAPIView):
 
     def get_queryset(self):
         qs_models = {'job_templates': JobTemplate, 'workflow_job_templates': WorkflowJobTemplate}
-        self.model = qs_models.get(self.kwargs['model_kwarg'])
+        if getattr(self, 'swagger_fake_view', False) and ('model_kwarg' not in self.kwargs):
+            self.model = JobTemplate
+        else:
+            self.model = qs_models.get(self.kwargs['model_kwarg'])
 
         return super().get_queryset()
 
@@ -55,7 +58,10 @@ class WebhookReceiverBase(APIView):
 
     def get_queryset(self):
         qs_models = {'job_templates': JobTemplate, 'workflow_job_templates': WorkflowJobTemplate}
-        model = qs_models.get(self.kwargs['model_kwarg'])
+        if getattr(self, 'swagger_fake_view', False) and ('model_kwarg' not in self.kwargs):
+            model = JobTemplate
+        else:
+            model = qs_models.get(self.kwargs['model_kwarg'])
         if model is None:
             raise PermissionDenied
 


### PR DESCRIPTION
##### SUMMARY
Troubleshooting schema failures due to a recent DAB change, the output is swamped by:

```
2024-05-17T14:13:03.6034850Z Traceback (most recent call last):
2024-05-17T14:13:03.6035405Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/drf_yasg/inspectors/base.py", line 42, in call_view_method
2024-05-17T14:13:03.6035504Z     return view_method()
2024-05-17T14:13:03.6035586Z            ^^^^^^^^^^^^^
2024-05-17T14:13:03.6035791Z   File "/awx_devel/awx/api/generics.py", line 538, in get_queryset
2024-05-17T14:13:03.6035907Z     parent = self.get_parent_object()
2024-05-17T14:13:03.6035997Z              ^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-17T14:13:03.6036225Z   File "/awx_devel/awx/api/generics.py", line 498, in get_parent_object
2024-05-17T14:13:03.6036475Z     self.parent_object = get_object_or_404(self.parent_model, **parent_filter)
2024-05-17T14:13:03.6036612Z                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-17T14:13:03.6037135Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/shortcuts.py", line 87, in get_object_or_404
2024-05-17T14:13:03.6037331Z     raise Http404(
2024-05-17T14:13:03.6037637Z django.http.response.Http404: No WorkflowJobTemplateNode matches the given query.
2024-05-17T14:13:03.6038652Z WARNING  drf_yasg.inspectors.base:base.py:44 view's WorkflowJobNodeInstanceGroupsList raised exception during schema generation; use `getattr(self, 'swagger_fake_view', False)` to detect and short-circuit this
2024-05-17T14:13:03.6038763Z Traceback (most recent call last):
2024-05-17T14:13:03.6039283Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/shortcuts.py", line 85, in get_object_or_404
2024-05-17T14:13:03.6039403Z     return queryset.get(*args, **kwargs)
2024-05-17T14:13:03.6039497Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-05-17T14:13:03.6039984Z   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 637, in get
2024-05-17T14:13:03.6040103Z     raise self.model.DoesNotExist(
2024-05-17T14:13:03.6040522Z awx.main.models.workflow.WorkflowJobNode.DoesNotExist: WorkflowJobNode matching query does not exist.
2024-05-17T14:13:03.6040591Z 
```

...and other similar output. This is not the actual error. No. @TheRealHaoLiu recently identified this, but in doing so I'm not sure if anyone even looked at the actual problem. This PR isn't addressing that problem. This is only trying to cut through the weeds that blocks our view of the problem.

A sample output from https://github.com/ansible/awx/pull/15202 in the swagger check gives 46,969 lines. There's some noisy setup (which we have other solutions for), but then about 10% of the way in, it's this same error for the entire rest of the output. But this is a _suppressed_ error, given as a warning.

Here is a sample output of the current problem, after accomplishing this fix:

https://gist.github.com/AlanCoding/fb44e008939875b9434117c7632ba4aa

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION
What is going on here?

All tests are transactional. I'm aware we have a "piggyback" method to identify URLs in other tests and use them in later schema tests. Problem is that any objects that might have played a role won't exist... because the transactions of the prior tests are over.

Exasperated, I use their hook to identify that the call is _only for schema generation_ to give _any_ available object. This also requires creating an object of every type where the queryset requires looking up a parent object.

This also requires a supporting DAB change which does basically the same thing.
