### PR TITLE
Add gateway support to awxkit

### DIFF
--- a/awxkit/awxkit/api/pages/base.py
+++ b/awxkit/awxkit/api/pages/base.py
@@ -189,7 +189,7 @@ class Base(Page):
         try:
             return self._request_token(urls, username, password, client_id, description, client_secret, scope)
         except exc.NotFound:
-            urls: AuthUrls = {
+            urls = {
                 "access_token": f"{config.api_base_path}o/token/",
                 "personal_token": f"{config.api_base_path}v2/users/{username}/personal_tokens/",
             }

--- a/awxkit/awxkit/api/pages/base.py
+++ b/awxkit/awxkit/api/pages/base.py
@@ -1,5 +1,6 @@
 import collections
 import logging
+import typing
 
 from requests.auth import HTTPBasicAuth
 
@@ -10,6 +11,11 @@ import awxkit.exceptions as exc
 
 
 log = logging.getLogger(__name__)
+
+
+class AuthUrls(typing.TypedDict):
+    access_token: str
+    personal_token: str
 
 
 class Base(Page):
@@ -147,21 +153,21 @@ class Base(Page):
             HTTPBasicAuth(client_id, client_secret)(req)
             req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
             resp = self.connection.post(
-                auth_urls.access_token,
+                auth_urls["access_token"],
                 data={"grant_type": "password", "username": username, "password": password, "scope": scope},
                 headers=req.headers,
             )
         elif client_id:
             req.headers['Content-Type'] = 'application/x-www-form-urlencoded'
             resp = self.connection.post(
-                auth_urls.access_token,
+                auth_urls["access_token"],
                 data={"grant_type": "password", "username": username, "password": password, "client_id": client_id, "scope": scope},
                 headers=req.headers,
             )
         else:
             HTTPBasicAuth(username, password)(req)
             resp = self.connection.post(
-                f"{auth_urls.personal_token}{username}/personal_tokens/",
+                auth_urls['personal_token'],
                 json={"description": description, "application": None, "scope": scope},
                 headers=req.headers,
             )
@@ -178,13 +184,15 @@ class Base(Page):
         default_cred = config.credentials.default
         username = username or default_cred.username
         password = password or default_cred.password
-        AuthUrls = collections.namedtuple("AuthUrls", ["access_token", "personal_token"])
         # Try gateway first, fallback to controller
+        urls: AuthUrls = {"access_token": "/o/token/", "personal_token": f"{config.gateway_base_path}v1/tokens/"}
         try:
-            urls = AuthUrls(access_token="/o/token/", personal_token=f"{config.gateway_base_path}v1/users/")
             return self._request_token(urls, username, password, client_id, description, client_secret, scope)
         except exc.NotFound:
-            urls = AuthUrls(access_token=f"{config.api_base_path}o/token/", personal_token=f"{config.api_base_path}v2/users/")
+            urls: AuthUrls = {
+                "access_token": f"{config.api_base_path}o/token/",
+                "personal_token": f"{config.api_base_path}v2/users/{username}/personal_tokens/",
+            }
             return self._request_token(urls, username, password, client_id, description, client_secret, scope)
 
     def load_session(self, username='', password=''):

--- a/awxkit/awxkit/config.py
+++ b/awxkit/awxkit/config.py
@@ -33,3 +33,4 @@ config.client_connection_attempts = int(os.getenv('AWXKIT_CLIENT_CONNECTION_ATTE
 config.prevent_teardown = to_bool(os.getenv('AWXKIT_PREVENT_TEARDOWN', False))
 config.use_sessions = to_bool(os.getenv('AWXKIT_SESSIONS', False))
 config.api_base_path = os.getenv('AWXKIT_API_BASE_PATH', '/api/')
+config.gateway_base_path = os.getenv('AWXKIT_GATEWAY_BASE_PATH', '/api/gateway/')

--- a/awxkit/test/api/pages/test_base.py
+++ b/awxkit/test/api/pages/test_base.py
@@ -1,21 +1,21 @@
-from unittest.mock import Mock, PropertyMock
-
 from http.client import NOT_FOUND
 import pytest
+from pytest_mock import MockerFixture
+from requests import Response
 
 from awxkit.api.pages import Base
 from awxkit.config import config
 
 
 @pytest.fixture(autouse=True)
-def setup_config():
-    config.credentials = {"default": {"username": "foo", "password": "bar"}}
-    config.base_url = ""
+def setup_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "credentials", {"default": {"username": "foo", "password": "bar"}}, raising=False)
+    monkeypatch.setattr(config, "base_url", "", raising=False)
 
 
 @pytest.fixture
-def response():
-    r = Mock()
+def response(mocker):
+    r = mocker.Mock()
     r.status_code = NOT_FOUND
     r.json.return_value = {
         "token": "my_personal_token",
@@ -25,35 +25,35 @@ def response():
 
 
 @pytest.mark.parametrize(
-    "kwargs,url,token",
+    ("auth_creds", "url", "token"),
     [
         ({"client_id": "foo", "client_secret": "bar"}, "/o/token/", "my_token"),
         ({"client_id": "foo"}, "/o/token/", "my_token"),
         ({}, "/api/gateway/v1/tokens/", "my_personal_token"),
     ],
 )
-def test_get_oauth2_token_from_gateway(mocker, response, kwargs, url, token):
+def test_get_oauth2_token_from_gateway(mocker: MockerFixture, response: Response, auth_creds, url, token):
     post = mocker.patch("requests.Session.post", return_value=response)
     base = Base()
-    ret = base.get_oauth2_token(**kwargs)
+    ret = base.get_oauth2_token(**auth_creds)
     assert post.call_count == 1
     assert post.call_args.args[0] == url
     assert ret == token
 
 
 @pytest.mark.parametrize(
-    "kwargs,url,token",
+    ("auth_creds", "url", "token"),
     [
         ({"client_id": "foo", "client_secret": "bar"}, "/api/o/token/", "my_token"),
         ({"client_id": "foo"}, "/api/o/token/", "my_token"),
         ({}, "/api/v2/users/foo/personal_tokens/", "my_personal_token"),
     ],
 )
-def test_get_oauth2_token_from_controller(mocker, response, kwargs, url, token):
-    type(response).ok = PropertyMock(side_effect=[False, True])
+def test_get_oauth2_token_from_controller(mocker: MockerFixture, response: Response, auth_creds, url, token):
+    type(response).ok = mocker.PropertyMock(side_effect=[False, True])
     post = mocker.patch("requests.Session.post", return_value=response)
     base = Base()
-    ret = base.get_oauth2_token(**kwargs)
+    ret = base.get_oauth2_token(**auth_creds)
     assert post.call_count == 2
     assert post.call_args.args[0] == url
     assert ret == token

--- a/awxkit/test/api/pages/test_base.py
+++ b/awxkit/test/api/pages/test_base.py
@@ -1,0 +1,59 @@
+from unittest.mock import Mock, PropertyMock
+
+from http.client import NOT_FOUND
+import pytest
+
+from awxkit.api.pages import Base
+from awxkit.config import config
+
+
+@pytest.fixture(autouse=True)
+def setup_config():
+    config.credentials = {"default": {"username": "foo", "password": "bar"}}
+    config.base_url = ""
+
+
+@pytest.fixture
+def response():
+    r = Mock()
+    r.status_code = NOT_FOUND
+    r.json.return_value = {
+        "token": "my_personal_token",
+        "access_token": "my_token",
+    }
+    return r
+
+
+@pytest.mark.parametrize(
+    "kwargs,url,token",
+    [
+        ({"client_id": "foo", "client_secret": "bar"}, "/o/token/", "my_token"),
+        ({"client_id": "foo"}, "/o/token/", "my_token"),
+        ({}, "/api/gateway/v1/tokens/", "my_personal_token"),
+    ],
+)
+def test_get_oauth2_token_from_gateway(mocker, response, kwargs, url, token):
+    post = mocker.patch("requests.Session.post", return_value=response)
+    base = Base()
+    ret = base.get_oauth2_token(**kwargs)
+    assert post.call_count == 1
+    assert post.call_args.args[0] == url
+    assert ret == token
+
+
+@pytest.mark.parametrize(
+    "kwargs,url,token",
+    [
+        ({"client_id": "foo", "client_secret": "bar"}, "/api/o/token/", "my_token"),
+        ({"client_id": "foo"}, "/api/o/token/", "my_token"),
+        ({}, "/api/v2/users/foo/personal_tokens/", "my_personal_token"),
+    ],
+)
+def test_get_oauth2_token_from_controller(mocker, response, kwargs, url, token):
+    type(response).ok = PropertyMock(side_effect=[False, True])
+    post = mocker.patch("requests.Session.post", return_value=response)
+    base = Base()
+    ret = base.get_oauth2_token(**kwargs)
+    assert post.call_count == 2
+    assert post.call_args.args[0] == url
+    assert ret == token


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This updates awxkit to add support for gateway when fetching oauth tokens, which is used during the `login` subcommand. awxkit will first try fetching a token from gateway and if that fails, fallback to existing behavior. This change is backwards compatible.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
