### PR TITLE
🧪🚑 Fix fetching the CI image on merges

### DIFF
--- a/.github/actions/awx_devel_image/action.yml
+++ b/.github/actions/awx_devel_image/action.yml
@@ -24,11 +24,11 @@ runs:
 
     - name: Pre-pull latest devel image to warm cache
       shell: bash
-      run: docker pull -q ghcr.io/${OWNER_LC}/awx_devel:${{ github.base_ref }}
+      run: docker pull -q ghcr.io/${OWNER_LC}/awx_devel:${{ github.base_ref || github.ref_name }}
 
     - name: Build image for current source checkout
       shell: bash
       run: |
         DEV_DOCKER_TAG_BASE=ghcr.io/${OWNER_LC} \
-        COMPOSE_TAG=${{ github.base_ref }} \
+        COMPOSE_TAG=${{ github.base_ref || github.ref_name }} \
         make docker-compose-build


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is a follow-up for #15507 making the in-tree `awx_devel_image` action compatible with `push` events.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Merging #15507 revealed that the `awx_devel_image` in-tree action was made to only work with PRs and referenced a variable that's only available under `pull_request` and `pull_request_target` events.