### PR TITLE
🧪🚑 Fix checking schema in CI on merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,10 @@ jobs:
           - name: awx-collection
             command: /start_tests.sh test_collection_all
           - name: api-schema
-            command: /start_tests.sh detect-schema-change SCHEMA_DIFF_BASE_BRANCH=${{ github.event.pull_request.base.ref }}
+            command: >-
+              /start_tests.sh detect-schema-change SCHEMA_DIFF_BASE_BRANCH=${{
+                github.event.pull_request.base.ref || github.ref_name
+              }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This is a variation of #15510, this time fixing the `detect-schema-change` make target.

<!-- Bug, Docs Fix or other nominal change -->