### PR TITLE
GitHub app scm project alt

### DIFF
--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -645,6 +645,9 @@ ManagedCredentialType(
             {'id': 'password', 'label': gettext_noop('Password'), 'type': 'string', 'secret': True},
             {'id': 'ssh_key_data', 'label': gettext_noop('SCM Private Key'), 'type': 'string', 'format': 'ssh_private_key', 'secret': True, 'multiline': True},
             {'id': 'ssh_key_unlock', 'label': gettext_noop('Private Key Passphrase'), 'type': 'string', 'secret': True},
+            {'id': 'github_app_id', 'label': gettext_noop('GitHub App ID'), 'type': 'string'},
+            {'id': 'github_app_installation_id', 'label': gettext_noop('GitHub App Installation ID'), 'type': 'string'},
+            {'id': 'github_api_url', 'label': gettext_noop('GitHub API URL'), 'type': 'string'},
         ],
     },
 )

--- a/awx/main/models/credential/__init__.py
+++ b/awx/main/models/credential/__init__.py
@@ -635,6 +635,28 @@ ManagedCredentialType(
 )
 
 ManagedCredentialType(
+    namespace='scm_github_app',
+    kind='scm',
+    name=gettext_noop('GitHub App'),
+    managed=True,
+    inputs={
+        'fields': [
+            {'id': 'github_app_id', 'label': gettext_noop('GitHub App ID'), 'type': 'string'},
+            {'id': 'github_app_installation_id', 'label': gettext_noop('GitHub App Installation ID'), 'type': 'string'},
+            {
+                'id': 'ssh_key_data',
+                'label': gettext_noop('GitHub App Private Key'),
+                'type': 'string',
+                'format': 'ssh_private_key',
+                'secret': True,
+                'multiline': True,
+            },
+            {'id': 'github_api_url', 'label': gettext_noop('GitHub API URL'), 'type': 'string'},
+        ],
+    },
+)
+
+ManagedCredentialType(
     namespace='scm',
     kind='scm',
     name=gettext_noop('Source Control'),
@@ -645,9 +667,6 @@ ManagedCredentialType(
             {'id': 'password', 'label': gettext_noop('Password'), 'type': 'string', 'secret': True},
             {'id': 'ssh_key_data', 'label': gettext_noop('SCM Private Key'), 'type': 'string', 'format': 'ssh_private_key', 'secret': True, 'multiline': True},
             {'id': 'ssh_key_unlock', 'label': gettext_noop('Private Key Passphrase'), 'type': 'string', 'secret': True},
-            {'id': 'github_app_id', 'label': gettext_noop('GitHub App ID'), 'type': 'string'},
-            {'id': 'github_app_installation_id', 'label': gettext_noop('GitHub App Installation ID'), 'type': 'string'},
-            {'id': 'github_api_url', 'label': gettext_noop('GitHub API URL'), 'type': 'string'},
         ],
     },
 )

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -14,6 +14,8 @@ import tempfile
 import traceback
 import time
 import urllib.parse as urlparse
+import jwt
+import requests
 
 # Django
 from django.conf import settings
@@ -1153,6 +1155,30 @@ class RunProjectUpdate(BaseTask):
                 private_data['credentials'][credential] = credential.get_input('ssh_key_data', default='')
         return private_data
 
+    def _get_github_app_installation_access_token(self, project_update):
+        jwt_token = jwt.encode(
+            {
+                'iat': int(time.time()),  # Issued at time
+                'exp': int(time.time()) + (10 * 60),  # JWT expiration time (10 minute maximum)
+                'iss': project_update.credential.get_input('github_app_id', default=''),  # GitHub App's identifier
+            },
+            project_update.credential.get_input('ssh_key_data', default=''),
+            algorithm='RS256',
+        )
+
+        headers = {'Authorization': f'Bearer {jwt_token}', 'Accept': 'application/vnd.github.v3+json'}
+
+        github_api_url = project_update.credential.get_input('github_api_url', default='https://api.github.com')
+        installation_id = project_update.credential.get_input('github_app_installation_id', default='')
+        url = f'{github_api_url}/app/installations/{installation_id}/access_tokens'
+        response = requests.post(url, headers=headers)
+
+        if response.status_code == 201:
+            access_token = response.json()['token']
+            return access_token
+        else:
+            raise Exception(f"Failed to get access token: {response.status_code} {response.text}")
+
     def build_passwords(self, project_update, runtime_passwords):
         """
         Build a dictionary of passwords for SSH private key unlock and SCM
@@ -1161,8 +1187,15 @@ class RunProjectUpdate(BaseTask):
         passwords = super(RunProjectUpdate, self).build_passwords(project_update, runtime_passwords)
         if project_update.credential:
             passwords['scm_key_unlock'] = project_update.credential.get_input('ssh_key_unlock', default='')
-            passwords['scm_username'] = project_update.credential.get_input('username', default='')
-            passwords['scm_password'] = project_update.credential.get_input('password', default='')
+            passwords['scm_key_data'] = project_update.credential.get_input('ssh_key_data', default='')
+            if project_update.credential.get_input('github_app_id', default=''):
+                github_installation_access_token = self._get_github_app_installation_access_token(project_update)
+                passwords['scm_username'] = 'x-access-token'
+                passwords['scm_password'] = github_installation_access_token
+            else:
+                passwords['scm_username'] = project_update.credential.get_input('username', default='')
+                passwords['scm_password'] = project_update.credential.get_input('password', default='')
+
         return passwords
 
     def build_env(self, project_update, private_data_dir, private_data_files=None):

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -106,6 +106,7 @@ def test_default_cred_types():
             'thycotic_tss',
             'vault',
             'vmware',
+            'scm_github_app',
         ]
     )
 

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1595,6 +1595,10 @@ class TestProjectUpdateCredentials(TestJobExecution):
         expect_passwords = task.create_expect_passwords_data_struct(password_prompts, passwords)
         assert 'bob' in expect_passwords.values()
 
+    def test_github_app_auth(self, project_update, mock_me):
+        # TODO: Implement me
+        pass
+
     def test_awx_task_env(self, project_update, settings, private_data_dir, scm_type, execution_environment, mock_me):
         project_update.execution_environment = execution_environment
         settings.AWX_TASK_ENV = {'FOO': 'BAR'}


### PR DESCRIPTION
##### SUMMARY
Alternative to https://github.com/ansible/awx/pull/15472

- Add new scm credential type scm_github_app
- Add ability to generate github app token to clone project with git for github

IMPORTANT: UI change needed currently UI hard codes to namespace='scm' need to change to kind='scm'
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
