### PR TITLE
Hide SUBSCRIPTION_USAGE_MODEL on UI

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -869,6 +869,7 @@ register(
     label=_('Defines subscription usage model and shows Host Metrics'),
     category=_('System'),
     category_slug='system',
+    hidden=True,
 )
 
 register(


### PR DESCRIPTION
##### SUMMARY
New UI dynamically populate setting page base on OPTION response, this setting is not runtime modifiable mark it as hidden


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
