### PR TITLE
🧪🚑 Fix escaping EOLs in `curl` invocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,11 @@ jobs:
           do
               curl \
                 -v \
-                --user "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}"
+                --user "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}:${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}" \
                 --form "xunit_xml=@${junit_file}" \
-                --form "component_name=awx"
-                --form "git_commit_sha=${{ github.sha }}"
-                --form "git_repository_url=https://github.com/${{ github.repository }}"
+                --form "component_name=awx" \
+                --form "git_commit_sha=${{ github.sha }}" \
+                --form "git_repository_url=https://github.com/${{ github.repository }}" \
                 "${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}/api/results/upload/"
           done
 


### PR DESCRIPTION
This is a follow up for #15532.
<!-- Bug, Docs Fix or other nominal change -->