### PR TITLE
Create very strict migration ordering around new DAB apps

### DIFF
--- a/awx/main/migrations/0191_add_django_permissions.py
+++ b/awx/main/migrations/0191_add_django_permissions.py
@@ -4,10 +4,12 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-    dependencies = [
-        ('main', '0190_alter_inventorysource_source_and_more'),
-        ('dab_rbac', '__first__'),
-    ]
+    dependencies = [('main', '0190_alter_inventorysource_source_and_more')]
+    # This run_before list is the same as dependencies for 192
+    # so this enforces a very strict ordering, which is good, so DAB post_migrate logic
+    # will never run before these model Meta changes
+    # This also zeros out these DAB apps in the case that you migrate to 190, before DAB RBAC
+    run_before = [('dab_rbac', '__first__'), ('dab_resource_registry', '__first__')]
 
     operations = [
         # Add custom permissions for all special actions, like update, use, adhoc, and so on

--- a/awx/main/migrations/0192_custom_roles.py
+++ b/awx/main/migrations/0192_custom_roles.py
@@ -6,10 +6,7 @@ from awx.main.migrations._dab_rbac import migrate_to_new_rbac, create_permission
 
 
 class Migration(migrations.Migration):
-    dependencies = [
-        ('main', '0191_add_django_permissions'),
-        ('dab_rbac', '__first__'),
-    ]
+    dependencies = [('main', '0191_add_django_permissions'), ('dab_rbac', '__first__'), ('dab_resource_registry', '__first__')]
 
     operations = [
         # make sure permissions and content types have been created by now


### PR DESCRIPTION
##### SUMMARY
This makes reverse migrations aggressively back-out changes made by DAB apps. Intended use:

```
awx-manage migrate main 0190
```

This avoids the need to run additional commands like

```
awx-manage migrate dab_rbac zero
```

I would not ever want you to migrate back to 0190, and _not_ back out DAB RBAC, simply because I have not good sense about whether that would result in a consistent outcome. It is much better to back it all out, and count on the data migration logic _re-applying_ everything that it previously did.

If you created some permission structure in DAB RBAC, and you want to keep it, _you shouldn't be reverse migrating_!

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

