### PR TITLE
Fix analytic ship

### DIFF
--- a/awx/main/analytics/core.py
+++ b/awx/main/analytics/core.py
@@ -368,7 +368,7 @@ def ship(path):
     rh_user = getattr(settings, 'REDHAT_USERNAME', None)
     rh_password = getattr(settings, 'REDHAT_PASSWORD', None)
 
-    if rh_user is None or rh_password is None:
+    if not rh_user or not rh_password:
         logger.info('REDHAT_USERNAME and REDHAT_PASSWORD are not set, using SUBSCRIPTIONS_USERNAME and SUBSCRIPTIONS_PASSWORD')
         rh_user = getattr(settings, 'SUBSCRIPTIONS_USERNAME', None)
         rh_password = getattr(settings, 'SUBSCRIPTIONS_PASSWORD', None)

--- a/awx/main/tests/functional/analytics/test_core.py
+++ b/awx/main/tests/functional/analytics/test_core.py
@@ -82,18 +82,18 @@ def mock_analytic_post():
 @pytest.mark.parametrize(
     "setting_map, expected_result, expected_auth",
     [
-        # Test case 1: Valid Red Hat credentials
+        # Valid Red Hat credentials
         (
             {
                 'REDHAT_USERNAME': 'redhat_user',
                 'REDHAT_PASSWORD': 'redhat_pass',  # NOSONAR
-                'SUBSCRIPTIONS_USERNAME': None,
-                'SUBSCRIPTIONS_PASSWORD': None,
+                'SUBSCRIPTIONS_USERNAME': '',
+                'SUBSCRIPTIONS_PASSWORD': '',
             },
             True,
             ('redhat_user', 'redhat_pass'),
         ),
-        # Test case 2: Valid Subscription credentials
+        # Valid Subscription credentials with no Red Hat credentials
         (
             {
                 'REDHAT_USERNAME': None,
@@ -104,24 +104,35 @@ def mock_analytic_post():
             True,
             ('subs_user', 'subs_pass'),
         ),
-        # Test case 3: No credentials
+        # Valid Subscription credentials with empty Red Hat credentials
         (
             {
-                'REDHAT_USERNAME': None,
-                'REDHAT_PASSWORD': None,
-                'SUBSCRIPTIONS_USERNAME': None,
-                'SUBSCRIPTIONS_PASSWORD': None,
+                'REDHAT_USERNAME': '',
+                'REDHAT_PASSWORD': '',
+                'SUBSCRIPTIONS_USERNAME': 'subs_user',
+                'SUBSCRIPTIONS_PASSWORD': 'subs_pass',  # NOSONAR
+            },
+            True,
+            ('subs_user', 'subs_pass'),
+        ),
+        # No credentials
+        (
+            {
+                'REDHAT_USERNAME': '',
+                'REDHAT_PASSWORD': '',
+                'SUBSCRIPTIONS_USERNAME': '',
+                'SUBSCRIPTIONS_PASSWORD': '',
             },
             False,
             None,  # No request should be made
         ),
-        # Test case 4: Mixed credentials
+        # Mixed credentials
         (
             {
-                'REDHAT_USERNAME': None,
+                'REDHAT_USERNAME': '',
                 'REDHAT_PASSWORD': 'redhat_pass',  # NOSONAR
                 'SUBSCRIPTIONS_USERNAME': 'subs_user',
-                'SUBSCRIPTIONS_PASSWORD': None,
+                'SUBSCRIPTIONS_PASSWORD': '',
             },
             False,
             None,  # Invalid, no request should be made


### PR DESCRIPTION
##### SUMMARY
REDHAT_USERNAME and REDHAT_PASSWORD are default to empty string instead of None

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
