### PR TITLE
Allow deleting org of a running workflow job

### DIFF
--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -692,16 +692,16 @@ def sync_parents_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs)
             try:
                 child_role = Role.objects.get(id=role_id)
             except Role.DoesNotExist:
-                child_role = None
+                continue
         else:
             try:
                 parent_role = Role.objects.get(id=role_id)
             except Role.DoesNotExist:
-                parent_role = None
+                continue
 
         # To a fault, we want to avoid running this if triggered from implicit_parents management
         # we only want to do anything if we know for sure this is a non-implicit team role
-        if child_role and parent_role and parent_role.role_field == 'member_role' and parent_role.content_type.model == 'team':
+        if parent_role.role_field == 'member_role' and parent_role.content_type.model == 'team':
             # Team internal parents are member_role->read_role and admin_role->member_role
             # for the same object, this parenting will also be implicit_parents management
             # do nothing for internal parents, but OTHER teams may still be assigned permissions to a team

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -689,13 +689,19 @@ def sync_parents_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs)
 
     for role_id in pk_set:
         if reverse:
-            child_role = Role.objects.get(id=role_id)
+            try:
+                child_role = Role.objects.get(id=role_id)
+            except Role.DoesNotExist:
+                child_role = None
         else:
-            parent_role = Role.objects.get(id=role_id)
+            try:
+                parent_role = Role.objects.get(id=role_id)
+            except Role.DoesNotExist:
+                parent_role = None
 
         # To a fault, we want to avoid running this if triggered from implicit_parents management
         # we only want to do anything if we know for sure this is a non-implicit team role
-        if parent_role.role_field == 'member_role' and parent_role.content_type.model == 'team':
+        if child_role and parent_role and parent_role.role_field == 'member_role' and parent_role.content_type.model == 'team':
             # Team internal parents are member_role->read_role and admin_role->member_role
             # for the same object, this parenting will also be implicit_parents management
             # do nothing for internal parents, but OTHER teams may still be assigned permissions to a team

--- a/awx/main/tests/functional/test_rbac_organization.py
+++ b/awx/main/tests/functional/test_rbac_organization.py
@@ -53,7 +53,7 @@ def test_org_resource_role(ext_auth, organization, rando, org_admin):
 
 
 @pytest.mark.django_db
-def test_deleting_org_while_workflow_active(workflow_job_template):
+def test_delete_org_while_workflow_active(workflow_job_template):
     '''
     Delete org while workflow job is active (i.e. changing status)
     '''

--- a/awx/main/tests/functional/test_rbac_organization.py
+++ b/awx/main/tests/functional/test_rbac_organization.py
@@ -6,8 +6,6 @@ from awx.main.access import (
     OrganizationAccess,
 )
 
-from awx.main.models import Role
-
 
 @mock.patch.object(BaseAccess, 'check_license', return_value=None)
 @pytest.mark.django_db


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Old RBAC system hits DOESNOTEXIST query errors if a user deletes an org while a workflow job is active.

The error is triggered by
1. starting workflow job
2. delete the org that the workflow job is a part of
3. The workflow changes status (e.g. pending to waiting)

This error message would surface
awx.main.models.rbac.Role.DoesNotExist: Role matching query does not exist.

The fix is wrap the query in a try catch, and skip over some logic if the roles don't exist.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
