### PR TITLE
Fix a test in preparation for syncing description

### DIFF
--- a/awx/main/tests/functional/api/test_immutablesharedfields.py
+++ b/awx/main/tests/functional/api/test_immutablesharedfields.py
@@ -32,18 +32,16 @@ class TestImmutableSharedFields:
 
     def test_perform_update(self, admin_user, patch):
         orgA = Organization.objects.create(name='orgA')
-        team = orgA.teams.create(name='teamA')
         # allow patching non-shared fields
         patch(
-            url=reverse('api:team_detail', kwargs={'pk': team.id}),
-            data={"description": "can change this field"},
+            url=reverse('api:organization_detail', kwargs={'pk': orgA.id}),
+            data={"max_hosts": 76},
             user=admin_user,
             expect=200,
         )
-        orgB = Organization.objects.create(name='orgB')
         # prevent patching shared fields
-        resp = patch(url=reverse('api:team_detail', kwargs={'pk': team.id}), data={"organization": orgB.id}, user=admin_user, expect=403)
-        assert "Cannot change shared field" in resp.data['organization']
+        resp = patch(url=reverse('api:organization_detail', kwargs={'pk': orgA.id}), data={"name": "orgB"}, user=admin_user, expect=403)
+        assert "Cannot change shared field" in resp.data['name']
 
     @pytest.mark.parametrize(
         'role',


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Refs ansible/django-ansible-base#447

Fix test in preparation for syncing descriptions across resource servers.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

