### PR TITLE
🧪 Unmeasure coverage in tests expected to fail

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -23,6 +23,8 @@ exclude_lines =
     if 0:
     if __name__ == .__main__.:
 
+    ^\s*@pytest\.mark\.xfail
+
 ignore_errors = True
 
 [xml]


### PR DESCRIPTION
These tests are known to only be executed partially or not at all. So we always get incomplete, missing, and sometimes flaky, coverage in the test functions that are expected to fail.

This change updates the ``coverage.py`` config to prevent said tests from influencing the coverage level measurement.

Ref https://github.com/pytest-dev/pytest/pull/12531

<!-- Bug, Docs Fix or other nominal change -->