### PR TITLE
Fix subscription username password setting name

### DIFF
--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -183,7 +183,7 @@ def gather(dest=None, module=None, subset=None, since=None, until=None, collecti
 
         if not (
             settings.AUTOMATION_ANALYTICS_URL
-            and ((settings.REDHAT_USERNAME and settings.REDHAT_PASSWORD) or (settings.SUBSCRIPTION_USERNAME and settings.SUBSCRIPTION_PASSWORD))
+            and ((settings.REDHAT_USERNAME and settings.REDHAT_PASSWORD) or (settings.SUBSCRIPTIONS_USERNAME and settings.SUBSCRIPTIONS_PASSWORD))
         ):
             logger.log(log_level, "Not gathering analytics, configuration is invalid. Use --dry-run to gather locally without sending.")
             return None
@@ -369,9 +369,9 @@ def ship(path):
     rh_password = getattr(settings, 'REDHAT_PASSWORD', None)
 
     if rh_user is None or rh_password is None:
-        logger.info('REDHAT_USERNAME and REDHAT_PASSWORD are not set, using SUBSCRIPTION_USERNAME and SUBSCRIPTION_PASSWORD')
-        rh_user = getattr(settings, 'SUBSCRIPTION_USERNAME', None)
-        rh_password = getattr(settings, 'SUBSCRIPTION_PASSWORD', None)
+        logger.info('REDHAT_USERNAME and REDHAT_PASSWORD are not set, using SUBSCRIPTIONS_USERNAME and SUBSCRIPTIONS_PASSWORD')
+        rh_user = getattr(settings, 'SUBSCRIPTIONS_USERNAME', None)
+        rh_password = getattr(settings, 'SUBSCRIPTIONS_PASSWORD', None)
 
     if not rh_user:
         logger.error('REDHAT_USERNAME and SUBSCRIPTIONS_USERNAME are not set')

--- a/awx/main/tests/functional/analytics/test_core.py
+++ b/awx/main/tests/functional/analytics/test_core.py
@@ -87,8 +87,8 @@ def mock_analytic_post():
             {
                 'REDHAT_USERNAME': 'redhat_user',
                 'REDHAT_PASSWORD': 'redhat_pass',  # NOSONAR
-                'SUBSCRIPTION_USERNAME': None,
-                'SUBSCRIPTION_PASSWORD': None,
+                'SUBSCRIPTIONS_USERNAME': None,
+                'SUBSCRIPTIONS_PASSWORD': None,
             },
             True,
             ('redhat_user', 'redhat_pass'),
@@ -98,8 +98,8 @@ def mock_analytic_post():
             {
                 'REDHAT_USERNAME': None,
                 'REDHAT_PASSWORD': None,
-                'SUBSCRIPTION_USERNAME': 'subs_user',
-                'SUBSCRIPTION_PASSWORD': 'subs_pass',  # NOSONAR
+                'SUBSCRIPTIONS_USERNAME': 'subs_user',
+                'SUBSCRIPTIONS_PASSWORD': 'subs_pass',  # NOSONAR
             },
             True,
             ('subs_user', 'subs_pass'),
@@ -109,8 +109,8 @@ def mock_analytic_post():
             {
                 'REDHAT_USERNAME': None,
                 'REDHAT_PASSWORD': None,
-                'SUBSCRIPTION_USERNAME': None,
-                'SUBSCRIPTION_PASSWORD': None,
+                'SUBSCRIPTIONS_USERNAME': None,
+                'SUBSCRIPTIONS_PASSWORD': None,
             },
             False,
             None,  # No request should be made
@@ -120,8 +120,8 @@ def mock_analytic_post():
             {
                 'REDHAT_USERNAME': None,
                 'REDHAT_PASSWORD': 'redhat_pass',  # NOSONAR
-                'SUBSCRIPTION_USERNAME': 'subs_user',
-                'SUBSCRIPTION_PASSWORD': None,
+                'SUBSCRIPTIONS_USERNAME': 'subs_user',
+                'SUBSCRIPTIONS_PASSWORD': None,
             },
             False,
             None,  # Invalid, no request should be made


### PR DESCRIPTION
##### SUMMARY
Fix typo:
- SUBSCRIPTION_USERNAME -> SUBSCRIPTIONS_USERNAME
- SUBSCRIPTION_PASSWORD -> SUBSCRIPTIONS_PASSWORD

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
