### PR TITLE
Catch harakiri graceful signal in middlware and log debug info

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1017,6 +1017,7 @@ RECEPTOR_LOG_LEVEL = 'info'
 
 MIDDLEWARE = [
     'django_guid.middleware.guid_middleware',
+    'ansible_base.lib.middleware.logging.log_request.LogTracebackMiddleware',
     'awx.main.middleware.SettingsCacheMiddleware',
     'awx.main.middleware.TimingMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tools/ansible/roles/dockerfile/files/uwsgi.ini
+++ b/tools/ansible/roles/dockerfile/files/uwsgi.ini
@@ -10,6 +10,11 @@ master-fifo = /var/lib/awx/awxfifo
 max-requests = 1000
 buffer-size = 32768
 
+harakiri = 115
+harakiri-graceful-timeout = 110
+harakiri-graceful-signal = 6
+py-call-osafterfork = true
+
 if-env = UWSGI_MOUNT_PATH
 mount = %(_)=awx.wsgi:application
 endif =


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Requests that exceed a certain timeout can be killed by uwsgi
But it begs the question -- what were they doing?!

By configuring uwsgi harakiri to send a SIGABRT (signal 6) as a first "graceful" signal, we can catch it in middleware and log a message with the stack where code was executing (probably stuck) and more information about the request

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
inspired by https://github.com/getsentry/sentry-python/discussions/1783

May require update to uwisgi.ini in operator/any other installer that lays down uwsgi config if doesn't just use tools/ansible/roles/dockerfile/files/uwsgi.ini from here


Sample traceback:
(this was contrived by putting "time.sleep(300)" in the root view)
```
tools_awx_1       | Fri Aug 16 15:30:15 2024 - *** HARAKIRI ON WORKER 1 (pid: 13747, try: 1, graceful: yes) ***                                                                                                                                                                                                             
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI !!! worker 1 status !!!                                                                               
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI [core 0] 172.23.0.1 - GET /api/ since 1723822210                                                      
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI !!! end of worker 1 status !!!                                                                        
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI: graceful termination attempt on worker 1 with signal 31. Next harakiri: 1723822217                                                                                                                                                                                 
tools_awx_1       | Fri Aug 16 15:30:15 2024 - HARAKIRI triggered by worker 1 core 0 !!!                                                                      
tools_awx_1       | 2024-08-16 15:30:15,942 ERROR    [60200fba] awx.main.middleware Catching harakiri graceful signal for b3762186-1014-4608-a1f5-225d9f1bcd4a with method: GET path: /api/                                                                                                                                 
tools_awx_1       | 2024-08-16 15:30:15,948 ERROR    [60200fba] awx.main.middleware Received harakiri graceful signal while in stack:   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch                                                                          
tools_awx_1       |     response = handler(request, *args, **kwargs)                                                                                          
tools_awx_1       |   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/utils/decorators.py", line 46, in _wrapper                                                                                                                                                                                          
tools_awx_1       |     return bound_method(*args, **kwargs)                                                                                                  
tools_awx_1       |   File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/utils/decorators.py", line 134, in _wrapper_view                                                                                                                                                                                    
tools_awx_1       |     response = view_func(request, *args, **kwargs)                                                                                        
tools_awx_1       |   File "/awx_devel/awx/api/views/root.py", line 53, in get                                                                                
tools_awx_1       |     time.sleep(300)                                        
tools_awx_1       |   File "/awx_devel/awx/main/harakiri_middleware.py", line 15, in handle_signal                                                            
tools_awx_1       |     logger.error(f"Received harakiri graceful signal while in stack: {''.join(traceback.format_stack()[-5:])}")                 
```