### PR TITLE
Various RBAC fixes related to managed RoleDefinitions

### DIFF
--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -591,8 +591,13 @@ def get_role_from_object_role(object_role):
         role_name = role_name.lower()
         model_cls = apps.get_model('main', target_model_name)
         target_model_name = get_type_for_model(model_cls)
+
+        # exception cases completely specific to one model naming convention
         if target_model_name == 'notification_template':
-            target_model_name = 'notification'  # total exception
+            target_model_name = 'notification'
+        elif target_model_name == 'workflow_job_template':
+            target_model_name = 'workflow'
+
         role_name = f'{target_model_name}_admin_role'
     elif rd.name.endswith(' Admin'):
         # cases like "project-admin"

--- a/awx/main/tests/functional/dab_rbac/test_access_list.py
+++ b/awx/main/tests/functional/dab_rbac/test_access_list.py
@@ -109,3 +109,17 @@ def test_team_indirect_access(get, team, admin_user, inventory):
     assert len(by_username['u1']['summary_fields']['indirect_access']) == 0
     access_entry = by_username['u1']['summary_fields']['direct_access'][0]
     assert sorted(access_entry['descendant_roles']) == sorted(['adhoc_role', 'use_role', 'update_role', 'read_role', 'admin_role'])
+
+
+@pytest.mark.django_db
+def test_workflow_access_list(workflow_job_template, alice, bob, setup_managed_roles, get, admin_user):
+    """Basic verification that WFJT access_list is functional AAP-25084"""
+    workflow_job_template.admin_role.members.add(alice)
+    workflow_job_template.organization.workflow_admin_role.members.add(bob)
+
+    url = reverse('api:workflow_job_template_access_list', kwargs={'pk': workflow_job_template.pk})
+    for u in (alice, bob, admin_user):
+        response = get(url, user=u, expect=200)
+        user_ids = [item['id'] for item in response.data['results']]
+        assert alice.pk in user_ids
+        assert bob.pk in user_ids

--- a/awx/main/tests/functional/dab_rbac/test_access_list.py
+++ b/awx/main/tests/functional/dab_rbac/test_access_list.py
@@ -113,7 +113,7 @@ def test_team_indirect_access(get, team, admin_user, inventory):
 
 @pytest.mark.django_db
 def test_workflow_access_list(workflow_job_template, alice, bob, setup_managed_roles, get, admin_user):
-    """Basic verification that WFJT access_list is functional AAP-25084"""
+    """Basic verification that WFJT access_list is functional"""
     workflow_job_template.admin_role.members.add(alice)
     workflow_job_template.organization.workflow_admin_role.members.add(bob)
 

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -94,7 +94,7 @@ def test_assign_custom_add_role(admin_user, rando, organization, post, setup_man
 @pytest.mark.django_db
 def test_jt_creation_permissions(setup_managed_roles, inventory, project, rando):
     """This tests that if you assign someone required permissions in the new API
-    using the managed roles, then that works to give permissions to create a job template AAP-25603"""
+    using the managed roles, then that works to give permissions to create a job template"""
     inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
     proj_rd = RoleDefinition.objects.get(name='Project Admin')
     # establish prior state
@@ -109,7 +109,7 @@ def test_jt_creation_permissions(setup_managed_roles, inventory, project, rando)
 
 @pytest.mark.django_db
 def test_workflow_creation_permissions(setup_managed_roles, organization, workflow_job_template, rando):
-    """Similar to JT, assigning new roles gives creator permissions AAP-25635"""
+    """Similar to JT, assigning new roles gives creator permissions"""
     org_wf_rd = RoleDefinition.objects.get(name='Organization WorkflowJobTemplate Admin')
     assert workflow_job_template.organization == organization  # sanity
     # establish prior state

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -25,7 +25,7 @@ def test_project_update_role(setup_managed_roles):
 def test_org_child_add_permission(setup_managed_roles):
     for model_name in ('Project', 'NotificationTemplate', 'WorkflowJobTemplate', 'Inventory'):
         rd = RoleDefinition.objects.get(name=f'Organization {model_name} Admin')
-        assert 'add_' in str(rd.permissions.values_list('codename', flat=True)), f'The {rd.name} role definition expected to not contain add_ permissions'
+        assert 'add_' in str(rd.permissions.values_list('codename', flat=True)), f'The {rd.name} role definition expected to contain add_ permissions'
 
     # special case for JobTemplate, anyone can create one with use permission to project/inventory
     assert not DABPermission.objects.filter(codename='add_jobtemplate').exists()

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -22,7 +22,7 @@ def test_project_update_role(setup_managed_roles):
 
 @pytest.mark.django_db
 def test_org_child_add_permission(setup_managed_roles):
-    for model_name in ('Project', 'NotificationTemplate', 'Inventory'):
+    for model_name in ('Project', 'NotificationTemplate', 'WorkflowJobTemplate', 'Inventory'):
         rd = RoleDefinition.objects.get(name=f'Organization {model_name} Admin')
         assert 'add_' in str(rd.permissions.values_list('codename', flat=True)), f'The {rd.name} role definition expected to not contain add_ permissions'
 

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ansible_base.rbac.models import RoleDefinition
+
+
+@pytest.mark.django_db
+def test_roles_to_not_create(setup_managed_roles):
+    assert RoleDefinition.objects.filter(name='Organization Admin').count() == 1
+
+    SHOULD_NOT_EXIST = ('Organization Organization Admin', 'Organization Team Admin', 'Organization InstanceGroup Admin')
+
+    bad_rds = RoleDefinition.objects.filter(name__in=SHOULD_NOT_EXIST)
+    if bad_rds.exists():
+        raise Exception(f'Found RoleDefinitions that should not exist: {list(bad_rds.values_list('name', flat=True))}')
+
+
+@pytest.mark.django_db
+def test_project_update_role(setup_managed_roles):
+    assert RoleDefinition.objects.filter(name='Project Update').count() == 1

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -17,6 +17,7 @@ def test_roles_to_not_create(setup_managed_roles):
 
 @pytest.mark.django_db
 def test_project_update_role(setup_managed_roles):
+    """Role to allow updating a project on the object-level should exist AAP-24847"""
     assert RoleDefinition.objects.filter(name='Project Update').count() == 1
 
 

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -17,7 +17,7 @@ def test_roles_to_not_create(setup_managed_roles):
 
 @pytest.mark.django_db
 def test_project_update_role(setup_managed_roles):
-    """Role to allow updating a project on the object-level should exist AAP-24847"""
+    """Role to allow updating a project on the object-level should exist"""
     assert RoleDefinition.objects.filter(name='Project Update').count() == 1
 
 

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer.py
@@ -16,7 +16,16 @@ from ansible_base.rbac.models import RoleUserAssignment, RoleDefinition
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     'role_name',
-    ['execution_environment_admin_role', 'project_admin_role', 'admin_role', 'auditor_role', 'read_role', 'execute_role', 'notification_admin_role'],
+    [
+        'execution_environment_admin_role',
+        'workflow_admin_role',
+        'project_admin_role',
+        'admin_role',
+        'auditor_role',
+        'read_role',
+        'execute_role',
+        'notification_admin_role',
+    ],
 )
 def test_round_trip_roles(organization, rando, role_name, setup_managed_roles):
     """

--- a/awx/main/tests/functional/test_migrations.py
+++ b/awx/main/tests/functional/test_migrations.py
@@ -85,3 +85,10 @@ class TestMigrationSmoke:
 
         RoleUserAssignment = new_state.apps.get_model('dab_rbac', 'RoleUserAssignment')
         assert RoleUserAssignment.objects.filter(user=user.id, object_id=org.id).exists()
+
+        # Regression testing for bug that comes from current vs past models mismatch
+        RoleDefinition = new_state.apps.get_model('dab_rbac', 'RoleDefinition')
+        assert not RoleDefinition.objects.filter(name='Organization Organization Admin').exists()
+        # Test special cases in managed role creation
+        assert not RoleDefinition.objects.filter(name='Organization Team Admin').exists()
+        assert not RoleDefinition.objects.filter(name='Organization InstanceGroup Admin').exists()


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/awx/issues/15224

Also fixes bug not reported here - undesired RoleDefinitions were created in migrations because a criteria was not hitting right. I discovered I couldn't reproduce in the tests (likely why I didn't see it before). This was because of criteria like `if 'object_admin' in to_create and cls != Organization:`, which I can't believe I ever wrote. Obviously, `Organization` isn't `Organization` because of Django migration state, at least if this is called from a migration step, which it totally is.

This PR was originally created to run the tests, and (see comment), I got the failure I wanted, and then more commits here fixed the bug.

Internal refs:

- AAP-25603 just testing JT permissions working (doesn't fix anything)
- AAP-25084 organization workflow role mapping issue caused server errors
- AAP-25635 organization workflow role mapping issue didn't give permission like intended
- AAP-24847 Project Update role missing
- AAP-25491 org-IG-admin role created unintentionally
- AAP-23816 org-org-admin role created unintentionally

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

