### PR TITLE
Fix up ansible-test sanity checks due to ansible 2.17 release

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -107,7 +107,7 @@ class ControllerModule(AnsibleModule):
         # Perform magic depending on whether controller_oauthtoken is a string or a dict
         if self.params.get('controller_oauthtoken'):
             token_param = self.params.get('controller_oauthtoken')
-            if type(token_param) is dict:
+            if isinstance(token_param, dict):
                 if 'token' in token_param:
                     self.oauth_token = self.params.get('controller_oauthtoken')['token']
                 else:
@@ -215,7 +215,7 @@ class ControllerModule(AnsibleModule):
                 try:
                     config_data = yaml.load(config_string, Loader=yaml.SafeLoader)
                     # If this is an actual ini file, yaml will return the whole thing as a string instead of a dict
-                    if type(config_data) is not dict:
+                    if not isinstance(config_data, dict):
                         raise AssertionError("The yaml config file is not properly formatted as a dict.")
                     try_config_parsing = False
 
@@ -257,7 +257,7 @@ class ControllerModule(AnsibleModule):
             if honorred_setting in config_data:
                 # Veriffy SSL must be a boolean
                 if honorred_setting == 'verify_ssl':
-                    if type(config_data[honorred_setting]) is str:
+                    if isinstance(config_data[honorred_setting], str):
                         setattr(self, honorred_setting, strtobool(config_data[honorred_setting]))
                     else:
                         setattr(self, honorred_setting, bool(config_data[honorred_setting]))

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -163,7 +163,7 @@ def main():
     for arg in ['job_type', 'limit', 'forks', 'verbosity', 'extra_vars', 'become_enabled', 'diff_mode']:
         if module.params.get(arg):
             # extra_var can receive a dict or a string, if a dict covert it to a string
-            if arg == 'extra_vars' and type(module.params.get(arg)) is not str:
+            if arg == 'extra_vars' and isinstance(module.params.get(arg), str):
                 post_data[arg] = json.dumps(module.params.get(arg))
             else:
                 post_data[arg] = module.params.get(arg)

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -163,7 +163,7 @@ def main():
     for arg in ['job_type', 'limit', 'forks', 'verbosity', 'extra_vars', 'become_enabled', 'diff_mode']:
         if module.params.get(arg):
             # extra_var can receive a dict or a string, if a dict covert it to a string
-            if arg == 'extra_vars' and isinstance(module.params.get(arg), str):
+            if arg == 'extra_vars' and not isinstance(module.params.get(arg), str):
                 post_data[arg] = json.dumps(module.params.get(arg))
             else:
                 post_data[arg] = module.params.get(arg)

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -137,20 +137,6 @@ except ImportError:
 def main():
     argument_spec = dict(
         all=dict(type='bool', default=False),
-        organizations=dict(type='list', elements='str'),
-        users=dict(type='list', elements='str'),
-        teams=dict(type='list', elements='str'),
-        credential_types=dict(type='list', elements='str'),
-        credentials=dict(type='list', elements='str'),
-        execution_environments=dict(type='list', elements='str'),
-        notification_templates=dict(type='list', elements='str'),
-        inventory_sources=dict(type='list', elements='str'),
-        inventory=dict(type='list', elements='str'),
-        projects=dict(type='list', elements='str'),
-        job_templates=dict(type='list', elements='str'),
-        workflow_job_templates=dict(type='list', elements='str'),
-        applications=dict(type='list', elements='str'),
-        schedules=dict(type='list', elements='str'),
     )
 
     # We are not going to raise an error here because the __init__ method of ControllerAWXKitModule will do that for us

--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -137,6 +137,20 @@ except ImportError:
 def main():
     argument_spec = dict(
         all=dict(type='bool', default=False),
+        organizations=dict(type='list', elements='str'),
+        users=dict(type='list', elements='str'),
+        teams=dict(type='list', elements='str'),
+        credential_types=dict(type='list', elements='str'),
+        credentials=dict(type='list', elements='str'),
+        execution_environments=dict(type='list', elements='str'),
+        notification_templates=dict(type='list', elements='str'),
+        inventory_sources=dict(type='list', elements='str'),
+        inventory=dict(type='list', elements='str'),
+        projects=dict(type='list', elements='str'),
+        job_templates=dict(type='list', elements='str'),
+        workflow_job_templates=dict(type='list', elements='str'),
+        applications=dict(type='list', elements='str'),
+        schedules=dict(type='list', elements='str'),
     )
 
     # We are not going to raise an error here because the __init__ method of ControllerAWXKitModule will do that for us

--- a/awx_collection/plugins/modules/import.py
+++ b/awx_collection/plugins/modules/import.py
@@ -56,6 +56,8 @@ import logging
 
 # In this module we don't use EXPORTABLE_RESOURCES, we just want to validate that our installed awxkit has import/export
 try:
+    from awxkit.api.pages.api import EXPORTABLE_RESOURCES # noqa: F401; pylint: disable=unused-import
+
     HAS_EXPORTABLE_RESOURCES = True
 except ImportError:
     HAS_EXPORTABLE_RESOURCES = False

--- a/awx_collection/plugins/modules/import.py
+++ b/awx_collection/plugins/modules/import.py
@@ -56,8 +56,6 @@ import logging
 
 # In this module we don't use EXPORTABLE_RESOURCES, we just want to validate that our installed awxkit has import/export
 try:
-    from awxkit.api.pages.api import EXPORTABLE_RESOURCES  # noqa
-
     HAS_EXPORTABLE_RESOURCES = True
 except ImportError:
     HAS_EXPORTABLE_RESOURCES = False

--- a/awx_collection/plugins/modules/import.py
+++ b/awx_collection/plugins/modules/import.py
@@ -56,7 +56,7 @@ import logging
 
 # In this module we don't use EXPORTABLE_RESOURCES, we just want to validate that our installed awxkit has import/export
 try:
-    from awxkit.api.pages.api import EXPORTABLE_RESOURCES # noqa: F401; pylint: disable=unused-import
+    from awxkit.api.pages.api import EXPORTABLE_RESOURCES  # noqa: F401; pylint: disable=unused-import
 
     HAS_EXPORTABLE_RESOURCES = True
 except ImportError:

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -19,6 +19,7 @@ from ansible.module_utils.six import raise_from
 
 from ansible_base.rbac.models import RoleDefinition, DABPermission
 from awx.main.tests.functional.conftest import _request
+from awx.main.tests.functional.conftest import credentialtype_scm, credentialtype_ssh  # noqa: F401; pylint: disable=unused-import
 from awx.main.models import (
     Organization,
     Project,

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -19,7 +19,6 @@ from ansible.module_utils.six import raise_from
 
 from ansible_base.rbac.models import RoleDefinition, DABPermission
 from awx.main.tests.functional.conftest import _request
-from awx.main.tests.functional.conftest import credentialtype_scm, credentialtype_ssh  # noqa: F401; pylint: disable=unused-variable
 from awx.main.models import (
     Organization,
     Project,

--- a/awx_collection/tests/sanity/ignore-2.17.txt
+++ b/awx_collection/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/modules/export.py validate-modules:nonexistent-parameter-documented  # needs awxkit to construct argspec


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Address the following ansible sanity errors

```
ERROR: Found 7 pylint issue(s) which need to be resolved:
ERROR: plugins/module_utils/controller_api.py:110:15: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: plugins/module_utils/controller_api.py:218:23: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: plugins/module_utils/controller_api.py:260:23: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: plugins/modules/ad_hoc_command.py:166:39: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: plugins/modules/import.py:59:4: unused-import: Unused EXPORTABLE_RESOURCES imported from awxkit.api.pages.api
ERROR: test/awx/conftest.py:22:0: unused-import: Unused credentialtype_scm imported from awx.main.tests.functional.conftest
ERROR: test/awx/conftest.py:22:0: unused-import: Unused credentialtype_ssh imported from awx.main.tests.functional.conftest

ERROR: Found 14 validate-modules issue(s) which need to be resolved:
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'applications' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'credential_types' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'credentials' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'execution_environments' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'inventory' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'inventory_sources' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'job_templates' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'notification_templates' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'organizations' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'projects' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'schedules' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'teams' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'users' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/export.py:0:0: nonexistent-parameter-documented: Argument 'workflow_job_templates' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
```
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.3.1.dev22+g805e06ed2c.d20240521
```
