### PR TITLE
Mark the collection role module as deprecated

### DIFF
--- a/awx_collection/meta/runtime.yml
+++ b/awx_collection/meta/runtime.yml
@@ -265,5 +265,5 @@ plugin_routing:
       redirect: awx.awx.workflow_node_wait
     role:
       deprecation:
-        removal_date: '2025-02-01'
+        removal_version: '25.0.0'
         warning_text: This is replaced by the DAB role system, via the role_definition module.

--- a/awx_collection/meta/runtime.yml
+++ b/awx_collection/meta/runtime.yml
@@ -263,3 +263,7 @@ plugin_routing:
         removal_date: '2022-01-23'
         warning_text: The tower_* modules have been deprecated, use awx.awx.workflow_node_wait instead.
       redirect: awx.awx.workflow_node_wait
+    role:
+      deprecation:
+        removal_date: '2025-02-01'
+        warning_text: This is replaced by the DAB role system, via the role_definition module.

--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -17,6 +17,7 @@ DOCUMENTATION = '''
 module: role
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: grant or revoke an Automation Platform Controller role.
+deprecated: true
 description:
     - Roles are used for access control, this module is for managing user access to server resources.
     - Grant or revoke Automation Platform Controller roles to users. See U(https://www.ansible.com/tower) for an overview.

--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -17,7 +17,10 @@ DOCUMENTATION = '''
 module: role
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: grant or revoke an Automation Platform Controller role.
-deprecated: true
+deprecated:
+  remove_by_date: 2025-02-01
+  why: Endpoints corresponding to module will be removed in the API
+  alternative: Use the role_user_assignment and role_team_assignment modules instead.
 description:
     - Roles are used for access control, this module is for managing user access to server resources.
     - Grant or revoke Automation Platform Controller roles to users. See U(https://www.ansible.com/tower) for an overview.

--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -18,9 +18,9 @@ module: role
 author: "Wayne Witzel III (@wwitzel3)"
 short_description: grant or revoke an Automation Platform Controller role.
 deprecated:
-  remove_by_date: 2025-02-01
-  why: Endpoints corresponding to module will be removed in the API
-  alternative: Use the role_user_assignment and role_team_assignment modules instead.
+    removed_in: '25.0.0'
+    why: Endpoints corresponding to module will be removed in the API
+    alternative: Use the role_user_assignment and role_team_assignment modules instead.
 description:
     - Roles are used for access control, this module is for managing user access to server resources.
     - Grant or revoke Automation Platform Controller roles to users. See U(https://www.ansible.com/tower) for an overview.


### PR DESCRIPTION
##### SUMMARY
Work to add new, replacement, modules has already been done in 3bb559dd09642277aef5d610878ba9de6b17c7ac but that did not make it fully clear that the old module will be removed via the standard way of doing this.

Putting up this PR, hoping that the collection sanity test checks it properly.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
