### PR TITLE
Remove links from docker-compose template

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -47,7 +47,7 @@ services:
 {% if minikube_container_group|bool %}
       MINIKUBE_CONTAINER_GROUP: "true"
 {% endif %}
-    links:
+    depends_on:
       - postgres
       - redis_{{ container_postfix }}
     networks:
@@ -197,10 +197,6 @@ services:
     volumes:
       - "../../docker-compose/_sources/prometheus.yml:/etc/prometheus/prometheus.yml"
       - "prometheus_storage:/prometheus:rw"
-    links:
-{% for i in range(control_plane_node_count|int) %}
-      - awx_{{ loop.index }}:awx{{ loop.index }} # because underscores are not valid in hostnames
-{% endfor %}
 {% endif %}
 {% if enable_grafana|bool %}
   grafana:
@@ -214,8 +210,6 @@ services:
     volumes:
       - "../../grafana:/etc/grafana/provisioning"
       - "grafana_storage:/var/lib/grafana:rw"
-    links:
-      - prometheus
     depends_on:
       - prometheus
 {% endif %}
@@ -318,8 +312,6 @@ services:
     container_name: tools_receptor_hop
     hostname: receptor-hop
     command: 'receptor --config /etc/receptor/receptor.conf'
-    links:
-      - awx_1
     networks:
       - awx
     ports:
@@ -335,8 +327,6 @@ services:
     command: 'receptor --config /etc/receptor/receptor.conf'
     environment:
       RECEPTORCTL_SOCKET: {{ receptor_socket_file }}
-    links:
-      - receptor-hop
     networks:
       - awx
     volumes:


### PR DESCRIPTION
##### SUMMARY
Links are use to indicate network connectivity and optionally provide alias

it is not needed for communication since all the container are on the awx network

in the prometheus container case since awx_ container now have valid hostname it's no longer required (also i think the link is missing a `-` anyway...)

links also implicitly imply dependency between services in this i see awx container depends on redis and postgres so i switch to depends_on to retain that

Making this change to be podman compatible
because i get
```
Error response from daemon: bad parameter: link is not supported
```


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
