### PR TITLE
fix: catch correct exception when parsing filter

### DIFF
--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -1,5 +1,7 @@
 import re
 from functools import reduce
+
+from django.core.exceptions import FieldDoesNotExist
 from pyparsing import (
     infixNotation,
     opAssoc,
@@ -353,7 +355,7 @@ class SmartFilter(object):
 
         try:
             res = boolExpr.parseString('(' + filter_string + ')')
-        except ParseException:
+        except (ParseException, FieldDoesNotExist):
             raise RuntimeError(u"Invalid query %s" % filter_string_raw)
 
         if len(res) > 0:


### PR DESCRIPTION
##### SUMMARY

When parsing filters, different exceptions than `ParseException` could be thrown. We could also consider catching `Exception` to make sure we're safe.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
