### PR TITLE
Set awx_job_revision in addition to awx_project_revision.

### DIFF
--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -818,6 +818,7 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
                 r['{}_project_scm_branch'.format(name)] = self.project.scm_branch
         if self.scm_branch:
             for name in JOB_VARIABLE_PREFIXES:
+                r['{}_job_revision'.format(name)] = self.scm_revision
                 r['{}_job_scm_branch'.format(name)] = self.scm_branch
         if self.job_template:
             for name in JOB_VARIABLE_PREFIXES:

--- a/docs/docsite/rst/userguide/job_templates.rst
+++ b/docs/docsite/rst/userguide/job_templates.rst
@@ -441,8 +441,9 @@ Along with any extra variables set in the job template and survey, AWX automatic
 - ``awx_job_template_id``: The Job Template ID that this job run uses
 - ``awx_job_template_name``: The Job Template name that this job uses
 - ``awx_execution_node``: The Execution Node name that launched this job
-- ``awx_project_revision``: The revision identifier for the source tree that this particular job uses (it is also the same as the job's field ``scm_revision``)
+- ``awx_project_revision``: The revision identifier for the source tree that this particular job uses (it is the same as ``awx_job_revision`` unless the job uses another branch)
 - ``awx_project_scm_branch``: The configured default project SCM branch for the project the job template uses
+- ``awx_job_revision``: The revision identifier for the source tree that this particular job uses.
 - ``awx_job_scm_branch`` If the SCM Branch is overwritten by the job, the value is shown here
 - ``awx_user_email``: The user email of the AWX user that started this job. This is not available for callback or scheduled jobs.
 - ``awx_user_first_name``: The user's first name of the AWX user that started this job. This is not available for callback or scheduled jobs.


### PR DESCRIPTION
##### SUMMARY

Currently AWX only exposes `awx_project_revision` which is not necessarily the same revision that the job uses (the job templates can [if the project allows it] set a different branch). As such I have adjusted to code to also record the job revision.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other

##### AWX VERSION
```
awx: 24.6.2.dev45+gcc35d7c554
```