### PR TITLE
Periodically sync from share resource provider

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -36,6 +36,9 @@ import ansible_runner.cleanup
 # dateutil
 from dateutil.parser import parse as parse_date
 
+# django-ansible-base
+from ansible_base.resource_registry.tasks.sync import SyncExecutor
+
 # AWX
 from awx import __version__ as awx_application_version
 from awx.main.access import access_registry
@@ -964,3 +967,17 @@ def deep_copy_model_obj(model_module, model_name, obj_pk, new_obj_pk, user_pk, p
             permission_check_func(creater, copy_mapping.values())
     if isinstance(new_obj, Inventory):
         update_inventory_computed_fields.delay(new_obj.id)
+
+
+@task(queue=get_task_queuename)
+def periodic_resource_sync():
+    with advisory_lock('periodic_resource_sync', wait=False) as acquired:
+        if acquired is False:
+            logger.debug("Not running periodic_resource_sync, another task holds lock")
+            return
+
+        if getattr(settings, 'RESOURCE_SERVER', None):
+            logger.debug("Running periodic resource_sync")
+            SyncExecutor().run()
+        else:
+            logger.debug("Skipping periodic resource_sync, RESOURCE_SERVER not configured")

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -971,13 +971,13 @@ def deep_copy_model_obj(model_module, model_name, obj_pk, new_obj_pk, user_pk, p
 
 @task(queue=get_task_queuename)
 def periodic_resource_sync():
+    if not getattr(settings, 'RESOURCE_SERVER', None):
+        logger.debug("Skipping periodic resource_sync, RESOURCE_SERVER not configured")
+        return
+
     with advisory_lock('periodic_resource_sync', wait=False) as acquired:
         if acquired is False:
             logger.debug("Not running periodic_resource_sync, another task holds lock")
             return
 
-        if getattr(settings, 'RESOURCE_SERVER', None):
-            logger.debug("Running periodic resource_sync")
-            SyncExecutor().run()
-        else:
-            logger.debug("Skipping periodic resource_sync, RESOURCE_SERVER not configured")
+        SyncExecutor().run()

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -492,6 +492,7 @@ CELERYBEAT_SCHEDULE = {
     'cleanup_images': {'task': 'awx.main.tasks.system.cleanup_images_and_files', 'schedule': timedelta(hours=3)},
     'cleanup_host_metrics': {'task': 'awx.main.tasks.host_metrics.cleanup_host_metrics', 'schedule': timedelta(hours=3, minutes=30)},
     'host_metric_summary_monthly': {'task': 'awx.main.tasks.host_metrics.host_metric_summary_monthly', 'schedule': timedelta(hours=4)},
+    'periodic_resource_sync': {'task': 'awx.main.tasks.system.periodic_resource_sync', 'schedule': timedelta(minutes=15)},
 }
 
 # Django Caching Configuration


### PR DESCRIPTION
##### SUMMARY
- add periodic task `periodic_resource_sync` run once every 15 min
- if `RESOURCE_SERVER` is not configured sync will not run
- only 1 task dispatcher needs to run the resource sync

example RESOURCE_SERVER configuration
```
RESOURCE_SERVER = {
    "URL": "<resource server url>",
    "SECRET_KEY": "<resource server auth token>",
    "VALIDATE_HTTPS": <True/False>,
}
RESOURCE_SERVICE_PATH = <resource_service_path>
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
