### PR TITLE
Update ActivityStream UI query to order by id

### DIFF
--- a/awx/ui/src/screens/ActivityStream/ActivityStream.js
+++ b/awx/ui/src/screens/ActivityStream/ActivityStream.js
@@ -59,7 +59,7 @@ function ActivityStream() {
     {
       page: 1,
       page_size: 20,
-      order_by: '-timestamp',
+      order_by: '-id',
     },
     ['id', 'page', 'page_size']
   );


### PR DESCRIPTION
##### SUMMARY
Timestamp for activity stream is not indexed result in slow query. switching to ID (which effectively will is order by created time) to improve performance

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - UI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
