### PR TITLE
Guard around race condition

### DIFF
--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -450,7 +450,12 @@ class Licenser(object):
         if first_host:
             automated_since = int(first_host.first_automation.timestamp())
         else:
-            automated_since = int(Instance.objects.order_by('id').first().created.timestamp())
+            try:
+                automated_since = int(Instance.objects.order_by('id').first().created.timestamp())
+            except AttributeError:
+                # In the odd scenario that create_preload_data was not run, there are no hosts
+                # Then we CAN end up here before any instance has registered
+                automated_since = int(time.time())
         instance_count = int(attrs.get('instance_count', 0))
         attrs['current_instances'] = current_instances
         attrs['automated_instances'] = automated_instances


### PR DESCRIPTION
I had the luck of running into this race condition that broke my deployment. No instance was ever able to register because on running "awx-manage" in some check of a setting, it would end up failing here with 

```
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/conf/license.py", line 10, in _get_validated_license_data
    return get_licenser().validate()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/utils/licensing.py", line 453, in validate
    automated_since = int(Instance.objects.order_by('id').first().created.timestamp())
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'created'
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```
