### PR TITLE
awx.awx.schedule: Do not fail if state is absent and unified_job_template does not exist

### DIFF
--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -263,8 +263,10 @@ def main():
     unified_job_template_id = None
     if unified_job_template:
         search_fields['name'] = unified_job_template
-        unified_job_template_id = module.get_one('unified_job_templates', **{'data': search_fields})['id']
-        sched_search_fields['unified_job_template'] = unified_job_template_id
+        unified_job_template_obj = module.get_one('unified_job_templates', **{'data': search_fields})
+        if unified_job_template_obj is not None:
+            unified_job_template_id = unified_job_template_obj['id']
+            sched_search_fields['unified_job_template'] = unified_job_template_id
 
     # Attempt to look up an existing item based on the provided data
     existing_item = module.get_one('schedules', name_or_id=name, check_exists=(state == 'exists'), **{'data': sched_search_fields})


### PR DESCRIPTION
##### SUMMARY
Module managing schedules does is not idempotent in case `unified_job_template` is provided and such `unified_job_template` does not exist and so schedule does not exist anymore. Module should still provide OK.

This is affecting mainly configuration as code, when switching object with state to absent. It is then not consistent to have one playbook managing creation and removal at same time.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection - awx.awx.schedule

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.4.0
```


##### ADDITIONAL INFORMATION

Using following example for configuration as code using dispatch within `infra.controller_configuration` is gonna deploy it.
```yaml
controller_templates:
  - name: foobar_jobtemplate
     playbook: dummy_playbook
     organization: org
     state: present
controller_schedules:
  - name: foobar_schedule
    rrule: "{{ query('awx.awx.schedule_rrule',
      'day',
      start_date='2023-01-01 03:33:00',
      timezone='America/New_York')
      }}"
    unified_job_template: foobar_jobtemplate
    organization: org
    enabled: true
    state: present
```

Simple changing state to absent, keeping the rest of the values intact will make it fail on schedules as job templates are removed first and schedule still refer to non-existing `unified_job_template`.


<!--- Paste verbatim command output below, e.g. before and after your change -->
Error:
```
plugins/modules/schedule.py\", line 279, in main", "TypeError: argument of type 'NoneType' is not iterable
```
With proposed update it manages both states successfully (present and absent).