### PR TITLE
Check for admin_role in role_check.py

### DIFF
--- a/tools/scripts/ig-hotfix/scenarios/test3.py
+++ b/tools/scripts/ig-hotfix/scenarios/test3.py
@@ -21,7 +21,9 @@ with connection.cursor() as cursor:
     cursor.execute("UPDATE main_instancegroup SET use_role_id = NULL WHERE name = 'red'")
     cursor.execute(f"UPDATE main_instancegroup SET use_role_id = {green.use_role_id} WHERE name = 'yellow'")
 
-    cursor.execute("ALTER TABLE main_instancegroup ADD CONSTRAINT main_instancegroup_use_role_id_48ea7ecc_fk_main_rbac_roles_id FOREIGN KEY (use_role_id) REFERENCES public.main_rbac_roles(id) DEFERRABLE INITIALLY DEFERRED NOT VALID")
+    cursor.execute(
+        "ALTER TABLE main_instancegroup ADD CONSTRAINT main_instancegroup_use_role_id_48ea7ecc_fk_main_rbac_roles_id FOREIGN KEY (use_role_id) REFERENCES public.main_rbac_roles(id) DEFERRABLE INITIALLY DEFERRED NOT VALID"
+    )
 
 print("=====================================")
 for ig in InstanceGroup.objects.all():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Script was falsely identifying cross-linked parents. It needs to check if parent role is content type Team and role_field is member_role OR admin_role.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

