### PR TITLE
Use settings fixture in tests

### DIFF
--- a/awx/main/tests/functional/test_named_url.py
+++ b/awx/main/tests/functional/test_named_url.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from django.conf import settings
-
 from awx.api.versioning import reverse
 from awx.main.middleware import URLModificationMiddleware
 from awx.main.models import (  # noqa
@@ -121,7 +119,7 @@ def test_notification_template(get, admin_user):
 
 
 @pytest.mark.django_db
-def test_instance(get, admin_user):
+def test_instance(get, admin_user, settings):
     test_instance = Instance.objects.create(uuid=settings.SYSTEM_UUID, hostname="localhost", capacity=100)
     url = reverse('api:instance_detail', kwargs={'pk': test_instance.pk})
     response = get(url, user=admin_user, expect=200)
@@ -230,7 +228,7 @@ class TestConvertNamedUrl:
             "/api/foobar/v2/organizations/1/inventories/",
         ),
     )
-    def test_noop(self, url):
+    def test_noop(self, url, settings):
         settings.OPTIONAL_API_URLPATTERN_PREFIX = ''
         assert URLModificationMiddleware._convert_named_url(url) == url
 


### PR DESCRIPTION
##### SUMMARY
Example of the failure this was causing here `FAILED awx/main/tests/unit/test_settings.py::test_default_settings - Assertio...` https://github.com/ansible/awx/actions/runs/9304287261/job/25608497427?pr=15199


* Otherwise, settings value changes bleeds over into other tests.
* Remove django.conf settings import so that we do not accidentally forget to use the settings fixture.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
