### PR TITLE
Fix create_preload_data to allow running without an admin user created

### DIFF
--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -2,4 +2,4 @@ git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 git+https://github.com/ansible/python3-saml.git@devel#egg=python3-saml
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
+django-ansible-base @ git+https://github.com/alancoding/django-ansible-base@new_user2#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -2,4 +2,4 @@ git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 git+https://github.com/ansible/python3-saml.git@devel#egg=python3-saml
-django-ansible-base @ git+https://github.com/alancoding/django-ansible-base@new_user2#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
+django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]


### PR DESCRIPTION
##### SUMMARY
The code here shows an _intent_ to support this, and I needed it for my own purposes.

The heuristic about whether it runs or not is "does the Default organization exist?" If not, then it runs. I also made this atomic, because I have too-many times had this create partial data and then error, messing up further testing.

This is a part of a larger collection of patches for a fix, so that's why I'm putting it up in draft, with a temporary DAB pin.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

