### PR TITLE
Suppress docker pull output in checks

### DIFF
--- a/.github/actions/awx_devel_image/action.yml
+++ b/.github/actions/awx_devel_image/action.yml
@@ -24,7 +24,7 @@ runs:
 
     - name: Pre-pull latest devel image to warm cache
       shell: bash
-      run: docker pull ghcr.io/${OWNER_LC}/awx_devel:${{ github.base_ref }}
+      run: docker pull -q ghcr.io/${OWNER_LC}/awx_devel:${{ github.base_ref }}
 
     - name: Build image for current source checkout
       shell: bash

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -136,9 +136,9 @@ jobs:
       - name: Pulling images for test deployment with awx-operator
         # awx operator molecue test expect to kind load image and buildx exports image to registry and not local
         run: |
-          docker pull ${AWX_OPERATOR_TEST_IMAGE}
-          docker pull ${AWX_EE_TEST_IMAGE}
-          docker pull ${AWX_TEST_IMAGE}:${AWX_TEST_VERSION}
+          docker pull -q ${AWX_OPERATOR_TEST_IMAGE}
+          docker pull -q ${AWX_EE_TEST_IMAGE}
+          docker pull -q ${AWX_TEST_IMAGE}:${AWX_TEST_VERSION}
 
       - name: Run test deployment with awx-operator
         working-directory: awx-operator

--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Pre-pull image to warm build cache
         run: |
-          docker pull ghcr.io/${{ github.repository_owner }}/awx_devel:${GITHUB_REF##*/} || :
+          docker pull -q ghcr.io/${{ github.repository_owner }}/awx_devel:${GITHUB_REF##*/} || :
 
       - name: Build image
         run: |


### PR DESCRIPTION
##### SUMMARY
If you look at output from some checks, you see a lot of redundant and low-quality output like this:

```
2024-07-02T18:15:23.7137876Z devel: Pulling from ansible/awx_devel
2024-07-02T18:15:23.7677673Z 0d9665cbb1e4: Pulling fs layer
2024-07-02T18:15:23.7679211Z 27539475c0a4: Pulling fs layer
2024-07-02T18:15:23.7680320Z 5218e8872ec3: Pulling fs layer
2024-07-02T18:15:23.7681500Z 1b7a59365104: Pulling fs layer
2024-07-02T18:15:23.7682664Z 46a95a4c2d71: Pulling fs layer
2024-07-02T18:15:23.7683556Z 7fa2cc3e1467: Pulling fs layer
2024-07-02T18:15:23.7684413Z 4eb063f37718: Pulling fs layer
2024-07-02T18:15:23.7685534Z 74498915e0e5: Pulling fs layer
2024-07-02T18:15:23.7686456Z 3b973abdbf43: Pulling fs layer
2024-07-02T18:15:23.7687298Z e46b234c2a2a: Pulling fs layer
2024-07-02T18:15:23.7688763Z 05546d71ca2c: Pulling fs layer
2024-07-02T18:15:23.7689736Z 644386d70d6d: Pulling fs layer
2024-07-02T18:15:23.7690874Z b4c509e6df1e: Pulling fs layer
2024-07-02T18:15:23.7691838Z 3cbf691386e0: Pulling fs layer
2024-07-02T18:15:23.7692996Z c1f6cc2d52d1: Pulling fs layer
2024-07-02T18:15:23.7694656Z 26f8a6dacebb: Pulling fs layer
2024-07-02T18:15:23.7695196Z 77bd7afa3588: Pulling fs layer
```

This should get rid of that to help clean things up.

AAP-26564

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

