### PR TITLE
Use public methods to reference registered models

### DIFF
--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -290,7 +290,7 @@ def setup_managed_role_definitions(apps, schema_editor):
     managed_role_definitions = []
 
     org_perms = set()
-    for cls in permission_registry._registry:
+    for cls in permission_registry.all_registered_models:
         ct = ContentType.objects.get_for_model(cls)
         object_perms = set(Permission.objects.filter(content_type=ct))
         # Special case for InstanceGroup which has an organiation field, but is not an organization child object


### PR DESCRIPTION
##### SUMMARY
In https://github.com/ansible/django-ansible-base/pull/475 I found need to change the structure of `_registry` in the permission registry... which fails the AWX downstream checks because it uses that. So I guess this is why we have public / private methods.

This code was coppied over from DAB at some time, so that kind of explains how this reference seeped in. This is a really simple (easy) change, just change from referencing the internal variable to the public property that gives all the models.

The purpose is to unblock that DAB change.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

