### PR TITLE
🧪🚑 Fix running awx image in CI on merge

### DIFF
--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         DEV_DOCKER_OWNER=${{ github.repository_owner }} \
-        COMPOSE_TAG=${{ github.base_ref }} \
+        COMPOSE_TAG=${{ github.base_ref || github.ref_name }} \
         COMPOSE_UP_OPTS="-d" \
         make docker-compose
 


### PR DESCRIPTION
This is a variation of #15509, fixing the `run_awx_devel` in-tree action this time.

<!-- Bug, Docs Fix or other nominal change -->