### PR TITLE
fix: maintain order of insertions into m2m relationship tables

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -1039,7 +1039,7 @@ class OrderedManyToManyField(models.ManyToManyField):
             descriptor = getattr(instance, self.name)
             order_with_respect_to = descriptor.source_field_name
 
-            for i, ig in enumerate(sender.objects.filter(**{order_with_respect_to: instance.pk})):
+            for i, ig in enumerate(sender.objects.filter(**{order_with_respect_to: instance.pk}).order_by('id')):
                 if ig.position != i:
                     ig.position = i
                     ig.save()


### PR DESCRIPTION
##### SUMMARY

We need to make sure that the position column (which represents the order of items in a m2m relationship, e.g. galaxy credentials or instance groups inside organizations) reflects the order of insertion into the relationship table.

This guarantees that the order of items will be the same as they were submitted in.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
