### PR TITLE
Fix instance UI url

### DIFF
--- a/awx/main/management/commands/disable_instance.py
+++ b/awx/main/management/commands/disable_instance.py
@@ -63,7 +63,7 @@ class AWXInstance:
     def instance_pretty(self):
         instance = (
             self.instance.hostname,
-            urljoin(settings.TOWER_URL_BASE, f"/#/instances/{self.instance.pk}/details"),
+            urljoin(settings.TOWER_URL_BASE, f"{settings.OPTIONAL_UI_URL_PREFIX}/infrastructure/instances/{self.instance.pk}/details"),
         )
         return f"[\"{instance[0]}\"]({instance[1]})"
 


### PR DESCRIPTION
##### SUMMARY
instance url is now at /infrastructure/instance/... on the new UI

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
