### PR TITLE
Fix notification name search

### DIFF
--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplateList/NotificationTemplateList.js
@@ -120,7 +120,7 @@ function NotificationTemplatesList() {
             toolbarSearchColumns={[
               {
                 name: t`Name`,
-                key: 'name',
+                key: 'name__icontains',
                 isDefault: true,
               },
               {


### PR DESCRIPTION
##### SUMMARY

Fixes the partial search/filtering of `Name` under `Administration->Notifications`. 
This PR makes it consistent with the rest of the website (Templates, Credentials, Projects) - where the partial `Name` filtering works.
This is, typing part of the name filters the right results.



##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
```


##### ADDITIONAL INFORMATION
I couldn't find a github issue for it. Typing `aaa` finds/filters the right templates

![notifications_fixed](https://github.com/ansible/awx/assets/238607/0bc6cb41-6cb3-4073-9d4d-bfc1bef90b66)

--- 

Tested by:
* added some filters (for Description, Name, etc.) manually and checking they continue to work
* ran
```
npm run prettier
npm run lint
npm run test
```
