### PR TITLE
🧪💅 Migrate to `exclude_also` @ `coveragerc`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,10 +7,7 @@ omit =
 
 [report]
 # Regexes for lines to exclude from consideration
-exclude_lines =
-    # Have to re-enable the standard pragma
-    pragma: no cover
-
+exclude_also =
     # Don't complain about missing debug-only code:
     def __repr__
     if self\.debug


### PR DESCRIPTION
This is an option that appeared in Coverage.py v7.2.0.

<!-- Bug, Docs Fix or other nominal change -->