### PR TITLE
Do not use cache in github image build action

### DIFF
--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -2,6 +2,7 @@
 name: Build/Push Development Images
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
+  DOCKER_CACHE: "--no-cache" # using the cache will not rebuild git requirements and other things
 on:
   workflow_dispatch:
   push:

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ DEV_DOCKER_OWNER ?= ansible
 DEV_DOCKER_OWNER_LOWER = $(shell echo $(DEV_DOCKER_OWNER) | tr A-Z a-z)
 DEV_DOCKER_TAG_BASE ?= ghcr.io/$(DEV_DOCKER_OWNER_LOWER)
 DEVEL_IMAGE_NAME ?= $(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG)
+IMAGE_KUBE_DEV=$(DEV_DOCKER_TAG_BASE)/awx_kube_devel:$(COMPOSE_TAG)
 
 # Common command to use for running ansible-playbook
 ANSIBLE_PLAYBOOK ?= ansible-playbook -e ansible_python_interpreter=$(PYTHON)
@@ -88,6 +89,16 @@ I18N_FLAG_FILE = .i18n_built
 
 ## PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 PLATFORMS ?= linux/amd64,linux/arm64  # linux/ppc64le,linux/s390x
+
+# Set up cache variables for image builds, allowing to control whether cache is used or not, ex:
+# DOCKER_CACHE=--no-cache make docker-compose-build
+ifeq ($(DOCKER_CACHE),)
+ DOCKER_KUBE_DEV_CACHE_FLAG=--cache-from=$(IMAGE_KUBE_DEV)
+ DOCKER_DEVEL_CACHE_FLAG=--cache-from=$(DEVEL_IMAGE_NAME)
+else
+ DOCKER_KUBE_DEV_CACHE_FLAG=$(DOCKER_CACHE)
+ DOCKER_DEVEL_CACHE_FLAG=$(DOCKER_CACHE)
+endif
 
 .PHONY: awx-link clean clean-tmp clean-venv requirements requirements_dev \
 	develop refresh adduser migrate dbchange \
@@ -606,8 +617,7 @@ docker-compose-build: Dockerfile.dev
 		-f Dockerfile.dev \
 		-t $(DEVEL_IMAGE_NAME) \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--cache-from=$(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG) .
-
+		$(DOCKER_DEVEL_CACHE_FLAG) .
 
 .PHONY: docker-compose-buildx
 ## Build awx_devel image for docker compose development environment for multiple architectures
@@ -617,7 +627,7 @@ docker-compose-buildx: Dockerfile.dev
 	- docker buildx build \
 		--push \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--cache-from=$(DEV_DOCKER_TAG_BASE)/awx_devel:$(COMPOSE_TAG) \
+		$(DOCKER_DEVEL_CACHE_FLAG) \
 		--platform=$(PLATFORMS) \
 		--tag $(DEVEL_IMAGE_NAME) \
 		-f Dockerfile.dev .
@@ -710,8 +720,8 @@ Dockerfile.kube-dev: tools/ansible/roles/dockerfile/templates/Dockerfile.j2
 awx-kube-dev-build: Dockerfile.kube-dev
 	DOCKER_BUILDKIT=1 docker build -f Dockerfile.kube-dev \
 	    --build-arg BUILDKIT_INLINE_CACHE=1 \
-	    --cache-from=$(DEV_DOCKER_TAG_BASE)/awx_kube_devel:$(COMPOSE_TAG) \
-	    -t $(DEV_DOCKER_TAG_BASE)/awx_kube_devel:$(COMPOSE_TAG) .
+	     $(DOCKER_KUBE_DEV_CACHE_FLAG) \
+	    -t $(IMAGE_KUBE_DEV) .
 
 ## Build and push multi-arch awx_kube_devel image for development on local Kubernetes environment.
 awx-kube-dev-buildx: Dockerfile.kube-dev
@@ -720,14 +730,14 @@ awx-kube-dev-buildx: Dockerfile.kube-dev
 	- docker buildx build \
 		--push \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--cache-from=$(DEV_DOCKER_TAG_BASE)/awx_kube_devel:$(COMPOSE_TAG) \
+		$(DOCKER_KUBE_DEV_CACHE_FLAG) \
 		--platform=$(PLATFORMS) \
-		--tag $(DEV_DOCKER_TAG_BASE)/awx_kube_devel:$(COMPOSE_TAG) \
+		--tag $(IMAGE_KUBE_DEV) \
 		-f Dockerfile.kube-dev .
 	- docker buildx rm awx-kube-dev-buildx
 
 kind-dev-load: awx-kube-dev-build
-	$(KIND_BIN) load docker-image $(DEV_DOCKER_TAG_BASE)/awx_kube_devel:$(COMPOSE_TAG)
+	$(KIND_BIN) load docker-image $(IMAGE_KUBE_DEV)
 
 # Translation TASKS
 # --------------------------------------


### PR DESCRIPTION
##### SUMMARY
I create this due to struggling with the action:

https://github.com/ansible/awx/actions/workflows/devel_images.yml

It will not pick up a new DAB version.

```
2024-06-27T13:43:16.1730206Z #34 [linux/amd64 builder  8/10] RUN cd /tmp && make requirements_awx
2024-06-27T13:43:16.1730918Z #34 CACHED
```

When it does this, it produces an image that uses a DAB git hash 3 commits behind the latest. Clearly, because it never installed requirements. You frequently see these timings:

![Screenshot from 2024-06-27 12-02-13](https://github.com/ansible/awx/assets/1385596/ef4a0281-acc9-4faf-890f-963dfa1e6384)

It's probable that requirements were not installed if it took less than 1 minute.

I don't want to re-install requirements on ever PR, which creates the central challenge here.

Either we use `--cache-from` or we use `--no-cache`. It is hard to do this in `make` language. This is my best shot.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

