### PR TITLE
Remove requirements_git comments in output file

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -77,6 +77,7 @@ botocore==1.34.47
 cachetools==5.3.2
     # via google-auth
     # via
+    #   -r /awx_devel/requirements/requirements_git.txt
     #   kubernetes
     #   msrest
     #   requests

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -13,7 +13,6 @@ aiosignal==1.3.1
     # via aiohttp
 annotated-types==0.6.0
     # via pydantic
-    # via -r /awx_devel/requirements/requirements_git.txt
 ansiconv==1.0.0
     # via -r /awx_devel/requirements/requirements.in
 asciichartpy==1.5.25
@@ -78,7 +77,6 @@ botocore==1.34.47
 cachetools==5.3.2
     # via google-auth
     # via
-    #   -r /awx_devel/requirements/requirements_git.txt
     #   kubernetes
     #   msrest
     #   requests
@@ -142,7 +140,6 @@ django==4.2.10
     #   django-solo
     #   djangorestframework
     #   social-auth-app-django
-    # via -r /awx_devel/requirements/requirements_git.txt
 django-auth-ldap==4.6.0
     # via -r /awx_devel/requirements/requirements.in
 django-cors-headers==4.3.1
@@ -433,7 +430,6 @@ python-tss-sdk==1.2.2
     # via -r /awx_devel/requirements/requirements.in
 python3-openid==3.2.0
     # via social-auth-core
-    # via -r /awx_devel/requirements/requirements_git.txt
 pytz==2024.1
     # via
     #   irc

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -29,10 +29,13 @@ generate_requirements() {
   if [[ "$sanitize_git" == "1" ]] ; then
     while IFS= read -r line; do
       if [[ $line != \#* ]]; then  # ignore comments
+        echo ""
+        echo "Removing git+ entry:"
+        grep "${line%#*}" requirements.txt -C 4
         sed -i "\!${line%#*}!d" requirements.txt
       fi
     done < "${requirements_git}"
-    sed -i "/ -r \\/awx_devel\\/requirements\\/requirements_git/d" requirements.txt
+    sed -i "/via -r \\/awx_devel\\/requirements\\/requirements_git/d" requirements.txt
   fi;
 }
 

--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -32,6 +32,7 @@ generate_requirements() {
         sed -i "\!${line%#*}!d" requirements.txt
       fi
     done < "${requirements_git}"
+    sed -i "/ -r \\/awx_devel\\/requirements\\/requirements_git/d" requirements.txt
   fi;
 }
 


### PR DESCRIPTION
##### SUMMARY
I was reminded of this looking at https://github.com/ansible/awx/pull/15314

Elevator pitch:

We consider `requirements_git.txt` in resolution of dependencies (so that we get dependencies of git requirements) but we remove the direct git requirements from the resultant `requirements.txt` file... but that was implemented before pip-tools changed their format. At the time it was implemented, it was fully correct because the lines it operated on looked like:

```
git+foo.invalid  # via -r requirements_git.txt
```

But then pip-tools changed format to be like

```
git+foo
    # via -r requirements_git.txt
```

So the prior logic would remove the `git+` lines. After the format change, it started leaving around the comment lines.

I believe people have been leaving these comments lines around, mis-interpreting them as the source for the requirement above `git+foo`, which it is not.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

