### PR TITLE
Remove archaic monkey patches

### DIFF
--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -61,23 +61,6 @@ else:
     from django.db import connection
 
 
-def find_commands(management_dir):
-    # Modified version of function from django/core/management/__init__.py.
-    command_dir = os.path.join(management_dir, 'commands')
-    commands = []
-    try:
-        for f in os.listdir(command_dir):
-            if f.startswith('_'):
-                continue
-            elif f.endswith('.py') and f[:-3] not in commands:
-                commands.append(f[:-3])
-            elif f.endswith('.pyc') and f[:-4] not in commands:  # pragma: no cover
-                commands.append(f[:-4])
-    except OSError:
-        pass
-    return commands
-
-
 def oauth2_getattribute(self, attr):
     # Custom method to override
     # oauth2_provider.settings.OAuth2ProviderSettings.__getattribute__
@@ -106,45 +89,12 @@ def prepare_env():
 
     if not settings.DEBUG:  # pragma: no cover
         warnings.simplefilter('ignore', DeprecationWarning)
-    # Monkeypatch Django find_commands to also work with .pyc files.
-    import django.core.management
-
-    django.core.management.find_commands = find_commands
 
     # Monkeypatch Oauth2 toolkit settings class to check for settings
     # in django.conf settings each time, not just once during import
     import oauth2_provider.settings
 
     oauth2_provider.settings.OAuth2ProviderSettings.__getattribute__ = oauth2_getattribute
-
-    # Use the AWX_TEST_DATABASE_* environment variables to specify the test
-    # database settings to use when management command is run as an external
-    # program via unit tests.
-    for opt in ('ENGINE', 'NAME', 'USER', 'PASSWORD', 'HOST', 'PORT'):  # pragma: no cover
-        if os.environ.get('AWX_TEST_DATABASE_%s' % opt, None):
-            settings.DATABASES['default'][opt] = os.environ['AWX_TEST_DATABASE_%s' % opt]
-    # Disable capturing all SQL queries in memory when in DEBUG mode.
-    if settings.DEBUG and not getattr(settings, 'SQL_DEBUG', True):
-        from django.db.backends.base.base import BaseDatabaseWrapper
-        from django.db.backends.utils import CursorWrapper
-
-        BaseDatabaseWrapper.make_debug_cursor = lambda self, cursor: CursorWrapper(cursor, self)
-
-    # Use the default devserver addr/port defined in settings for runserver.
-    default_addr = getattr(settings, 'DEVSERVER_DEFAULT_ADDR', '127.0.0.1')
-    default_port = getattr(settings, 'DEVSERVER_DEFAULT_PORT', 8000)
-    from django.core.management.commands import runserver as core_runserver
-
-    original_handle = core_runserver.Command.handle
-
-    def handle(self, *args, **options):
-        if not options.get('addrport'):
-            options['addrport'] = '%s:%d' % (default_addr, int(default_port))
-        elif options.get('addrport').isdigit():
-            options['addrport'] = '%s:%d' % (default_addr, int(options['addrport']))
-        return original_handle(self, *args, **options)
-
-    core_runserver.Command.handle = handle
 
 
 def manage():


### PR DESCRIPTION
##### SUMMARY
I am about 95% sure that we don't need any of these for any reason anymore.

Some are fairly obvious, like, if it modifies `awx-manage runserver` behavior, then we should be good, because that's outrageously unsupported in every sense of the word.

However, `find_commands` is the most likely to have fallout here. I believe this was written for a time when the source was not distributed along with the compiled files, which is an issue resolved by going open source. I find it incredibly unlikely that someone is distributing AWX without the source files, and if they are, I would ask them to stop.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
