### PR TITLE
collection: 'Terraform State' inventory source support (#15252)

### DIFF
--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -42,7 +42,7 @@ options:
     source:
       description:
         - The source to use for this group.
-      choices: [ "scm", "ec2", "gce", "azure_rm", "vmware", "satellite6", "openstack", "rhv", "controller", "insights" ]
+      choices: [ "scm", "ec2", "gce", "azure_rm", "vmware", "satellite6", "openstack", "rhv", "controller", "insights", "terraform" ]
       type: str
     source_path:
       description:
@@ -170,7 +170,7 @@ def main():
         #
         # How do we handle manual and file? The controller does not seem to be able to activate them
         #
-        source=dict(choices=["scm", "ec2", "gce", "azure_rm", "vmware", "satellite6", "openstack", "rhv", "controller", "insights"]),
+        source=dict(choices=["scm", "ec2", "gce", "azure_rm", "vmware", "satellite6", "openstack", "rhv", "controller", "insights", "terraform"]),
         source_path=dict(),
         source_vars=dict(type='dict'),
         enabled_var=dict(),


### PR DESCRIPTION
##### SUMMARY
Fixes ansible/awx#15252

AWX [24.0.0](https://github.com/ansible/awx/releases/tag/24.0.0) introduced a terraform state inventory source.
This change allows creating a terraform state inventory source with the 'awx.awx.inventory_source' module.

##### ISSUE TYPE

 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Collection (awx.awx.inventory_source module)


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Example usage:

```
---
- name: Lookup plugin test
  hosts: localhost
  become: no
  gather_facts: no
  environment:
    CONTROLLER_HOST: https://yourawxurl.com/
    CONTROLLER_USERNAME: admin
    CONTROLLER_PASSWORD: foofoo

  tasks:
    - name: Add Inventory_TEST_TF_SOURCE
      awx.awx.inventory:
        name: Inventory_TEST_TF_SOURCE
        organization: Default
        state: present

    - name: Add TF backend configuration
      awx.awx.credential:
        name: TF_TEST
        credential_type: Terraform backend configuration
        organization: Default
        inputs:
          configuration: |
            bucket = "example-tfstates"
            key = "aws-test-instance/tf_state.tfstate"
            region = "us-east-1"
            access_key = "CHANGEME"
            secret_key = "CHANGEME"
    
    - name: Add an inventory source 'TF_source'
      awx.awx.inventory_source:
        inventory: Inventory_TEST_TF_SOURCE
        name: TF_soruce
        source: terraform
        source_vars:
          backend_type: s3
        credential: TF_TEST
        organization: Default
        overwrite: true
        overwrite_vars: true
        update_on_launch: true
        verbosity: 1
        state: present
```
