### PR TITLE
🧪 Use xunit1 in pytest by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -11,4 +11,11 @@ markers =
     activity_stream_access:
     job_runtime_vars:
     fixture_args:
-junit_family=xunit2
+
+# https://docs.pytest.org/en/stable/usage.html#creating-junitxml-format-files
+junit_duration_report = call
+# xunit1 contains more metadata than xunit2 so it's better for CI UIs:
+junit_family = xunit1
+junit_logging = all
+junit_log_passing_tests = true
+junit_suite_name = awx_test_suite


### PR DESCRIPTION
This format is contains file paths unlike the newer implementation.

<!-- Bug, Docs Fix or other nominal change -->
