### PR TITLE
Rewrite more access logic in terms of permissions instead of roles

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -242,9 +242,14 @@ class BaseAccess(object):
         return qs
 
     def filtered_queryset(self):
-        # Override in subclasses
-        # filter objects according to user's read access
-        return self.model.objects.none()
+        if permission_registry.is_registered(self.model):
+            return self.model.access_qs(self.user, 'view')
+        elif self.user.is_superuser:
+            return self.model.objects.all()
+        else:
+            # models not tracked in DAB RBAC - Override in subclasses
+            # filter objects according to user's read access
+            return self.model.none()
 
     def can_read(self, obj):
         return bool(obj and self.get_queryset().filter(pk=obj.pk).exists())

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -244,12 +244,8 @@ class BaseAccess(object):
     def filtered_queryset(self):
         if permission_registry.is_registered(self.model):
             return self.model.access_qs(self.user, 'view')
-        elif self.user.is_superuser:
-            return self.model.objects.all()
         else:
-            # models not tracked in DAB RBAC - Override in subclasses
-            # filter objects according to user's read access
-            return self.model.none()
+            raise NotImplemented('Filtered queryset for model is not written')
 
     def can_read(self, obj):
         return bool(obj and self.get_queryset().filter(pk=obj.pk).exists())

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -245,7 +245,7 @@ class BaseAccess(object):
         if permission_registry.is_registered(self.model):
             return self.model.access_qs(self.user, 'view')
         else:
-            raise NotImplemented('Filtered queryset for model is not written')
+            raise NotImplementedError('Filtered queryset for model is not written')
 
     def can_read(self, obj):
         return bool(obj and self.get_queryset().filter(pk=obj.pk).exists())
@@ -606,9 +606,6 @@ class InstanceGroupAccess(BaseAccess):
 
     model = InstanceGroup
     prefetch_related = ('instances',)
-
-    def filtered_queryset(self):
-        return self.model.access_qs(self.user, 'view')
 
     @check_superuser
     def can_use(self, obj):
@@ -1449,9 +1446,6 @@ class ProjectAccess(NotificationAttachMixin, BaseAccess):
     prefetch_related = ('modified_by', 'created_by', 'organization', 'last_job', 'current_job')
     notification_attach_roles = ['admin_role']
 
-    def filtered_queryset(self):
-        return self.model.access_qs(self.user, 'view')
-
     @check_superuser
     def can_add(self, data):
         if not data:  # So the browseable API will work
@@ -2075,9 +2069,6 @@ class WorkflowJobTemplateAccess(NotificationAttachMixin, BaseAccess):
         'execute_role',
         'read_role',
     )
-
-    def filtered_queryset(self):
-        return self.model.access_qs(self.user, 'view')
 
     @check_superuser
     def can_add(self, data):

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1389,7 +1389,7 @@ class ExecutionEnvironmentAccess(BaseAccess):
 
     def filtered_queryset(self):
         return ExecutionEnvironment.objects.filter(
-            Q(organization__in=Organization.access_qs(self.user, 'view'))
+            Q(organization__in=Organization.access_ids_qs(self.user, 'view'))
             | Q(organization__isnull=True)
             | Q(id__in=ExecutionEnvironment.access_ids_qs(self.user, 'change'))
         ).distinct()

--- a/awx/main/tests/functional/test_rbac_execution_environment.py
+++ b/awx/main/tests/functional/test_rbac_execution_environment.py
@@ -98,7 +98,7 @@ def test_team_can_have_permission(org_ee, ee_rd, rando, admin_user, post):
 
 
 @pytest.mark.django_db
-def test_give_object_permission_to_ee(org_ee, ee_rd, org_member, check_user_capabilities):
+def test_give_object_permission_to_ee(setup_managed_roles, org_ee, ee_rd, org_member, check_user_capabilities):
     access = ExecutionEnvironmentAccess(org_member)
     assert access.can_read(org_ee)  # by virtue of being an org member
     assert not access.can_change(org_ee, {'name': 'new'})
@@ -130,7 +130,7 @@ def test_need_related_organization_access(org_ee, ee_rd, org_member):
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('style', ['new', 'old'])
-def test_give_org_permission_to_ee(org_ee, organization, org_member, check_user_capabilities, style, org_ee_rd):
+def test_give_org_permission_to_ee(setup_managed_roles, org_ee, organization, org_member, check_user_capabilities, style, org_ee_rd):
     access = ExecutionEnvironmentAccess(org_member)
     assert not access.can_change(org_ee, {'name': 'new'})
     check_user_capabilities(org_member, org_ee, {'edit': False, 'delete': False, 'copy': False})


### PR DESCRIPTION
##### SUMMARY
We have these "old" patterns in the ORM based on the old RBAC models, and then we have "new" patterns, those coming from DAB RBAC.

These needed to be migrated anyway, but I believe I may have hit an issue in https://github.com/ansible/django-ansible-base/pull/562 where we checked for the "member_role" specifically, but multiple roles can convey the "member" permission in the new parlance.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

