### PR TITLE
Workaround receptor backward incompatibility

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -312,7 +312,7 @@ services:
     user: root
     container_name: tools_receptor_hop
     hostname: receptor-hop
-    command: 'receptor --config /etc/receptor/receptor.conf'
+    command: 'receptor --legacy --config /etc/receptor/receptor.conf'
     networks:
       - awx
     ports:
@@ -325,7 +325,7 @@ services:
     user: "{{ ansible_user_uid }}"
     container_name: tools_receptor_{{ loop.index }}
     hostname: receptor-{{ loop.index }}
-    command: 'receptor --config /etc/receptor/receptor.conf'
+    command: 'receptor --legacy --config /etc/receptor/receptor.conf'
     environment:
       RECEPTORCTL_SOCKET: {{ receptor_socket_file }}
     networks:

--- a/tools/docker-compose/supervisor.conf
+++ b/tools/docker-compose/supervisor.conf
@@ -110,7 +110,7 @@ stderr_logfile_maxbytes=0
 stderr_events_enabled = true
 
 [program:awx-receptor]
-command = receptor --config /etc/receptor/receptor.conf
+command = receptor --legacy --config /etc/receptor/receptor.conf
 autorestart = true
 stopasgroup=true
 killasgroup=true


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/receptor/pull/1043 introduced receptor config file v2
`--legacy` option needed to be passed in for it to be backward compatible with v1 interfaces

this itself causes backward compatibility issue as in 
if you already have a receptor running and upgrade the receptor receptor will fail to function and u need to add the `--legacy` flag in order for it to work (as we see in our CI)

this change should be temporary and serve to unblock our CI i have communicated with the maintainer of the receptor project about this problem

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
