### PR TITLE
🧪💅 Categorize the Codecov status checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -33,13 +33,21 @@ coverage:
         flags:
           - pytest
         paths:
-          - src/
+          - awx/
         target: 100%
       tests:
         flags:
           - pytest
         paths:
           - tests/
+          - >-
+            **/test/
+          - >-
+            **/tests/
+          - >-
+            **/test/**
+          - >-
+            **/tests/**
         target: 100%
       typing:
         flags:


### PR DESCRIPTION
This make Codecov properly identify and separate metrics for tests and awx modules. This will enable Codecov to send status separate reports to GitHub per category. And in turn, will enable us to use some of those checks in branch protection.

<!-- Bug, Docs Fix or other nominal change -->
