### PR TITLE
Trust proxy headers for host provision callback

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -36,6 +36,7 @@ from ansible_base.lib.utils.models import get_all_field_names
 from ansible_base.lib.utils.requests import get_remote_host
 from ansible_base.rbac.models import RoleEvaluation, RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
+from ansible_base.jwt_consumer.common.util import validate_x_trusted_proxy_header
 
 # AWX
 from awx.main.models import UnifiedJob, UnifiedJobTemplate, User, Role, Credential, WorkflowJobTemplateNode, WorkflowApprovalTemplate
@@ -43,6 +44,7 @@ from awx.main.models.rbac import give_creator_permissions
 from awx.main.access import optimize_queryset
 from awx.main.utils import camelcase_to_underscore, get_search_fields, getattrd, get_object_or_400, decrypt_field, get_awx_version
 from awx.main.utils.licensing import server_product_name
+from awx.main.utils.proxy import is_proxy_in_headers, delete_headers
 from awx.main.views import ApiErrorView
 from awx.api.serializers import ResourceAccessListElementSerializer, CopySerializer
 from awx.api.versioning import URLPathVersioning
@@ -153,22 +155,23 @@ class APIView(views.APIView):
         Store the Django REST Framework Request object as an attribute on the
         normal Django request, store time the request started.
         """
+        remote_headers = ['REMOTE_ADDR', 'REMOTE_HOST']
+
         self.time_started = time.time()
         if getattr(settings, 'SQL_DEBUG', False):
             self.queries_before = len(connection.queries)
 
+        if 'HTTP_X_TRUSTED_PROXY' in request.environ:
+            if validate_x_trusted_proxy_header(request.environ['HTTP_X_TRUSTED_PROXY']):
+                remote_headers = settings.REMOTE_HOST_HEADERS
+            else:
+                logger.warning("Request appeared to be a trusted upstream proxy but failed to provide a matching shared secret.")
+
         # If there are any custom headers in REMOTE_HOST_HEADERS, make sure
         # they respect the allowed proxy list
-        if all(
-            [
-                settings.PROXY_IP_ALLOWED_LIST,
-                request.environ.get('REMOTE_ADDR') not in settings.PROXY_IP_ALLOWED_LIST,
-                request.environ.get('REMOTE_HOST') not in settings.PROXY_IP_ALLOWED_LIST,
-            ]
-        ):
-            for custom_header in settings.REMOTE_HOST_HEADERS:
-                if custom_header.startswith('HTTP_'):
-                    request.environ.pop(custom_header, None)
+        if settings.PROXY_IP_ALLOWED_LIST:
+            if not is_proxy_in_headers(self.request, settings.PROXY_IP_ALLOWED_LIST, remote_headers):
+                delete_headers(request, settings.REMOTE_HOST_HEADERS)
 
         drf_request = super(APIView, self).initialize_request(request, *args, **kwargs)
         request.drf_request = drf_request

--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -44,7 +44,7 @@ from awx.main.models.rbac import give_creator_permissions
 from awx.main.access import optimize_queryset
 from awx.main.utils import camelcase_to_underscore, get_search_fields, getattrd, get_object_or_400, decrypt_field, get_awx_version
 from awx.main.utils.licensing import server_product_name
-from awx.main.utils.proxy import is_proxy_in_headers, delete_headers
+from awx.main.utils.proxy import is_proxy_in_headers, delete_headers_starting_with_http
 from awx.main.views import ApiErrorView
 from awx.api.serializers import ResourceAccessListElementSerializer, CopySerializer
 from awx.api.versioning import URLPathVersioning
@@ -171,7 +171,7 @@ class APIView(views.APIView):
         # they respect the allowed proxy list
         if settings.PROXY_IP_ALLOWED_LIST:
             if not is_proxy_in_headers(self.request, settings.PROXY_IP_ALLOWED_LIST, remote_headers):
-                delete_headers(request, settings.REMOTE_HOST_HEADERS)
+                delete_headers_starting_with_http(request, settings.REMOTE_HOST_HEADERS)
 
         drf_request = super(APIView, self).initialize_request(request, *args, **kwargs)
         request.drf_request = drf_request

--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -36,7 +36,6 @@ from ansible_base.lib.utils.models import get_all_field_names
 from ansible_base.lib.utils.requests import get_remote_host
 from ansible_base.rbac.models import RoleEvaluation, RoleDefinition
 from ansible_base.rbac.permission_registry import permission_registry
-from ansible_base.jwt_consumer.common.util import validate_x_trusted_proxy_header
 
 # AWX
 from awx.main.models import UnifiedJob, UnifiedJobTemplate, User, Role, Credential, WorkflowJobTemplateNode, WorkflowApprovalTemplate
@@ -154,21 +153,13 @@ class APIView(views.APIView):
         Store the Django REST Framework Request object as an attribute on the
         normal Django request, store time the request started.
         """
-        is_trusted_proxy = False
-
         self.time_started = time.time()
         if getattr(settings, 'SQL_DEBUG', False):
             self.queries_before = len(connection.queries)
 
-        if 'HTTP_X_TRUSTED_PROXY' in request.META:
-            if validate_x_trusted_proxy_header(request.META['HTTP_X_TRUSTED_PROXY']):
-                is_trusted_proxy = True
-            else:
-                logger.warning("Request appeared to be a trusted upstream proxy but failed to provide a matching shared secret.")
-
         # If there are any custom headers in REMOTE_HOST_HEADERS, make sure
         # they respect the allowed proxy list
-        if not is_trusted_proxy and all(
+        if all(
             [
                 settings.PROXY_IP_ALLOWED_LIST,
                 request.environ.get('REMOTE_ADDR') not in settings.PROXY_IP_ALLOWED_LIST,

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -61,6 +61,7 @@ import pytz
 from wsgiref.util import FileWrapper
 
 # django-ansible-base
+from ansible_base.lib.utils.requests import get_remote_hosts
 from ansible_base.rbac.models import RoleEvaluation, ObjectRole
 from ansible_base.resource_registry.shared_types import OrganizationType, TeamType, UserType
 
@@ -2770,12 +2771,7 @@ class JobTemplateCallback(GenericAPIView):
         host for the current request.
         """
         # Find the list of remote host names/IPs to check.
-        remote_hosts = set()
-        for header in settings.REMOTE_HOST_HEADERS:
-            for value in self.request.META.get(header, '').split(','):
-                value = value.strip()
-                if value:
-                    remote_hosts.add(value)
+        remote_hosts = set(get_remote_hosts(self.request))
         # Add the reverse lookup of IP addresses.
         for rh in list(remote_hosts):
             try:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -61,6 +61,7 @@ import pytz
 from wsgiref.util import FileWrapper
 
 # django-ansible-base
+from ansible_base.lib.utils.requests import get_remote_hosts
 from ansible_base.rbac.models import RoleEvaluation, ObjectRole
 from ansible_base.resource_registry.shared_types import OrganizationType, TeamType, UserType
 
@@ -2770,12 +2771,8 @@ class JobTemplateCallback(GenericAPIView):
         host for the current request.
         """
         # Find the list of remote host names/IPs to check.
-        remote_hosts = set()
-        for header in settings.REMOTE_HOST_HEADERS:
-            for value in self.request.META.get(header, '').split(','):
-                value = value.strip()
-                if value:
-                    remote_hosts.add(value)
+
+        remote_hosts = set(get_remote_hosts(self.request))
         # Add the reverse lookup of IP addresses.
         for rh in list(remote_hosts):
             try:

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -61,7 +61,6 @@ import pytz
 from wsgiref.util import FileWrapper
 
 # django-ansible-base
-from ansible_base.lib.utils.requests import get_remote_hosts
 from ansible_base.rbac.models import RoleEvaluation, ObjectRole
 from ansible_base.resource_registry.shared_types import OrganizationType, TeamType, UserType
 
@@ -2771,8 +2770,12 @@ class JobTemplateCallback(GenericAPIView):
         host for the current request.
         """
         # Find the list of remote host names/IPs to check.
-
-        remote_hosts = set(get_remote_hosts(self.request))
+        remote_hosts = set()
+        for header in settings.REMOTE_HOST_HEADERS:
+            for value in self.request.META.get(header, '').split(','):
+                value = value.strip()
+                if value:
+                    remote_hosts.add(value)
         # Add the reverse lookup of IP addresses.
         for rh in list(remote_hosts):
             try:

--- a/awx/main/tests/functional/api/test_generic.py
+++ b/awx/main/tests/functional/api/test_generic.py
@@ -2,20 +2,27 @@ import pytest
 
 from awx.api.versioning import reverse
 
+from django.test.utils import override_settings
+
+from ansible_base.jwt_consumer.common.util import generate_x_trusted_proxy_header
+from ansible_base.lib.testing.fixtures import rsa_keypair_factory, rsa_keypair  # noqa: F401; pylint: disable=unused-import
+
+
+class HeaderTrackingMiddleware(object):
+    def __init__(self):
+        self.environ = {}
+
+    def process_request(self, request):
+        pass
+
+    def process_response(self, request, response):
+        self.environ = request.environ
+
 
 @pytest.mark.django_db
 def test_proxy_ip_allowed(get, patch, admin):
     url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'system'})
     patch(url, user=admin, data={'REMOTE_HOST_HEADERS': ['HTTP_X_FROM_THE_LOAD_BALANCER', 'REMOTE_ADDR', 'REMOTE_HOST']})
-
-    class HeaderTrackingMiddleware(object):
-        environ = {}
-
-        def process_request(self, request):
-            pass
-
-        def process_response(self, request, response):
-            self.environ = request.environ
 
     # By default, `PROXY_IP_ALLOWED_LIST` is disabled, so custom `REMOTE_HOST_HEADERS`
     # should just pass through
@@ -43,6 +50,64 @@ def test_proxy_ip_allowed(get, patch, admin):
     middleware = HeaderTrackingMiddleware()
     get(url, user=admin, middleware=middleware, REMOTE_ADDR='8.9.10.11', REMOTE_HOST='my.proxy.example.org', HTTP_X_FROM_THE_LOAD_BALANCER='some-actual-ip')
     assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
+
+
+@pytest.mark.django_db
+def test_x_trusted_proxy(get, patch, admin, rsa_keypair):  # noqa: F811
+    url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'system'})
+    patch(url, user=admin, data={'REMOTE_HOST_HEADERS': ['HTTP_X_FROM_THE_LOAD_BALANCER', 'REMOTE_ADDR', 'REMOTE_HOST']})
+
+    # Invalid x_trusted_proxy value SHOULD result in sensitive headers deleted
+    middleware = HeaderTrackingMiddleware()
+    headers = {
+        'HTTP_X_TRUSTED_PROXY': generate_x_trusted_proxy_header(rsa_keypair.private),
+        'HTTP_X_FROM_THE_LOAD_BALANCER': 'some-actual-ip',
+    }
+    get(url, user=admin, middleware=middleware, **headers)
+    assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
+
+
+@pytest.mark.django_db
+class TestTrustedProxyAllowListIntegration:
+    @pytest.fixture
+    def url(self, patch, admin):
+        url = reverse('api:setting_singleton_detail', kwargs={'category_slug': 'system'})
+        patch(url, user=admin, data={'REMOTE_HOST_HEADERS': ['HTTP_X_FROM_THE_LOAD_BALANCER', 'REMOTE_ADDR', 'REMOTE_HOST']})
+        patch(url, user=admin, data={'PROXY_IP_ALLOWED_LIST': ['my.proxy.example.org']})
+        return url
+
+    @pytest.fixture
+    def middleware(self):
+        return HeaderTrackingMiddleware()
+
+    def test_x_trusted_proxy_valid_signature(self, get, admin, rsa_keypair, url, middleware):  # noqa: F811
+        # Invalid x_trusted_proxy value SHOULD result in sensitive headers deleted
+        headers = {
+            'HTTP_X_TRUSTED_PROXY': generate_x_trusted_proxy_header(rsa_keypair.private),
+            'HTTP_X_FROM_THE_LOAD_BALANCER': 'some-actual-ip',
+        }
+        with override_settings(ANSIBLE_BASE_JWT_KEY=rsa_keypair.public):
+            get(url, user=admin, middleware=middleware, **headers)
+        assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
+
+    def test_x_trusted_proxy_invalid_signature(self, get, admin, url, middleware):
+        # Invalid x_trusted_proxy value SHOULD result in sensitive headers deleted
+        headers = {
+            'HTTP_X_TRUSTED_PROXY': 'DEAD-BEEF',
+            'HTTP_X_FROM_THE_LOAD_BALANCER': 'some-actual-ip',
+        }
+        get(url, user=admin, middleware=middleware, **headers)
+        assert 'HTTP_X_FROM_THE_LOAD_BALANCER' not in middleware.environ
+
+    def test_x_trusted_proxy_invalid_signature_valid_proxy(self, get, admin, url, middleware):
+        # A valid explicit proxy SHOULD result in sensitive headers NOT being deleted, regardless of the trusted proxy signature results
+        headers = {
+            'HTTP_X_TRUSTED_PROXY': 'DEAD-BEEF',
+            'REMOTE_ADDR': 'my.proxy.example.org',
+            'HTTP_X_FROM_THE_LOAD_BALANCER': 'some-actual-ip',
+        }
+        get(url, user=admin, middleware=middleware, **headers)
+        assert middleware.environ['HTTP_X_FROM_THE_LOAD_BALANCER'] == 'some-actual-ip'
 
 
 @pytest.mark.django_db

--- a/awx/main/utils/proxy.py
+++ b/awx/main/utils/proxy.py
@@ -13,6 +13,24 @@ It is the source data from which request.headers (read-only) is constructed.
 
 
 def is_proxy_in_headers(request: Request, proxy_list: list[str], headers: list[str]) -> bool:
+    """
+    Determine if the request went through at least one proxy in the list.
+    Example:
+    request.environ = {
+        "HTTP_X_FOO": "8.8.8.8, 192.168.2.1",
+        "REMOTE_ADDR": "192.168.2.1",
+        "REMOTE_HOST": "foobar"
+    }
+    proxy_list = ["192.168.2.1"]
+    headers = ["HTTP_X_FOO", "REMOTE_ADDR", "REMOTE_HOST"]
+
+    The above would return True since 192.168.2.1 is a value for the header HTTP_X_FOO
+
+    request: The DRF/Django request. request.environ dict will be used for searching for proxies
+    proxy_list: A list of known and trusted proxies may be ip or hostnames
+    headers: A list of keys for which to consider values that may contain a proxy
+    """
+
     remote_hosts = set()
 
     for header in headers:

--- a/awx/main/utils/proxy.py
+++ b/awx/main/utils/proxy.py
@@ -24,7 +24,7 @@ def is_proxy_in_headers(request: Request, proxy_list: list[str], headers: list[s
     return bool(remote_hosts.intersection(set(proxy_list)))
 
 
-def delete_headers(request: Request, headers: list[str]):
+def delete_headers_starting_with_http(request: Request, headers: list[str]):
     for header in headers:
         if header.startswith('HTTP_'):
             request.environ.pop(header, None)

--- a/awx/main/utils/proxy.py
+++ b/awx/main/utils/proxy.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Ansible, Inc.
+# All Rights Reserved.
+
+
+# DRF
+from rest_framework.request import Request
+
+
+"""
+Note that these methods operate on request.environ. This data is from uwsgi.
+It is the source data from which request.headers (read-only) is constructed.
+"""
+
+
+def is_proxy_in_headers(request: Request, proxy_list: list[str], headers: list[str]) -> bool:
+    remote_hosts = set()
+
+    for header in headers:
+        for value in request.environ.get(header, '').split(','):
+            value = value.strip()
+            if value:
+                remote_hosts.add(value)
+
+    return bool(remote_hosts.intersection(set(proxy_list)))
+
+
+def delete_headers(request: Request, headers: list[str]):
+    for header in headers:
+        if header.startswith('HTTP_'):
+            request.environ.pop(header, None)


### PR DESCRIPTION
##### SUMMARY
* Do not remove special header list if request is from a trusted proxy.
* Continue to remove headers if request if from a non-trusted proxy.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
