### PR TITLE
Add TASK_MANAGER_LOCK_TIMEOUT

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -138,7 +138,8 @@ class TaskBase:
 
         # Lock
         with task_manager_bulk_reschedule():
-            with advisory_lock(f"{self.prefix}_lock", wait=False) as acquired:
+            lock_session_timeout_milliseconds = settings.TASK_MANAGER_LOCK_TIMEOUT * 1000  # convert to milliseconds
+            with advisory_lock(f"{self.prefix}_lock", lock_session_timeout_milliseconds=lock_session_timeout_milliseconds, wait=False) as acquired:
                 with transaction.atomic():
                     if acquired is False:
                         logger.debug(f"Not running {self.prefix} scheduler, another task holds lock")

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -715,7 +715,8 @@ def awx_k8s_reaper():
 
 @task(queue=get_task_queuename)
 def awx_periodic_scheduler():
-    with advisory_lock('awx_periodic_scheduler_lock', wait=False) as acquired:
+    lock_session_timeout_milliseconds = settings.TASK_MANAGER_LOCK_TIMEOUT * 1000
+    with advisory_lock('awx_periodic_scheduler_lock', lock_session_timeout_milliseconds=lock_session_timeout_milliseconds, wait=False) as acquired:
         if acquired is False:
             logger.debug("Not running periodic scheduler, another task holds lock")
             return

--- a/awx/main/utils/pglock.py
+++ b/awx/main/utils/pglock.py
@@ -8,9 +8,22 @@ from django.db import connection
 
 
 @contextmanager
-def advisory_lock(*args, **kwargs):
+def advisory_lock(*args, lock_session_timeout_milliseconds=0, **kwargs):
     if connection.vendor == 'postgresql':
+        cur = None
+        idle_in_transaction_session_timeout = None
+        idle_session_timeout = None
+        if lock_session_timeout_milliseconds > 0:
+            cur = connection.cursor()
+            idle_in_transaction_session_timeout = cur.execute('SHOW idle_in_transaction_session_timeout').fetchone()[0]
+            idle_session_timeout = cur.execute('SHOW idle_session_timeout').fetchone()[0]
+            cur.execute(f"SET idle_in_transaction_session_timeout = {lock_session_timeout_milliseconds}")
+            cur.execute(f"SET idle_session_timeout = {lock_session_timeout_milliseconds}")
         with django_pglocks_advisory_lock(*args, **kwargs) as internal_lock:
             yield internal_lock
+            if lock_session_timeout_milliseconds > 0:
+                cur.execute(f"SET idle_in_transaction_session_timeout = {idle_in_transaction_session_timeout}")
+                cur.execute(f"SET idle_session_timeout = {idle_session_timeout}")
+                cur.close()
     else:
         yield True

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -262,6 +262,7 @@ START_TASK_LIMIT = 100
 # We have the grace period so the task manager can bail out before the timeout.
 TASK_MANAGER_TIMEOUT = 300
 TASK_MANAGER_TIMEOUT_GRACE_PERIOD = 60
+TASK_MANAGER_LOCK_TIMEOUT = TASK_MANAGER_TIMEOUT + TASK_MANAGER_TIMEOUT_GRACE_PERIOD
 
 # Number of seconds _in addition to_ the task manager timeout a job can stay
 # in waiting without being reaped


### PR DESCRIPTION
##### SUMMARY
`TASK_MANAGER_LOCK_TIMEOUT` controls the `idle_in_transaction_session_timeout` and `idle_session_timeout` DB connection setting for task manager connections and lock in database

hope to prevent the situation that the task instance that holds the lock becomes unresponsive and preventing other instance to be able to run task manager


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
