### PR TITLE
update terminology

### DIFF
--- a/docs/docsite/rst/administration/configure_awx.rst
+++ b/docs/docsite/rst/administration/configure_awx.rst
@@ -23,7 +23,6 @@ Authentication
 .. index::
     single: social authentication
     single: authentication
-    single: enterprise authentication
     pair: configuration; authentication
 
 .. include:: ./configure_awx_authentication.rst

--- a/docs/docsite/rst/common/logos_branding.rst
+++ b/docs/docsite/rst/common/logos_branding.rst
@@ -18,7 +18,7 @@ For example, if you uploaded a specific logo, and added the following text:
 	:alt: Edit User Interface Settings form populated with custom text and logo.
 
 
-The Tower login dialog would look like this:
+The AWX login dialog would look like this:
 
 .. image:: ../common/images/configure-awx-ui-angry-spud-login.png
 	:alt: AWX login screen with custom text and logo.

--- a/docs/docsite/rst/rest_api/authentication.rst
+++ b/docs/docsite/rst/rest_api/authentication.rst
@@ -8,7 +8,7 @@ Authentication Methods Using the API
    pair: OAuth 2 Token; authentication
    pair: SSO; authentication
 
-This chapter describes the numerous enterprise authentication methods, the best use case for each, and examples:
+This chapter describes different authentication methods, the best use case for each, and examples:
 
 .. contents::
     :local:

--- a/docs/docsite/rst/userguide/overview.rst
+++ b/docs/docsite/rst/userguide/overview.rst
@@ -240,7 +240,7 @@ Job Distribution
    pair: features; jobs, slicing
    pair: features; jobs, distribution
 
-AWX offer the ability to take a fact gathering or configuration job running across thousands of machines and slice it into individual job slices that can be distributed across your AWX cluster for increased reliability, faster job completion, and better cluster utilization.
+AWX offers the ability to take a fact gathering or configuration job running across thousands of machines and slice it into individual job slices that can be distributed across your AWX cluster for increased reliability, faster job completion, and better cluster utilization.
 If you need to change a parameter across 15,000 switches at scale, or gather information across your multi-thousand-node RHEL estate, you can now do so easily.
 
 

--- a/docs/docsite/rst/userguide/overview.rst
+++ b/docs/docsite/rst/userguide/overview.rst
@@ -189,7 +189,7 @@ Authentication Enhancements
    pair: features; authentication
    pair: features; OAuth 2 token
 
-AWX supports LDAP, SAML, token-based authentication. Enhanced LDAP and SAML support allows you to integrate your enterprise account information in a more flexible manner. Token-based Authentication allows for easily authentication of third-party tools and services with AWX via integrated OAuth 2 token support.
+AWX supports LDAP, SAML, token-based authentication. Enhanced LDAP and SAML support allows you to integrate your account information in a more flexible manner. Token-based Authentication allows for easily authentication of third-party tools and services with AWX via integrated OAuth 2 token support.
 
 Cluster Management
 ~~~~~~~~~~~~~~~~~~~~
@@ -240,9 +240,8 @@ Job Distribution
    pair: features; jobs, slicing
    pair: features; jobs, distribution
 
-As automation moves enterprise-wide, the need to automate at scale grows. AWX offer the ability to take a fact gathering or
-configuration job running across thousands of machines and slice it into individual job slices that can be distributed across your AWX cluster for increased reliability, faster job completion, and better cluster utilization. If you need to change a parameter across 15,000 switches at
-scale, or gather information across your multi-thousand-node RHEL estate, you can now do so easily.
+AWX offer the ability to take a fact gathering or configuration job running across thousands of machines and slice it into individual job slices that can be distributed across your AWX cluster for increased reliability, faster job completion, and better cluster utilization.
+If you need to change a parameter across 15,000 switches at scale, or gather information across your multi-thousand-node RHEL estate, you can now do so easily.
 
 
 Support for deployment in a FIPS-enabled environment

--- a/docs/docsite/rst/userguide/rbac.rst
+++ b/docs/docsite/rst/userguide/rbac.rst
@@ -21,7 +21,7 @@ DAB RBAC
    single: roles   
    pair: DAB; RBAC
 
-This section describes the latest changes to RBAC, involving use of the ``django-ansible-base`` (DAB) library, to enhance existing roles, provide a uniformed model that is compatible with platform (enterprise) components, and allow creation of custom roles. However, the internals of the system in the backend have changes implemented, but they are not reflected yet in the AWX UI. The change to the backend maintains a compatibility layer so the “old” roles in the API still exists temporarily, until a fully-functional compatible UI replaces the existing roles. 
+This section describes the latest changes to RBAC, involving use of the ``django-ansible-base`` (DAB) library, to enhance existing roles, and allow creation of custom roles. However, the internals of the system in the backend have changes implemented, but they are not reflected yet in the AWX UI. The change to the backend maintains a compatibility layer so the “old” roles in the API still exists temporarily, until a fully-functional compatible UI replaces the existing roles. 
 
 New functionality, specifically custom roles, are possible through direct API clients or the API browser, but the presentation in the AWX UI might not reflect the changes made in the API.
 


### PR DESCRIPTION
##### SUMMARY
Replace some instances of Tower with AWX and remove some references to enterprise left over from the migration of RST content from the Automation Controller docs.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### AWX VERSION
n/a


##### ADDITIONAL INFORMATION
n/a
