### PR TITLE
Update workflow_job_template.py for correct error in workflow_nodes  with inventory null

### DIFF
--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -657,7 +657,7 @@ def create_workflow_nodes(module, response, workflow_nodes, workflow_id):
                 )['id']
 
         # Two lookup methods are used based on a fix added in 21.11.0, and the awx export model
-        if 'inventory' in workflow_node:
+        if 'inventory' in workflow_node and workflow_node['inventory'] is not None:
             if 'name' in workflow_node['inventory']:
                 inv_lookup_data = {}
                 if 'organization' in workflow_node['inventory']:


### PR DESCRIPTION
Update workflow_job_template.py for correct error in workflow_nodes with inventory null in json or yaml

Detect error when file vars include in workflow_nodes a inventory with value null

workflow_nodes:
  inventory: null

This problem detect when use export information from module export in old version of tower

##### SUMMARY
Correct error

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### AWX VERSION
24.4.0


##### ADDITIONAL INFORMATION
