### PR TITLE
Fix for awx.awx.schedule - Specifying unified_job_template as ID does…

### DIFF
--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -262,8 +262,7 @@ def main():
         search_fields['organization'] = module.resolve_name_to_id('organizations', organization)
     unified_job_template_id = None
     if unified_job_template:
-        search_fields['name'] = unified_job_template
-        unified_job_template_id = module.get_one('unified_job_templates', **{'data': search_fields})['id']
+        unified_job_template_id = module.get_one('unified_job_templates', name_or_id=unified_job_template)['id']
         sched_search_fields['unified_job_template'] = unified_job_template_id
 
     # Attempt to look up an existing item based on the provided data


### PR DESCRIPTION
…n't work #14458

Summary: remove  **{'data': search_fields} and use name_or_id = unified_job_template

##### SUMMARY
related  #14458

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
awx: 0.1.dev34115+g0e11de0.d20240723
```


##### ADDITIONAL INFORMATION

Before change:
```
"exception": "Traceback (most recent call last):\n File "/home/runner/.ansible/tmp/ansible-tmp-1695053652.058952-44-236635489272730/AnsiballZ_schedule.py", line 107, in \n _ansiballz_main()\n File "/home/runner/.ansible/tmp/ansible-tmp-1695053652.058952-44-236635489272730/AnsiballZ_schedule.py", line 99, in _ansiballz_main\n invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n File "/home/runner/.ansible/tmp/ansible-tmp-1695053652.058952-44-236635489272730/AnsiballZ_schedule.py", line 47, in invoke_module\n runpy.run_module(mod_name='ansible_collections.awx.awx.plugins.modules.schedule', init_globals=dict(_module_fqn='ansible_collections.awx.awx.plugins.modules.schedule', _modlib_path=modlib_path),\n File "/usr/lib64/python3.9/runpy.py", line 225, in run_module\n return _run_module_code(code, init_globals, run_name, mod_spec)\n File "/usr/lib64/python3.9/runpy.py", line 97, in _run_module_code\n _run_code(code, mod_globals, init_globals,\n File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code\n exec(code, run_globals)\n File "/tmp/ansible_awx.awx.schedule_payload_tnadnbuu/ansible_awx.awx.schedule_payload.zip/ansible_collections/awx/awx/plugins/modules/schedule.py", line 362, in \n File "/tmp/ansible_awx.awx.schedule_payload_tnadnbuu/ansible_awx.awx.schedule_payload.zip/ansible_collections/awx/awx/plugins/modules/schedule.py", line 266, in main\nTypeError: 'NoneType' object is not subscriptable\n",
```

After change:
```
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'

PLAY [Create a scheduled job in AWX 2] ***********************************************************************************************************************************************************************************************

TASK [Test schedule job in farfar future] ********************************************************************************************************************************************************************************************
[DEPRECATION WARNING]: The lookup plugin 'awx.awx.schedule_rrule' was expected to return a list, got '<class 'str'>' instead. The lookup plugin 'awx.awx.schedule_rrule' needs to be changed to return a list. This will be an error
in Ansible 2.18. This feature will be removed in version 2.18. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
changed: [localhost]

PLAY RECAP ***************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

To verify change i use following steps:
build dev environment with command make docker-compose-build
1. Run it with make docker-compose
2. Start dev ui with command docker exec -ti tools_awx_1 make ui-devel-test
3. Create superuser, for example admin2 qith password awx - docker exec -ti tools_awx_1 awx-manage createsuperuser
4. Prepare environment variables for ansible-playbook with commands
 export CONTROLLER_HOST=https://127.0.0.1:3000
 export CONTROLLER_USERNAME=admin2
 export CONTROLLER_PASSWORD=awx
5. Build and install collection with make build_collection make install_collection
6. After this run playbook (i'm already have job template with id 7)
```
- name: Create a scheduled job in AWX
  hosts: localhost
  gather_facts: no
  tasks:
    - name: Test schedule job in future
      vars:
        start_time: "2025-05-02 19:05:14"
      awx.awx.schedule:
        name: "Test with ID 2025"
        unified_job_template: '7'
        validate_certs: false
        rrule: "{{ query('awx.awx.schedule_rrule', 'minute', start_date=start_time, timezone='UTC', every='1', end_on='1') }}"
```