### PR TITLE
Only refresh session if updating own password

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1038,7 +1038,9 @@ class UserSerializer(BaseSerializer):
             # as the modified user then inject a session key derived from
             # the updated user to prevent logout. This is the logic used by
             # the Django admin's own user_change_password view.
-            update_session_auth_hash(self.context['request'], obj)
+            if self.instance and self.context['request'].user.username == obj.username:
+                update_session_auth_hash(self.context['request'], obj)
+
         elif not obj.password:
             obj.set_unusable_password()
             obj.save(update_fields=['password'])

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -50,7 +50,7 @@ def test_updating_own_password_refreshes_session(patch, admin):
     Updating your own password should refresh the session id.
     '''
     with mock.patch('awx.main.models.User.update_session_auth_hash') as update_session_auth_hash:
-        patch(reverse('api:user_detail', kwargs={'pk': admin.pk}), {'password': 'r$TyKiOCb#ED'}, admin)
+        patch(reverse('api:user_detail', kwargs={'pk': admin.pk}), {'password': 'r$TyKiOCb#ED'}, admin, middleware=SessionMiddleware(mock.Mock()))
         assert update_session_auth_hash.called
 
 

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -34,6 +34,27 @@ def test_fail_double_create_user(post, admin):
 
 
 @pytest.mark.django_db
+def test_creating_user_retains_session(post, admin):
+    '''
+    Creating a new user should not refresh a new session id for the current user.
+    '''
+    with mock.patch('awx.main.models.User.update_session_auth_hash') as update_session_auth_hash:
+        response = post(reverse('api:user_list'), EXAMPLE_USER_DATA, admin, middleware=SessionMiddleware(mock.Mock()))
+        assert response.status_code == 201
+        assert not update_session_auth_hash.called
+
+
+@pytest.mark.django_db
+def test_updating_own_password_refreshes_session(patch, admin):
+    '''
+    Updating your own password should refresh the session id.
+    '''
+    with mock.patch('awx.main.models.User.update_session_auth_hash') as update_session_auth_hash:
+        patch(reverse('api:user_detail', kwargs={'pk': admin.pk}), {'password': 'r$TyKiOCb#ED'}, admin)
+        assert update_session_auth_hash.called
+
+
+@pytest.mark.django_db
 def test_create_delete_create_user(post, delete, admin):
     response = post(reverse('api:user_list'), EXAMPLE_USER_DATA, admin, middleware=SessionMiddleware(mock.Mock()))
     assert response.status_code == 201

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -38,8 +38,8 @@ def test_creating_user_retains_session(post, admin):
     '''
     Creating a new user should not refresh a new session id for the current user.
     '''
-    with mock.patch('awx.main.models.User.update_session_auth_hash') as update_session_auth_hash:
-        response = post(reverse('api:user_list'), EXAMPLE_USER_DATA, admin, middleware=SessionMiddleware(mock.Mock()))
+    with mock.patch('awx.api.serializers.update_session_auth_hash') as update_session_auth_hash:
+        response = post(reverse('api:user_list'), EXAMPLE_USER_DATA, admin)
         assert response.status_code == 201
         assert not update_session_auth_hash.called
 
@@ -49,8 +49,8 @@ def test_updating_own_password_refreshes_session(patch, admin):
     '''
     Updating your own password should refresh the session id.
     '''
-    with mock.patch('awx.main.models.User.update_session_auth_hash') as update_session_auth_hash:
-        patch(reverse('api:user_detail', kwargs={'pk': admin.pk}), {'password': 'r$TyKiOCb#ED'}, admin, middleware=SessionMiddleware(mock.Mock()))
+    with mock.patch('awx.api.serializers.update_session_auth_hash') as update_session_auth_hash:
+        patch(reverse('api:user_detail', kwargs={'pk': admin.pk}), {'password': 'newpassword'}, admin, middleware=SessionMiddleware(mock.Mock()))
         assert update_session_auth_hash.called
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes bug where creating a new user will request a new awx_sessionid cookie, invalidating the previous session.

The code should not refresh session if updating or creating a password for a different user.

This was causing a lot of 401 issues with UI testing code, where a session would be suddenly logged out because a
different test had created a new user.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

