### PR TITLE
🧪 Use modern `source_pkgs` @ `coveragerc`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -22,7 +22,10 @@ branch = True
 omit =
     awx/main/migrations/*
     awx/lib/site-packages/*
-source = awx
+source =
+    .
+source_pkgs =
+    awx
 
 [xml]
 output = ./reports/coverage.xml


### PR DESCRIPTION
This helps disambiguate main project code from the tests.

<!-- Bug, Docs Fix or other nominal change -->
