### PR TITLE
Sensible log behavior when redis is unavailable

### DIFF
--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -15,6 +15,7 @@ from datetime import timedelta
 
 from django import db
 from django.conf import settings
+import redis.exceptions
 
 from ansible_base.lib.logging.runtime import log_excess_runtime
 
@@ -130,10 +131,13 @@ class AWXConsumerBase(object):
     @log_excess_runtime(logger, debug_cutoff=0.05, cutoff=0.2)
     def record_statistics(self):
         if time.time() - self.last_stats > 1:  # buffer stat recording to once per second
+            save_data = self.pool.debug()
             try:
-                self.redis.set(f'awx_{self.name}_statistics', self.pool.debug())
+                self.redis.set(f'awx_{self.name}_statistics', save_data)
+            except redis.exceptions.ConnectionError as exc:
+                logger.warning(f'Redis connection error saving {self.name} status data:\n{exc}\nmissed data:\n{save_data}')
             except Exception:
-                logger.exception(f"encountered an error communicating with redis to store {self.name} statistics")
+                logger.exception(f"Unknown redis error saving {self.name} status data:\nmissed data:\n{save_data}")
             self.last_stats = time.time()
 
     def run(self, *args, **kwargs):
@@ -189,7 +193,10 @@ class AWXConsumerPG(AWXConsumerBase):
         current_time = time.time()
         self.pool.produce_subsystem_metrics(self.subsystem_metrics)
         self.subsystem_metrics.set('dispatcher_availability', self.listen_cumulative_time / (current_time - self.last_metrics_gather))
-        self.subsystem_metrics.pipe_execute()
+        try:
+            self.subsystem_metrics.pipe_execute()
+        except redis.exceptions.ConnectionError as exc:
+            logger.warning(f'Redis connection error saving dispatcher metrics, error:\n{exc}')
         self.listen_cumulative_time = 0.0
         self.last_metrics_gather = current_time
 

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -86,6 +86,7 @@ class CallbackBrokerWorker(BaseWorker):
         return os.getpid()
 
     def read(self, queue):
+        has_redis_error = False
         try:
             res = self.redis.blpop(self.queue_name, timeout=1)
             if res is None:
@@ -95,14 +96,21 @@ class CallbackBrokerWorker(BaseWorker):
             self.subsystem_metrics.inc('callback_receiver_events_popped_redis', 1)
             self.subsystem_metrics.inc('callback_receiver_events_in_memory', 1)
             return json.loads(res[1])
+        except redis.exceptions.ConnectionError as exc:
+            # Low noise log, because very common and many workers will write this
+            logger.error(f"redis connection error: {exc}")
+            has_redis_error = True
+            time.sleep(5)
         except redis.exceptions.RedisError:
             logger.exception("encountered an error communicating with redis")
+            has_redis_error = True
             time.sleep(1)
         except (json.JSONDecodeError, KeyError):
             logger.exception("failed to decode JSON message from redis")
         finally:
-            self.record_statistics()
-            self.record_read_metrics()
+            if not has_redis_error:
+                self.record_statistics()
+                self.record_read_metrics()
 
         return {'event': 'FLUSH'}
 

--- a/awx/main/management/commands/run_callback_receiver.py
+++ b/awx/main/management/commands/run_callback_receiver.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 
+import redis
+
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-
-from redis.exceptions import ConnectionError
+import redis.exceptions
 
 from awx.main.analytics.subsystem_metrics import CallbackReceiverMetricsServer
 from awx.main.dispatch.control import Control
@@ -31,8 +32,8 @@ class Command(BaseCommand):
 
         try:
             CallbackReceiverMetricsServer().start()
-        except ConnectionError as exc:
-            raise CommandError(f'Could not connect to redis, error:\n{exc}\n')
+        except redis.exceptions.ConnectionError as exc:
+            raise CommandError(f'Callback receiver could not connect to redis, error: {exc}')
 
         try:
             consumer = AWXConsumerRedis(

--- a/awx/main/management/commands/run_callback_receiver.py
+++ b/awx/main/management/commands/run_callback_receiver.py
@@ -2,9 +2,11 @@
 # All Rights Reserved.
 
 from django.conf import settings
-from django.core.management.base import BaseCommand
-from awx.main.analytics.subsystem_metrics import CallbackReceiverMetricsServer
+from django.core.management.base import BaseCommand, CommandError
 
+from redis.exceptions import ConnectionError
+
+from awx.main.analytics.subsystem_metrics import CallbackReceiverMetricsServer
 from awx.main.dispatch.control import Control
 from awx.main.dispatch.worker import AWXConsumerRedis, CallbackBrokerWorker
 
@@ -27,7 +29,10 @@ class Command(BaseCommand):
             return
         consumer = None
 
-        CallbackReceiverMetricsServer().start()
+        try:
+            CallbackReceiverMetricsServer().start()
+        except ConnectionError as exc:
+            raise CommandError(f'Could not connect to redis, error:\n{exc}\n')
 
         try:
             consumer = AWXConsumerRedis(

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -3,8 +3,10 @@
 import logging
 import yaml
 
+import redis
+
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from awx.main.dispatch import get_task_queuename
 from awx.main.dispatch.control import Control
@@ -63,7 +65,10 @@ class Command(BaseCommand):
 
         consumer = None
 
-        DispatcherMetricsServer().start()
+        try:
+            DispatcherMetricsServer().start()
+        except redis.exceptions.ConnectionError as exc:
+            raise CommandError(f'Dispatcher could not connect to redis, error: {exc}')
 
         try:
             queues = ['tower_broadcast_all', 'tower_settings_change', get_task_queuename()]

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -10,6 +10,8 @@ import time
 import sys
 import signal
 
+import redis
+
 # Django
 from django.db import transaction
 from django.utils.translation import gettext_lazy as _, gettext_noop
@@ -120,6 +122,8 @@ class TaskBase:
                     self.subsystem_metrics.pipe_execute()
                 else:
                     logger.debug(f"skipping recording {self.prefix} metrics, last recorded {time_last_recorded} seconds ago")
+            except redis.exceptions.ConnectionError as exc:
+                logger.warning(f"Redis connection error saving metrics for {self.prefix}, error: {exc}")
             except Exception:
                 logger.exception(f"Error saving metrics for {self.prefix}")
 


### PR DESCRIPTION
##### SUMMARY
This picks up on the "redis" part of a prior PR https://github.com/ansible/awx/pull/12698 and goes further.

That prior PR was too unfocused, trying to solve both the redis and receptor problems. Backing up, why am I looking at this problem in the first place? Because it gets in my way (personally) trying to diagnose other problems. Because when I look at logs, those logs are swamped due to 2 main reasons:

 - Problems with install ordering mean that dispatcher and other stuff runs _before_ receptor is fully running and available
 - When redis goes down (which we do intentionally sometimes) various services absolutely _scream_ in the logs about this fact

This PR is only concerned with the 2nd bullet point.

So when you get the log file you want (finally, after wading through the rest of the SOS report), you find that 95% of that log is stuff you don't want. Even worse, the noise is all "Traceback:" entries... which isn't great when what _you're looking for_ is a stack trace of that format.

With that segway, here's a demo of the log behavior after taking redis down:

```
tools_redis_1     | 1:M 26 Aug 2024 02:03:54.472 # Redis is now ready to exit, bye bye...
tools_awx_1       | 2024-08-26 02:03:54,475 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Connection closed by server.
tools_awx_1       | 2024-08-26 02:03:54,474 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Connection closed by server.
tools_awx_1       | 2024-08-26 02:03:54,474 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Connection closed by server.
tools_awx_1       | 2024-08-26 02:03:54,474 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Connection closed by server.
tools_redis_1 exited with code 0
tools_awx_1       | 2024-08-26 02:03:57,650 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:03:59,498 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:03:59,498 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:03:59,498 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:03:59,502 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:02,707 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:02,894 WARNING  [-] awx.main.dispatch Redis connection error saving status data:
tools_awx_1       | Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | missed data:
tools_awx_1       | Recorded at: 2024-08-26 02:04:02 UTC 
tools_awx_1       | awx-1[pid:3477] workers total=4 min=4 max=631 
tools_awx_1       | .  worker[pid:3484] sent=0 qsize=0 rss=152.594MB [IDLE]
tools_awx_1       | .  worker[pid:3485] sent=0 qsize=0 rss=152.621MB [IDLE]
tools_awx_1       | .  worker[pid:3486] sent=0 qsize=0 rss=152.625MB [IDLE]
tools_awx_1       | .  worker[pid:3487] sent=0 qsize=0 rss=152.633MB [IDLE]
tools_awx_1       | 2024-08-26 02:04:04,524 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:04,523 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:04,530 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:04,534 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:07,762 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:08,819 WARNING  [-] awx.main.dispatch Redis connection error saving status data:
tools_awx_1       | Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | missed data:
tools_awx_1       | Recorded at: 2024-08-26 02:04:08 UTC 
tools_awx_1       | awx-1[pid:3477] workers total=4 min=4 max=631 
tools_awx_1       | .  worker[pid:3484] sent=0 qsize=0 rss=152.594MB [IDLE]
tools_awx_1       | .  worker[pid:3485] sent=0 qsize=0 rss=152.621MB [IDLE]
tools_awx_1       | .  worker[pid:3486] sent=0 qsize=0 rss=152.625MB [IDLE]
tools_awx_1       | .  worker[pid:3487] sent=0 qsize=0 rss=152.633MB [IDLE]
tools_awx_1       | 2024-08-26 02:04:08,869 WARNING  [-] awx.main.scheduler Redis connection error saving metrics for task_manager, error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:09,546 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:09,550 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:09,550 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:09,558 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:09,853 WARNING  [-] awx.main.scheduler Redis connection error saving metrics for dependency_manager, error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:12,811 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:14,569 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:14,572 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:14,572 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:14,583 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:14,818 WARNING  [-] awx.main.dispatch Redis connection error saving status data:
tools_awx_1       | Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | missed data:
tools_awx_1       | Recorded at: 2024-08-26 02:04:14 UTC 
tools_awx_1       | awx-1[pid:3477] workers total=4 min=4 max=631 
tools_awx_1       | .  worker[pid:3484] sent=1 finished=1 qsize=0 rss=159.254MB [IDLE]
tools_awx_1       | .  worker[pid:3485] sent=0 qsize=0 rss=152.621MB [IDLE]
tools_awx_1       | .  worker[pid:3486] sent=1 qsize=1 rss=159.078MB
tools_awx_1       |      - running cf27e9ed-2fd6-4a32-b675-ae1403e1ce0e dependency_manager(*[])
tools_awx_1       | .  worker[pid:3487] sent=0 qsize=0 rss=152.633MB [IDLE]
tools_awx_1       | 2024-08-26 02:04:14,823 WARNING  [-] awx.main.analytics Connection error in send_metrics: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:14,823 WARNING  [-] awx.main.analytics Connection error in send_metrics: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:17,856 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:19,593 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:19,595 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:19,595 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:19,609 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:22,823 WARNING  [-] awx.main.dispatch Redis connection error saving status data:
tools_awx_1       | Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | missed data:
tools_awx_1       | Recorded at: 2024-08-26 02:04:22 UTC 
tools_awx_1       | awx-1[pid:3477] workers total=4 min=4 max=631 
tools_awx_1       | .  worker[pid:3484] sent=1 finished=1 qsize=0 rss=159.254MB [IDLE]
tools_awx_1       | .  worker[pid:3485] sent=1 qsize=1 rss=158.738MB
tools_awx_1       |      - running 4e5206e4-31f0-48ad-92fb-4957ed1f5d54 awx_periodic_scheduler(*[])
tools_awx_1       | .  worker[pid:3486] sent=2 finished=1 qsize=1 rss=159.078MB
tools_awx_1       |      - running 8d600d28-831e-4306-8b63-ffb33e491cba send_subsystem_metrics(*[])
tools_awx_1       | .  worker[pid:3487] sent=0 qsize=0 rss=152.633MB [IDLE]
tools_awx_1       | 2024-08-26 02:04:22,833 WARNING  [-] awx.main.dispatch Redis connection error saving dispatcher metrics, error:
tools_awx_1       | Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:22,910 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:24,620 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:24,620 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:24,620 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:24,630 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:27,939 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:28,820 WARNING  [-] awx.main.dispatch Redis connection error saving status data:
tools_awx_1       | Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | missed data:
tools_awx_1       | Recorded at: 2024-08-26 02:04:28 UTC 
tools_awx_1       | awx-1[pid:3477] workers total=4 min=4 max=631 
tools_awx_1       | .  worker[pid:3484] sent=1 finished=1 qsize=0 rss=159.254MB [IDLE]
tools_awx_1       | .  worker[pid:3485] sent=1 qsize=1 rss=158.738MB
tools_awx_1       |      - running 4e5206e4-31f0-48ad-92fb-4957ed1f5d54 awx_periodic_scheduler(*[])
tools_awx_1       | .  worker[pid:3486] sent=2 finished=1 qsize=1 rss=159.078MB
tools_awx_1       |      - running 8d600d28-831e-4306-8b63-ffb33e491cba send_subsystem_metrics(*[])
tools_awx_1       | .  worker[pid:3487] sent=0 qsize=0 rss=152.633MB [IDLE]
tools_awx_1       | 2024-08-26 02:04:28,866 WARNING  [-] awx.main.scheduler Redis connection error saving metrics for task_manager, error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:29,650 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:29,655 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:29,653 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:29,651 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:29,836 WARNING  [-] awx.main.scheduler Redis connection error saving metrics for dependency_manager, error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:32,995 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:34,670 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:34,673 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:34,678 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:34,679 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:34,823 WARNING  [-] awx.main.dispatch Redis connection error saving status data:
tools_awx_1       | Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | missed data:
tools_awx_1       | Recorded at: 2024-08-26 02:04:34 UTC 
tools_awx_1       | awx-1[pid:3477] workers total=4 min=4 max=631 
tools_awx_1       | .  worker[pid:3484] sent=1 finished=1 qsize=0 rss=159.254MB [IDLE]
tools_awx_1       | .  worker[pid:3485] sent=1 finished=1 qsize=0 rss=158.738MB [IDLE]
tools_awx_1       | .  worker[pid:3486] sent=4 finished=3 qsize=1 rss=159.488MB
tools_awx_1       |      - running c5ec804f-f846-4226-aa48-84104e56d129 dependency_manager(*[])
tools_awx_1       | .  worker[pid:3487] sent=0 qsize=0 rss=152.633MB [IDLE]
tools_awx_1       | 2024-08-26 02:04:34,876 WARNING  [-] awx.main.analytics Connection error in send_metrics: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:34,877 WARNING  [-] awx.main.analytics Connection error in send_metrics: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:38,047 WARNING  [-] awx.analytics.broadcast_websocket Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:39,703 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:39,702 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:39,703 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:39,711 ERROR    [-] awx.main.commands.run_callback_receiver redis connection error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
tools_awx_1       | 2024-08-26 02:04:45,860 WARNING  [-] awx.main.tasks.system Heartbeat skew - interval=62.9535, expected=60
```

This is noisy on a certain point, but that is actually an interesting point.

The dispatcher "statistics" are used for the `--status` command. So if we can't get the statistics to stash into redis... what do we do? Before, we would drop that data on the floor and then log a giant stack trace. But, since redis connection errors are a _very_ well-known quality, better to show the details of the error, and then print the data that we're dropping. Right? There's a non-zero chance that we have a pool management bug while at the same time hitting this, confounding debugging even more.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

