### PR TITLE
fix: avoid calling undefined method for anonymous users

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -33,7 +33,6 @@ from django.http import HttpResponse, HttpResponseRedirect
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 
-
 # Django REST Framework
 from rest_framework.exceptions import APIException, PermissionDenied, ParseError, NotFound
 from rest_framework.parsers import FormParser
@@ -129,7 +128,6 @@ from awx.api.views.mixin import (
 )
 from awx.api.pagination import UnifiedJobEventPagination
 from awx.main.utils import set_environ
-
 
 logger = logging.getLogger('awx.api.views')
 
@@ -2394,9 +2392,12 @@ class JobTemplateList(ListCreateAPIView):
 
     def check_permissions(self, request):
         if request.method == 'POST':
-            can_access, messages = request.user.can_access_with_errors(self.model, 'add', request.data)
-            if not can_access:
-                self.permission_denied(request, message=messages)
+            if request.user.is_anonymous:
+                self.permission_denied(request)
+            else:
+                can_access, messages = request.user.can_access_with_errors(self.model, 'add', request.data)
+                if not can_access:
+                    self.permission_denied(request, message=messages)
 
         super(JobTemplateList, self).check_permissions(request)
 
@@ -3121,9 +3122,12 @@ class WorkflowJobTemplateList(ListCreateAPIView):
 
     def check_permissions(self, request):
         if request.method == 'POST':
-            can_access, messages = request.user.can_access_with_errors(self.model, 'add', request.data)
-            if not can_access:
-                self.permission_denied(request, message=messages)
+            if request.user.is_anonymous:
+                self.permission_denied(request)
+            else:
+                can_access, messages = request.user.can_access_with_errors(self.model, 'add', request.data)
+                if not can_access:
+                    self.permission_denied(request, message=messages)
 
         super(WorkflowJobTemplateList, self).check_permissions(request)
 


### PR DESCRIPTION
##### SUMMARY

The method `can_access_with_errors` is not defined on `AnonymousUser` and this raises an exception when accessing the job_templates or workflow_job_templates APIs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
