### PR TITLE
Include Kube credentials in the inventory source picker

### DIFF
--- a/awx/ui/src/components/Lookup/CredentialLookup.js
+++ b/awx/ui/src/components/Lookup/CredentialLookup.js
@@ -62,7 +62,7 @@ function CredentialLookup({
         ? { credential_type: credentialTypeId }
         : {};
       const typeKindParams = credentialTypeKind
-        ? { credential_type__kind: credentialTypeKind }
+        ? { credential_type__kind__in: credentialTypeKind }
         : {};
       const typeNamespaceParams = credentialTypeNamespace
         ? { credential_type__namespace: credentialTypeNamespace }
@@ -125,7 +125,7 @@ function CredentialLookup({
           ? { credential_type: credentialTypeId }
           : {};
         const typeKindParams = credentialTypeKind
-          ? { credential_type__kind: credentialTypeKind }
+          ? { credential_type__kind__in: credentialTypeKind }
           : {};
         const typeNamespaceParams = credentialTypeNamespace
           ? { credential_type__namespace: credentialTypeNamespace }

--- a/awx/ui/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.js
+++ b/awx/ui/src/screens/Inventory/shared/InventorySourceSubForms/SCMSubForm.js
@@ -87,7 +87,7 @@ const SCMSubForm = ({ autoPopulateProject }) => {
         />
       )}
       <CredentialLookup
-        credentialTypeKind="cloud"
+        credentialTypeKind="cloud,kubernetes"
         label={t`Credential`}
         value={credentialField.value}
         onChange={handleCredentialUpdate}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 24.4.1.dev5+g1495b2a540
```


##### ADDITIONAL INFORMATION
This should fixes #15165

This takes advantage of the __in operator which just expects a comma separated list of types.