### PR TITLE
Fix 500 error due to None data in DAB response

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -244,7 +244,8 @@ class APIView(views.APIView):
             if hasattr(self, '__init_request_error__'):
                 response = self.handle_exception(self.__init_request_error__)
             if response.status_code == 401:
-                response.data['detail'] += _(' To establish a login session, visit') + ' /api/login/.'
+                if response.data and 'detail' in response.data:
+                    response.data['detail'] += _(' To establish a login session, visit') + ' /api/login/.'
                 logger.info(status_msg)
             else:
                 logger.warning(status_msg)

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -8,7 +8,7 @@ from django.test.utils import override_settings
 from django.contrib.auth.models import AnonymousUser
 
 from ansible_base.lib.utils.response import get_relative_url
-from ansible_base.lib.testing.fixtures import settings_override_mutable
+from ansible_base.lib.testing.fixtures import settings_override_mutable  # NOQA: F401 imported to be a pytest fixture
 
 from awx.main.models import User
 from awx.api.versioning import reverse
@@ -22,7 +22,7 @@ EXAMPLE_USER_DATA = {"username": "affable", "first_name": "a", "last_name": "a",
 
 
 @pytest.mark.django_db
-def test_validate_local_user(post, admin_user, settings, settings_override_mutable):
+def test_validate_local_user(post, admin_user, settings, settings_override_mutable):  # NOQA: F811 this is how you use a pytest fixture
     "Copy of the test by same name in django-ansible-base for integration and compatibility testing"
     url = get_relative_url('validate-local-account')
     admin_user.set_password('password')

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -4,6 +4,11 @@ from unittest import mock
 import pytest
 
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.test.utils import override_settings
+from django.contrib.auth.models import AnonymousUser
+
+from ansible_base.lib.utils.response import get_relative_url
+from ansible_base.lib.testing.fixtures import settings_override_mutable
 
 from awx.main.models import User
 from awx.api.versioning import reverse
@@ -14,6 +19,33 @@ from awx.api.versioning import reverse
 #
 
 EXAMPLE_USER_DATA = {"username": "affable", "first_name": "a", "last_name": "a", "email": "a@a.com", "is_superuser": False, "password": "r$TyKiOCb#ED"}
+
+
+@pytest.mark.django_db
+def test_validate_local_user(post, admin_user, settings, settings_override_mutable):
+    "Copy of the test by same name in django-ansible-base for integration and compatibility testing"
+    url = get_relative_url('validate-local-account')
+    admin_user.set_password('password')
+    admin_user.save()
+    data = {
+        "username": admin_user.username,
+        "password": "password",
+    }
+    with override_settings(RESOURCE_SERVER={"URL": "https://foo.invalid", "SECRET_KEY": "foobar"}):
+        response = post(url=url, data=data, user=AnonymousUser(), expect=200)
+
+    assert 'ansible_id' in response.data
+    assert response.data['auth_code'] is not None, response.data
+
+    # No resource server, return coherent response but can not provide auth code
+    response = post(url=url, data=data, user=AnonymousUser(), expect=200)
+    assert 'ansible_id' in response.data
+    assert response.data['auth_code'] is None
+
+    # wrong password
+    data['password'] = 'foobar'
+    response = post(url=url, data=data, user=AnonymousUser(), expect=401)
+    # response.data may be none here, this is just testing that we get no server error
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
We had a report from server errors from the `service-index/validate-local-account/` endpoint, but I was really grasping for a reproducer. The mechanic was specific to interaction of DAB views with AWX generic views. Because of this, I really wanted some form of coverage for the scenario.

It took me a little bit but I finally got this test with I feel fairly satisfied with. Yes, it is mostly a lazy copy of the existing test from DAB, but since AWX is configured differently from test_app in defaults, some differences remain.

This test lets me feel a little bit better about how the server error is fixed. And it's a good thing, because otherwise I would have assumed `response.data` is a dictionary, and it wasn't!

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

