### PR TITLE
Fix object-level permission bugs with DAB RBAC system

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2649,7 +2649,7 @@ class NotificationTemplateAccess(BaseAccess):
 
     @check_superuser
     def can_change(self, obj, data):
-        return self.user.has_obj_perm(obj, 'change')
+        return self.user.has_obj_perm(obj, 'change') and self.check_related('organization', Organization, data, obj=obj, role_field='notification_admin_role')
 
     def can_admin(self, obj, data):
         return self.can_change(obj, data)

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -598,7 +598,7 @@ class InstanceGroupAccess(BaseAccess):
        - a superuser
        - admin role on the Instance group
     I can add/delete Instance Groups:
-       - a superuser(system administrator)
+       - a superuser(system administrator), because these are not org-scoped
     I can use Instance Groups when I have:
        - use_role on the instance group
     """
@@ -627,7 +627,7 @@ class InstanceGroupAccess(BaseAccess):
     def can_delete(self, obj):
         if obj.name in [settings.DEFAULT_EXECUTION_QUEUE_NAME, settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME]:
             return False
-        return self.user.is_superuser
+        return self.user.has_obj_perm(obj, 'delete')
 
 
 class UserAccess(BaseAccess):
@@ -2628,7 +2628,7 @@ class ScheduleAccess(UnifiedCredentialsMixin, BaseAccess):
 
 class NotificationTemplateAccess(BaseAccess):
     """
-    I can see/use a notification_template if I have permission to
+    Run standard logic from DAB RBAC
     """
 
     model = NotificationTemplate
@@ -2649,10 +2649,7 @@ class NotificationTemplateAccess(BaseAccess):
 
     @check_superuser
     def can_change(self, obj, data):
-        if obj.organization is None:
-            # only superusers are allowed to edit orphan notification templates
-            return False
-        return self.check_related('organization', Organization, data, obj=obj, role_field='notification_admin_role', mandatory=True)
+        return self.user.has_obj_perm(obj, 'change')
 
     def can_admin(self, obj, data):
         return self.can_change(obj, data)
@@ -2662,9 +2659,7 @@ class NotificationTemplateAccess(BaseAccess):
 
     @check_superuser
     def can_start(self, obj, validate_license=True):
-        if obj.organization is None:
-            return False
-        return self.user in obj.organization.notification_admin_role
+        return self.can_change(obj, None)
 
 
 class NotificationAccess(BaseAccess):

--- a/awx/main/tests/functional/api/test_instance_group.py
+++ b/awx/main/tests/functional/api/test_instance_group.py
@@ -33,13 +33,6 @@ def node_type_instance():
 
 
 @pytest.fixture
-def instance_group(job_factory):
-    ig = InstanceGroup(name="east")
-    ig.save()
-    return ig
-
-
-@pytest.fixture
 def containerized_instance_group(instance_group, kube_credential):
     ig = InstanceGroup(name="container")
     ig.credential = kube_credential

--- a/awx/main/tests/functional/conftest.py
+++ b/awx/main/tests/functional/conftest.py
@@ -20,7 +20,7 @@ from awx.main.migrations._dab_rbac import setup_managed_role_definitions
 
 # AWX
 from awx.main.models.projects import Project
-from awx.main.models.ha import Instance
+from awx.main.models.ha import Instance, InstanceGroup
 
 from rest_framework.test import (
     APIRequestFactory,
@@ -728,6 +728,11 @@ def jt_linked(organization, project, inventory, machine_credential, credential, 
     jt = JobTemplate.objects.create(project=project, inventory=inventory, playbook='helloworld.yml', organization=organization)
     jt.credentials.add(machine_credential, vault_credential, credential, net_credential)
     return jt
+
+
+@pytest.fixture
+def instance_group():
+    return InstanceGroup.objects.create(name="east")
 
 
 @pytest.fixture

--- a/awx/main/tests/functional/dab_rbac/test_access_regressions.py
+++ b/awx/main/tests/functional/dab_rbac/test_access_regressions.py
@@ -7,6 +7,7 @@ from ansible_base.rbac.models import RoleDefinition
 
 @pytest.mark.django_db
 def test_instance_group_object_role_delete(rando, instance_group, setup_managed_roles):
+    """Basic functionality of IG object-level admin role function AAP-25506"""
     rd = RoleDefinition.objects.get(name='InstanceGroup Admin')
     rd.give_permission(rando, instance_group)
     access = InstanceGroupAccess(rando)
@@ -15,6 +16,7 @@ def test_instance_group_object_role_delete(rando, instance_group, setup_managed_
 
 @pytest.mark.django_db
 def test_notification_template_object_role_change(rando, notification_template, setup_managed_roles):
+    """Basic functionality of NT object-level admin role function AAP-25493"""
     rd = RoleDefinition.objects.get(name='NotificationTemplate Admin')
     rd.give_permission(rando, notification_template)
     access = NotificationTemplateAccess(rando)

--- a/awx/main/tests/functional/dab_rbac/test_access_regressions.py
+++ b/awx/main/tests/functional/dab_rbac/test_access_regressions.py
@@ -1,0 +1,21 @@
+import pytest
+
+from awx.main.access import InstanceGroupAccess, NotificationTemplateAccess
+
+from ansible_base.rbac.models import RoleDefinition
+
+
+@pytest.mark.django_db
+def test_instance_group_object_role_delete(rando, instance_group, setup_managed_roles):
+    rd = RoleDefinition.objects.get(name='InstanceGroup Admin')
+    rd.give_permission(rando, instance_group)
+    access = InstanceGroupAccess(rando)
+    assert access.can_delete(instance_group)
+
+
+@pytest.mark.django_db
+def test_notification_template_object_role_change(rando, notification_template, setup_managed_roles):
+    rd = RoleDefinition.objects.get(name='NotificationTemplate Admin')
+    rd.give_permission(rando, notification_template)
+    access = NotificationTemplateAccess(rando)
+    assert access.can_change(notification_template, {'name': 'new name'})

--- a/awx/main/tests/functional/test_rbac_notifications.py
+++ b/awx/main/tests/functional/test_rbac_notifications.py
@@ -99,7 +99,9 @@ def test_notification_template_access_org_user(notification_template, user):
 @pytest.mark.django_db
 def test_notificaiton_template_orphan_access_org_admin(notification_template, organization, org_admin):
     notification_template.organization = None
+    notification_template.save(update_fields=['organization'])
     access = NotificationTemplateAccess(org_admin)
+    assert not org_admin.has_obj_perm(notification_template, 'change')
     assert not access.can_change(notification_template, {'organization': organization.id})
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes API bugs when permissions are assigned through the DAB RBAC API

AAP-25493

AAP-25506

Ping @PabloHiro 

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


##### ADDITIONAL INFORMATION
I'm separating these from other fixes, as this is a really specific category of bug, and the easiest to fix, by far. This is just simple logic that needed to be updated in the "access" python logic to work with either system. No migration or data integrity issues are involved, evaluations were just giving the wrong answer in cases.

These wrong answers were almost exclusively due to "new" role content, where the NotificationTemplate object-level role assignments were not possible before, as an example. So it's not surprising that the old logic isn't compatible and I just never looked at it.
