### PR TITLE
Bring WFJT job access to parity with UnifiedJobAccess

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2098,7 +2098,7 @@ class WorkflowJobAccess(BaseAccess):
     def filtered_queryset(self):
         return WorkflowJob.objects.filter(
             Q(unified_job_template__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'))
-            | Q(organization__in=Organization.objects.filter(Q(admin_role__members=self.user)), is_bulk_job=True)
+            | Q(organization__in=Organization.accessible_pk_qs(self.user, 'auditor_role'))
         )
 
     def can_read(self, obj):
@@ -2496,12 +2496,11 @@ class UnifiedJobAccess(BaseAccess):
 
     def filtered_queryset(self):
         inv_pk_qs = Inventory._accessible_pk_qs(Inventory, self.user, 'read_role')
-        org_auditor_qs = Organization.objects.filter(Q(admin_role__members=self.user) | Q(auditor_role__members=self.user))
         qs = self.model.objects.filter(
             Q(unified_job_template_id__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'))
             | Q(inventoryupdate__inventory_source__inventory__id__in=inv_pk_qs)
             | Q(adhoccommand__inventory__id__in=inv_pk_qs)
-            | Q(organization__in=org_auditor_qs)
+            | Q(organization__in=Organization.accessible_pk_qs(self.user, 'auditor_role'))
         )
         return qs
 

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer.py
@@ -107,6 +107,17 @@ def test_compat_role_naming(setup_managed_roles, job_template, rando, alice):
 
 
 @pytest.mark.django_db
+def test_organization_admin_has_audit(setup_managed_roles):
+    """This formalizes a behavior change from old to new RBAC system
+
+    Previously, the auditor_role did not list admin_role as a parent
+    this made various queries hard to deal with, requiring adding 2 conditions
+    The new system should explicitly list the auditor permission in org admin role"""
+    rd = RoleDefinition.objects.get(name='Organization Admin')
+    assert 'audit_organization' in rd.permissions.values_list('codename', flat=True)
+
+
+@pytest.mark.django_db
 def test_organization_level_permissions(organization, inventory, setup_managed_roles):
     u1 = User.objects.create(username='alice')
     u2 = User.objects.create(username='bob')

--- a/awx/main/tests/functional/rbac/test_rbac_workflow.py
+++ b/awx/main/tests/functional/rbac/test_rbac_workflow.py
@@ -7,7 +7,7 @@ from awx.main.access import (
     WorkflowJobAccess,
     # WorkflowJobNodeAccess
 )
-from awx.main.models import JobTemplate, WorkflowJobTemplateNode, WorkflowJob
+from awx.main.models import JobTemplate, WorkflowJobTemplateNode
 
 from rest_framework.exceptions import PermissionDenied
 

--- a/awx/main/tests/functional/rbac/test_rbac_workflow.py
+++ b/awx/main/tests/functional/rbac/test_rbac_workflow.py
@@ -1,12 +1,13 @@
 import pytest
 
 from awx.main.access import (
+    UnifiedJobAccess,
     WorkflowJobTemplateAccess,
     WorkflowJobTemplateNodeAccess,
     WorkflowJobAccess,
     # WorkflowJobNodeAccess
 )
-from awx.main.models import JobTemplate, WorkflowJobTemplateNode
+from awx.main.models import JobTemplate, WorkflowJobTemplateNode, WorkflowJob
 
 from rest_framework.exceptions import PermissionDenied
 
@@ -244,6 +245,30 @@ class TestWorkflowJobAccess:
             WorkflowJobAccess(rando).can_start(workflow_job)
         inventory.use_role.members.add(rando)
         assert WorkflowJobAccess(rando).can_start(workflow_job)
+
+    @pytest.mark.parametrize('org_role', ['admin_role', 'auditor_role'])
+    def test_workflow_job_org_audit_access(self, workflow_job_template, rando, org_role):
+        assert workflow_job_template.organization  # sanity
+        workflow_job = workflow_job_template.create_unified_job()
+        assert workflow_job.organization  # sanity
+
+        assert not UnifiedJobAccess(rando).can_read(workflow_job)
+        assert not WorkflowJobAccess(rando).can_read(workflow_job)
+        assert workflow_job not in WorkflowJobAccess(rando).filtered_queryset()
+
+        org = workflow_job.organization
+        role = getattr(org, org_role)
+        role.members.add(rando)
+
+        assert UnifiedJobAccess(rando).can_read(workflow_job)
+        assert WorkflowJobAccess(rando).can_read(workflow_job)
+        assert workflow_job in WorkflowJobAccess(rando).filtered_queryset()
+
+        # Organization-level permissions should persist after deleting the WFJT
+        workflow_job_template.delete()
+        assert UnifiedJobAccess(rando).can_read(workflow_job)
+        assert WorkflowJobAccess(rando).can_read(workflow_job)
+        assert workflow_job in WorkflowJobAccess(rando).filtered_queryset()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
Quick rundown in code - the method `WorkflowJobAccess.filtered_queryset` should always yield the same result as `UnifiedJobAccess.filtered_queryset`. The same should be true for all other "unified" job types generally, since this is a polymorphic model.

Quick rundown of net effect - if you visit `/api/v2/workflow_jobs/:id/`, that will use the concrete model (workflow job) rules, and this should not give a different "answer" than the listing at `/api/v2/unified_jobs/`.

The particular issue that we were seeing was that a user unexpectedly didn't have permission to view a workflow job. As I expected, when I wrote the test for this I found that it was essentially a solved problem... if the object was treated as a `UnifiedJob` as opposed to a `WorkflowJob`.

This makes it very hard to argue against a change. A courtroom judge need not be impartial, but must be _consistent_ in their rulings if they are to maintain the rule of law.

This is written to allow a backport with the changes:
 - `UnifiedJob.filtered_queryset` should revert to no changes
 - translation layer tests to be deleted
 - The `WorkflowJobAccess.filtered_queryset` must revert to use the `auditor_qs` due to the lack of admin->auditor inheritance

AAP-20831 and AAP-26658

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

