### PR TITLE
Move receptor and AWX images to environment variables

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -154,7 +154,6 @@ jobs:
         run: |
           ansible-playbook -v tools/ansible/stage.yml \
             -e repo=${{ github.repository }} \
-            -e awx_image=ghcr.io/${{ github.repository }} \
             -e version=${{ github.event.inputs.version }} \
             -e github_token=${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -151,7 +151,6 @@ jobs:
         run: |
           ansible-playbook -v tools/ansible/stage.yml \
             -e repo=${{ github.repository }} \
-            -e awx_image=ghcr.io/${{ github.repository }} \
             -e version=${{ github.event.inputs.version }} \
             -e github_token=${{ secrets.GITHUB_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -500,8 +500,6 @@ docker-compose-sources: .git/hooks/pre-commit
 	fi;
 
 	$(ANSIBLE_PLAYBOOK) -i tools/docker-compose/inventory tools/docker-compose/ansible/sources.yml \
-	    -e awx_image=$(DEV_DOCKER_TAG_BASE)/awx_devel \
-	    -e awx_image_tag=$(COMPOSE_TAG) \
 	    -e receptor_image=$(RECEPTOR_IMAGE) \
 	    -e control_plane_node_count=$(CONTROL_PLANE_NODE_COUNT) \
 	    -e execution_node_count=$(EXECUTION_NODE_COUNT) \

--- a/Makefile
+++ b/Makefile
@@ -536,8 +536,6 @@ docker-compose-sources:
 	fi;
 
 	$(ANSIBLE_PLAYBOOK) -i tools/docker-compose/inventory tools/docker-compose/ansible/sources.yml \
-	    -e awx_image=$(DEV_DOCKER_TAG_BASE)/$(GIT_REPO_NAME)_devel \
-	    -e awx_image_tag=$(COMPOSE_TAG) \
 	    -e receptor_image=$(RECEPTOR_IMAGE) \
 	    -e control_plane_node_count=$(CONTROL_PLANE_NODE_COUNT) \
 	    -e execution_node_count=$(EXECUTION_NODE_COUNT) \

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 compose_name: 'docker-compose.yml'
-awx_image: 'ghcr.io/ansible/awx_devel'
 pg_port: 5432
 pg_username: 'awx'
 pg_database: 'awx'
@@ -8,7 +7,6 @@ pg_tls: false
 control_plane_node_count: 1
 minikube_container_group: false
 receptor_socket_file: /var/run/awx-receptor/receptor.sock
-receptor_image: quay.io/ansible/receptor:devel
 ingress_path: /
 api_urlpattern_prefix: ''
 

--- a/tools/docker-compose/ansible/roles/sources/tasks/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/tasks/main.yml
@@ -80,11 +80,6 @@
   set_fact:
     user_id: "'{{ current_user.stdout }}'"
 
-- name: Set global version if not provided
-  set_fact:
-    awx_image_tag: "{{ lookup('file', playbook_dir + '/../../../VERSION') }}"
-  when: awx_image_tag is not defined
-
 - name: Generate Private RSA key for signing work
   command: openssl genrsa -out {{ work_sign_private_keyfile }} {{ receptor_rsa_bits }}
   args:

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -1,10 +1,9 @@
 #jinja2: lstrip_blocks: True
 ---
-version: '2.1'
 services:
 {% if editable_dependencies | length > 0 %}
   init_awx:
-    image: "{{ awx_image }}:{{ awx_image_tag }}"
+    image: ${DEVEL_IMAGE_NAME:-ghcr.io/ansible/awx_devel:devel}
     container_name: tools_init_awx
     command: /awx_devel/tools/docker-compose/editable_dependencies/install.sh
     user: root
@@ -25,7 +24,7 @@ services:
   # Primary AWX Development Container
   awx_{{ container_postfix }}:
     user: "{{ ansible_user_uid }}"
-    image: "{{ awx_image }}:{{ awx_image_tag }}"
+    image: ${DEVEL_IMAGE_NAME:-ghcr.io/ansible/awx_devel:devel}
     container_name: tools_awx_{{ container_postfix }}
     hostname: awx-{{ container_postfix }}
     command: launch_awx.sh
@@ -308,7 +307,7 @@ services:
 
 {% if execution_node_count|int > 0 %}
   receptor-hop:
-    image: {{ receptor_image }}
+    image: ${RECEPTOR_IMAGE:-quay.io/ansible/receptor:devel}
     user: root
     container_name: tools_receptor_hop
     hostname: receptor-hop
@@ -321,7 +320,7 @@ services:
       - "../../docker-compose/_sources/receptor/receptor-hop.conf:/etc/receptor/receptor.conf"
   {% for i in range(execution_node_count|int) %}
   receptor-{{ loop.index }}:
-    image: "{{ awx_image }}:{{ awx_image_tag }}"
+    image: ${DEVEL_IMAGE_NAME:-ghcr.io/ansible/awx_devel:devel}
     user: "{{ ansible_user_uid }}"
     container_name: tools_receptor_{{ loop.index }}
     hostname: receptor-{{ loop.index }}

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -1,10 +1,9 @@
 #jinja2: lstrip_blocks: True
 ---
-version: '2.1'
 services:
 {% if editable_dependencies | length > 0 %}
   init_awx:
-    image: "{{ awx_image }}:{{ awx_image_tag }}"
+    image: ${DEVEL_IMAGE_NAME:-ghcr.io/ansible/awx_devel:devel}
     container_name: tools_init_awx
     command: /awx_devel/tools/docker-compose/editable_dependencies/install.sh
     user: root
@@ -25,7 +24,7 @@ services:
   # Primary AWX Development Container
   awx_{{ container_postfix }}:
     user: "{{ ansible_user_uid }}"
-    image: "{{ awx_image }}:{{ awx_image_tag }}"
+    image: ${DEVEL_IMAGE_NAME:-ghcr.io/ansible/awx_devel:devel}
     container_name: tools_awx_{{ container_postfix }}
     hostname: awx-{{ container_postfix }}
     command: launch_awx.sh supervisord --pidfile=/tmp/supervisor_pid ${SUPERVISOR_ARGS:--n}
@@ -255,7 +254,7 @@ services:
 
 {% if execution_node_count|int > 0 %}
   receptor-hop:
-    image: {{ receptor_image }}
+    image: ${RECEPTOR_IMAGE:-quay.io/ansible/receptor:devel}
     user: root
     container_name: tools_receptor_hop
     hostname: receptor-hop
@@ -268,7 +267,7 @@ services:
       - "../../docker-compose/_sources/receptor/receptor-hop.conf:/etc/receptor/receptor.conf"
   {% for i in range(execution_node_count|int) %}
   receptor-{{ loop.index }}:
-    image: "{{ awx_image }}:{{ awx_image_tag }}"
+    image: ${DEVEL_IMAGE_NAME:-ghcr.io/ansible/awx_devel:devel}
     user: "{{ ansible_user_uid }}"
     container_name: tools_receptor_{{ loop.index }}
     hostname: receptor-{{ loop.index }}

--- a/tools/docker-compose/inventory
+++ b/tools/docker-compose/inventory
@@ -15,5 +15,4 @@ localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env pyth
 # pg_username=""
 # pg_hostname=""
 
-# awx_image="ghcr.io/ansible/awx_devel"
 # migrate_local_docker=false


### PR DESCRIPTION
##### SUMMARY
This tries to de-template just a few things from our docker-compose setup. We already have the inputs as environment variables in the `Makefile`, so if we use the feature of docker compose, itself, to use environment variables we don't have to deal with any templating of these things.

The receptor image is still a playbook input because it is used in the Dockerfile. So this does not attempt to change that.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily updates dev/staging configuration to source image names from Docker Compose environment variables, with minimal logic changes. Main risk is breaking local `docker-compose` setups if expected env vars are unset or overrides relied on the old Ansible vars.
> 
> **Overview**
> **Simplifies the docker-compose dev environment by removing Ansible-templated image settings.** `docker-compose.yml` now pulls the AWX dev image from `${DEVEL_IMAGE_NAME}` (with a default) and the hop node image from `${RECEPTOR_IMAGE}` rather than `awx_image`/`awx_image_tag`/`receptor_image` Ansible variables.
> 
> This drops related plumbing: the `Makefile` no longer passes `awx_image`/`awx_image_tag` into the `sources` role, the role defaults/tasks stop defining those vars, and the `stage.yml` release workflow stops passing an `awx_image` override to the staging playbook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8380c809532f6bcbb5fe64fa726b01fb488bc26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Simplified development environment setup by consolidating how container images are specified and configured across build and deployment processes.
* Updated staging workflow, build targets, and Ansible configuration to use environment variable-based defaults for container image specifications.
* Streamlined configuration by removing explicit image variable declarations in favor of environment variable fallbacks with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->