### PR TITLE
Log conflicts and created items by the periodic resource sync

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -981,4 +981,6 @@ def periodic_resource_sync():
             logger.debug("Not running periodic_resource_sync, another task holds lock")
             return
 
-        SyncExecutor().run()
+        executor = SyncExecutor()
+        executor.run()
+        logger.info(f'Periodic resource sync results:\n{executor.results}')

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -983,4 +983,11 @@ def periodic_resource_sync():
 
         executor = SyncExecutor()
         executor.run()
-        logger.info(f'Periodic resource sync results:\n{executor.results}')
+        for key, item_list in executor.results:
+            if not item_list or key == 'noop':
+                continue
+            # Log creations and conflicts
+            if len(item_list) > 10 and settings.LOG_AGGREGATOR_LEVEL != 'DEBUG':
+                logger.info(f'Periodic resource sync {key}, first 10 items:\n{item_list[:10]}')
+            else:
+                logger.info(f'Periodic resource sync {key}:\n{item_list}')

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -980,6 +980,7 @@ def periodic_resource_sync():
         if acquired is False:
             logger.debug("Not running periodic_resource_sync, another task holds lock")
             return
+        logger.debug("Running periodic resource sync")
 
         executor = SyncExecutor()
         executor.run()


### PR DESCRIPTION
##### SUMMARY
This gets us some visibility as to what happens in the resource sync.

I will leave this as draft until I get some logs from integration testing to confirm it is working as expected.

You can run `awx-manage resource_sync`, and this is my answer if someone wants the "noop" entries. Otherwise, I don't want to periodically log that a list of items exist, even at debug level.

Ping @rochacbruno

Internal:
AAP-26390
yolo 9479, 9486

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

