### PR TITLE
📦 Discover injectors through entrypoints

### DIFF
--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -2,5 +2,5 @@ git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
-awx-plugins-core @ git+https://git@github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core
-awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+awx-plugins-core @ git+https://github.com/webknjaz/ansible--awx-plugins.git@features/inventory-entry-points#egg=awx-plugins-core
+awx_plugins.interfaces @ git+https://github.com/webknjaz/ansible--awx_plugins.interfaces.git@features/inventory-entry-points


### PR DESCRIPTION
This patch eliminates import-based injector discovery, switching to
distribution package-independent hosting of the respective callables.

<!-- Bug, Docs Fix or other nominal change -->