### PR TITLE
Prevent assigning credential to user of other org

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -45,7 +45,7 @@ from awx.main.models.rbac import (
     ROLE_SINGLETON_SYSTEM_ADMINISTRATOR,
     ROLE_SINGLETON_SYSTEM_AUDITOR,
 )
-from awx.main.models import Team
+from awx.main.models import Team, Organization
 from awx.main.utils import encrypt_field
 from . import injectors as builtin_injectors
 
@@ -322,7 +322,7 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
 
     def validate_role_assignment(self, actor, role_definition):
         if isinstance(actor, User):
-            if actor.is_superuser or self.organization in actor.organizations:
+            if actor.is_superuser or Organization.access_qs(actor, 'change').filter(id=self.organization.id).exists():
                 return
         if isinstance(actor, Team):
             if actor.organization == self.organization:

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -23,6 +23,9 @@ from django.utils.functional import cached_property
 from django.utils.timezone import now
 from django.contrib.auth.models import User
 
+# DRF
+from rest_framework.serializers import ValidationError as DRFValidationError
+
 # AWX
 from awx.api.versioning import reverse
 from awx.main.fields import (
@@ -324,7 +327,7 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
         if isinstance(actor, Team):
             if actor.organization == self.organization:
                 return
-        return f"You cannot grant credential access to a {actor._meta.object_name} not in the credentials' organization"
+        raise DRFValidationError({'detail': _(f"You cannot grant credential access to a {actor._meta.object_name} not in the credentials' organization")})
 
 
 class CredentialType(CommonModelNameNotUnique):

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -122,6 +122,23 @@ def test_workflow_creation_permissions(setup_managed_roles, organization, workfl
 
 
 @pytest.mark.django_db
+def test_cannot_assign_credential_to_user_of_another_org(setup_managed_roles, credential, admin_user, rando, organization, post):
+    '''Test that a credential can only be assigned to a user in the same organization'''
+    credential.organization = organization
+    credential.save(update_fields=['organization'])
+    assert credential.organization not in rando.organizations
+
+    rd = RoleDefinition.objects.get(name="Credential Admin")
+    url = django_reverse('roleuserassignment-list')
+    resp = post(url=url, data={"user": rando.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=400)
+    assert "You cannot grant credential access to a User not in the credentials' organization" in str(resp.data)
+
+    # superuser can be assigned any credential
+    assert organization not in admin_user.organizations
+    post(url=url, data={"user": admin_user.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
+
+
+@pytest.mark.django_db
 @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
 def test_team_member_role_not_assignable(team, rando, post, admin_user, setup_managed_roles):
     member_rd = RoleDefinition.objects.get(name='Organization Member')

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -134,7 +134,7 @@ def test_assign_credential_to_user_of_another_org(setup_managed_roles, credentia
     assert "You cannot grant credential access to a User not in the credentials' organization" in str(resp.data)
 
     # can assign credential to superuser
-    rando.super_user = True
+    rando.is_superuser = True
     rando.save()
     assert organization not in rando.organizations
     post(url=url, data={"user": rando.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -137,9 +137,11 @@ def test_assign_credential_to_user_of_another_org(setup_managed_roles, credentia
     assert admin_user.is_superuser
     assert organization not in admin_user.organizations
     post(url=url, data={"user": admin_user.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
+
     # can assign credential to org_member
     assert credential.organization in org_member.organizations
     post(url=url, data={"user": org_member.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
+
 
 @pytest.mark.django_db
 @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -134,9 +134,10 @@ def test_assign_credential_to_user_of_another_org(setup_managed_roles, credentia
     assert "You cannot grant credential access to a User not in the credentials' organization" in str(resp.data)
 
     # can assign credential to superuser
-    assert admin_user.is_superuser
-    assert organization not in admin_user.organizations
-    post(url=url, data={"user": admin_user.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
+    rando.super_user = True
+    rando.save()
+    assert organization not in rando.organizations
+    post(url=url, data={"user": rando.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
 
     # can assign credential to org_member
     assert credential.organization in org_member.organizations

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -122,13 +122,13 @@ def test_workflow_creation_permissions(setup_managed_roles, organization, workfl
 
 
 @pytest.mark.django_db
-def test_assign_credential_to_user_of_another_org(setup_managed_roles, credential, admin_user, rando, org_member, organization, post):
+def test_assign_credential_to_user_of_another_org(setup_managed_roles, credential, admin_user, rando, org_admin, organization, post):
     '''Test that a credential can only be assigned to a user in the same organization'''
     # cannot assign credential to rando, as rando is not in the same org as the credential
     rd = RoleDefinition.objects.get(name="Credential Admin")
     credential.organization = organization
     credential.save(update_fields=['organization'])
-    assert credential.organization not in rando.organizations
+    assert credential.organization not in Organization.access_qs(rando, 'change')
     url = django_reverse('roleuserassignment-list')
     resp = post(url=url, data={"user": rando.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=400)
     assert "You cannot grant credential access to a User not in the credentials' organization" in str(resp.data)
@@ -136,12 +136,11 @@ def test_assign_credential_to_user_of_another_org(setup_managed_roles, credentia
     # can assign credential to superuser
     rando.is_superuser = True
     rando.save()
-    assert organization not in rando.organizations
     post(url=url, data={"user": rando.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
 
-    # can assign credential to org_member
-    assert credential.organization in org_member.organizations
-    post(url=url, data={"user": org_member.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
+    # can assign credential to org_admin
+    assert credential.organization in Organization.access_qs(org_admin, 'change')
+    post(url=url, data={"user": org_admin.id, "role_definition": rd.id, "object_id": credential.id}, user=admin_user, expect=201)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
AAP-24919

<!--- Describe the change, including rationale and design decisions -->
requires https://github.com/ansible/django-ansible-base/pull/490

Utilizes the `validate_role_assignment` callback from dab to prevent granting credential access to a user of another organization.

This prevention was already being handled correctly for the `RoleUsersList` view, but not through the newer
role assignment endpoints.

This change is for assignments that are made through the role_user_assignments and role_team_assignments endpoints.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
