### PR TITLE
Make controller specific team and org roles

### DIFF
--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -309,6 +309,16 @@ def setup_managed_role_definitions(apps, schema_editor):
                     to_create['object_admin'].format(cls=cls), f'Has all permissions to a single {cls._meta.verbose_name}', ct, indiv_perms, RoleDefinition
                 )
             )
+            if cls_name == 'team':
+                managed_role_definitions.append(
+                    get_or_create_managed(
+                        'Controller Team Admin',
+                        f'Has all permissions to a single {cls._meta.verbose_name}',
+                        ct,
+                        indiv_perms,
+                        RoleDefinition,
+                    )
+                )
 
         if 'org_children' in to_create and (cls_name not in ('organization', 'instancegroup', 'team')):
             org_child_perms = object_perms.copy()
@@ -349,11 +359,32 @@ def setup_managed_role_definitions(apps, schema_editor):
                         RoleDefinition,
                     )
                 )
+                if action == 'member' and cls_name in ('organization', 'team'):
+                    suffix = to_create['special'].format(cls=cls, action=action.title())
+                    rd_name = f'Controller {suffix}'
+                    managed_role_definitions.append(
+                        get_or_create_managed(
+                            rd_name,
+                            f'Has {action} permissions to a single {cls._meta.verbose_name}',
+                            ct,
+                            perm_list,
+                            RoleDefinition,
+                        )
+                    )
 
     if 'org_admin' in to_create:
         managed_role_definitions.append(
             get_or_create_managed(
                 to_create['org_admin'].format(cls=Organization),
+                'Has all permissions to a single organization and all objects inside of it',
+                org_ct,
+                org_perms,
+                RoleDefinition,
+            )
+        )
+        managed_role_definitions.append(
+            get_or_create_managed(
+                'Controller Organization Admin',
                 'Has all permissions to a single organization and all objects inside of it',
                 org_ct,
                 org_perms,

--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -167,7 +167,7 @@ def migrate_to_new_rbac(apps, schema_editor):
             perm.delete()
 
     managed_definitions = dict()
-    for role_definition in RoleDefinition.objects.filter(managed=True):
+    for role_definition in RoleDefinition.objects.filter(managed=True).exclude(name__in=(settings.ANSIBLE_BASE_JWT_MANAGED_ROLES)):
         permissions = frozenset(role_definition.permissions.values_list('id', flat=True))
         managed_definitions[permissions] = role_definition
 

--- a/awx/main/models/organization.py
+++ b/awx/main/models/organization.py
@@ -10,9 +10,6 @@ from django.contrib.sessions.models import Session
 from django.utils.timezone import now as tz_now
 from django.utils.translation import gettext_lazy as _
 
-# DRF
-from rest_framework.serializers import ValidationError as DRFValidationError
-
 # django-ansible-base
 from ansible_base.resource_registry.fields import AnsibleResourceField
 

--- a/awx/main/models/organization.py
+++ b/awx/main/models/organization.py
@@ -126,10 +126,6 @@ class Organization(CommonModel, NotificationFieldsModel, ResourceMixin, CustomVi
     def _get_related_jobs(self):
         return UnifiedJob.objects.non_polymorphic().filter(organization=self)
 
-    def validate_role_assignment(self, actor, role_definition):
-        if role_definition.name in ['Organization Admin', 'Organization Member']:
-            raise DRFValidationError({'detail': _(f"Assignment must use the Controller {role_definition.name} role.")})
-
 
 class OrganizationGalaxyCredentialMembership(models.Model):
     organization = models.ForeignKey('Organization', on_delete=models.CASCADE)
@@ -172,10 +168,6 @@ class Team(CommonModelNameNotUnique, ResourceMixin):
 
     def get_absolute_url(self, request=None):
         return reverse('api:team_detail', kwargs={'pk': self.pk}, request=request)
-
-    def validate_role_assignment(self, actor, role_definition):
-        if role_definition.name in ['Team Admin', 'Team Member']:
-            raise DRFValidationError({'detail': _(f"Assignment must use the Controller {role_definition.name} role.")})
 
 
 class Profile(CreatedModifiedModel):

--- a/awx/main/models/organization.py
+++ b/awx/main/models/organization.py
@@ -10,6 +10,9 @@ from django.contrib.sessions.models import Session
 from django.utils.timezone import now as tz_now
 from django.utils.translation import gettext_lazy as _
 
+# DRF
+from rest_framework.serializers import ValidationError as DRFValidationError
+
 # django-ansible-base
 from ansible_base.resource_registry.fields import AnsibleResourceField
 
@@ -123,6 +126,10 @@ class Organization(CommonModel, NotificationFieldsModel, ResourceMixin, CustomVi
     def _get_related_jobs(self):
         return UnifiedJob.objects.non_polymorphic().filter(organization=self)
 
+    def validate_role_assignment(self, actor, role_definition):
+        if role_definition.name in ['Organization Admin', 'Organization Member']:
+            raise DRFValidationError({'detail': _(f"Assignment must use the Controller {role_definition.name} role.")})
+
 
 class OrganizationGalaxyCredentialMembership(models.Model):
     organization = models.ForeignKey('Organization', on_delete=models.CASCADE)
@@ -165,6 +172,10 @@ class Team(CommonModelNameNotUnique, ResourceMixin):
 
     def get_absolute_url(self, request=None):
         return reverse('api:team_detail', kwargs={'pk': self.pk}, request=request)
+
+    def validate_role_assignment(self, actor, role_definition):
+        if role_definition.name in ['Team Admin', 'Team Member']:
+            raise DRFValidationError({'detail': _(f"Assignment must use the Controller {role_definition.name} role.")})
 
 
 class Profile(CreatedModifiedModel):

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -598,6 +598,12 @@ def get_role_from_object_role(object_role):
         model_name, role_name, _ = rd.name.split()
         role_name = role_name.lower()
         role_name += '_role'
+    elif rd.name.startswith('Controller') and rd.name.endswith(' Admin'):
+        # Controller Organization Admin and Controller Team Admin
+        role_name = 'admin_role'
+    elif rd.name.startswith('Controller') and rd.name.endswith(' Member'):
+        # Controller Organization Member and Controller Team Member
+        role_name = 'member_role'
     elif rd.name.endswith(' Admin') and rd.name.count(' ') == 2:
         # cases like "Organization Project Admin"
         model_name, target_model_name, role_name = rd.name.split()

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -557,8 +557,15 @@ def get_role_definition(role):
     f = obj._meta.get_field(role.role_field)
     action_name = f.name.rsplit("_", 1)[0]
     model_print = type(obj).__name__
-    rd_name = f'{model_print} {action_name.title()} Compat'
-    perm_list = get_role_codenames(role)
+    # use Controller-specific role definitions for Team/Organization and member/admin
+    # instead of platform role definitions
+    # these should exist in the system already, so just do a lookup by role definition name
+    if model_print in ['Team', 'Organization'] and action_name in ['member', 'admin']:
+        perm_list = None
+        rd_name = f'Controller {model_print} {action_name.title()}'
+    else:
+        rd_name = f'{model_print} {action_name.title()} Compat'
+        perm_list = get_role_codenames(role)
     defaults = {
         'content_type_id': role.content_type_id,
         'description': f'Has {action_name.title()} permission to {model_print} for backwards API compatibility',

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -162,14 +162,14 @@ def test_adding_user_to_org_member_role(setup_managed_roles, organization, admin
     Adding user to organization member role via the legacy RBAC endpoints
     should give them access to the organization detail
     '''
-    url_org_detail = reverse('api:organization_detail', kwargs={'pk': organization.id})
-    get(url_org_detail, user=bob, expect=403)
+    url_detail = reverse('api:organization_detail', kwargs={'pk': organization.id})
+    get(url_detail, user=bob, expect=403)
 
     role = organization.member_role
     url = reverse('api:role_users_list', kwargs={'pk': role.id})
     post(url, data={'id': bob.id}, user=admin, expect=204)
 
-    get(url_org_detail, user=bob, expect=200)
+    get(url_detail, user=bob, expect=200)
 
 
 @pytest.mark.django_db
@@ -196,12 +196,14 @@ def test_adding_user_to_controller_team_roles(setup_managed_roles, role_name, te
     '''
     Allow user to be added to Controller Team Admin or Controller Team Member
     '''
+    url_detail = reverse('api:team_detail', kwargs={'pk': team.id})
+    get(url_detail, user=bob, expect=403)
+
     rd = RoleDefinition.objects.get(name=role_name)
     url = django_reverse('roleuserassignment-list')
     post(url, data={'object_id': team.id, 'role_definition': rd.id, 'user': bob.id}, user=admin, expect=201)
 
-    url = reverse('api:team_detail', kwargs={'pk': team.id})
-    get(url, user=bob, expect=200)
+    get(url_detail, user=bob, expect=200)
 
 
 @pytest.mark.django_db
@@ -210,9 +212,11 @@ def test_adding_user_to_controller_organization_roles(setup_managed_roles, role_
     '''
     Allow user to be added to Controller Organization Admin or Controller Organization Member
     '''
+    url_detail = reverse('api:organization_detail', kwargs={'pk': organization.id})
+    get(url_detail, user=bob, expect=403)
+
     rd = RoleDefinition.objects.get(name=role_name)
     url = django_reverse('roleuserassignment-list')
     post(url, data={'object_id': organization.id, 'role_definition': rd.id, 'user': bob.id}, user=admin, expect=201)
 
-    url = reverse('api:organization_detail', kwargs={'pk': organization.id})
     get(url, user=bob, expect=200)

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest import mock
 
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse as django_reverse
@@ -151,11 +150,10 @@ def test_assign_credential_to_user_of_another_org(setup_managed_roles, credentia
 @pytest.mark.django_db
 @override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
 def test_team_member_role_not_assignable(team, rando, post, admin_user, setup_managed_roles):
-    with mock.patch('awx.main.models.organization.Organization.validate_role_assignment') as mock_validate:
-        member_rd = RoleDefinition.objects.get(name='Organization Member')
-        url = django_reverse('roleuserassignment-list')
-        r = post(url, data={'object_id': team.id, 'role_definition': member_rd.id, 'user': rando.id}, user=admin_user, expect=400)
-        assert 'Not managed locally' in str(r.data)
+    member_rd = RoleDefinition.objects.get(name='Controller Organization Member')
+    url = django_reverse('roleuserassignment-list')
+    r = post(url, data={'object_id': team.id, 'role_definition': member_rd.id, 'user': rando.id}, user=admin_user, expect=400)
+    assert 'Not managed locally' in str(r.data)
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_api.py
@@ -148,9 +148,9 @@ def test_assign_credential_to_user_of_another_org(setup_managed_roles, credentia
 
 
 @pytest.mark.django_db
-@override_settings(ALLOW_LOCAL_RESOURCE_MANAGEMENT=False)
+@override_settings(ALLOW_LOCAL_ASSIGNING_JWT_ROLES=False)
 def test_team_member_role_not_assignable(team, rando, post, admin_user, setup_managed_roles):
-    member_rd = RoleDefinition.objects.get(name='Controller Organization Member')
+    member_rd = RoleDefinition.objects.get(name='Organization Member')
     url = django_reverse('roleuserassignment-list')
     r = post(url, data={'object_id': team.id, 'role_definition': member_rd.id, 'user': rando.id}, user=admin_user, expect=400)
     assert 'Not managed locally' in str(r.data)
@@ -187,7 +187,7 @@ def test_prevent_adding_actor_to_platform_roles(setup_managed_roles, role_name, 
     actor_id = bob.id if actor == 'user' else team.id
     data[actor] = actor_id
     r = post(url, data=data, user=admin, expect=400)
-    assert f'Assignment must use the Controller {role_name} role' in str(r.data)
+    assert 'Not managed locally' in str(r.data)
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -32,7 +32,7 @@ def test_org_child_add_permission(setup_managed_roles):
 
 
 @pytest.mark.django_db
-def test_controller_specific_roles(setup_managed_roles):
+def test_controller_specific_roles_have_correct_permissions(setup_managed_roles):
     '''
     Controller specific roles should have the same permissions as the platform roles
     e.g. Controller Team Admin should have same permission set as Team Admin
@@ -46,7 +46,7 @@ def test_controller_specific_roles(setup_managed_roles):
 @pytest.mark.django_db
 @pytest.mark.parametrize('resource_name', ['Team', 'Organization'])
 @pytest.mark.parametrize('action', ['Member', 'Admin'])
-def test_use_controller_specific_role_definitions(setup_managed_roles, resource_name, action, team, bob, organization):
+def test_old_RBAC_uses_controller_specific_roles(setup_managed_roles, resource_name, action, team, bob, organization):
     '''
     Assignment to old RBAC roles should use controller specific role definitions
     e.g. Controller Team Admin, Controller Team Member, Controller Organization Member, Controller Organization Admin

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansible_base.rbac.models import RoleDefinition, DABPermission
+from ansible_base.rbac.models import RoleDefinition, DABPermission, RoleUserAssignment
 
 
 @pytest.mark.django_db
@@ -29,3 +29,37 @@ def test_org_child_add_permission(setup_managed_roles):
 
     # special case for JobTemplate, anyone can create one with use permission to project/inventory
     assert not DABPermission.objects.filter(codename='add_jobtemplate').exists()
+
+
+@pytest.mark.django_db
+def test_controller_specific_roles(setup_managed_roles):
+    '''
+    Controller specific roles should have the same permissions as the platform roles
+    e.g. Controller Team Admin should have same permission set as Team Admin
+    '''
+    for rd_name in ['Controller Team Admin', 'Controller Team Member', 'Controller Organization Member', 'Controller Organization Admin']:
+        rd = RoleDefinition.objects.get(name=rd_name)
+        rd_platform = RoleDefinition.objects.get(name=rd_name.split('Controller ')[1])
+        assert set(rd.permissions.all()) == set(rd_platform.permissions.all())
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('resource_name', ['Team', 'Organization'])
+@pytest.mark.parametrize('action', ['Member', 'Admin'])
+def test_use_controller_specific_role_definitions(setup_managed_roles, resource_name, action, team, bob, organization):
+    '''
+    Assignment to old RBAC roles should use controller specific role definitions
+    e.g. Controller Team Admin, Controller Team Member, Controller Organization Member, Controller Organization Admin
+    '''
+    if resource_name == 'Team':
+        resource = team
+    else:
+        resource = organization
+    if action == 'Member':
+        resource.member_role.members.add(bob)
+    else:
+        resource.admin_role.members.add(bob)
+    rd = RoleDefinition.objects.get(name=f'Controller {resource_name} {action}')
+    rd_platform = RoleDefinition.objects.get(name=f'{resource_name} {action}')
+    assert RoleUserAssignment.objects.filter(role_definition=rd, user=bob, object_id=resource.id).exists()
+    assert not RoleUserAssignment.objects.filter(role_definition=rd_platform, user=bob, object_id=resource.id).exists()

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -46,9 +46,9 @@ def test_controller_specific_roles_have_correct_permissions(setup_managed_roles)
 @pytest.mark.django_db
 @pytest.mark.parametrize('resource_name', ['Team', 'Organization'])
 @pytest.mark.parametrize('action', ['Member', 'Admin'])
-def test_old_RBAC_uses_controller_specific_roles(setup_managed_roles, resource_name, action, team, bob, organization):
+def test_legacy_RBAC_uses_controller_specific_roles(setup_managed_roles, resource_name, action, team, bob, organization):
     '''
-    Assignment to old RBAC roles should use controller specific role definitions
+    Assignment to legacy RBAC roles should use controller specific role definitions
     e.g. Controller Team Admin, Controller Team Member, Controller Organization Member, Controller Organization Admin
     '''
     if resource_name == 'Team':

--- a/awx/main/tests/functional/dab_rbac/test_managed_roles.py
+++ b/awx/main/tests/functional/dab_rbac/test_managed_roles.py
@@ -51,10 +51,7 @@ def test_legacy_RBAC_uses_controller_specific_roles(setup_managed_roles, resourc
     Assignment to legacy RBAC roles should use controller specific role definitions
     e.g. Controller Team Admin, Controller Team Member, Controller Organization Member, Controller Organization Admin
     '''
-    if resource_name == 'Team':
-        resource = team
-    else:
-        resource = organization
+    resource = team if resource_name == 'Team' else organization
     if action == 'Member':
         resource.member_role.members.add(bob)
     else:

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer.py
@@ -197,12 +197,12 @@ def test_user_auditor_rel(organization, rando, setup_managed_roles):
 @pytest.mark.django_db
 @pytest.mark.parametrize('resource_name', ['Organization', 'Team'])
 @pytest.mark.parametrize('role_name', ['Member', 'Admin'])
-def test_role_from_controller_organization_and_team_roles(organization, team, rando, role_name, resource_name, setup_managed_roles):
+def test_mapping_from_controller_role_definitions_to_roles(organization, team, rando, role_name, resource_name, setup_managed_roles):
     """
     ensure mappings for controller roles are correct
     e.g.
-    Controller Organization Member > organizaiton.member_role
-    Controller Organization Admin > organizaiton.admin_role
+    Controller Organization Member > organization.member_role
+    Controller Organization Admin > organization.admin_role
     Controller Team Member > team.member_role
     Controller Team Admin > team.admin_role
     """

--- a/awx/main/tests/functional/test_migrations.py
+++ b/awx/main/tests/functional/test_migrations.py
@@ -81,7 +81,7 @@ class TestMigrationSmoke:
         org.read_role.members.add(user)
         org.member_role.members.add(user)
 
-        team = Team.objects.create(name='arbitrary-team', organization=org)
+        team = Team.objects.create(name='arbitrary-team', organization=org, created=now(), modified=now())
         team.member_role.members.add(user)
 
         new_state = migrator.apply_tested_migration(

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -660,6 +660,9 @@ AWX_AUTO_DEPROVISION_INSTANCES = False
 # e.g. organizations, teams, and users
 ALLOW_LOCAL_RESOURCE_MANAGEMENT = True
 
+# If True, allow users to be assigned to roles that were created via JWT
+ALLOW_LOCAL_ASSIGNING_JWT_ROLES = False
+
 # Enable Pendo on the UI, possible values are 'off', 'anonymous', and 'detailed'
 # Note: This setting may be overridden by database settings.
 PENDO_TRACKING_STATE = "off"

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -2,4 +2,4 @@ git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 git+https://github.com/ansible/python3-saml.git@devel#egg=python3-saml
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@2024.8.19#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
+django-ansible-base @ git+https://github.com/ansible/django-ansible-base@2024.8.22#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Controller Team Admin
Controller Team Member
Controller Organization Admin
Controller Organization Member

Permissions-wise, these four roles are identical to the platform roles, those without the `Controller` prefix.

Role assignments that are issued via the AWX API utilize these role definitions, not the platform roles. Role assignments for the platform roles must be issued in gateway and synced to AWX via JWT payloads. A followup PR will add a flag and some logic to role definitions to implement this restriction. 

For role assigments that use the deprecated RBAC system, the Controller specific roles will be used.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

TODO
- [x] make sure migrate_to_new_rbac is using these roles