### PR TITLE
Validate org-user membership from gateway

### DIFF
--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -93,23 +93,34 @@ def check_resource_server_for_user_in_organization(user, organization, requestin
     if not requesting_user:
         return False
 
-    client = get_resource_server_client(settings.RESOURCE_SERVICE_PATH, jwt_user_id=str(requesting_user.resource.ansible_id), raise_if_bad_request=True)
+    client = get_resource_server_client(settings.RESOURCE_SERVICE_PATH, jwt_user_id=str(requesting_user.resource.ansible_id), raise_if_bad_request=False)
     # need to get the organization object_id in resource server, by querying with ansible_id
-    response = client._make_request(path=f'resources/?ansible_id={str(organization.resource.ansible_id)}', method='GET').json()
-    if response.get('count', 0) == 0:
+    response = client._make_request(path=f'resources/?ansible_id={str(organization.resource.ansible_id)}', method='GET')
+    response_json = response.json()
+    if response.status_code != 200:
+        logger.error(f'Failed to get organization object_id in resource server: {response_json.get("detail", "")}')
         return False
-    org_id_in_resource_server = response['results'][0]['object_id']
+
+    if response_json.get('count', 0) == 0:
+        return False
+    org_id_in_resource_server = response_json['results'][0]['object_id']
 
     client.base_url = client.base_url.replace('/api/gateway/v1/service-index/', '/api/gateway/v1/')
     # find role assignments with:
     # - roles Organization Member or Organization Admin
     # - user ansible id
     # - organization object id
+
     response = client._make_request(
         path=f'role_user_assignments/?role_definition__name__in=Organization Member,Organization Admin&user__resource__ansible_id={str(user.resource.ansible_id)}&object_id={org_id_in_resource_server}',
         method='GET',
-    ).json()
-    if response.get('count', 0) > 0:
+    )
+    response_json = response.json()
+    if response.status_code != 200:
+        logger.error(f'Failed to get role user assignments in resource server: {response_json.get("detail", "")}')
+        return False
+
+    if response_json.get('count', 0) > 0:
         return True
 
     return False

--- a/awx/main/models/execution_environments.py
+++ b/awx/main/models/execution_environments.py
@@ -58,11 +58,20 @@ class ExecutionEnvironment(CommonModel):
     def get_absolute_url(self, request=None):
         return reverse('api:execution_environment_detail', kwargs={'pk': self.pk}, request=request)
 
-    def validate_role_assignment(self, actor, role_definition):
+    def validate_role_assignment(self, actor, role_definition, **kwargs):
+        from awx.main.models.credential import check_gateway_for_user_in_organization
+
         if self.managed:
             raise ValidationError({'object_id': _('Can not assign object roles to managed Execution Environments')})
         if self.organization_id is None:
             raise ValidationError({'object_id': _('Can not assign object roles to global Execution Environments')})
 
-        if actor._meta.model_name == 'user' and (not actor.has_obj_perm(self.organization, 'view')):
+        if actor._meta.model_name == 'user':
+            if actor.has_obj_perm(self.organization, 'view'):
+                return
+
+            requesting_user = kwargs.get('requesting_user', None)
+            if check_gateway_for_user_in_organization(actor, self.organization, requesting_user):
+                return
+
             raise ValidationError({'user': _('User must have view permission to Execution Environment organization')})

--- a/awx/main/models/execution_environments.py
+++ b/awx/main/models/execution_environments.py
@@ -59,7 +59,7 @@ class ExecutionEnvironment(CommonModel):
         return reverse('api:execution_environment_detail', kwargs={'pk': self.pk}, request=request)
 
     def validate_role_assignment(self, actor, role_definition, **kwargs):
-        from awx.main.models.credential import check_gateway_for_user_in_organization
+        from awx.main.models.credential import check_resource_server_for_user_in_organization
 
         if self.managed:
             raise ValidationError({'object_id': _('Can not assign object roles to managed Execution Environments')})
@@ -71,7 +71,7 @@ class ExecutionEnvironment(CommonModel):
                 return
 
             requesting_user = kwargs.get('requesting_user', None)
-            if check_gateway_for_user_in_organization(actor, self.organization, requesting_user):
+            if check_resource_server_for_user_in_organization(actor, self.organization, requesting_user):
                 return
 
             raise ValidationError({'user': _('User must have view permission to Execution Environment organization')})

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -2,5 +2,5 @@ git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 git+https://github.com/ansible/python3-saml.git@devel#egg=python3-saml
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
+django-ansible-base @ git+https://github.com/fosterseth/django-ansible-base@pass_requesting_user#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
 awx-plugins-core @ git+https://git@github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -2,5 +2,5 @@ git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 git+https://github.com/ansible/python3-saml.git@devel#egg=python3-saml
-django-ansible-base @ git+https://github.com/fosterseth/django-ansible-base@pass_requesting_user#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
+django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
 awx-plugins-core @ git+https://git@github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding credential and execution environment roles validates that the user belongs to the same org as the credential or EE.

In some situations, the user-org membership has not yet been synced from gateway to controller.

In this case, controller will make a request to gateway to check if the user is part of the org.

relies on https://github.com/ansible/aap-gateway/pull/557
and
https://github.com/ansible/django-ansible-base/pull/614
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
