### PR TITLE
Fix warning for test asserting validation does not throw error

### DIFF
--- a/awx/main/tests/unit/utils/test_common.py
+++ b/awx/main/tests/unit/utils/test_common.py
@@ -318,7 +318,7 @@ class TestHostnameRegexValidator:
 
     def test_good_call(self, regex_expr, re_flags):
         h = HostnameRegexValidator(regex=regex_expr, flags=re_flags)
-        assert (h("192.168.56.101"), None)
+        h("192.168.56.101")
 
     def test_bad_call(self, regex_expr, re_flags):
         h = HostnameRegexValidator(regex=regex_expr, flags=re_flags)
@@ -336,4 +336,4 @@ class TestHostnameRegexValidator:
 
     def test_bad_call_with_inverse(self, regex_expr, re_flags, inverse_match=True):
         h = HostnameRegexValidator(regex=regex_expr, flags=re_flags, inverse_match=inverse_match)
-        assert (h("@#$%)$#(TUFAS_DG"), None)
+        h("@#$%)$#(TUFAS_DG")


### PR DESCRIPTION
##### SUMMARY
The `assert` here was doing nothing and the test warnings were telling us, so I thought I would go ahead and put this up because it's the easiest of all fixes for warnings.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
