### PR TITLE
Add RECEPTOR_KEEP_WORK_ON_ERROR setting

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -929,6 +929,16 @@ register(
     category_slug='debug',
 )
 
+register(
+    'RECEPTOR_KEEP_WORK_ON_ERROR',
+    field_class=fields.BooleanField,
+    label=_('Keep receptor work on error'),
+    default=False,
+    help_text=_('Prevent receptor work from being released on when error is detected'),
+    category=('Debug'),
+    category_slug='debug',
+)
+
 
 def logging_validate(serializer, attrs):
     if not serializer.instance or not hasattr(serializer.instance, 'LOG_AGGREGATOR_HOST') or not hasattr(serializer.instance, 'LOG_AGGREGATOR_TYPE'):

--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -43,6 +43,7 @@ STANDARD_INVENTORY_UPDATE_ENV = {
 }
 CAN_CANCEL = ('new', 'pending', 'waiting', 'running')
 ACTIVE_STATES = CAN_CANCEL
+ERROR_STATES = ('error',)
 MINIMAL_EVENTS = set(['playbook_on_play_start', 'playbook_on_task_start', 'playbook_on_stats', 'EOF'])
 CENSOR_VALUE = '************'
 ENV_BLOCKLIST = frozenset(

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -405,10 +405,11 @@ class AWXReceptorJob:
         finally:
             # Make sure to always release the work unit if we established it
             if self.unit_id is not None and settings.RECEPTOR_RELEASE_WORK:
-                try:
-                    receptor_ctl.simple_command(f"work release {self.unit_id}")
-                except Exception:
-                    logger.exception(f"Error releasing work unit {self.unit_id}.")
+                if settings.RECPETOR_KEEP_WORK_ON_ERROR and getattr(res, 'status', 'error') == 'error':
+                    try:
+                        receptor_ctl.simple_command(f"work release {self.unit_id}")
+                    except Exception:
+                        logger.exception(f"Error releasing work unit {self.unit_id}.")
 
     def _run_internal(self, receptor_ctl):
         # Create a socketpair. Where the left side will be used for writing our payload

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1009,6 +1009,7 @@ AWX_RUNNER_KEEPALIVE_SECONDS = 0
 
 # Delete completed work units in receptor
 RECEPTOR_RELEASE_WORK = True
+RECPETOR_KEEP_WORK_ON_ERROR = False
 
 # K8S only. Use receptor_log_level on AWX spec to set this properly
 RECEPTOR_LOG_LEVEL = 'info'

--- a/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingEdit/TroubleshootingEdit.js
+++ b/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingEdit/TroubleshootingEdit.js
@@ -117,6 +117,10 @@ function TroubleshootingEdit() {
                   name="RECEPTOR_RELEASE_WORK"
                   config={debug.RECEPTOR_RELEASE_WORK}
                 />
+                <BooleanField
+                  name="RECEPTOR_KEEP_WORK_ON_ERROR"
+                  config={debug.RECEPTOR_KEEP_WORK_ON_ERROR}
+                />
                 {submitError && <FormSubmitError error={submitError} />}
                 {revertError && <FormSubmitError error={revertError} />}
               </FormColumnLayout>

--- a/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingEdit/data.defaultTroubleshootingSettings.json
+++ b/awx/ui/src/screens/Setting/Troubleshooting/TroubleshootingEdit/data.defaultTroubleshootingSettings.json
@@ -1,5 +1,6 @@
 {
   "AWX_CLEANUP_PATHS": false,
   "AWX_REQUEST_PROFILE": false,
-  "RECEPTOR_RELEASE_WORK": false
+  "RECEPTOR_RELEASE_WORK": false,
+  "RECEPTOR_KEEP_WORK_ON_ERROR": false
 }

--- a/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettingOptions.json
@@ -830,6 +830,15 @@
               "category_slug": "debug",
               "default": true
           },
+          "RECEPTOR_KEEP_WORK_ON_ERROR": {
+            "type": "boolean",
+            "required": false,
+            "label": "Keep receptor work on error",
+            "help_text": "Prevent receptor work from being released on when error is detected",
+            "category": "Debug",
+            "category_slug": "debug",
+            "default": false
+          },
           "SESSION_COOKIE_AGE": {
               "type": "integer",
               "required": true,
@@ -5169,6 +5178,14 @@
               "type": "boolean",
               "label": "Release Receptor Work",
               "help_text": "Release receptor work",
+              "category": "Debug",
+              "category_slug": "debug",
+              "defined_in_file": false
+          },
+          "RECEPTOR_KEEP_WORK_ON_ERROR": {
+              "type": "boolean",
+              "label": "Keep receptor work on error",
+              "help_text": "Prevent receptor work from being released on when error is detected",
               "category": "Debug",
               "category_slug": "debug",
               "defined_in_file": false

--- a/awx/ui/src/screens/Setting/shared/data.allSettings.json
+++ b/awx/ui/src/screens/Setting/shared/data.allSettings.json
@@ -91,6 +91,7 @@
       "slirp4netns:enable_ipv6=true"
   ],
   "RECEPTOR_RELEASE_WORK": true,
+  "RECEPTOR_KEEP_WORK_ON_ERROR": false,
   "SESSION_COOKIE_AGE": 1800,
   "SESSIONS_PER_USER": -1,
   "DISABLE_LOCAL_AUTH": false,


### PR DESCRIPTION
##### SUMMARY
If RECEPTOR_KEEP_WORK_ON_ERROR is set to true receptor work unit will not be automatically released

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
