### PR TITLE
Upgrade to v4 checkout, hide output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
           - name: ui-test-general
             command: make ui-test-general
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Build awx_devel image for running checks
         uses: ./.github/actions/awx_devel_image
@@ -52,7 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - uses: ./.github/actions/run_awx_devel
         id: awx
@@ -70,13 +74,15 @@ jobs:
       DEBUG_OUTPUT_DIR: /tmp/awx_operator_molecule_test
     steps:
       - name: Checkout awx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           path: awx
 
       - name: Checkout awx-operator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false\
           repository: ansible/awx-operator
           path: awx-operator
 
@@ -130,7 +136,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       # The containers that GitHub Actions use have Ansible installed, so upgrade to make sure we have the latest version.
       - name: Upgrade ansible-core
@@ -154,7 +162,9 @@ jobs:
           - name: r-z0-9
             regex: ^[r-z0-9]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - uses: ./.github/actions/run_awx_devel
         id: awx
@@ -200,7 +210,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Upgrade ansible-core
         run: python3 -m pip install --upgrade ansible-core

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -35,7 +35,9 @@ jobs:
           exit 0
         if: matrix.build-targets.image-name == 'awx' && !endsWith(github.repository, '/awx')
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: install tox
         run: pip install tox

--- a/.github/workflows/label_issue.yml
+++ b/.github/workflows/label_issue.yml
@@ -30,7 +30,10 @@ jobs:
     timeout-minutes: 20
     name: Label Issue - Community
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
       - uses: actions/setup-python@v4
       - name: Install python requests
         run: pip install requests

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -29,7 +29,10 @@ jobs:
     timeout-minutes: 20
     name: Label PR - Community
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+
       - uses: actions/setup-python@v4
       - name: Install python requests
         run: pip install requests

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -32,7 +32,9 @@ jobs:
           echo "TAG_NAME=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Checkout awx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Get python version from Makefile
         run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -45,19 +45,22 @@ jobs:
           exit 0
 
       - name: Checkout awx
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           path: awx
 
       - name: Checkout awx-operator
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           repository: ${{ github.repository_owner }}/awx-operator
           path: awx-operator
 
       - name: Checkout awx-logos
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           repository: ansible/awx-logos
           path: awx-logos
 

--- a/.github/workflows/update_dependabot_prs.yml
+++ b/.github/workflows/update_dependabot_prs.yml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Update PR Body
         env:

--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -18,7 +18,9 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Get python version from Makefile
         run: echo py_version=`make PYTHON_VERSION` >> $GITHUB_ENV


### PR DESCRIPTION
##### SUMMARY
Quality of life change I'm borrowing from a similar patch I did in DAB. A very significant fraction of the output of checks is this:

```
2024-07-02T16:19:20.9207790Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin +671cb4202173df0bce91edb49c817222ee7b7a87:refs/remotes/pull/15320/merge
2024-07-02T16:19:21.1584293Z remote: Enumerating objects: 4884, done.        
2024-07-02T16:19:21.1586027Z remote: Counting objects:   0% (1/4884)        
2024-07-02T16:19:21.1587198Z remote: Counting objects:   1% (49/4884)        
2024-07-02T16:19:21.1588065Z remote: Counting objects:   2% (98/4884)        
2024-07-02T16:19:21.1588719Z remote: Counting objects:   3% (147/4884)        
2024-07-02T16:19:21.1589457Z remote: Counting objects:   4% (196/4884)        
2024-07-02T16:19:21.1590201Z remote: Counting objects:   5% (245/4884)        
2024-07-02T16:19:21.1590905Z remote: Counting objects:   6% (294/4884)        
2024-07-02T16:19:21.1591567Z remote: Counting objects:   7% (342/4884)        
2024-07-02T16:19:21.1592316Z remote: Counting objects:   8% (391/4884)        
```

There's no value in this. Nobody wants this. I don't think I have ever been debugging the `git clone` command out of the many things that go wrong in checks. This turns on the output to hide that output, leaving more room for what we want.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

