### PR TITLE
Register any discovered CredentialType after migration

### DIFF
--- a/awx/main/management/commands/setup_managed_credential_types.py
+++ b/awx/main/management/commands/setup_managed_credential_types.py
@@ -10,4 +10,9 @@ class Command(BaseCommand):
     help = 'Load default managed credential types.'
 
     def handle(self, *args, **options):
-        CredentialType.setup_tower_managed_defaults()
+        """
+        Note that the call below is almost redundant. The same call as below is called in the Django ready() code path. The ready() code path runs
+        before every management command. The one difference in the below call is that the below call is _more_ likely to _actually_ run. The ready() code path
+        version _can_ be a NOOP if the lock is not acquired. The below version waits to acquire the lock. This can be useful for recreating bugs or pdb.
+        """
+        CredentialType.setup_tower_managed_defaults(wait_for_lock=True)

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -12,18 +12,6 @@ from awx.api.versioning import reverse
 EXAMPLE_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nxyz==\n-----END PRIVATE KEY-----'
 EXAMPLE_ENCRYPTED_PRIVATE_KEY = '-----BEGIN PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nxyz==\n-----END PRIVATE KEY-----'
 
-
-@pytest.mark.django_db
-def test_idempotent_credential_type_setup():
-    assert CredentialType.objects.count() == 0
-    CredentialType.setup_tower_managed_defaults()
-    total = CredentialType.objects.count()
-    assert total > 0
-
-    CredentialType.setup_tower_managed_defaults()
-    assert CredentialType.objects.count() == total
-
-
 #
 # user credential creation
 #

--- a/awx/main/tests/functional/test_apps.py
+++ b/awx/main/tests/functional/test_apps.py
@@ -1,0 +1,26 @@
+import pytest
+
+from django.apps import apps
+
+
+@pytest.fixture
+def mock_setup_tower_managed_defaults(mocker):
+    return mocker.patch('awx.main.models.credential.CredentialType.setup_tower_managed_defaults')
+
+
+@pytest.mark.django_db
+def test_load_credential_types_feature_migrations_ran(mocker, mock_setup_tower_managed_defaults):
+    mocker.patch('awx.main.apps.is_database_synchronized', return_value=True)
+
+    apps.get_app_config('main')._load_credential_types_feature()
+
+    mock_setup_tower_managed_defaults.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_load_credential_types_feature_migrations_not_ran(mocker, mock_setup_tower_managed_defaults):
+    mocker.patch('awx.main.apps.is_database_synchronized', return_value=False)
+
+    apps.get_app_config('main')._load_credential_types_feature()
+
+    mock_setup_tower_managed_defaults.assert_not_called()

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -339,3 +339,25 @@ def test_credential_get_input(organization_factory):
     # verify return values for encrypted secret fields are decrypted
     assert cred.inputs['vault_password'].startswith('$encrypted$')
     assert cred.get_input('vault_password') == 'testing321'
+
+
+@pytest.mark.django_db
+def test_idempotent_credential_type_setup():
+    """
+    awx main app ready() calls `setup_tower_managed_defaults()` to register CredentialType(s).
+    This is problematic in our testing system. pytest_django deviates from the production ready() call path. pytest_django calls our apps ready() function
+    before migrations run. This is a problem since we interact with tables in the database that do not yet exist.
+
+    Now forget about what you just read because we do not _actually_ want to register CredentialType(s) in our test at all. So then
+    you would expect this bit of code to spy on `setup_tower_managed_defaults` and assert it was not called BUT registering a spy early
+    enough is hard. The call to ready() from pytest_django happens via pytest hooks very early https://github.com/pytest-dev/pytest-django/blob/1157a7c5c74f4b4e0f4aca8312f3fe67eb00568e/pytest_django/plugin.py#L266C5-L266C34
+
+    Instead of ensuring that `setup_tower_managed_defaults()` is explicitly not called, we check it _implicitly_ by observing that no credential type records are created.
+    """
+    assert CredentialType.objects.count() == 0
+    CredentialType.setup_tower_managed_defaults()
+    total = CredentialType.objects.count()
+    assert total > 0
+
+    CredentialType.setup_tower_managed_defaults()
+    assert CredentialType.objects.count() == total

--- a/awx/main/tests/unit/models/test_credential.py
+++ b/awx/main/tests/unit/models/test_credential.py
@@ -4,6 +4,8 @@ import pytest
 
 from awx.main.models import Credential, CredentialType
 
+from django.apps import apps
+
 
 @pytest.mark.django_db
 def test_unique_hash_with_unicode():
@@ -16,3 +18,32 @@ def test_custom_cred_with_empty_encrypted_field():
     ct = CredentialType(name='My Custom Cred', kind='custom', inputs={'fields': [{'id': 'some_field', 'label': 'My Field', 'secret': True}]})
     cred = Credential(id=4, name='Testing 1 2 3', credential_type=ct, inputs={})
     assert cred.encrypt_field('some_field', None) is None
+
+
+@pytest.mark.parametrize(
+    (
+        'apps',
+        'app_config',
+    ),
+    [
+        (
+            apps,
+            None,
+        ),
+        (
+            None,
+            apps.get_app_config('main'),
+        ),
+    ],
+)
+def test__get_credential_type_class(apps, app_config):
+    ct = CredentialType._get_credential_type_class(apps=apps, app_config=app_config)
+    assert ct.__name__ == 'CredentialType'
+
+
+def test__get_credential_type_class_invalid_params():
+    with pytest.raises(ValueError) as e:
+        CredentialType._get_credential_type_class(apps=apps, app_config=apps.get_app_config('main'))
+
+    assert type(e.value) is ValueError
+    assert str(e.value) == 'Expected only apps or app_config to be defined, not both'

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -147,6 +147,14 @@ def is_testing(argv=None):
     return False
 
 
+def bypass_in_test(func):
+    def fn(*args, **kwargs):
+        if not is_testing():
+            return func(*args, **kwargs)
+
+    return fn
+
+
 class RequireDebugTrueOrTest(logging.Filter):
     """
     Logging filter to output when in DEBUG mode or running tests.

--- a/awx/main/utils/migration.py
+++ b/awx/main/utils/migration.py
@@ -1,0 +1,14 @@
+from django.db.migrations.executor import MigrationExecutor
+from django.db import connections, DEFAULT_DB_ALIAS
+
+
+def is_database_synchronized(database=DEFAULT_DB_ALIAS):
+    """_summary_
+    Ensure all migrations have ran
+    https://stackoverflow.com/questions/31838882/check-for-pending-django-migrations
+    """
+    connection = connections[database]
+    connection.prepare_database()
+    executor = MigrationExecutor(connection)
+    targets = executor.loader.graph.leaf_nodes()
+    return not executor.migration_plan(targets)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
* Register all discovered CredentialType(s) after Django finishes
  loading
* Protect parallel registrations using shared postgres advisory lock
* The down-side of this is that this will run when it does not need to,
  adding overhead to the init process.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
