### PR TITLE
Allow local edits if RESOURCE_SERVER not defined

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -662,7 +662,8 @@ AWX_AUTO_DEPROVISION_INSTANCES = False
 
 # If False, do not allow creation of resources that are shared with the platform ingress
 # e.g. organizations, teams, and users
-ALLOW_LOCAL_RESOURCE_MANAGEMENT = True
+# This setting is ignored if RESOURCE_SERVER is not set, implying standalone config
+ALLOW_LOCAL_RESOURCE_MANAGEMENT = False
 
 # If True, allow users to be assigned to roles that were created via JWT
 ALLOW_LOCAL_ASSIGNING_JWT_ROLES = False

--- a/awx/sso/conf.py
+++ b/awx/sso/conf.py
@@ -92,7 +92,7 @@ SOCIAL_AUTH_TEAM_MAP_PLACEHOLDER = collections.OrderedDict(
     ]
 )
 
-if settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT:
+if settings.ALLOW_LOCAL_RESOURCE_MANAGEMENT or (not bool(getattr(settings, 'RESOURCE_SERVER', {}).get('URL', ''))):
     ###############################################################################
     # AUTHENTICATION BACKENDS DYNAMIC SETTING
     ###############################################################################


### PR DESCRIPTION
##### SUMMARY
This is a minor modification to simplify the complexity of settings that someone has to manage. We made similar changes to DAB, such that if `RESOURCE_SERVER` is not defined, it doesn't give unreasonable behavior.

With this change, `ALLOW_LOCAL_RESOURCE_MANAGEMENT` is basically ignored if no `RESOURCE_SERVER` is defined. This prevents needing to re-define both in the layers of settings override. Still a proposal as of opening this.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

