### PR TITLE
Add check_instance_ready management command

### DIFF
--- a/awx/main/management/commands/check_instance_ready.py
+++ b/awx/main/management/commands/check_instance_ready.py
@@ -1,0 +1,12 @@
+from django.core.management.base import BaseCommand, CommandError
+from awx.main.models.ha import Instance
+
+
+class Command(BaseCommand):
+    help = 'Check if the task manager instance is ready throw error if not ready, can be use as readiness probe for k8s.'
+
+    def handle(self, *args, **options):
+        if Instance.objects.me().node_state != Instance.States.READY:
+            raise CommandError('Instance is not ready')  # so that return code is not 0
+
+        return


### PR DESCRIPTION
##### SUMMARY
- throw exception and return 1 if instance not ready
- return 0 if ready

use by https://github.com/ansible/awx-operator/pull/1885 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
