### PR TITLE
Add in missing read permissions for organization audit role

### DIFF
--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -356,12 +356,14 @@ def setup_managed_role_definitions(apps, schema_editor):
         )
 
     if 'org_audit' in to_create:
+        audit_permissions = [perm for perm in org_perms if perm.codename.startswith('view_')]
+        audit_permissions.append(Permission.objects.get(codename='audit_organization'))
         managed_role_definitions.append(
             get_or_create_managed(
                 to_create['org_audit'].format(cls=Organization),
                 'Has permission to view all objects inside of a single organization',
                 org_ct,
-                [perm for perm in org_perms if perm.codename.startswith('view_')],
+                audit_permissions,
                 RoleDefinition,
             )
         )

--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -277,6 +277,7 @@ def setup_managed_role_definitions(apps, schema_editor):
     to_create = {
         'object_admin': '{cls.__name__} Admin',
         'org_admin': 'Organization Admin',
+        'org_audit': 'Organization Audit',
         'org_children': 'Organization {cls.__name__} Admin',
         'special': '{cls.__name__} {action}',
     }
@@ -327,7 +328,8 @@ def setup_managed_role_definitions(apps, schema_editor):
         if 'special' in to_create:
             special_perms = []
             for perm in object_perms:
-                if perm.codename.split('_')[0] not in ('add', 'change', 'delete', 'view'):
+                # Organization auditor is handled separately
+                if perm.codename.split('_')[0] not in ('add', 'change', 'delete', 'view', 'audit'):
                     special_perms.append(perm)
             for perm in special_perms:
                 action = perm.codename.split('_')[0]
@@ -349,6 +351,17 @@ def setup_managed_role_definitions(apps, schema_editor):
                 'Has all permissions to a single organization and all objects inside of it',
                 org_ct,
                 org_perms,
+                RoleDefinition,
+            )
+        )
+
+    if 'org_audit' in to_create:
+        managed_role_definitions.append(
+            get_or_create_managed(
+                to_create['org_audit'].format(cls=Organization),
+                'Has permission to view all objects inside of a single organization',
+                org_ct,
+                [perm for perm in org_perms if perm.codename.startswith('view_')],
                 RoleDefinition,
             )
         )

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -602,8 +602,9 @@ def get_role_from_object_role(object_role):
     elif rd.name.endswith(' Admin'):
         # cases like "project-admin"
         role_name = 'admin_role'
+    elif rd.name == 'Organization Audit':
+        role_name = 'auditor_role'
     else:
-        print(rd.name)
         model_name, role_name = rd.name.split()
         role_name = role_name.lower()
         role_name += '_role'

--- a/awx/main/tests/functional/dab_rbac/test_access_regressions.py
+++ b/awx/main/tests/functional/dab_rbac/test_access_regressions.py
@@ -34,8 +34,8 @@ def test_organization_auditor_role(rando, setup_managed_roles, organization, inv
     rd = RoleDefinition.objects.get(name='Organization Audit')
     rd.give_permission(rando, organization)
 
-    assert 'view_inventory' in list(rd.permissions.values_list('codename', flat=True))  # sanity
-    assert 'view_jobtemplate' in list(rd.permissions.values_list('codename', flat=True))  # sanity
+    codename_set = set(rd.permissions.values_list('codename', flat=True))
+    assert not ({'view_inventory', 'view_jobtemplate', 'audit_organization'} - codename_set)  # sanity
 
     assert [obj in type(obj).access_qs(rando) for obj in obj_list] == [True for i in range(3)], obj_list
     assert [rando.has_obj_perm(obj, 'view') for obj in obj_list] == [True for i in range(3)], obj_list

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer.py
@@ -35,7 +35,6 @@ def test_round_trip_roles(organization, rando, role_name, setup_managed_roles):
     """
     getattr(organization, role_name).members.add(rando)
     assignment = RoleUserAssignment.objects.get(user=rando)
-    print(assignment.role_definition.name)
     old_role = get_role_from_object_role(assignment.object_role)
     assert old_role.id == getattr(organization, role_name).id
 


### PR DESCRIPTION
##### SUMMARY
Organization audit role wasn't working. Obviously the point was to give read permission to everything in the organization, but the criteria for creating the role wasn't working. There are 2 different paths for creating managed roles, and some details between them look like they still need to be smoothed over.

AAP-26514

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

