### PR TITLE
LISTENER_DATABASES clobbers DATABASES OPTIONS in wsrelay

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -102,7 +102,8 @@ def create_listener_connection():
 
     # Apply overrides specifically for the listener connection
     for k, v in settings.LISTENER_DATABASES.get('default', {}).items():
-        conf[k] = v
+        if k != 'OPTIONS':
+            conf[k] = v
     for k, v in settings.LISTENER_DATABASES.get('default', {}).get('OPTIONS', {}).items():
         conf['OPTIONS'][k] = v
 

--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -306,7 +306,8 @@ class WebSocketRelayManager(object):
         database_conf['OPTIONS'] = deepcopy(database_conf.get('OPTIONS', {}))
 
         for k, v in settings.LISTENER_DATABASES.get('default', {}).items():
-            database_conf[k] = v
+            if k != 'OPTIONS':
+                database_conf[k] = v
         for k, v in settings.LISTENER_DATABASES.get('default', {}).get('OPTIONS', {}).items():
             database_conf['OPTIONS'][k] = v
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
LISTENER_DATABASES OPTIONS overwrites DATABASES options in wsrelay which could remove alternative authentication methods for postgres in django.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 -  Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
