### PR TITLE
Fix task ending in error due to bad iterator

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -984,7 +984,7 @@ def periodic_resource_sync():
 
         executor = SyncExecutor()
         executor.run()
-        for key, item_list in executor.results:
+        for key, item_list in executor.results.items():
             if not item_list or key == 'noop':
                 continue
             # Log creations and conflicts


### PR DESCRIPTION
##### SUMMARY
Fixes bug from https://github.com/ansible/awx/pull/15337

before

```
In [1]: from awx.main.tasks.system import periodic_resource_sync

In [2]: periodic_resource_sync()
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 periodic_resource_sync()

File /awx_devel/awx/main/tasks/system.py:987, in periodic_resource_sync()
    985 executor = SyncExecutor()
    986 executor.run()
--> 987 for key, item_list in executor.results:
    988     if not item_list or key == 'noop':
    989         continue

ValueError: too many values to unpack (expected 2)
```

after

```
In [1]: from awx.main.tasks.system import periodic_resource_sync

In [2]: periodic_resource_sync()
2024-07-10 19:19:17,725 INFO     [-] awx.main.tasks.system Periodic resource sync conflict:
[ManifestItem(ansible_id='8062ab7e-22e7-4ab0-9ced-81ac62a3fe3e', resource_hash='86f06a619dd768393c4969f725bae089a265168fb79f1fdcac2d4442e41ac529', service_id='d9215204-ed67-4da8-882c-2a4a401a6d9e', resource_data={'username': 'admin', 'email': 'admin@localhost', 'first_name': '', 'last_name': '', 'is_superuser': True})]
```

tested using @chrismeyersfsu aap-dev environment

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
