### PR TITLE
use optional api prefix in collection if set as environ vairable

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -17,7 +17,7 @@ import time
 import re
 from json import loads, dumps
 from os.path import isfile, expanduser, split, join, exists, isdir
-from os import access, R_OK, getcwd, environ
+from os import access, R_OK, getcwd, environ, getenv
 
 
 try:
@@ -148,9 +148,10 @@ class ControllerModule(AnsibleModule):
         # Make sure we start with /api/vX
         if not endpoint.startswith("/"):
             endpoint = "/{0}".format(endpoint)
-        prefix = self.url_prefix.rstrip("/")
-        if not endpoint.startswith(prefix + "/api/"):
-            endpoint = prefix + "/api/v2{0}".format(endpoint)
+        hostname_prefix = self.url_prefix.rstrip("/")
+        api_path = self.api_path()
+        if not endpoint.startswith(hostname_prefix + api_path):
+            endpoint = hostname_prefix + f"{api_path}v2{endpoint}"
         if not endpoint.endswith('/') and '?' not in endpoint:
             endpoint = "{0}/".format(endpoint)
 
@@ -603,6 +604,10 @@ class ControllerAPIModule(ControllerModule):
             status_code = response.status
         return {'status_code': status_code, 'json': response_json}
 
+    def api_path(self):
+        prefix = getenv('CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX', '/api/')
+        return prefix
+
     def authenticate(self, **kwargs):
         if self.username and self.password:
             # Attempt to get a token from /api/v2/tokens/ by giving it our username/password combo
@@ -613,7 +618,7 @@ class ControllerAPIModule(ControllerModule):
                 "scope": "write",
             }
             # Preserve URL prefix
-            endpoint = self.url_prefix.rstrip('/') + '/api/v2/tokens/'
+            endpoint = self.url_prefix.rstrip('/') + f'{self.api_path()}v2/tokens/'
             # Post to the tokens endpoint with baisc auth to try and get a token
             api_token_url = (self.url._replace(path=endpoint)).geturl()
 
@@ -1002,7 +1007,7 @@ class ControllerAPIModule(ControllerModule):
         if self.authenticated and self.oauth_token_id:
             # Attempt to delete our current token from /api/v2/tokens/
             # Post to the tokens endpoint with baisc auth to try and get a token
-            endpoint = self.url_prefix.rstrip('/') + '/api/v2/tokens/{0}/'.format(self.oauth_token_id)
+            endpoint = self.url_prefix.rstrip('/') + f'{self.api_path()}v2/tokens/{self.oauth_token_id}/'
             api_token_url = (self.url._replace(path=endpoint, query=None)).geturl()  # in error cases, fail_json exists before exception handling
 
             try:

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -605,7 +605,11 @@ class ControllerAPIModule(ControllerModule):
         return {'status_code': status_code, 'json': response_json}
 
     def api_path(self):
-        prefix = getenv('CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX', '/api/')
+
+        default_api_path = "/api/"
+        if self._COLLECTION_TYPE != "awx":
+            default_api_path = "/api/controller/"
+        prefix = getenv('CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX', default_api_path)
         return prefix
 
     def authenticate(self, **kwargs):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change make the collection compatible with OPTIONAL_API_URLPATTERN_PREFIX environment variable. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection


##### ADDITIONAL INFORMATION
<!---
see this PR for more context: https://github.com/ansible/awx/pull/15080/files
  -->
Testing:
To test this change I cloned the awx repo, made the change in the controller_api.py file and created a basic ansible playbook which references the updated awx code. The playbook launches a job against the controller. The playbook looks like this:
```
- hosts: localhost
  gather_facts: false
  environment: 
    CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX: '/api/controller/'
  tasks: 
    - name: Launch a job on controller
      awx.awx.job_launch:
        job_template: 7
        controller_password: 'SECRET'
        controller_host: 'https://my.controller.com'
        controller_username: 'admin'
      register: job
   
    - name: Wait for controller job
      awx.awx.job_wait:
        job_id: "{{ job.id }}"
        controller_password: 'SECRET'
        controller_host: 'https://my.controller.com'
        controller_username: 'admin'
        timeout: 120
```
to run the playbook i ran the following command: 
ansible-playbook -i localhost, play.yml -e ansible_connection=local

