### PR TITLE
fix: websocket callback errors

### DIFF
--- a/awxkit/awxkit/ws.py
+++ b/awxkit/awxkit/ws.py
@@ -205,8 +205,8 @@ class WSClient(object):
         else:
             self._send(json.dumps(dict(groups={}, xrftoken=self.csrftoken)))
 
-    def _on_message(self, message):
-        message = json.loads(message)
+    def _on_message(self, *args):
+        message = json.loads(args[1])
         log.debug('received message: {}'.format(message))
         if self._add_received_time:
             message['received_time'] = datetime.datetime.utcnow()
@@ -230,13 +230,13 @@ class WSClient(object):
         self.subscribe(**subscription)
         self._should_subscribe_to_pending_job = False
 
-    def _on_open(self):
+    def _on_open(self, *args):
         self._ws_connected_flag.set()
 
-    def _on_error(self, error):
-        log.info('Error received: {}'.format(error))
+    def _on_error(self, *args):
+        log.info('Error received: {}'.format(args[1]))
 
-    def _on_close(self):
+    def _on_close(self, *args):
         log.info('Successfully closed ws.')
         self._ws_closed = True
 


### PR DESCRIPTION
##### SUMMARY
When using websockets using AWXKIT, upon error one would get the following trace:
```
[ERROR] error from callback <bound method WSClient._on_error of <awxkit.ws.WSClient object at 0x7fa3f355a110>>: WSClient._on_error() takes 2 positional arguments but 3 were given
[ERROR] error from callback <bound method WSClient._on_error of <awxkit.ws.WSClient object at 0x7fa3f355a110>>: WSClient._on_close() takes 2 positional arguments but 4 were given
```
Problem is that there is always one argument passed to the callback which is the `WebSocketApp` object, not to be confused with the child object `WSClient`. Relevant source code:
https://github.com/websocket-client/websocket-client/blob/master/websocket/_app.py#L578

With this change it is possible to get the contents of the Exception being raised
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change


##### COMPONENT NAME
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx:
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
