### PR TITLE
Add License Expiry Metric

### DIFF
--- a/awx/main/analytics/metrics.py
+++ b/awx/main/analytics/metrics.py
@@ -128,6 +128,7 @@ def metrics():
         registry=REGISTRY,
     )
 
+    LICENSE_EXPIRY = Gauge('awx_license_expiry', 'Time before AWX license expires', registry=REGISTRY)
     LICENSE_INSTANCE_TOTAL = Gauge('awx_license_instance_total', 'Total number of managed hosts provided by your license', registry=REGISTRY)
     LICENSE_INSTANCE_FREE = Gauge('awx_license_instance_free', 'Number of remaining managed hosts provided by your license', registry=REGISTRY)
 
@@ -148,6 +149,7 @@ def metrics():
         }
     )
 
+    LICENSE_EXPIRY.set(str(license_info.get('time_remaining', 0)))
     LICENSE_INSTANCE_TOTAL.set(str(license_info.get('instance_count', 0)))
     LICENSE_INSTANCE_FREE.set(str(license_info.get('free_instances', 0)))
 

--- a/awx/main/analytics/metrics.py
+++ b/awx/main/analytics/metrics.py
@@ -128,7 +128,7 @@ def metrics():
         registry=REGISTRY,
     )
 
-    LICENSE_EXPIRY = Gauge('awx_license_expiry', 'Time before AWX license expires', registry=REGISTRY)
+    LICENSE_EXPIRY = Gauge('awx_license_expiry', 'Time before license expires', registry=REGISTRY)
     LICENSE_INSTANCE_TOTAL = Gauge('awx_license_instance_total', 'Total number of managed hosts provided by your license', registry=REGISTRY)
     LICENSE_INSTANCE_FREE = Gauge('awx_license_instance_free', 'Number of remaining managed hosts provided by your license', registry=REGISTRY)
 

--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -30,6 +30,7 @@ EXPECTED_VALUES = {
     'awx_license_instance_free': 0,
     'awx_pending_jobs_total': 0,
     'awx_database_connections_total': 1,
+    'awx_license_expiry': 0
 }
 
 

--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -30,7 +30,7 @@ EXPECTED_VALUES = {
     'awx_license_instance_free': 0,
     'awx_pending_jobs_total': 0,
     'awx_database_connections_total': 1,
-    'awx_license_expiry': 0
+    'awx_license_expiry': 0,
 }
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a metric to show the time until the license for the awx/automation controller will expire.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Metrics

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.6.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This will add the expiry like describe in this issue, https://github.com/ansible/awx/issues/3781
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
