### PR TITLE
Fix EE admin not being able to PATCH/PUT object while providing `organization`

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1411,19 +1411,19 @@ class ExecutionEnvironmentAccess(BaseAccess):
 
     @check_superuser
     def can_change(self, obj, data):
+        logger.warning(f'EE data {data}')
         if obj and obj.organization_id is None:
             raise PermissionDenied
         if settings.ANSIBLE_BASE_ROLE_SYSTEM_ACTIVATED:
             if not self.user.has_obj_perm(obj, 'change'):
+                logger.warning('does not have EE object access')
                 return False
         else:
             if self.user not in obj.organization.execution_environment_admin_role:
                 raise PermissionDenied
-        if data and 'organization' in data:
-            new_org = get_object_from_data('organization', Organization, data, obj=obj)
-            if not new_org or self.user not in new_org.execution_environment_admin_role:
-                return False
-        return self.check_related('organization', Organization, data, obj=obj, role_field='execution_environment_admin_role')
+        ret = self.check_related('organization', Organization, data, obj=obj, role_field='execution_environment_admin_role')
+        logger.warning(f'Org check value {ret}')
+        return ret
 
     def can_delete(self, obj):
         if obj.managed:

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1411,19 +1411,15 @@ class ExecutionEnvironmentAccess(BaseAccess):
 
     @check_superuser
     def can_change(self, obj, data):
-        logger.warning(f'EE data {data}')
         if obj and obj.organization_id is None:
             raise PermissionDenied
         if settings.ANSIBLE_BASE_ROLE_SYSTEM_ACTIVATED:
             if not self.user.has_obj_perm(obj, 'change'):
-                logger.warning('does not have EE object access')
                 return False
         else:
             if self.user not in obj.organization.execution_environment_admin_role:
                 raise PermissionDenied
-        ret = self.check_related('organization', Organization, data, obj=obj, role_field='execution_environment_admin_role')
-        logger.warning(f'Org check value {ret}')
-        return ret
+        return self.check_related('organization', Organization, data, obj=obj, role_field='execution_environment_admin_role')
 
     def can_delete(self, obj):
         if obj.managed:

--- a/awx/main/tests/functional/test_rbac_execution_environment.py
+++ b/awx/main/tests/functional/test_rbac_execution_environment.py
@@ -114,11 +114,18 @@ def test_give_object_permission_to_ee(org_ee, ee_rd, org_member, check_user_capa
 def test_need_related_organization_access(org_ee, ee_rd, org_member):
     org2 = Organization.objects.create(name='another organization')
     ee_rd.give_permission(org_member, org_ee)
+    org2.member_role.members.add(org_member)
     access = ExecutionEnvironmentAccess(org_member)
     assert access.can_change(org_ee, {'name': 'new', 'organization': org_ee.organization})
     assert access.can_change(org_ee, {'name': 'new', 'organization': org_ee.organization.id})
     assert not access.can_change(org_ee, {'name': 'new', 'organization': org2.id})
     assert not access.can_change(org_ee, {'name': 'new', 'organization': org2})
+
+    # User can make the change if they have relevant permission to the new organization
+    org_ee.organization.execution_environment_admin_role.members.add(org_member)
+    org2.execution_environment_admin_role.members.add(org_member)
+    assert access.can_change(org_ee, {'name': 'new', 'organization': org2.id})
+    assert access.can_change(org_ee, {'name': 'new', 'organization': org2})
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/test_rbac_execution_environment.py
+++ b/awx/main/tests/functional/test_rbac_execution_environment.py
@@ -105,9 +105,20 @@ def test_give_object_permission_to_ee(org_ee, ee_rd, org_member, check_user_capa
     check_user_capabilities(org_member, org_ee, {'edit': False, 'delete': False, 'copy': False})
 
     ee_rd.give_permission(org_member, org_ee)
-    assert access.can_change(org_ee, {'name': 'new'})
+    assert access.can_change(org_ee, {'name': 'new', 'organization': org_ee.organization.id})
 
     check_user_capabilities(org_member, org_ee, {'edit': True, 'delete': True, 'copy': False})
+
+
+@pytest.mark.django_db
+def test_need_related_organization_access(org_ee, ee_rd, org_member):
+    org2 = Organization.objects.create(name='another organization')
+    ee_rd.give_permission(org_member, org_ee)
+    access = ExecutionEnvironmentAccess(org_member)
+    assert access.can_change(org_ee, {'name': 'new', 'organization': org_ee.organization})
+    assert access.can_change(org_ee, {'name': 'new', 'organization': org_ee.organization.id})
+    assert not access.can_change(org_ee, {'name': 'new', 'organization': org2.id})
+    assert not access.can_change(org_ee, {'name': 'new', 'organization': org2})
 
 
 @pytest.mark.django_db
@@ -123,5 +134,5 @@ def test_give_org_permission_to_ee(org_ee, organization, org_member, check_user_
     else:
         organization.execution_environment_admin_role.members.add(org_member)
 
-    assert access.can_change(org_ee, {'name': 'new'})
+    assert access.can_change(org_ee, {'name': 'new', 'organization': organization.id})
     check_user_capabilities(org_member, org_ee, {'edit': True, 'delete': True, 'copy': True})


### PR DESCRIPTION
##### SUMMARY
I left around some old redundant checks in the access method, thinking they wouldn't cause a problem (how common is it that someone would change an EE's organization?) but this messes up PUT requests, in particular as it appears to re-apply the existing EE's organization.

AAP-25268

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
