### PR TITLE
fix ActivityStream button at details page

### DIFF
--- a/awx/ui/src/components/ScreenHeader/ScreenHeader.js
+++ b/awx/ui/src/components/ScreenHeader/ScreenHeader.js
@@ -15,7 +15,7 @@ import {
 import { HistoryIcon } from '@patternfly/react-icons';
 import { Link, Route, useRouteMatch, useLocation } from 'react-router-dom';
 
-const ScreenHeader = ({ breadcrumbConfig, streamType }) => {
+const ScreenHeader = ({ breadcrumbConfig, activityStream = {} }) => {
   const { light } = PageSectionVariants;
   const oneCrumbMatch = useRouteMatch({
     path: Object.keys(breadcrumbConfig)[0],
@@ -32,6 +32,15 @@ const ScreenHeader = ({ breadcrumbConfig, streamType }) => {
   useTitle(pathTitle);
 
   const isOnlyOneCrumb = oneCrumbMatch && oneCrumbMatch.isExact;
+
+  const { streamType, streamId } = activityStream;
+  let streamUrlParams = '';
+  if (streamType !== '') {
+    streamUrlParams += `?type=${streamType}`;
+    if (Number.isInteger(streamId)) {
+      streamUrlParams += `&${streamType}__id=${streamId}`;
+    }
+  }
 
   return (
     <PageSection variant={light}>
@@ -68,9 +77,7 @@ const ScreenHeader = ({ breadcrumbConfig, streamType }) => {
                 aria-label={t`View activity stream`}
                 variant="plain"
                 component={Link}
-                to={`/activity_stream${
-                  streamType ? `?type=${streamType}` : ''
-                }`}
+                to={`/activity_stream${streamUrlParams}`}
               >
                 <HistoryIcon />
               </Button>

--- a/awx/ui/src/components/ScreenHeader/ScreenHeader.test.js
+++ b/awx/ui/src/components/ScreenHeader/ScreenHeader.test.js
@@ -27,7 +27,10 @@ describe('<ScreenHeader />', () => {
   test('initially renders successfully', () => {
     breadcrumbWrapper = mountWithContexts(
       <MemoryRouter initialEntries={['/foo/1/bar']} initialIndex={0}>
-        <ScreenHeader streamType="all_activity" breadcrumbConfig={config} />
+        <ScreenHeader
+          activityStream={{ streamType: 'all_activity' }}
+          breadcrumbConfig={config}
+        />
       </MemoryRouter>
     );
 
@@ -54,7 +57,10 @@ describe('<ScreenHeader />', () => {
     routes.forEach(([location, crumbLength]) => {
       breadcrumbWrapper = mountWithContexts(
         <MemoryRouter initialEntries={[location]}>
-          <ScreenHeader streamType="all_activity" breadcrumbConfig={config} />
+          <ScreenHeader
+            activityStream={{ streamType: 'all_activity' }}
+            breadcrumbConfig={config}
+          />
         </MemoryRouter>
       );
 

--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -54,12 +54,21 @@ function ActivityStream() {
     };
   }
 
+  let activityStreamId = {};
+  if (activityStreamType !== 'all') {
+    const streamIdKey = `${activityStreamType}__id`;
+    if (urlParams.get(streamIdKey)) {
+      activityStreamId = { [streamIdKey]: urlParams.get(streamIdKey) };
+    }
+  }
+
   const QS_CONFIG = getQSConfig(
     'activity_stream',
     {
       page: 1,
       page_size: 20,
       order_by: '-timestamp',
+      ...activityStreamId,
     },
     ['id', 'page', 'page_size']
   );

--- a/awx/ui/src/screens/Application/Application/Application.js
+++ b/awx/ui/src/screens/Application/Application/Application.js
@@ -20,7 +20,7 @@ import ApplicationEdit from '../ApplicationEdit';
 import ApplicationDetails from '../ApplicationDetails';
 import ApplicationTokens from '../ApplicationTokens';
 
-function Application({ setBreadcrumb }) {
+function Application({ setBreadcrumb, buildActivityStream }) {
   const { id } = useParams();
   const { pathname } = useLocation();
   const {
@@ -50,6 +50,7 @@ function Application({ setBreadcrumb }) {
         })
       );
       setBreadcrumb(detail.data);
+      buildActivityStream(detail.data);
 
       return {
         application: detail.data,

--- a/awx/ui/src/screens/Application/Applications.js
+++ b/awx/ui/src/screens/Application/Applications.js
@@ -41,10 +41,24 @@ function Applications() {
     });
   }, []);
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'o_auth2_application,o_auth2_access_token',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item &&
+        setActivityStream({
+          streamId: item.id,
+          streamType: item.type,
+        });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="o_auth2_application,o_auth2_access_token"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -54,7 +68,10 @@ function Applications() {
           />
         </Route>
         <Route path="/applications/:id">
-          <Application setBreadcrumb={buildBreadcrumbConfig} />
+          <Application
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/applications">
           <PersistentFilters pageKey="applications">

--- a/awx/ui/src/screens/Credential/Credential.js
+++ b/awx/ui/src/screens/Credential/Credential.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useRef, useCallback, useEffect } from 'react';
 import { t } from '@lingui/macro';
 
 import { CaretLeftIcon } from '@patternfly/react-icons';
@@ -37,7 +37,7 @@ const unacceptableCredentialTypes = [
   'scm',
 ];
 
-function Credential({ setBreadcrumb }) {
+function Credential({ setBreadcrumb, buildActivityStream }) {
   const { pathname } = useLocation();
 
   const match = useRouteMatch({
@@ -71,6 +71,14 @@ function Credential({ setBreadcrumb }) {
       setBreadcrumb(credential);
     }
   }, [credential, setBreadcrumb]);
+
+  const callback = useRef();
+  callback.current = buildActivityStream;
+  useEffect(() => {
+    if (credential) {
+      callback.current(credential);
+    }
+  }, [credential, callback]);
 
   const tabsArray = [
     {

--- a/awx/ui/src/screens/Credential/Credential.test.js
+++ b/awx/ui/src/screens/Credential/Credential.test.js
@@ -33,7 +33,9 @@ describe('<Credential />', () => {
       data: mockMachineCredential,
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Credential setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <Credential setBreadcrumb={() => {}} buildActivityStream={() => {}} />
+      );
     });
     wrapper.update();
     expect(wrapper.find('Credential').length).toBe(1);
@@ -45,7 +47,9 @@ describe('<Credential />', () => {
       data: mockSCMCredential,
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Credential setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <Credential setBreadcrumb={() => {}} buildActivityStream={() => {}} />
+      );
     });
     wrapper.update();
     expect(wrapper.find('Credential').length).toBe(1);
@@ -60,7 +64,9 @@ describe('<Credential />', () => {
       'Job Templates',
     ];
     await act(async () => {
-      wrapper = mountWithContexts(<Credential setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <Credential setBreadcrumb={() => {}} buildActivityStream={() => {}} />
+      );
     });
     wrapper.find('RoutedTabs li').forEach((tab, index) => {
       expect(tab.text()).toEqual(expectedTabs[index]);
@@ -73,7 +79,9 @@ describe('<Credential />', () => {
     });
     const expectedTabs = ['Back to Credentials', 'Details', 'Access'];
     await act(async () => {
-      wrapper = mountWithContexts(<Credential setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <Credential setBreadcrumb={() => {}} buildActivityStream={() => {}} />
+      );
     });
     wrapper.find('RoutedTabs li').forEach((tab, index) => {
       expect(tab.text()).toEqual(expectedTabs[index]);
@@ -85,21 +93,24 @@ describe('<Credential />', () => {
       initialEntries: ['/credentials/2/foobar'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Credential setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-            route: {
-              location: history.location,
-              match: {
-                params: { id: 1 },
-                url: '/credentials/2/foobar',
-                path: '/credentials/2/foobar',
+      wrapper = mountWithContexts(
+        <Credential setBreadcrumb={() => {}} buildActivityStream={() => {}} />,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: history.location,
+                match: {
+                  params: { id: 1 },
+                  url: '/credentials/2/foobar',
+                  path: '/credentials/2/foobar',
+                },
               },
             },
           },
-        },
-      });
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });

--- a/awx/ui/src/screens/Credential/Credentials.js
+++ b/awx/ui/src/screens/Credential/Credentials.js
@@ -31,10 +31,20 @@ function Credentials() {
     });
   }, []);
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'credential',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="credential"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -42,7 +52,10 @@ function Credentials() {
           <Config>{({ me }) => <CredentialAdd me={me || {}} />}</Config>
         </Route>
         <Route path="/credentials/:id">
-          <Credential setBreadcrumb={buildBreadcrumbConfig} />
+          <Credential
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/credentials">
           <PersistentFilters pageKey="credentials">

--- a/awx/ui/src/screens/Credential/Credentials.test.js
+++ b/awx/ui/src/screens/Credential/Credentials.test.js
@@ -7,7 +7,7 @@ describe('<Credentials />', () => {
     const wrapper = shallow(<Credentials />);
 
     const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toEqual('credential');
+    expect(header.prop('activityStream')['streamType']).toEqual('credential');
     expect(header.prop('breadcrumbConfig')).toEqual({
       '/credentials': 'Credentials',
       '/credentials/add': 'Create New Credential',

--- a/awx/ui/src/screens/CredentialType/CredentialType.js
+++ b/awx/ui/src/screens/CredentialType/CredentialType.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import {
   Link,
   Redirect,
@@ -21,7 +21,7 @@ import ContentLoading from 'components/ContentLoading';
 import CredentialTypeDetails from './CredentialTypeDetails';
 import CredentialTypeEdit from './CredentialTypeEdit';
 
-function CredentialType({ setBreadcrumb }) {
+function CredentialType({ setBreadcrumb, buildActivityStream }) {
   const { id } = useParams();
   const { pathname } = useLocation();
 
@@ -46,6 +46,14 @@ function CredentialType({ setBreadcrumb }) {
       setBreadcrumb(credentialType);
     }
   }, [credentialType, setBreadcrumb]);
+
+  const callback = useRef();
+  callback.current = buildActivityStream;
+  useEffect(() => {
+    if (credentialType) {
+      callback.current(credentialType);
+    }
+  }, [credentialType, callback]);
 
   const tabsArray = [
     {

--- a/awx/ui/src/screens/CredentialType/CredentialTypes.js
+++ b/awx/ui/src/screens/CredentialType/CredentialTypes.js
@@ -26,10 +26,21 @@ function CredentialTypes() {
       [`/credential_types/${credentialTypes.id}/details`]: t`Details`,
     });
   }, []);
+
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'credential_type',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="credential_type"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -37,7 +48,10 @@ function CredentialTypes() {
           <CredentialTypeAdd />
         </Route>
         <Route path="/credential_types/:id">
-          <CredentialType setBreadcrumb={buildBreadcrumbConfig} />
+          <CredentialType
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/credential_types">
           <PersistentFilters pageKey="credentialTypes">

--- a/awx/ui/src/screens/Dashboard/Dashboard.js
+++ b/awx/ui/src/screens/Dashboard/Dashboard.js
@@ -86,7 +86,7 @@ function Dashboard() {
         </Banner>
       )}
       <ScreenHeader
-        streamType="all"
+        activityStream={{ streamType: 'all' }}
         breadcrumbConfig={{ '/home': t`Dashboard` }}
       />
       <PageSection>

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironment.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironment.js
@@ -22,7 +22,7 @@ import ExecutionEnvironmentDetails from './ExecutionEnvironmentDetails';
 import ExecutionEnvironmentEdit from './ExecutionEnvironmentEdit';
 import ExecutionEnvironmentTemplateList from './ExecutionEnvironmentTemplate';
 
-function ExecutionEnvironment({ setBreadcrumb }) {
+function ExecutionEnvironment({ setBreadcrumb, buildActivityStream }) {
   const { id } = useParams();
   const { pathname } = useLocation();
 
@@ -34,6 +34,7 @@ function ExecutionEnvironment({ setBreadcrumb }) {
   } = useRequest(
     useCallback(async () => {
       const { data } = await ExecutionEnvironmentsAPI.readDetail(id);
+      buildActivityStream(data);
       return data;
     }, [id]),
     null

--- a/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironments.js
+++ b/awx/ui/src/screens/ExecutionEnvironment/ExecutionEnvironments.js
@@ -26,10 +26,22 @@ function ExecutionEnvironments() {
       [`/execution_environments/${executionEnvironments.id}/details`]: t`Details`,
     });
   }, []);
+
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'execution_environment',
+  });
+
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="execution_environment"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -37,7 +49,10 @@ function ExecutionEnvironments() {
           <ExecutionEnvironmentAdd />
         </Route>
         <Route path="/execution_environments/:id">
-          <ExecutionEnvironment setBreadcrumb={buildBreadcrumbConfig} />
+          <ExecutionEnvironment
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/execution_environments">
           <PersistentFilters pageKey="executionEnvironments">

--- a/awx/ui/src/screens/Host/Host.js
+++ b/awx/ui/src/screens/Host/Host.js
@@ -22,7 +22,7 @@ import HostDetail from './HostDetail';
 import HostEdit from './HostEdit';
 import HostGroups from './HostGroups';
 
-function Host({ setBreadcrumb }) {
+function Host({ setBreadcrumb, buildActivityStream }) {
   const location = useLocation();
   const match = useRouteMatch('/hosts/:id');
   const {
@@ -34,6 +34,7 @@ function Host({ setBreadcrumb }) {
     useCallback(async () => {
       const { data } = await HostsAPI.readDetail(match.params.id);
       setBreadcrumb(data);
+      buildActivityStream(data);
       return data;
     }, [match.params.id, setBreadcrumb])
   );

--- a/awx/ui/src/screens/Host/Hosts.js
+++ b/awx/ui/src/screens/Host/Hosts.js
@@ -31,9 +31,20 @@ function Hosts() {
     });
   }, []);
 
+  const [activityStream, setActivityStream] = useState({ streamType: 'host' });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
-      <ScreenHeader streamType="host" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={activityStream}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <Switch>
         <Route path="/hosts/add">
           <HostAdd />
@@ -41,7 +52,11 @@ function Hosts() {
         <Route path="/hosts/:id">
           <Config>
             {({ me }) => (
-              <Host setBreadcrumb={buildBreadcrumbConfig} me={me || {}} />
+              <Host
+                setBreadcrumb={buildBreadcrumbConfig}
+                me={me || {}}
+                buildActivityStream={buildActivityStream}
+              />
             )}
           </Config>
         </Route>

--- a/awx/ui/src/screens/Host/Hosts.test.js
+++ b/awx/ui/src/screens/Host/Hosts.test.js
@@ -14,7 +14,7 @@ describe('<Hosts />', () => {
     const wrapper = shallow(<Hosts />);
 
     const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toEqual('host');
+    expect(header.prop('activityStream')['streamType']).toEqual('host');
     expect(header.prop('breadcrumbConfig')).toEqual({
       '/hosts': 'Hosts',
       '/hosts/add': 'Create New Host',

--- a/awx/ui/src/screens/HostMetrics/HostMetrics.js
+++ b/awx/ui/src/screens/HostMetrics/HostMetrics.js
@@ -54,7 +54,10 @@ function HostMetrics() {
 
   return (
     <>
-      <ScreenHeader streamType="none" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={{ streamType: 'none' }}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <PageSection>
         <Card>
           <PaginatedTable

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroup.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 import {
   Link,
   Redirect,
@@ -23,7 +23,7 @@ import InstanceGroupDetails from './InstanceGroupDetails';
 import InstanceGroupEdit from './InstanceGroupEdit';
 import Instances from './Instances/Instances';
 
-function InstanceGroup({ setBreadcrumb }) {
+function InstanceGroup({ setBreadcrumb, buildActivityStream }) {
   const { id } = useParams();
   const { pathname } = useLocation();
 
@@ -52,6 +52,14 @@ function InstanceGroup({ setBreadcrumb }) {
       setBreadcrumb(instanceGroup);
     }
   }, [instanceGroup, setBreadcrumb]);
+
+  const callback = useRef();
+  callback.current = buildActivityStream;
+  useEffect(() => {
+    if (instanceGroup) {
+      callback.current(instanceGroup);
+    }
+  }, [instanceGroup, callback]);
 
   const tabsArray = [
     {

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.js
@@ -45,11 +45,20 @@ function InstanceGroups() {
   const streamType = pathname.includes('instances')
     ? 'instance'
     : 'instance_group';
+  const [activityStream, setActivityStream] = useState({
+    streamType: streamType,
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
 
   return (
     <>
       <ScreenHeader
-        streamType={streamType}
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -63,7 +72,10 @@ function InstanceGroups() {
           <InstanceGroupAdd />
         </Route>
         <Route path="/instance_groups/:id">
-          <InstanceGroup setBreadcrumb={buildBreadcrumbConfig} />
+          <InstanceGroup
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/instance_groups">
           <PersistentFilters pageKey="instanceGroups">

--- a/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
+++ b/awx/ui/src/screens/InstanceGroup/InstanceGroups.test.js
@@ -32,7 +32,9 @@ describe('<InstanceGroups/>', () => {
     const wrapper = shallow(<InstanceGroups />);
 
     const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toEqual('instance_group');
+    expect(header.prop('activityStream')['streamType']).toEqual(
+      'instance_group'
+    );
     expect(header.prop('breadcrumbConfig')).toEqual({
       '/instance_groups': 'Instance Groups',
       '/instance_groups/add': 'Create new instance group',
@@ -50,6 +52,8 @@ describe('<InstanceGroups/>', () => {
 
     const wrapper = shallow(<InstanceGroups />);
 
-    expect(wrapper.find('ScreenHeader').prop('streamType')).toEqual('instance');
+    expect(
+      wrapper.find('ScreenHeader').prop('activityStream')['streamType']
+    ).toEqual('instance');
   });
 });

--- a/awx/ui/src/screens/Instances/Instance.js
+++ b/awx/ui/src/screens/Instances/Instance.js
@@ -14,7 +14,7 @@ import InstanceDetail from './InstanceDetail';
 import InstancePeerList from './InstancePeers';
 import InstanceListenerAddressList from './InstanceListenerAddressList';
 
-function Instance({ setBreadcrumb }) {
+function Instance({ setBreadcrumb, buildActivityStream }) {
   const { me } = useConfig();
   const canReadSettings = me.is_superuser || me.is_system_auditor;
 
@@ -76,7 +76,11 @@ function Instance({ setBreadcrumb }) {
         <Switch>
           <Redirect from="/instances/:id" to="/instances/:id/details" exact />
           <Route path="/instances/:id/details" key="details">
-            <InstanceDetail isK8s={isK8s} setBreadcrumb={setBreadcrumb} />
+            <InstanceDetail
+              isK8s={isK8s}
+              setBreadcrumb={setBreadcrumb}
+              buildActivityStream={buildActivityStream}
+            />
           </Route>
           {isK8s && (
             <Route

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useRef, useCallback, useEffect, useState } from 'react';
 
 import { useHistory, useParams, Link } from 'react-router-dom';
 import { t, Plural } from '@lingui/macro';
@@ -62,7 +62,7 @@ function computeForks(memCapacity, cpuCapacity, selectedCapacityAdjustment) {
   );
 }
 
-function InstanceDetail({ setBreadcrumb, isK8s }) {
+function InstanceDetail({ setBreadcrumb, isK8s, buildActivityStream }) {
   const config = useConfig();
 
   const { id } = useParams();
@@ -116,6 +116,14 @@ function InstanceDetail({ setBreadcrumb, isK8s }) {
       setBreadcrumb(instance);
     }
   }, [instance, setBreadcrumb]);
+
+  const callback = useRef();
+  callback.current = buildActivityStream;
+  useEffect(() => {
+    if (instance) {
+      callback.current(instance);
+    }
+  }, [instance, callback]);
 
   const { error: healthCheckError, request: fetchHealthCheck } = useRequest(
     useCallback(async () => {

--- a/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.test.js
+++ b/awx/ui/src/screens/Instances/InstanceDetail/InstanceDetail.test.js
@@ -89,7 +89,12 @@ describe('<InstanceDetail/>', () => {
       me: { is_superuser: true },
     }));
     await act(async () => {
-      wrapper = mountWithContexts(<InstanceDetail setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <InstanceDetail
+          setBreadcrumb={() => {}}
+          buildActivityStream={() => {}}
+        />
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('InstanceDetail')).toHaveLength(1);
@@ -106,7 +111,12 @@ describe('<InstanceDetail/>', () => {
       me: { is_superuser: true },
     }));
     await act(async () => {
-      wrapper = mountWithContexts(<InstanceDetail setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <InstanceDetail
+          setBreadcrumb={() => {}}
+          buildActivityStream={() => {}}
+        />
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
 
@@ -147,7 +157,12 @@ describe('<InstanceDetail/>', () => {
       me: { is_system_auditor: true },
     }));
     await act(async () => {
-      wrapper = mountWithContexts(<InstanceDetail setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <InstanceDetail
+          setBreadcrumb={() => {}}
+          buildActivityStream={() => {}}
+        />
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
 
@@ -161,7 +176,12 @@ describe('<InstanceDetail/>', () => {
       me: { is_system_auditor: true },
     }));
     await act(async () => {
-      wrapper = mountWithContexts(<InstanceDetail setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <InstanceDetail
+          setBreadcrumb={() => {}}
+          buildActivityStream={() => {}}
+        />
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(wrapper.find('InstanceToggle').length).toBe(1);
@@ -184,7 +204,12 @@ describe('<InstanceDetail/>', () => {
       me: { is_superuser: true },
     }));
     await act(async () => {
-      wrapper = mountWithContexts(<InstanceDetail setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <InstanceDetail
+          setBreadcrumb={() => {}}
+          buildActivityStream={() => {}}
+        />
+      );
     });
     await waitForElement(wrapper, 'ContentLoading', (el) => el.length === 0);
     expect(

--- a/awx/ui/src/screens/Instances/Instances.js
+++ b/awx/ui/src/screens/Instances/Instances.js
@@ -30,9 +30,22 @@ function Instances() {
     });
   }, []);
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'instance',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
-      <ScreenHeader streamType="instance" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={activityStream}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <Switch>
         <Route path="/instances/add">
           <InstanceAdd setBreadcrumb={buildBreadcrumbConfig} />
@@ -41,7 +54,10 @@ function Instances() {
           <InstanceEdit setBreadcrumb={buildBreadcrumbConfig} />
         </Route>
         <Route path="/instances/:id">
-          <Instance setBreadcrumb={buildBreadcrumbConfig} />
+          <Instance
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/instances">
           <PersistentFilters pageKey="instances">

--- a/awx/ui/src/screens/Inventory/Inventories.js
+++ b/awx/ui/src/screens/Inventory/Inventories.js
@@ -97,10 +97,20 @@ function Inventories() {
     [inventory, nestedObject, schedule]
   );
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'inventory',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="inventory"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -116,7 +126,11 @@ function Inventories() {
         <Route path="/inventories/inventory/:id">
           <Config>
             {({ me }) => (
-              <Inventory setBreadcrumb={setBreadcrumbConfig} me={me || {}} />
+              <Inventory
+                setBreadcrumb={setBreadcrumbConfig}
+                me={me || {}}
+                buildActivityStream={buildActivityStream}
+              />
             )}
           </Config>
         </Route>

--- a/awx/ui/src/screens/Inventory/Inventory.js
+++ b/awx/ui/src/screens/Inventory/Inventory.js
@@ -25,7 +25,7 @@ import InventoryHosts from './InventoryHosts/InventoryHosts';
 import InventorySources from './InventorySources';
 import { getInventoryPath } from './shared/utils';
 
-function Inventory({ setBreadcrumb }) {
+function Inventory({ setBreadcrumb, buildActivityStream }) {
   const [contentError, setContentError] = useState(null);
   const [hasContentLoading, setHasContentLoading] = useState(true);
   const [inventory, setInventory] = useState(null);
@@ -39,6 +39,7 @@ function Inventory({ setBreadcrumb }) {
       try {
         const { data } = await InventoriesAPI.readDetail(match.params.id);
         setBreadcrumb(data);
+        buildActivityStream(data);
         setInventory(data);
       } catch (error) {
         setContentError(error);
@@ -48,7 +49,7 @@ function Inventory({ setBreadcrumb }) {
     }
 
     fetchData();
-  }, [match.params.id, location.pathname, setBreadcrumb]);
+  }, [match.params.id, location.pathname, setBreadcrumb, buildActivityStream]);
 
   const tabsArray = [
     {

--- a/awx/ui/src/screens/Inventory/Inventory.test.js
+++ b/awx/ui/src/screens/Inventory/Inventory.test.js
@@ -29,7 +29,9 @@ describe('<Inventory />', () => {
 
   test('initially renders successfully', async () => {
     await act(async () => {
-      wrapper = mountWithContexts(<Inventory setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <Inventory setBreadcrumb={() => {}} buildActivityStream={() => {}} />
+      );
     });
     wrapper.update();
     expect(wrapper.find('Inventory').length).toBe(1);
@@ -47,7 +49,9 @@ describe('<Inventory />', () => {
       'Job Templates',
     ];
     await act(async () => {
-      wrapper = mountWithContexts(<Inventory setBreadcrumb={() => {}} />);
+      wrapper = mountWithContexts(
+        <Inventory setBreadcrumb={() => {}} buildActivityStream={() => {}} />
+      );
     });
     wrapper.find('RoutedTabs li').forEach((tab, index) => {
       expect(tab.text()).toEqual(expectedTabs[index]);
@@ -59,21 +63,24 @@ describe('<Inventory />', () => {
       initialEntries: ['/inventories/inventory/1/foobar'],
     });
     await act(async () => {
-      wrapper = mountWithContexts(<Inventory setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-            route: {
-              location: history.location,
-              match: {
-                params: { id: 1 },
-                url: '/inventories/inventory/1/foobar',
-                path: '/inventories/inventory/1/foobar',
+      wrapper = mountWithContexts(
+        <Inventory setBreadcrumb={() => {}} buildActivityStream={() => {}} />,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: history.location,
+                match: {
+                  params: { id: 1 },
+                  url: '/inventories/inventory/1/foobar',
+                  path: '/inventories/inventory/1/foobar',
+                },
               },
             },
           },
-        },
-      });
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });

--- a/awx/ui/src/screens/Job/Jobs.js
+++ b/awx/ui/src/screens/Job/Jobs.js
@@ -38,7 +38,10 @@ function Jobs() {
 
   return (
     <>
-      <ScreenHeader streamType="job" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={{ streamType: 'job' }}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <Switch>
         <Route exact path={match.path}>
           <PageSection>

--- a/awx/ui/src/screens/ManagementJob/ManagementJobs.js
+++ b/awx/ui/src/screens/ManagementJob/ManagementJobs.js
@@ -30,7 +30,10 @@ function ManagementJobs() {
 
   return (
     <>
-      <ScreenHeader streamType="none" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={{ streamType: 'none' }}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <Switch>
         <Route path={`${basePath}/:id`}>
           <ManagementJob setBreadcrumb={buildBreadcrumbConfig} />

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplate.js
@@ -20,7 +20,7 @@ import ContentLoading from 'components/ContentLoading';
 import NotificationTemplateDetail from './NotificationTemplateDetail';
 import NotificationTemplateEdit from './NotificationTemplateEdit';
 
-function NotificationTemplate({ setBreadcrumb }) {
+function NotificationTemplate({ setBreadcrumb, buildActivityStream }) {
   const { id: templateId } = useParams();
   const match = useRouteMatch();
   const location = useLocation();
@@ -36,11 +36,12 @@ function NotificationTemplate({ setBreadcrumb }) {
         NotificationTemplatesAPI.readOptions(),
       ]);
       setBreadcrumb(detail.data);
+      buildActivityStream(detail.data);
       return {
         template: detail.data,
         defaultMessages: options.data.actions?.POST?.messages,
       };
-    }, [templateId, setBreadcrumb]),
+    }, [templateId, setBreadcrumb, buildActivityStream]),
     { template: null, defaultMessages: null }
   );
 

--- a/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
+++ b/awx/ui/src/screens/NotificationTemplate/NotificationTemplates.js
@@ -26,10 +26,20 @@ function NotificationTemplates() {
     });
   }, []);
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'notification_template',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="notification_template"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -37,7 +47,10 @@ function NotificationTemplates() {
           <NotificationTemplateAdd />
         </Route>
         <Route path={`${match.url}/:id`}>
-          <NotificationTemplate setBreadcrumb={updateBreadcrumbConfig} />
+          <NotificationTemplate
+            setBreadcrumb={updateBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path={`${match.url}`}>
           <PersistentFilters pageKey="notificationTemplates">

--- a/awx/ui/src/screens/Organization/Organization.js
+++ b/awx/ui/src/screens/Organization/Organization.js
@@ -23,7 +23,7 @@ import OrganizationEdit from './OrganizationEdit';
 import OrganizationTeams from './OrganizationTeams';
 import OrganizationExecEnvList from './OrganizationExecEnvList';
 
-function Organization({ setBreadcrumb, me }) {
+function Organization({ setBreadcrumb, me, buildActivityStream }) {
   const location = useLocation();
   const { id: organizationId } = useParams();
   const match = useRouteMatch();
@@ -42,11 +42,12 @@ function Organization({ setBreadcrumb, me }) {
       ]);
       data.galaxy_credentials = credentialsRes.data.results;
       setBreadcrumb(data);
+      buildActivityStream(data);
 
       return {
         organization: data,
       };
-    }, [setBreadcrumb, organizationId]),
+    }, [setBreadcrumb, organizationId, buildActivityStream]),
     {
       organization: null,
     }

--- a/awx/ui/src/screens/Organization/Organization.test.js
+++ b/awx/ui/src/screens/Organization/Organization.test.js
@@ -54,14 +54,24 @@ describe('<Organization />', () => {
 
   test('initially renders successfully', async () => {
     await act(async () => {
-      mountWithContexts(<Organization setBreadcrumb={() => {}} me={mockMe} />);
+      mountWithContexts(
+        <Organization
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
+      );
     });
   });
 
   test('notifications tab shown for admins', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <Organization setBreadcrumb={() => {}} me={mockMe} />
+        <Organization
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
 
@@ -83,7 +93,11 @@ describe('<Organization />', () => {
 
     await act(async () => {
       wrapper = mountWithContexts(
-        <Organization setBreadcrumb={() => {}} me={mockMe} />
+        <Organization
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
 
@@ -101,7 +115,11 @@ describe('<Organization />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Organization setBreadcrumb={() => {}} me={mockMe} />,
+        <Organization
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {

--- a/awx/ui/src/screens/Organization/Organizations.js
+++ b/awx/ui/src/screens/Organization/Organizations.js
@@ -36,10 +36,20 @@ function Organizations() {
     setBreadcrumbConfig(breadcrumb);
   }, []);
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'organization',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="organization"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -49,7 +59,11 @@ function Organizations() {
         <Route path={`${match.path}/:id`}>
           <Config>
             {({ me }) => (
-              <Organization setBreadcrumb={setBreadcrumb} me={me || {}} />
+              <Organization
+                setBreadcrumb={setBreadcrumb}
+                me={me || {}}
+                buildActivityStream={buildActivityStream}
+              />
             )}
           </Config>
         </Route>

--- a/awx/ui/src/screens/Project/Project.js
+++ b/awx/ui/src/screens/Project/Project.js
@@ -24,7 +24,7 @@ import { OrganizationsAPI, ProjectsAPI } from 'api';
 import ProjectDetail from './ProjectDetail';
 import ProjectEdit from './ProjectEdit';
 
-function Project({ setBreadcrumb }) {
+function Project({ setBreadcrumb, buildActivityStream }) {
   const { me = {} } = useConfig();
   const { id } = useParams();
   const location = useLocation();
@@ -56,11 +56,12 @@ function Project({ setBreadcrumb }) {
 
         data.summary_fields.credentials = results;
       }
+      buildActivityStream(data);
       return {
         project: data,
         isNotifAdmin: notifAdminRes.data.results.length > 0,
       };
-    }, [id]),
+    }, [id, buildActivityStream]),
     {
       project: null,
       notifAdminRes: null,

--- a/awx/ui/src/screens/Project/Project.test.js
+++ b/awx/ui/src/screens/Project/Project.test.js
@@ -48,14 +48,24 @@ describe('<Project />', () => {
 
   test('initially renders successfully', async () => {
     await act(async () => {
-      mountWithContexts(<Project setBreadcrumb={() => {}} me={mockMe} />);
+      mountWithContexts(
+        <Project
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
+      );
     });
   });
 
   test('notifications tab shown for admins', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
+        <Project
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     const tabs = await waitForElement(
@@ -75,7 +85,11 @@ describe('<Project />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
+        <Project
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     const tabs = await waitForElement(
@@ -96,7 +110,11 @@ describe('<Project />', () => {
 
     await act(async () => {
       wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
+        <Project
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     const tabs = await waitForElement(
@@ -119,7 +137,11 @@ describe('<Project />', () => {
 
     await act(async () => {
       wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />
+        <Project
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     const tabs = await waitForElement(
@@ -136,7 +158,11 @@ describe('<Project />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Project setBreadcrumb={() => {}} me={mockMe} />,
+        <Project
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {

--- a/awx/ui/src/screens/Project/Projects.js
+++ b/awx/ui/src/screens/Project/Projects.js
@@ -36,15 +36,32 @@ function Projects() {
     });
   }, []);
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'project',
+  });
+
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
-      <ScreenHeader streamType="project" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        breadcrumbConfig={breadcrumbConfig}
+        activityStream={activityStream}
+      />
       <Switch>
         <Route path="/projects/add">
           <ProjectAdd />
         </Route>
         <Route path="/projects/:id">
-          <Project setBreadcrumb={buildBreadcrumbConfig} />
+          <Project
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/projects">
           <PersistentFilters pageKey="projects">

--- a/awx/ui/src/screens/Project/Projects.test.js
+++ b/awx/ui/src/screens/Project/Projects.test.js
@@ -7,7 +7,7 @@ describe('<Projects />', () => {
     const wrapper = shallow(<Projects />);
 
     const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toBe('project');
+    expect(header.prop('activityStream')['streamType']).toBe('project');
     expect(header.prop('breadcrumbConfig')).toEqual({
       '/projects': 'Projects',
       '/projects/add': 'Create New Project',

--- a/awx/ui/src/screens/Schedule/AllSchedules.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.js
@@ -16,7 +16,7 @@ function AllSchedules() {
   return (
     <>
       <ScreenHeader
-        streamType="schedule"
+        activityStream={{ streamType: 'schedule' }}
         breadcrumbConfig={{
           '/schedules': t`Schedules`,
         }}

--- a/awx/ui/src/screens/Schedule/AllSchedules.test.js
+++ b/awx/ui/src/screens/Schedule/AllSchedules.test.js
@@ -7,7 +7,7 @@ describe('<AllSchedules />', () => {
     const wrapper = shallow(<AllSchedules />);
 
     const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toEqual('schedule');
+    expect(header.prop('activityStream')['streamType']).toEqual('schedule');
     expect(header.prop('breadcrumbConfig')).toEqual({
       '/schedules': 'Schedules',
     });

--- a/awx/ui/src/screens/Setting/Settings.js
+++ b/awx/ui/src/screens/Setting/Settings.js
@@ -150,7 +150,10 @@ function Settings() {
 
   return (
     <SettingsProvider value={result}>
-      <ScreenHeader streamType="setting" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={{ streamType: 'setting' }}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <Switch>
         <Route path="/settings/azure">
           <AzureAD />

--- a/awx/ui/src/screens/SubscriptionUsage/SubscriptionUsage.js
+++ b/awx/ui/src/screens/SubscriptionUsage/SubscriptionUsage.js
@@ -36,7 +36,7 @@ function SubscriptionUsage() {
         </Banner>
       )}
       <ScreenHeader
-        streamType="all"
+        activityStream={{ streamType: 'all' }}
         breadcrumbConfig={{ '/subscription_usage': t`Subscription Usage` }}
       />
       <MainPageSection>

--- a/awx/ui/src/screens/Team/Team.js
+++ b/awx/ui/src/screens/Team/Team.js
@@ -21,7 +21,7 @@ import TeamDetail from './TeamDetail';
 import TeamEdit from './TeamEdit';
 import TeamRolesList from './TeamRoles';
 
-function Team({ setBreadcrumb }) {
+function Team({ setBreadcrumb, buildActivityStream }) {
   const [team, setTeam] = useState(null);
   const [contentError, setContentError] = useState(null);
   const [hasContentLoading, setHasContentLoading] = useState(true);
@@ -33,6 +33,7 @@ function Team({ setBreadcrumb }) {
       try {
         const { data } = await TeamsAPI.readDetail(id);
         setBreadcrumb(data);
+        buildActivityStream(data);
         setTeam(data);
       } catch (error) {
         setContentError(error);
@@ -40,7 +41,7 @@ function Team({ setBreadcrumb }) {
         setHasContentLoading(false);
       }
     })();
-  }, [id, setBreadcrumb, location]);
+  }, [id, setBreadcrumb, location, buildActivityStream]);
 
   const tabsArray = [
     {

--- a/awx/ui/src/screens/Team/Team.test.js
+++ b/awx/ui/src/screens/Team/Team.test.js
@@ -48,7 +48,11 @@ describe('<Team />', () => {
   test('initially renders successfully', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <Team setBreadcrumb={() => {}} me={mockMe} />
+        <Team
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     expect(wrapper.find('Team').length).toBe(1);
@@ -60,7 +64,11 @@ describe('<Team />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Team setBreadcrumb={() => {}} me={mockMe} />,
+        <Team
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {

--- a/awx/ui/src/screens/Team/Teams.js
+++ b/awx/ui/src/screens/Team/Teams.js
@@ -33,15 +33,29 @@ function Teams() {
     });
   }, []);
 
+  const [activityStream, setActivityStream] = useState({ streamType: 'team' });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
-      <ScreenHeader streamType="team" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={activityStream}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <Switch>
         <Route path="/teams/add">
           <TeamAdd />
         </Route>
         <Route path="/teams/:id">
-          <Team setBreadcrumb={buildBreadcrumbConfig} />
+          <Team
+            setBreadcrumb={buildBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/teams">
           <PersistentFilters pageKey="teams">

--- a/awx/ui/src/screens/Template/Template.js
+++ b/awx/ui/src/screens/Template/Template.js
@@ -25,7 +25,7 @@ import JobTemplateDetail from './JobTemplateDetail';
 import JobTemplateEdit from './JobTemplateEdit';
 import TemplateSurvey from './TemplateSurvey';
 
-function Template({ setBreadcrumb }) {
+function Template({ setBreadcrumb, buildActivityStream }) {
   const match = useRouteMatch();
   const location = useLocation();
   const { id: templateId } = useParams();
@@ -84,6 +84,7 @@ function Template({ setBreadcrumb }) {
           data.webhook_key = webhook_key;
         }
       }
+      buildActivityStream(data);
       return {
         template: data,
         isNotifAdmin: notifAdminRes.data.results.length > 0,

--- a/awx/ui/src/screens/Template/Template.test.js
+++ b/awx/ui/src/screens/Template/Template.test.js
@@ -69,14 +69,22 @@ describe('<Template />', () => {
   test('initially renders successfully', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
+        <Template
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
   });
   test('When component mounts API is called and the response is put in state', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
+        <Template
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     expect(JobTemplatesAPI.readDetail).toBeCalled();
@@ -85,7 +93,11 @@ describe('<Template />', () => {
   test('notifications tab shown for admins', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
+        <Template
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
 
@@ -108,7 +120,11 @@ describe('<Template />', () => {
 
     await act(async () => {
       wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />
+        <Template
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     const tabs = await waitForElement(
@@ -126,7 +142,11 @@ describe('<Template />', () => {
 
     await act(async () => {
       wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />,
+        <Template
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {
@@ -153,7 +173,11 @@ describe('<Template />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />,
+        <Template
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {
@@ -185,7 +209,11 @@ describe('<Template />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <Template setBreadcrumb={() => {}} me={mockMe} />,
+        <Template
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {

--- a/awx/ui/src/screens/Template/Templates.js
+++ b/awx/ui/src/screens/Template/Templates.js
@@ -58,10 +58,24 @@ function Templates() {
     [template, schedule]
   );
 
+  const [activityStream, setActivityStream] = useState({
+    streamType: 'job_template,workflow_job_template,workflow_job_template_node',
+  });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item &&
+        setActivityStream({
+          streamId: item.id,
+          streamType: item.type,
+        });
+    },
+    [activityStream]
+  );
+
   return (
     <>
       <ScreenHeader
-        streamType="job_template,workflow_job_template,workflow_job_template_node"
+        activityStream={activityStream}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>
@@ -72,10 +86,16 @@ function Templates() {
           <WorkflowJobTemplateAdd />
         </Route>
         <Route path="/templates/job_template/:id">
-          <Template setBreadcrumb={setBreadcrumbConfig} />
+          <Template
+            setBreadcrumb={setBreadcrumbConfig}
+            buildActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/templates/workflow_job_template/:id">
-          <WorkflowJobTemplate setBreadcrumb={setBreadcrumbConfig} />
+          <WorkflowJobTemplate
+            setBreadcrumb={setBreadcrumbConfig}
+            buildtActivityStream={buildActivityStream}
+          />
         </Route>
         <Route path="/templates">
           <PageSection>

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.js
@@ -29,7 +29,7 @@ import WorkflowJobTemplateEdit from './WorkflowJobTemplateEdit';
 import TemplateSurvey from './TemplateSurvey';
 import { Visualizer } from './WorkflowJobTemplateVisualizer';
 
-function WorkflowJobTemplate({ setBreadcrumb }) {
+function WorkflowJobTemplate({ setBreadcrumb, buildActivityStream }) {
   const location = useLocation();
   const match = useRouteMatch();
   const { id: templateId } = useParams();
@@ -73,6 +73,7 @@ function WorkflowJobTemplate({ setBreadcrumb }) {
         }
       }
       setBreadcrumb(data);
+      buildActivityStream(data);
 
       return {
         template: data,

--- a/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
+++ b/awx/ui/src/screens/Template/WorkflowJobTemplate.test.js
@@ -58,7 +58,11 @@ describe('<WorkflowJobTemplate />', () => {
   test('initially renders successfully', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
+        <WorkflowJobTemplate
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
   });
@@ -66,7 +70,11 @@ describe('<WorkflowJobTemplate />', () => {
   test('When component mounts API is called and the response is put in state', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
+        <WorkflowJobTemplate
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     expect(WorkflowJobTemplatesAPI.readDetail).toBeCalled();
@@ -76,7 +84,11 @@ describe('<WorkflowJobTemplate />', () => {
   test('notifications tab shown for admins', async () => {
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
+        <WorkflowJobTemplate
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
 
@@ -100,7 +112,11 @@ describe('<WorkflowJobTemplate />', () => {
 
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />
+        <WorkflowJobTemplate
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />
       );
     });
     const tabs = await waitForElement(
@@ -118,7 +134,11 @@ describe('<WorkflowJobTemplate />', () => {
 
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />,
+        <WorkflowJobTemplate
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {
@@ -146,7 +166,11 @@ describe('<WorkflowJobTemplate />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />,
+        <WorkflowJobTemplate
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {
@@ -181,7 +205,11 @@ describe('<WorkflowJobTemplate />', () => {
     });
     await act(async () => {
       wrapper = mountWithContexts(
-        <WorkflowJobTemplate setBreadcrumb={() => {}} me={mockMe} />,
+        <WorkflowJobTemplate
+          setBreadcrumb={() => {}}
+          me={mockMe}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {
@@ -249,6 +277,7 @@ describe('<WorkflowJobTemplate />', () => {
           me={{
             is_system_auditor: true,
           }}
+          buildActivityStream={() => {}}
         />,
         {
           context: { router: { history } },

--- a/awx/ui/src/screens/User/User.js
+++ b/awx/ui/src/screens/User/User.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 
 import { t } from '@lingui/macro';
 import {
@@ -22,7 +22,7 @@ import UserTeams from './UserTeams';
 import UserTokens from './UserTokens';
 import UserRolesList from './UserRoles/UserRolesList';
 
-function User({ setBreadcrumb, me }) {
+function User({ setBreadcrumb, me, buildActivityStream }) {
   const location = useLocation();
   const match = useRouteMatch('/users/:id');
   const userListUrl = `/users`;
@@ -48,6 +48,14 @@ function User({ setBreadcrumb, me }) {
       setBreadcrumb(user);
     }
   }, [user, setBreadcrumb]);
+
+  const callback = useRef();
+  callback.current = buildActivityStream;
+  useEffect(() => {
+    if (user) {
+      callback.current(user);
+    }
+  }, [user, callback]);
 
   const tabsArray = [
     {

--- a/awx/ui/src/screens/User/User.test.js
+++ b/awx/ui/src/screens/User/User.test.js
@@ -32,21 +32,24 @@ describe('<User />', () => {
       initialEntries: ['/users/1'],
     });
     await act(async () => {
-      mountWithContexts(<User setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-            route: {
-              location: history.location,
-              match: {
-                params: { id: 1 },
-                url: '/users/1',
-                path: '/users/1',
+      mountWithContexts(
+        <User setBreadcrumb={() => {}} buildActivityStream={() => {}} />,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: history.location,
+                match: {
+                  params: { id: 1 },
+                  url: '/users/1',
+                  path: '/users/1',
+                },
               },
             },
           },
-        },
-      });
+        }
+      );
     });
   });
 
@@ -57,7 +60,11 @@ describe('<User />', () => {
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
-        <User me={{ id: 1 }} setBreadcrumb={() => {}} />,
+        <User
+          me={{ id: 1 }}
+          setBreadcrumb={() => {}}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {
@@ -88,7 +95,11 @@ describe('<User />', () => {
     let wrapper;
     await act(async () => {
       wrapper = mountWithContexts(
-        <User me={{ id: 2 }} setBreadcrumb={() => {}} />,
+        <User
+          me={{ id: 2 }}
+          setBreadcrumb={() => {}}
+          buildActivityStream={() => {}}
+        />,
         {
           context: {
             router: {
@@ -115,21 +126,24 @@ describe('<User />', () => {
     });
     let wrapper;
     await act(async () => {
-      wrapper = mountWithContexts(<User setBreadcrumb={() => {}} />, {
-        context: {
-          router: {
-            history,
-            route: {
-              location: history.location,
-              match: {
-                params: { id: 1 },
-                url: '/users/1/foobar',
-                path: '/users/1/foobar',
+      wrapper = mountWithContexts(
+        <User setBreadcrumb={() => {}} buildActivityStream={() => {}} />,
+        {
+          context: {
+            router: {
+              history,
+              route: {
+                location: history.location,
+                match: {
+                  params: { id: 1 },
+                  url: '/users/1/foobar',
+                  path: '/users/1/foobar',
+                },
               },
             },
           },
-        },
-      });
+        }
+      );
     });
     await waitForElement(wrapper, 'ContentError', (el) => el.length === 1);
   });

--- a/awx/ui/src/screens/User/Users.js
+++ b/awx/ui/src/screens/User/Users.js
@@ -36,9 +36,21 @@ function Users() {
       [`/users/${user.id}/tokens/${token && token.id}/details`]: t`Details`,
     });
   }, []);
+
+  const [activityStream, setActivityStream] = useState({ streamType: 'user' });
+  const buildActivityStream = useCallback(
+    (item) => {
+      item && setActivityStream({ ...activityStream, streamId: item.id });
+    },
+    [activityStream]
+  );
+
   return (
     <>
-      <ScreenHeader streamType="user" breadcrumbConfig={breadcrumbConfig} />
+      <ScreenHeader
+        activityStream={activityStream}
+        breadcrumbConfig={breadcrumbConfig}
+      />
       <Switch>
         <Route path={`${match.path}/add`}>
           <UserAdd />
@@ -46,7 +58,11 @@ function Users() {
         <Route path={`${match.path}/:id`}>
           <Config>
             {({ me }) => (
-              <User setBreadcrumb={addUserBreadcrumb} me={me || {}} />
+              <User
+                setBreadcrumb={addUserBreadcrumb}
+                me={me || {}}
+                buildActivityStream={buildActivityStream}
+              />
             )}
           </Config>
         </Route>

--- a/awx/ui/src/screens/User/Users.test.js
+++ b/awx/ui/src/screens/User/Users.test.js
@@ -14,7 +14,7 @@ describe('<Users />', () => {
     const wrapper = shallow(<Users />);
 
     const header = wrapper.find('ScreenHeader');
-    expect(header.prop('streamType')).toBe('user');
+    expect(header.prop('activityStream')['streamType']).toBe('user');
     expect(header.prop('breadcrumbConfig')).toEqual({
       '/users': 'Users',
       '/users/add': 'Create New User',

--- a/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
+++ b/awx/ui/src/screens/WorkflowApproval/WorkflowApprovals.js
@@ -28,7 +28,7 @@ function WorkflowApprovals() {
   return (
     <>
       <ScreenHeader
-        streamType="workflow_approval"
+        activityStream={{ streamType: 'workflow_approval' }}
         breadcrumbConfig={breadcrumbConfig}
       />
       <Switch>


### PR DESCRIPTION
##### SUMMARY

fixes bug: 
* when at the `/details` page for any item (host, project, schedule, etc.) and clicking on the Activity Stream button at the top right:
** there is not shown an Activity Stream specific to the item, but a general Activity Stream for the item category (schedules, templates, hosts, projects, inventories, etc.)

This PR adds a `item__id=N` to the Activity Stream button's URL from  `/details`. Like: `host__id=2` or `credential__id=13` or `project__id=5`, etc. - thus filtering to the specific item's ActivityStream.

(for [03771872](https://access.redhat.com/support/cases/#case/03771872))


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - UI

##### AWX VERSION
```
awx: 0.1.dev34000+gbdfdbf6.d20240620
```


##### ADDITIONAL INFORMATION
I'm sorry, I could not find a shorter way to fix this - resulting in a rather big PR. If you could spot a better way for fixing it, let me know, and I'll be happy to discuss and rework the code. Thank you.

![activitystream1](https://github.com/ansible/awx/assets/238607/2aaadda1-969c-4c62-bb50-36b6fe9db6a9)

---

![activitystream2](https://github.com/ansible/awx/assets/238607/df31d5b6-7598-4877-be71-d2c2d58d2e2e)

---

![activitystream3](https://github.com/ansible/awx/assets/238607/7925e0c6-2cd1-47e1-8945-491c9d8a02d3)

---

Ran npm tests, passed.
```
npm run test
npm run prettier
```
