### PR TITLE
Fix server error from DAB ValidationError with strings

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -227,7 +227,10 @@ class APIView(views.APIView):
             if type(response.data) is dict:
                 msg_data['error'] = response.data.get('error', response.status_text)
             elif type(response.data) is list:
-                msg_data['error'] = ", ".join(list(map(lambda x: x.get('error', response.status_text), response.data)))
+                if len(response.data) > 0 and isinstance(response.data[0], str):
+                    msg_data['error'] = str(response.data[0])
+                else:
+                    msg_data['error'] = ", ".join(list(map(lambda x: x.get('error', response.status_text), response.data)))
             else:
                 msg_data['error'] = response.status_text
 


### PR DESCRIPTION
##### SUMMARY
Took me a while to process, `msg_data` is _not_ what gets used in the response. It is only used for a _log message_. This threw errors when DAB code `raise ValidationError('foo')`, because of a baked-in assumption that when it gets a list (this is converted to a list of element 1) it is a list of dictionaries.

I'm not defending the specific error formatting in these cases, but that's a different subject. This fixes the server error that comes from logic _to build a log message_ that doesn't even go in the response. However we format the error, we should not return a 500.

AAP-25540

MORE CONTEXT:

This is happening because we have a DAB view (role user assignment list) which re-parents itself under the main AWX generic API view. It's weird. This allows DAB views to inherit request finalization logic (like this) but also can expose corner cases from assumptions that were always true in AWX but not always true generally.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

