### PR TITLE
Update test to conform with new DAB change

### DIFF
--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -68,6 +68,7 @@ def test_assign_managed_role(admin_user, alice, rando, inventory, post, setup_ma
 
 @pytest.mark.django_db
 def test_assign_custom_delete_role(admin_user, rando, inventory, delete, patch):
+    # TODO: just a delete_inventory, without change_inventory
     rd, _ = RoleDefinition.objects.get_or_create(
         name='inventory-delete',
         permissions=['delete_inventory', 'view_inventory', 'change_inventory'],
@@ -76,7 +77,8 @@ def test_assign_custom_delete_role(admin_user, rando, inventory, delete, patch):
     rd.give_permission(rando, inventory)
     inv_id = inventory.pk
     inv_url = reverse('api:inventory_detail', kwargs={'pk': inv_id})
-    patch(url=inv_url, data={"description": "new"}, user=rando, expect=403)
+    # TODO: eventually this will be valid test, for now ignore
+    # patch(url=inv_url, data={"description": "new"}, user=rando, expect=403)
     delete(url=inv_url, user=rando, expect=202)
     assert Inventory.objects.get(id=inv_id).pending_deletion
 

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -69,7 +69,9 @@ def test_assign_managed_role(admin_user, alice, rando, inventory, post, setup_ma
 @pytest.mark.django_db
 def test_assign_custom_delete_role(admin_user, rando, inventory, delete, patch):
     rd, _ = RoleDefinition.objects.get_or_create(
-        name='inventory-delete', permissions=['delete_inventory', 'view_inventory'], content_type=ContentType.objects.get_for_model(Inventory)
+        name='inventory-delete',
+        permissions=['delete_inventory', 'view_inventory', 'change_inventory'],
+        content_type=ContentType.objects.get_for_model(Inventory),
     )
     rd.give_permission(rando, inventory)
     inv_id = inventory.pk


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Next DAB release will include https://github.com/ansible/django-ansible-base/pull/520 which causes this test to fail. 

Updating now so that CI doesn't break.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.4.1.dev126+g18b94ce7c0

```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
