### PR TITLE
Make attached user models adhere to new API assignments

### DIFF
--- a/awx/main/models/__init__.py
+++ b/awx/main/models/__init__.py
@@ -176,17 +176,17 @@ pre_delete.connect(cleanup_created_modified_by, sender=User)
 
 @property
 def user_get_organizations(user):
-    return Organization.objects.filter(member_role__members=user)
+    return Organization.access_qs(user, 'member')
 
 
 @property
 def user_get_admin_of_organizations(user):
-    return Organization.objects.filter(admin_role__members=user)
+    return Organization.access_qs(user, 'change')
 
 
 @property
 def user_get_auditor_of_organizations(user):
-    return Organization.objects.filter(auditor_role__members=user)
+    return Organization.access_qs(user, 'audit')
 
 
 @property

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer.py
@@ -150,3 +150,11 @@ def test_implicit_parents_no_assignments(organization):
     with mock.patch('awx.main.models.rbac.give_or_remove_permission') as mck:
         Team.objects.create(name='random team', organization=organization)
     mck.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_user_auditor_rel(organization, rando, setup_managed_roles):
+    assert rando not in organization.auditor_role
+    audit_rd = RoleDefinition.objects.get(name='Organization Audit')
+    audit_rd.give_permission(rando, organization)
+    assert list(rando.auditor_of_organizations) == [organization]


### PR DESCRIPTION
##### SUMMARY
This is a problem because the new RBAC API doesn't sync back to the old RBAC API.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

