### PR TITLE
Upgrade django-oauth-toolkit

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -18,7 +18,7 @@ django-cors-headers
 django-crum
 django-extensions
 django-guid==3.2.1
-django-oauth-toolkit<2.0.0      # Version 2.0.0 has breaking changes that will need to be worked out before upgrading
+django-oauth-toolkit<2.4.0      # UPGRADE BLOCKER: inline with the version used in DAB
 django-polymorphic
 django-pglocks
 django-radius

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -155,7 +155,7 @@ django-extensions==3.2.3
     # via -r /awx_devel/requirements/requirements.in
 django-guid==3.2.1
     # via -r /awx_devel/requirements/requirements.in
-django-oauth-toolkit==1.7.1
+django-oauth-toolkit==2.3.0
     # via -r /awx_devel/requirements/requirements.in
 django-pglocks==1.0.4
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The blocker is over a year old and we're already integrating django-ansible-base which is on version 2.3.0.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
