### PR TITLE
Avoid side effect error in setting error handling

### DIFF
--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -99,8 +99,11 @@ def _ctit_db_wrapper(trans_safe=False):
             cause = e.__cause__
             if cause and hasattr(cause, 'sqlstate'):
                 sqlstate = cause.sqlstate
-                sqlstate_str = psycopg.errors.lookup(sqlstate)
-                logger.error('SQL Error state: {} - {}'.format(sqlstate, sqlstate_str))
+                if sqlstate:
+                    sqlstate_str = psycopg.errors.lookup(sqlstate)
+                    logger.error('SQL Error state: {} - {}'.format(sqlstate, sqlstate_str))
+                else:
+                    logger.error(f'Can not retreive settings because not connected. error: {str(e)}')
         else:
             logger.exception('Error modifying something related to database settings.')
     finally:


### PR DESCRIPTION
##### SUMMARY
This made it really hard to debug issues related to connecting to the database.

Locally, using docker-compose, I put in these settings:

```python
        'HOST': "localhost",  # was postgres
        'PORT': "5432",
```

These settings were wrong. But the message I got was:

```
(awx) alancoding@Sourdough:~/repos/awx$ awx-manage shell_plus
Traceback (most recent call last):
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 289, in ensure_connection
    self.connect()
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 270, in connect
    self.connection = self.get_new_connection(conn_params)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/postgresql/base.py", line 275, in get_new_connection
    connection = self.Database.connect(**conn_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 748, in connect
    raise last_ex.with_traceback(None)
psycopg.OperationalError: connection failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 83, in _ctit_db_wrapper
    yield
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 429, in _get_local_with_cache
    return self._get_local(name)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 370, in _get_local
    setting = _get_setting_from_db(self.registry, name)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 204, in _get_setting_from_db
    return get_settings_from_db_sync(registry, key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 201, in get_settings_from_db_sync
    return Setting.objects.filter(key=key, user__isnull=True).order_by('pk').first()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/models/query.py", line 1057, in first
    for obj in queryset[:1]:
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/models/query.py", line 398, in __iter__
    self._fetch_all()
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/models/query.py", line 1881, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/models/sql/compiler.py", line 1560, in execute_sql
    cursor = self.connection.cursor()
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 330, in cursor
    return self._cursor()
           ^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 306, in _cursor
    self.ensure_connection()
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 288, in ensure_connection
    with self.wrap_database_errors:
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 289, in ensure_connection
    self.connect()
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/base/base.py", line 270, in connect
    self.connection = self.get_new_connection(conn_params)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/utils/asyncio.py", line 26, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/db/backends/postgresql/base.py", line 275, in get_new_connection
    connection = self.Database.connect(**conn_params)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/psycopg/connection.py", line 748, in connect
    raise last_ex.with_traceback(None)
django.db.utils.OperationalError: connection failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/alancoding/venvs/awx/bin/awx-manage", line 8, in <module>
    sys.exit(manage())
             ^^^^^^^^
  File "/home/alancoding/repos/awx/awx/__init__.py", line 177, in manage
    execute_from_command_line(sys.argv)
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django_extensions/management/commands/shell_plus.py", line 125, in run_from_argv
    return super().run_from_argv(argv)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/management/base.py", line 453, in execute
    self.check()
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/management/base.py", line 485, in check
    all_issues = checks.run_checks(
                 ^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/checks/registry.py", line 88, in run_checks
    new_errors = check(app_configs=app_configs, databases=databases)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/django/core/checks/compatibility/django_4_0.py", line 9, in check_csrf_trusted_origins
    for origin in settings.CSRF_TRUSTED_ORIGINS:
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 540, in __getattr_without_cache__
    return getattr(self._wrapped, name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 438, in __getattr__
    value = self._get_local_with_cache(name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/cachetools/__init__.py", line 823, in wrapper
    v = method(self, *args, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 428, in _get_local_with_cache
    with _ctit_db_wrapper(trans_safe=True):
  File "/usr/lib64/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/alancoding/repos/awx/awx/conf/settings.py", line 102, in _ctit_db_wrapper
    sqlstate_str = psycopg.errors.lookup(sqlstate)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/psycopg/errors.py", line 513, in lookup
    return _sqlcodes[sqlstate.upper()]
                     ^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'upper'
```

This is a problematic error... yes, it has the _real_ error buried down in there, but that's not what I want it to give.

With this change:

```
$ awx-manage shell_plus
2024-06-24 15:47:55,526 ERROR    [-] awx.conf.settings Can not retreive settings because not connected. error: connection failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
2024-06-24 15:47:55,606 ERROR    [-] awx.conf.settings Can not retreive settings because not connected. error: connection failed: Connection refused
	Is the server running on that host and accepting TCP/IP connections?
# Shell Plus Model Imports
from ansible_base.rbac.models import DABPermission, ObjectRole, RoleDefinition, RoleEvaluation, RoleEvaluationUUID, RoleTeamAssignment, RoleUserAssignment

```

And it still gave me shell_plus.

Several commands are _required_ to work without database access like `collectstatic`, and what's surprising is that this _didn't_ break someone. I expect that's because those commands were never run while getting this _type_ of error, which leads to a secondary error that stops execution when that is not the expectation.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

