### PR TITLE
Change all uses of ImplicitRoleField to do on_delete=SET_NULL

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -252,7 +252,7 @@ class ImplicitRoleField(models.ForeignKey):
         kwargs.setdefault('related_name', '+')
         kwargs.setdefault('null', 'True')
         kwargs.setdefault('editable', False)
-        kwargs.setdefault('on_delete', models.CASCADE)
+        kwargs.setdefault('on_delete', models.SET_NULL)
         super(ImplicitRoleField, self).__init__(*args, **kwargs)
 
     def deconstruct(self):

--- a/awx/main/migrations/0021_v330_declare_new_rbac_roles.py
+++ b/awx/main/migrations/0021_v330_declare_new_rbac_roles.py
@@ -17,49 +17,49 @@ class Migration(migrations.Migration):
             model_name='organization',
             name='execute_role',
             field=awx.main.fields.ImplicitRoleField(
-                null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AddField(
             model_name='organization',
             name='job_template_admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                editable=False, null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                editable=False, null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AddField(
             model_name='organization',
             name='credential_admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AddField(
             model_name='organization',
             name='inventory_admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AddField(
             model_name='organization',
             name='project_admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AddField(
             model_name='organization',
             name='workflow_admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AddField(
             model_name='organization',
             name='notification_admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AlterField(
@@ -67,7 +67,7 @@ class Migration(migrations.Migration):
             name='admin_role',
             field=awx.main.fields.ImplicitRoleField(
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['singleton:system_administrator', 'organization.credential_admin_role'],
                 related_name='+',
                 to='main.Role',
@@ -77,7 +77,7 @@ class Migration(migrations.Migration):
             model_name='inventory',
             name='admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='organization.inventory_admin_role', related_name='+', to='main.Role'
+                null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='organization.inventory_admin_role', related_name='+', to='main.Role'
             ),
         ),
         migrations.AlterField(
@@ -85,7 +85,7 @@ class Migration(migrations.Migration):
             name='admin_role',
             field=awx.main.fields.ImplicitRoleField(
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['organization.project_admin_role', 'singleton:system_administrator'],
                 related_name='+',
                 to='main.Role',
@@ -96,7 +96,7 @@ class Migration(migrations.Migration):
             name='admin_role',
             field=awx.main.fields.ImplicitRoleField(
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['singleton:system_administrator', 'organization.workflow_admin_role'],
                 related_name='+',
                 to='main.Role',
@@ -107,7 +107,7 @@ class Migration(migrations.Migration):
             name='execute_role',
             field=awx.main.fields.ImplicitRoleField(
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['admin_role', 'organization.execute_role'],
                 related_name='+',
                 to='main.Role',
@@ -119,7 +119,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['project.organization.job_template_admin_role', 'inventory.organization.job_template_admin_role'],
                 related_name='+',
                 to='main.Role',
@@ -130,7 +130,7 @@ class Migration(migrations.Migration):
             name='execute_role',
             field=awx.main.fields.ImplicitRoleField(
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['admin_role', 'project.organization.execute_role', 'inventory.organization.execute_role'],
                 related_name='+',
                 to='main.Role',
@@ -142,7 +142,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=[
                     'admin_role',
                     'execute_role',

--- a/awx/main/migrations/0042_v330_org_member_role_deparent.py
+++ b/awx/main/migrations/0042_v330_org_member_role_deparent.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             model_name='organization',
             name='member_role',
             field=awx.main.fields.ImplicitRoleField(
-                editable=False, null='True', on_delete=django.db.models.deletion.CASCADE, parent_role=['admin_role'], related_name='+', to='main.Role'
+                editable=False, null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role=['admin_role'], related_name='+', to='main.Role'
             ),
         ),
         migrations.AlterField(
@@ -27,7 +27,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=[
                     'member_role',
                     'auditor_role',

--- a/awx/main/migrations/0086_v360_workflow_approval.py
+++ b/awx/main/migrations/0086_v360_workflow_approval.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
             model_name='organization',
             name='approval_role',
             field=awx.main.fields.ImplicitRoleField(
-                editable=False, null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                editable=False, null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
             preserve_default='True',
         ),
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['organization.approval_role', 'admin_role'],
                 related_name='+',
                 to='main.Role',
@@ -116,7 +116,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=[
                     'member_role',
                     'auditor_role',
@@ -139,7 +139,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['singleton:system_auditor', 'organization.auditor_role', 'execute_role', 'admin_role', 'approval_role'],
                 related_name='+',
                 to='main.Role',

--- a/awx/main/migrations/0109_v370_job_template_organization_field.py
+++ b/awx/main/migrations/0109_v370_job_template_organization_field.py
@@ -80,7 +80,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['organization.job_template_admin_role'],
                 related_name='+',
                 to='main.Role',
@@ -92,7 +92,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['admin_role', 'organization.execute_role'],
                 related_name='+',
                 to='main.Role',
@@ -104,7 +104,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['organization.auditor_role', 'inventory.organization.auditor_role', 'execute_role', 'admin_role'],
                 related_name='+',
                 to='main.Role',

--- a/awx/main/migrations/0125_more_ee_modeling_changes.py
+++ b/awx/main/migrations/0125_more_ee_modeling_changes.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
             model_name='organization',
             name='execution_environment_admin_role',
             field=awx.main.fields.ImplicitRoleField(
-                editable=False, null='True', on_delete=django.db.models.deletion.CASCADE, parent_role='admin_role', related_name='+', to='main.Role'
+                editable=False, null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role='admin_role', related_name='+', to='main.Role'
             ),
             preserve_default='True',
         ),

--- a/awx/main/migrations/0128_organiaztion_read_roles_ee_admin.py
+++ b/awx/main/migrations/0128_organiaztion_read_roles_ee_admin.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=[
                     'member_role',
                     'auditor_role',

--- a/awx/main/migrations/0177_instance_group_role_addition.py
+++ b/awx/main/migrations/0177_instance_group_role_addition.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['singleton:system_administrator'],
                 related_name='+',
                 to='main.role',
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
             field=awx.main.fields.ImplicitRoleField(
                 editable=False,
                 null='True',
-                on_delete=django.db.models.deletion.CASCADE,
+                on_delete=django.db.models.deletion.SET_NULL,
                 parent_role=['singleton:system_auditor', 'use_role', 'admin_role'],
                 related_name='+',
                 to='main.role',
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
             model_name='instancegroup',
             name='use_role',
             field=awx.main.fields.ImplicitRoleField(
-                editable=False, null='True', on_delete=django.db.models.deletion.CASCADE, parent_role=['admin_role'], related_name='+', to='main.role'
+                editable=False, null='True', on_delete=django.db.models.deletion.SET_NULL, parent_role=['admin_role'], related_name='+', to='main.role'
             ),
             preserve_default='True',
         ),


### PR DESCRIPTION
##### SUMMARY
This will mitigate the problem where if any Role gets deleted for some weird reason it could previously cascade delete important objects.


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
