### PR TITLE
adjust aiohttp for cve 2024-23829

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -1,4 +1,4 @@
-aiohttp>=3.8.6  # CVE-2023-47627
+aiohttp>=3.9.4 # CVE-2024-30251
 ansiconv==1.0.0  # UPGRADE BLOCKER: from 2013, consider replacing instead of upgrading
 asciichartpy
 asn1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 adal==1.2.7
     # via msrestazure
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   aiohttp-retry


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Requirements.txt update not needed (didn't get written to by our updater) due to us already being above this threshold. 

Double hitter here
CVE: https://bugzilla.redhat.com/show_bug.cgi?id=2261909
CVE: https://bugzilla.redhat.com/show_bug.cgi?id=2261887
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.4.1.dev23+g17a6d3a039

```


