### PR TITLE
Fixes pytest CI error

### DIFF
--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1259,7 +1259,6 @@ class TestJobCredentials(TestJobExecution):
         extra_vars = parse_extra_vars(args, private_data_dir)
 
         assert extra_vars["turbo_button"] == "True"
-        return ['successful', 0]
 
     def test_custom_environment_injectors_with_nested_extra_vars(self, private_data_dir, job, mock_me):
         task = jobs.RunJob()


### PR DESCRIPTION
##### SUMMARY
```
  /var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/python.py:163:
  PytestReturnNotNoneWarning: Expected None, but
  awx/main/tests/unit/test_tasks.py::TestJobCredentials::test_custom_environment_injectors_with_boolean_extra_vars
  returned ['successful', 0], which will be an error in a future version
  of pytest.  Did you mean to use `assert` instead of `return`?
```

* Dug into the git blame for this one 060585434abb5456935b7378211813b2ceaacaaa is the commit for any historians. It was wrongfully carried over from a mock pexpect implementation. Our new tests are nice. They don't go as far as trying to run the task so they do not need to mock pexpect. That is why it is safe to remove this code without finding it a new home.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
