### PR TITLE
Allow awxkit -e install without VERSION file

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -33,6 +33,8 @@ def setup_requires():
 extra_setup_args = {}
 if not version_file():
     extra_setup_args.update(dict(use_scm_version=dict(root="..", relative_to=__file__), setup_requires=setup_requires()))
+else:
+    extra_setup_args['version'] = get_version_from_file()
 
 
 class CleanCommand(Command):
@@ -77,7 +79,6 @@ class CleanCommand(Command):
 
 setup(
     name='awxkit',
-    version=get_version_from_file(),
     description='The official command line interface for Ansible AWX',
     author='Red Hat, Inc.',
     author_email='info@ansible.com',


### PR DESCRIPTION
##### SUMMARY
Without this, get this error:

```
(awx) alancoding@fedora:~/repos/awx$ pip install -e awxkit
Obtaining file:///home/alancoding/repos/awx/awxkit
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [42 lines of output]
      /home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/__init__.py:81: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
      !!
      
              ********************************************************************************
              Requirements should be satisfied by a PEP 517 installer.
              If you are using pip, you can try `pip install --use-pep517`.
              ********************************************************************************
      
      !!
        dist.fetch_build_eggs(dist.setup_requires)
      Traceback (most recent call last):
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/_normalization.py", line 61, in safe_version
          return str(packaging.version.Version(v))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/_vendor/packaging/version.py", line 198, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'None'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/alancoding/repos/awx/awxkit/setup.py", line 78, in <module>
          setup(
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/__init__.py", line 104, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/_distutils/core.py", line 147, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/dist.py", line 298, in __init__
          self.patch_missing_pkg_info(attrs)
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/dist.py", line 287, in patch_missing_pkg_info
          dist._version = _normalization.safe_version(str(attrs['version']))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/_normalization.py", line 64, in safe_version
          return str(packaging.version.Version(attempt))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/alancoding/venvs/awx/lib64/python3.12/site-packages/setuptools/_vendor/packaging/version.py", line 198, in __init__
          raise InvalidVersion(f"Invalid version: '{version}'")
      setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'None'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

[notice] A new release of pip is available: 23.2.1 -> 24.2
[notice] To update, run: pip install --upgrade pip
```

With this, it installs and shows

```
$ pip show awxkit
Name: awxkit
Version: 24.6.2.dev127+g579c2b7229.d20241008
Summary: The official command line interface for Ansible AWX
Home-page: https://github.com/ansible/awx
Author: Red Hat, Inc.
Author-email: info@ansible.com
License: Apache 2.0
Location: /home/alancoding/repos/awx/awxkit
Editable project location: /home/alancoding/repos/awx/awxkit
Requires: PyYAML, requests, setuptools
Required-by: 
```

That looks good to me.


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI

