### PR TITLE
Test if CI is failing

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -224,7 +224,7 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
     def _perform_unique_checks(self, unique_checks):
         # Handle the list of unique fields returned above. Replace with an
         # appropriate error message for the remaining field(s) in the unique
-        # check and cleanup the errors dictionary.
+        # check and cleanup the errors dictionary
         errors = super(UnifiedJobTemplate, self)._perform_unique_checks(unique_checks)
         for key, msgs in errors.items():
             if key != NON_FIELD_ERRORS:


### PR DESCRIPTION
##### SUMMARY
In another PR I saw the failure

```
_________ ERROR collecting awx/main/tests/functional/test_licenses.py __________
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/runner.py", line 341, in from_call
    result: Optional[TResult] = func()
                                ^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/runner.py", line 389, in collect
    return list(collector.collect())
                ^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pytest_asyncio/plugin.py", line 640, in _patched_collect
    module = collector.obj
             ^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/python.py", line 287, in obj
    self._obj = obj = self._getobj()
                      ^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/python.py", line 545, in _getobj
    return importtestmodule(self.path, self.config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/python.py", line 492, in importtestmodule
    mod = import_path(
          ^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/pathlib.py", line 591, in import_path
    importlib.import_module(module_name)
  File "/usr/lib64/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1[204](https://github.com/ansible/awx/actions/runs/9655309505/job/26630994638?pr=15291#step:4:205), in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/awx_devel/awx/main/tests/functional/test_licenses.py", line 8, in <module>
    from pip._internal.req import parse_requirements
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pip/_internal/req/__init__.py", line 9, in <module>
    from .req_install import InstallRequirement
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pip/_internal/req/req_install.py", line 40, in <module>
    from pip._internal.operations.install.wheel import install_wheel
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pip/_internal/operations/install/wheel.py", line 40, in <module>
    from pip._vendor.distlib.scripts import ScriptMaker
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py", line 178, in exec_module
    exec(co, module.__dict__)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pip/_vendor/distlib/scripts.py", line 66, in <module>
    for r in finder(distlib_package).iterator("")
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/pip/_vendor/distlib/resources.py", line 332, in finder
    raise DistlibException('Unable to locate finder for %r' % package)
pip._vendor.distlib.DistlibException: Unable to locate finder for 'pip._vendor.distlib'
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

