### PR TITLE
create receptor group if missing

### DIFF
--- a/awx/api/templates/instance_install_bundle/install_receptor.yml
+++ b/awx/api/templates/instance_install_bundle/install_receptor.yml
@@ -2,6 +2,12 @@
 - hosts: all
   become: yes
   tasks:
+    - name: Create the receptor group
+      group:
+{% verbatim %}
+        name: "{{ receptor_group }}"
+{% endverbatim %}
+        state: present
     - name: Create the receptor user
       user:
 {% verbatim %}


### PR DESCRIPTION
##### SUMMARY
Create receptor group if missing


##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- API

##### AWX VERSION
```
23.9.0
```


##### ADDITIONAL INFORMATION
It seems the receptor podman task fails if the group does not exist for AlmaLinux 9 as the group is not created.

```
TASK [ansible.receptor.podman : Create directory for podman runtime config] ***********************************************************************************************************************************************************************************************
fatal: [node01]: FAILED! => {"changed": false, "gid": 0, "group": "root", "mode": "0750", "msg": "chgrp failed: failed to look up group awx", "owner": "awx", "path": "/home/awx/.config", "secontext": "unconfined_u:object_r:config_home_t:s0", "size": 6, "state": "directory", "uid": 1001}
```
