### PR TITLE
Fix command to set db session timeout for locks

### DIFF
--- a/awx/main/utils/pglock.py
+++ b/awx/main/utils/pglock.py
@@ -17,13 +17,13 @@ def advisory_lock(*args, lock_session_timeout_milliseconds=0, **kwargs):
             with connection.cursor() as cur:
                 idle_in_transaction_session_timeout = cur.execute('SHOW idle_in_transaction_session_timeout').fetchone()[0]
                 idle_session_timeout = cur.execute('SHOW idle_session_timeout').fetchone()[0]
-                cur.execute(f"SET idle_in_transaction_session_timeout = {lock_session_timeout_milliseconds}")
-                cur.execute(f"SET idle_session_timeout = {lock_session_timeout_milliseconds}")
+                cur.execute(f"SET idle_in_transaction_session_timeout = '{lock_session_timeout_milliseconds}'")
+                cur.execute(f"SET idle_session_timeout = '{lock_session_timeout_milliseconds}'")
         with django_pglocks_advisory_lock(*args, **kwargs) as internal_lock:
             yield internal_lock
             if lock_session_timeout_milliseconds > 0:
                 with connection.cursor() as cur:
-                    cur.execute(f"SET idle_in_transaction_session_timeout = {idle_in_transaction_session_timeout}")
-                    cur.execute(f"SET idle_session_timeout = {idle_session_timeout}")
+                    cur.execute(f"SET idle_in_transaction_session_timeout = '{idle_in_transaction_session_timeout}'")
+                    cur.execute(f"SET idle_session_timeout = '{idle_session_timeout}'")
     else:
         yield True


### PR DESCRIPTION
##### SUMMARY
Add quote around the value of the setting

Example failures
```
2024-07-10 13:33:29,237 ERROR    [a7e55a64e6744a0e920bb1fd78615e5f] awx.main.dispatch Worker failed to run task awx.main.tasks.system.awx_periodic_scheduler(*[], **{}
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 87, in _execute
    return self.cursor.execute(sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/psycopg/cursor.py", line 732, in execute
    raise ex.with_traceback(None)
psycopg.errors.SyntaxError: trailing junk after numeric literal at or near "1d"
LINE 1: SET idle_in_transaction_session_timeout = 1d
                                                  ^
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
