### PR TITLE
Enable logging from ansible_base

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -926,6 +926,7 @@ LOGGING = {
         'social': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
+        'ansible_base': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG'},
     },
 }
 


### PR DESCRIPTION
##### SUMMARY
This was included in the diff by @jessicamack in https://github.com/ansible/awx/pull/14799, but the overall objective became unclear and that work stalled.

But we still never hooked up logging from ansible_base. I noticed then after running some commands side-by-side for AWX and then eda-server, and AWX was much more silent.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

