### PR TITLE
Make rrule fast forwarding stable

### DIFF
--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -46,7 +46,7 @@ def fast_forward_rrule(rrule):
 
     Returns a new rrule with a new dtstart
     '''
-    if not rrule._freq in (dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY):
+    if rrule._freq not in {dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY}:
         raise ValueError(f"Cannot fast forward rrule, frequency must be HOURLY or MINUTELY, but got {rrule._freq !r}")
 
     n = now()

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -40,7 +40,7 @@ def _assert_timezone_id_is_valid(rrules) -> None:
     if not broken_rrules:
         return
     raise ValueError(
-        f'The following rrules do not have a valid timezone: {broken_rrules}. Set a valid timezone (e.g., America/New_York).',
+        f'A valid TZID must be provided (e.g., America/New_York). Invalid: {broken_rrules}',
     ) from None
 
 

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -40,7 +40,7 @@ def _assert_timezone_id_is_valid(rrules) -> None:
     if not broken_rrules:
         return
     raise ValueError(
-        'The following rrules do not have a valid timezone: ' f'{broken_rrules}. Set a valid timezone ' '(e.g., America/New_York).',
+        f'The following rrules do not have a valid timezone: {broken_rrules}. Set a valid timezone (e.g., America/New_York).',
     ) from None
 
 

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -319,10 +319,11 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
             next_run_actual = None
 
         self.next_run = next_run_actual
-        try:
-            self.dtstart = future_rs[0].astimezone(pytz.utc)
-        except IndexError:
-            self.dtstart = None
+        if not self.dtstart:
+            try:
+                self.dtstart = future_rs[0].astimezone(pytz.utc)
+            except IndexError:
+                self.dtstart = None
         self.dtend = Schedule.get_end_date(future_rs)
 
         changed = any(getattr(self, field_name) != starting_values[field_name] for field_name in affects_fields)

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -35,17 +35,22 @@ __all__ = ['Schedule']
 UTC_TIMEZONES = {x: tzutc() for x in dateutil.parser.parserinfo().UTCZONE}
 
 
-def fast_forward_date(rrule):
+def fast_forward_rrule(rrule):
     '''
     Utility to fast forward an rrule, maintaining consistency in the resulting
-    occurrences
+    occurrences.
+
+    Uses the .replace() method to update the rrule with a newer dtstart
+    The operation ensures that the original occurrences (based on the original dtstart)
+    will match the occurrences after changing the dtstart.
 
     Returns a new rrule with a new dtstart
     '''
     if not rrule._freq in (dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY):
         raise RuntimeError("Cannot fast forward rrule, frequency must be HOURLY or MINUTELY")
 
-    if rrule._dtstart > now():
+    n = now()
+    if rrule._dtstart > n:
         return rrule
 
     interval = rrule._interval if rrule._interval else 1
@@ -57,7 +62,7 @@ def fast_forward_date(rrule):
     if type(interval) == float and not interval.is_integer():
         raise RuntimeError("Cannot fast forward rule, interval is a fraction of a second")
 
-    seconds_since_dtstart = (now() - rrule._dtstart).total_seconds()
+    seconds_since_dtstart = (n - rrule._dtstart).total_seconds()
 
     # it is important to fast forward by a number that is divisible by
     # interval. For example, if interval is 7 hours, we fast forward by 7, 14, 21, etc. hours.
@@ -249,11 +254,21 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
                 # If any rule has a minutely or hourly rule without a count...
                 if rule._freq in [dateutil.rrule.MINUTELY, dateutil.rrule.HOURLY] and not rule._count:
                     try:
-                        new_rrule = fast_forward_date(rule)
+                        new_rrule = fast_forward_rrule(rule)
                     except RuntimeError as e:
                         logger.warning(e)
                         new_rrule = rule
                     x._rrule[i] = new_rrule
+
+            for i, rule in enumerate(x._exrule):
+                # If any rule has a minutely or hourly rule without a count...
+                if rule._freq in [dateutil.rrule.MINUTELY, dateutil.rrule.HOURLY] and not rule._count:
+                    try:
+                        new_rrule = fast_forward_rrule(rule)
+                    except RuntimeError as e:
+                        logger.warning(e)
+                        new_rrule = rule
+                    x._exrule[i] = new_rrule
         except IndexError:
             pass
 

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -47,7 +47,7 @@ def fast_forward_rrule(rrule):
     Returns a new rrule with a new dtstart
     '''
     if not rrule._freq in (dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY):
-        raise RuntimeError("Cannot fast forward rrule, frequency must be HOURLY or MINUTELY")
+        raise ValueError(f"Cannot fast forward rrule, frequency must be HOURLY or MINUTELY, but got {rrule._freq !r}")
 
     n = now()
     if rrule._dtstart > n:

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -35,7 +35,19 @@ __all__ = ['Schedule']
 UTC_TIMEZONES = {x: tzutc() for x in dateutil.parser.parserinfo().UTCZONE}
 
 
-def fast_forward_rrule(rrule):
+def _check_valid_tzid(rrules):
+    for r in rrules:
+        if r._dtstart and r._dtstart.tzinfo is None:
+            raise ValueError('A valid TZID must be provided (e.g., America/New_York)')
+
+
+def _fast_forward_rrules(rrules, ref_dt=None):
+    for i, rule in enumerate(rrules):
+        rrules[i] = _fast_forward_rrule(rule, ref_dt=ref_dt)
+    return rrules
+
+
+def _fast_forward_rrule(rrule, ref_dt=None):
     '''
     Utility to fast forward an rrule, maintaining consistency in the resulting
     occurrences.
@@ -47,10 +59,12 @@ def fast_forward_rrule(rrule):
     Returns a new rrule with a new dtstart
     '''
     if rrule._freq not in {dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY}:
-        raise ValueError(f"Cannot fast forward rrule, frequency must be HOURLY or MINUTELY, but got {rrule._freq !r}")
+        return rrule
 
-    n = now()
-    if rrule._dtstart > n:
+    if ref_dt is None:
+        ref_dt = now()
+
+    if rrule._dtstart > ref_dt:
         return rrule
 
     interval = rrule._interval if rrule._interval else 1
@@ -59,16 +73,19 @@ def fast_forward_rrule(rrule):
     elif rrule._freq == dateutil.rrule.MINUTELY:
         interval *= 60
 
-    if type(interval) == float and not interval.is_integer():
-        raise RuntimeError("Cannot fast forward rule, interval is a fraction of a second")
+    # if after converting to seconds the interval is still a fraction,
+    # just return original rrule
+    if isinstance(interval, float) and not interval.is_integer():
+        return rrule
 
-    seconds_since_dtstart = (n - rrule._dtstart).total_seconds()
+    seconds_since_dtstart = (ref_dt - rrule._dtstart).total_seconds()
 
     # it is important to fast forward by a number that is divisible by
     # interval. For example, if interval is 7 hours, we fast forward by 7, 14, 21, etc. hours.
     # Otherwise, the occurrences after the fast forward might not match the ones before.
     # x // y is integer division, lopping off any remainder, so that we get the outcome we want.
-    new_start = rrule._dtstart + datetime.timedelta(seconds=(seconds_since_dtstart // interval) * interval)
+    interval_aligned_offset = datetime.timedelta(seconds=(seconds_since_dtstart // interval) * interval)
+    new_start = rrule._dtstart + interval_aligned_offset
     new_rrule = rrule.replace(dtstart=new_start)
     return new_rrule
 
@@ -232,47 +249,26 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         return " ".join(rules)
 
     @classmethod
-    def rrulestr(cls, rrule, **kwargs):
+    def rrulestr(cls, rrule, ref_dt=None, **kwargs):
         """
         Apply our own custom rrule parsing requirements
         """
         rrule = Schedule.coerce_naive_until(rrule)
         kwargs['forceset'] = True
-        x = dateutil.rrule.rrulestr(rrule, tzinfos=UTC_TIMEZONES, **kwargs)
+        rruleset = dateutil.rrule.rrulestr(rrule, tzinfos=UTC_TIMEZONES, **kwargs)
 
-        for r in x._rrule:
-            if r._dtstart and r._dtstart.tzinfo is None:
-                raise ValueError('A valid TZID must be provided (e.g., America/New_York)')
+        _check_valid_tzid(rruleset._rrule)
+        _check_valid_tzid(rruleset._exrule)
 
         # Fast forward is a way for us to limit the number of events in the rruleset
         # If we are fast forwarding and we don't have a count limited rule that is minutely or hourly
         # We will modify the start date of the rule to bring as close to the current date as possible
         # Even though the API restricts each rrule to have the same dtstart, each rrule in the rruleset
         # can fast forward to a difference dtstart. This is required in order to get stable occurrences.
-        try:
-            for i, rule in enumerate(x._rrule):
-                # If any rule has a minutely or hourly rule without a count...
-                if rule._freq in [dateutil.rrule.MINUTELY, dateutil.rrule.HOURLY] and not rule._count:
-                    try:
-                        new_rrule = fast_forward_rrule(rule)
-                    except RuntimeError as e:
-                        logger.warning(e)
-                        new_rrule = rule
-                    x._rrule[i] = new_rrule
+        rruleset._rrule = _fast_forward_rrules(rruleset._rrule, ref_dt=ref_dt)
+        rruleset._exrule = _fast_forward_rrules(rruleset._exrule, ref_dt=ref_dt)
 
-            for i, rule in enumerate(x._exrule):
-                # If any rule has a minutely or hourly rule without a count...
-                if rule._freq in [dateutil.rrule.MINUTELY, dateutil.rrule.HOURLY] and not rule._count:
-                    try:
-                        new_rrule = fast_forward_rrule(rule)
-                    except RuntimeError as e:
-                        logger.warning(e)
-                        new_rrule = rule
-                    x._exrule[i] = new_rrule
-        except IndexError:
-            pass
-
-        return x
+        return rruleset
 
     def __str__(self):
         return u'%s_t%s_%s_%s' % (self.name, self.unified_job_template.id, self.id, self.next_run)

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -35,18 +35,18 @@ __all__ = ['Schedule']
 UTC_TIMEZONES = {x: tzutc() for x in dateutil.parser.parserinfo().UTCZONE}
 
 
-SECONDS_IN_WEEK = 7 * 24 * 60 * 60
-
-
 def fast_forward_date(rrule):
     '''
     Utility to fast forward an rrule, maintaining consistency in the resulting
     occurrences
-    Fast forwards the rrule to 7 days ago
-    Returns a datetime object
+
+    Returns a new rrule with a new dtstart
     '''
     if not rrule._freq in (dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY):
         raise RuntimeError("Cannot fast forward rrule, frequency must be HOURLY or MINUTELY")
+
+    if rrule._dtstart > now():
+        return rrule
 
     interval = rrule._interval if rrule._interval else 1
     if rrule._freq == dateutil.rrule.HOURLY:
@@ -59,19 +59,13 @@ def fast_forward_date(rrule):
 
     seconds_since_dtstart = (now() - rrule._dtstart).total_seconds()
 
-    # fast forward to 7 days ago
-    fast_forward_seconds = seconds_since_dtstart - SECONDS_IN_WEEK
-
-    # make sure at least one chunk of interval can fit inside the time period we are trying to fast forward
-    if interval > fast_forward_seconds:
-        raise RuntimeError(f"Cannot fast forward rrule {rrule}, interval is greater than the fast forward amount of {fast_forward_seconds} seconds")
-
     # it is important to fast forward by a number that is divisible by
     # interval. For example, if interval is 7 hours, we fast forward by 7, 14, 21, etc. hours.
     # Otherwise, the occurrences after the fast forward might not match the ones before.
     # x // y is integer division, lopping off any remainder, so that we get the outcome we want.
-    new_start = rrule._dtstart + datetime.timedelta(seconds=(fast_forward_seconds // interval) * interval)
-    return new_start
+    new_start = rrule._dtstart + datetime.timedelta(seconds=(seconds_since_dtstart // interval) * interval)
+    new_rrule = rrule.replace(dtstart=new_start)
+    return new_rrule
 
 
 class ScheduleFilterMethods(object):
@@ -233,7 +227,7 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         return " ".join(rules)
 
     @classmethod
-    def rrulestr(cls, rrule, fast_forward=True, **kwargs):
+    def rrulestr(cls, rrule, **kwargs):
         """
         Apply our own custom rrule parsing requirements
         """
@@ -247,35 +241,21 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
 
         # Fast forward is a way for us to limit the number of events in the rruleset
         # If we are fast forwarding and we don't have a count limited rule that is minutely or hourly
-        # We will modify the start date of the rule to last week to prevent a large number of entries
-        if fast_forward:
-            try:
-                # All rules in a ruleset will have the same dtstart value
-                # so lets compare the first event to now to see if its > 30 days old
-                # we choose > 30 days because if rrule has FREQ=HOURLY and INTERVAL=23, it will take
-                # at least 23 days before we can fast forward reliably and retain stable occurrences.
-                # since we are fast forwarding to 7 days ago, we check fo rrrules older than (23+7) days
-                first_event = x[0]
-                if (now() - first_event).days > 30:
-                    for rule in x._rrule:
-                        # If any rule has a minutely or hourly rule without a count...
-                        if rule._freq in [dateutil.rrule.MINUTELY, dateutil.rrule.HOURLY] and not rule._count:
-                            # hourly/minutely rrules with far-past DTSTART values
-                            # are *really* slow to precompute
-                            # start *from* one week ago to speed things up drastically
-                            try:
-                                new_start = fast_forward_date(rule)
-                            except RuntimeError as e:
-                                logger.warning(e)
-                                # fallback to setting dtstart to 7 days ago, but this has the consequence of
-                                # occurrences not matching the old occurrences.
-                                new_start = now() - datetime.timedelta(days=7)
-                            new_start_fmt = new_start.strftime('%Y%m%d')
-                            # Now we want to replace the DTSTART:<value>T with the new date (which includes the T)
-                            new_rrule = re.sub('(DTSTART[^:]*):[^T]+T', r'\1:{0}T'.format(new_start_fmt), rrule)
-                            return Schedule.rrulestr(new_rrule, fast_forward=False)
-            except IndexError:
-                pass
+        # We will modify the start date of the rule to bring as close to the current date as possible
+        # Even though the API restricts each rrule to have the same dtstart, each rrule in the rruleset
+        # can fast forward to a difference dtstart. This is required in order to get stable occurrences.
+        try:
+            for i, rule in enumerate(x._rrule):
+                # If any rule has a minutely or hourly rule without a count...
+                if rule._freq in [dateutil.rrule.MINUTELY, dateutil.rrule.HOURLY] and not rule._count:
+                    try:
+                        new_rrule = fast_forward_date(rule)
+                    except RuntimeError as e:
+                        logger.warning(e)
+                        new_rrule = rule
+                    x._rrule[i] = new_rrule
+        except IndexError:
+            pass
 
         return x
 

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -35,10 +35,18 @@ __all__ = ['Schedule']
 UTC_TIMEZONES = {x: tzutc() for x in dateutil.parser.parserinfo().UTCZONE}
 
 
-def _check_valid_tzid(rrules):
-    for r in rrules:
-        if r._dtstart and r._dtstart.tzinfo is None:
-            raise ValueError('A valid TZID must be provided (e.g., America/New_York)')
+def _assert_timezone_id_is_valid(rrules) -> None:
+    broken_rrules = [
+        rrule for rrule in rrules
+        if r._dtstart and r._dtstart.tzinfo is None
+    ]
+    if not broken_rrules:
+        return
+    raise ValueError(
+        'The following rrules do not a timezone set: '
+        f'{broken_rrules}. Please, set it for each '
+        '(e.g., America/New_York).',
+    ) from None
 
 
 def _fast_forward_rrules(rrules, ref_dt=None):

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -36,16 +36,11 @@ UTC_TIMEZONES = {x: tzutc() for x in dateutil.parser.parserinfo().UTCZONE}
 
 
 def _assert_timezone_id_is_valid(rrules) -> None:
-    broken_rrules = [
-        rrule for rrule in rrules
-        if r._dtstart and r._dtstart.tzinfo is None
-    ]
+    broken_rrules = [str(rrule) for rrule in rrules if rrule._dtstart and rrule._dtstart.tzinfo is None]
     if not broken_rrules:
         return
     raise ValueError(
-        'The following rrules do not a timezone set: '
-        f'{broken_rrules}. Please, set it for each '
-        '(e.g., America/New_York).',
+        'The following rrules do not have a valid timezone: ' f'{broken_rrules}. Set a valid timezone ' '(e.g., America/New_York).',
     ) from None
 
 
@@ -265,8 +260,8 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         kwargs['forceset'] = True
         rruleset = dateutil.rrule.rrulestr(rrule, tzinfos=UTC_TIMEZONES, **kwargs)
 
-        _check_valid_tzid(rruleset._rrule)
-        _check_valid_tzid(rruleset._exrule)
+        _assert_timezone_id_is_valid(rruleset._rrule)
+        _assert_timezone_id_is_valid(rruleset._exrule)
 
         # Fast forward is a way for us to limit the number of events in the rruleset
         # If we are fast forwarding and we don't have a count limited rule that is minutely or hourly

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -35,6 +35,45 @@ __all__ = ['Schedule']
 UTC_TIMEZONES = {x: tzutc() for x in dateutil.parser.parserinfo().UTCZONE}
 
 
+SECONDS_IN_WEEK = 7 * 24 * 60 * 60
+
+
+def fast_forward_date(rrule):
+    '''
+    Utility to fast forward an rrule, maintaining consistency in the resulting
+    occurrences
+    Fast forwards the rrule to 7 days ago
+    Returns a datetime object
+    '''
+    if not rrule._freq in (dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY):
+        raise RuntimeError("Cannot fast forward rrule, frequency must be HOURLY or MINUTELY")
+
+    interval = rrule._interval if rrule._interval else 1
+    if rrule._freq == dateutil.rrule.HOURLY:
+        interval *= 60 * 60
+    elif rrule._freq == dateutil.rrule.MINUTELY:
+        interval *= 60
+
+    if type(interval) == float and not interval.is_integer():
+        raise RuntimeError("Cannot fast forward rule, interval is a fraction of a second")
+
+    seconds_since_dtstart = (now() - rrule._dtstart).total_seconds()
+
+    # fast forward to 7 days ago
+    fast_forward_seconds = seconds_since_dtstart - SECONDS_IN_WEEK
+
+    # make sure at least one chunk of interval can fit inside the time period we are trying to fast forward
+    if interval > fast_forward_seconds:
+        raise RuntimeError(f"Cannot fast forward rrule {rrule}, interval is greater than the fast forward amount of {fast_forward_seconds} seconds")
+
+    # it is important to fast forward by a number that is divisible by
+    # interval. For example, if interval is 7 hours, we fast forward by 7, 14, 21, etc. hours.
+    # Otherwise, the occurrences after the fast forward might not match the ones before.
+    # x // y is integer division, lopping off any remainder, so that we get the outcome we want.
+    new_start = rrule._dtstart + datetime.timedelta(seconds=(fast_forward_seconds // interval) * interval)
+    return new_start
+
+
 class ScheduleFilterMethods(object):
     def enabled(self, enabled=True):
         return self.filter(enabled=enabled)
@@ -207,23 +246,33 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
                 raise ValueError('A valid TZID must be provided (e.g., America/New_York)')
 
         # Fast forward is a way for us to limit the number of events in the rruleset
-        # If we are fastforwading and we don't have a count limited rule that is minutely or hourley
+        # If we are fast forwarding and we don't have a count limited rule that is minutely or hourly
         # We will modify the start date of the rule to last week to prevent a large number of entries
         if fast_forward:
             try:
                 # All rules in a ruleset will have the same dtstart value
-                #   so lets compare the first event to now to see if its > 7 days old
+                # so lets compare the first event to now to see if its > 30 days old
+                # we choose > 30 days because if rrule has FREQ=HOURLY and INTERVAL=23, it will take
+                # at least 23 days before we can fast forward reliably and retain stable occurrences.
+                # since we are fast forwarding to 7 days ago, we check fo rrrules older than (23+7) days
                 first_event = x[0]
-                if (now() - first_event).days > 7:
+                if (now() - first_event).days > 30:
                     for rule in x._rrule:
                         # If any rule has a minutely or hourly rule without a count...
                         if rule._freq in [dateutil.rrule.MINUTELY, dateutil.rrule.HOURLY] and not rule._count:
                             # hourly/minutely rrules with far-past DTSTART values
                             # are *really* slow to precompute
                             # start *from* one week ago to speed things up drastically
-                            new_start = (now() - datetime.timedelta(days=7)).strftime('%Y%m%d')
-                            # Now we want to repalce the DTSTART:<value>T with the new date (which includes the T)
-                            new_rrule = re.sub('(DTSTART[^:]*):[^T]+T', r'\1:{0}T'.format(new_start), rrule)
+                            try:
+                                new_start = fast_forward_date(rule)
+                            except RuntimeError as e:
+                                logger.warning(e)
+                                # fallback to setting dtstart to 7 days ago, but this has the consequence of
+                                # occurrences not matching the old occurrences.
+                                new_start = now() - datetime.timedelta(days=7)
+                            new_start_fmt = new_start.strftime('%Y%m%d')
+                            # Now we want to replace the DTSTART:<value>T with the new date (which includes the T)
+                            new_rrule = re.sub('(DTSTART[^:]*):[^T]+T', r'\1:{0}T'.format(new_start_fmt), rrule)
                             return Schedule.rrulestr(new_rrule, fast_forward=False)
             except IndexError:
                 pass

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -167,7 +167,7 @@ def test_survey_password_default(post, patch, admin_user, project, inventory, su
         # Multiple errors, first condition should be returned
         ("DTSTART:NONSENSE RRULE:NONSENSE RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=3,4", "Valid DTSTART required in rrule"),
         # Parsing Tests
-        ("DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5", "A valid TZID must be provided"),  # noqa
+        ("DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5", "The following rrules do not have a valid timezone"),  # noqa
         ("DTSTART:20300308T050000Z RRULE:FREQ=REGULARLY;INTERVAL=1", "rrule parsing failed validation: invalid 'FREQ': REGULARLY"),  # noqa
         ("DTSTART;TZID=America/New_York:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1", "rrule parsing failed validation"),
     ],

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -167,7 +167,7 @@ def test_survey_password_default(post, patch, admin_user, project, inventory, su
         # Multiple errors, first condition should be returned
         ("DTSTART:NONSENSE RRULE:NONSENSE RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=3,4", "Valid DTSTART required in rrule"),
         # Parsing Tests
-        ("DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5", "The following rrules do not have a valid timezone"),  # noqa
+        ("DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5", "A valid TZID must be provided"),  # noqa
         ("DTSTART:20300308T050000Z RRULE:FREQ=REGULARLY;INTERVAL=1", "rrule parsing failed validation: invalid 'FREQ': REGULARLY"),  # noqa
         ("DTSTART;TZID=America/New_York:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1", "rrule parsing failed validation"),
     ],

--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -139,12 +139,11 @@ def test_past_week_rrule(job_template, freq, delta):
 def test_really_old_dtstart(job_template, freq, delta):
     # see: https://github.com/ansible/awx/issues/8071
     # If an event is per-minute/per-hour and was created a *really long*
-    # time ago, we should just bump forward to start counting "in the last week"
+    # time ago, we should just bump forward the dtstart
     rrule = f'DTSTART;TZID=America/New_York:20150101T000000 RRULE:FREQ={freq};INTERVAL={delta}'  # noqa
     sched = Schedule.objects.create(name='example schedule', rrule=rrule, unified_job_template=job_template)
-    last_week = (datetime.utcnow() - timedelta(days=7)).date()
     first_event = sched.rrulestr(sched.rrule)[0]
-    assert last_week == first_event.date()
+    assert now() - first_event < timedelta(days=1)
 
     # the next few scheduled events should be the next minute/hour incremented
     next_five_events = list(sched.rrulestr(sched.rrule).xafter(now(), count=5))

--- a/awx/main/tests/functional/models/test_schedule.py
+++ b/awx/main/tests/functional/models/test_schedule.py
@@ -123,19 +123,6 @@ class TestComputedFields:
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('freq, delta', (('MINUTELY', 1), ('HOURLY', 1)))
-def test_past_week_rrule(job_template, freq, delta):
-    # see: https://github.com/ansible/awx/issues/8071
-    recent = datetime.utcnow() - timedelta(days=3)
-    recent = recent.replace(hour=0, minute=0, second=0, microsecond=0)
-    recent_dt = recent.strftime('%Y%m%d')
-    rrule = f'DTSTART;TZID=America/New_York:{recent_dt}T000000 RRULE:FREQ={freq};INTERVAL={delta};COUNT=5'  # noqa
-    sched = Schedule.objects.create(name='example schedule', rrule=rrule, unified_job_template=job_template)
-    first_event = sched.rrulestr(sched.rrule)[0]
-    assert first_event.replace(tzinfo=None) == recent
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('freq, delta', (('MINUTELY', 1), ('HOURLY', 1)))
 def test_really_old_dtstart(job_template, freq, delta):
     # see: https://github.com/ansible/awx/issues/8071
     # If an event is per-minute/per-hour and was created a *really long*

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -84,9 +84,9 @@ def test_multiple_rrules():
     assert exruleA._dtstart == rruleA._dtstart
 
     # the new dtstart should be within INTERVAL amount of hours from REF_DT
-    assert REF_DT - rruleA._dtstart < datetime.timedelta(hours=6)
-    assert REF_DT - rruleB._dtstart < datetime.timedelta(hours=8)
-    assert REF_DT - exruleA._dtstart < datetime.timedelta(hours=6)
+    assert (REF_DT - rruleA._dtstart) < datetime.timedelta(hours=6)
+    assert (REF_DT - rruleB._dtstart) < datetime.timedelta(hours=8)
+    assert (REF_DT - exruleA._dtstart) < datetime.timedelta(hours=6)
 
     # the freq=monthly rrule's dtstart should not have changed
     dateutil_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
@@ -110,10 +110,10 @@ def test_future_date_does_not_fast_forward():
 
 
 @pytest.mark.parametrize(
-    'freq, interval',
+    ('freq', 'interval'),
     [
-        (MINUTELY, 15.5555),
-        (MONTHLY, 1),
+        pytest.param(MINUTELY, 15.5555, id="freq-MINUTELY-interval-15.5555"),
+        pytest.param(MONTHLY, 1, id="freq-MONTHLY-interval-1"),
     ],
 )
 def test_does_not_fast_forward(freq, interval):

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -16,8 +16,14 @@ REF_DT = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
         pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5', id='every-5-min'),
         pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5', id='every-5-hours'),
         pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=YEARLY;INTERVAL=5', id='every-5-years'),
-        pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYMONTHDAY=18;BYHOUR=5;BYMINUTE=35;BYSECOND=0', id='every-5-minutes-at-5:35:00-am-on-the-18th-day-of-feb-or-march-with-week-starting-on-sundays'),
-        pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYHOUR=5', id='every-5-hours-at-5-am-in-feb-or-march-with-week-starting-on-sundays'),
+        pytest.param(
+            'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYMONTHDAY=18;BYHOUR=5;BYMINUTE=35;BYSECOND=0',
+            id='every-5-minutes-at-5:35:00-am-on-the-18th-day-of-feb-or-march-with-week-starting-on-sundays',
+        ),
+        pytest.param(
+            'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYHOUR=5',
+            id='every-5-hours-at-5-am-in-feb-or-march-with-week-starting-on-sundays',
+        ),
     ],
 )
 def test_fast_forwarded_rrule_matches_original_occurrence(rrulestr):

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -4,7 +4,7 @@ import dateutil
 
 from django.utils.timezone import now
 
-from awx.main.models.schedules import fast_forward_date, Schedule
+from awx.main.models.schedules import fast_forward_rrule, Schedule
 from dateutil.rrule import HOURLY, MINUTELY, MONTHLY
 
 
@@ -35,7 +35,7 @@ def test_fast_forwarded_rrule_matches_original_occurrence(rrulestr):
     assert occurrences == orig_occurrences
 
 
-def test_fast_forward_date_all_hours():
+def test_fast_forward_rrule_all_hours():
     '''
     Generate an rrule for each hour of the day
 
@@ -58,16 +58,32 @@ def test_fast_forward_date_all_hours():
 
 
 def test_multiple_rrule():
-    rrulestr = 'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5 RRULE:FREQ=HOURLY;INTERVAL=7'
+    '''
+    Create an rruleset that contains multiple rrules and an exrule
+    - freq HOURLY interval 5, dtstart should be fast forwarded
+    - freq HOURLY interval 7, dtstart should be fast forwarded
+    - freq MONTHLY interval 1, dtstart should not be fast forwarded
+    - exrule freq HOURLY interval 5, dtstart should be fast forwarded
+    '''
+    rrulestr = '''DTSTART;TZID=America/New_York:20201118T200000
+                RRULE:FREQ=HOURLY;INTERVAL=5
+                RRULE:FREQ=HOURLY;INTERVAL=7
+                RRULE:FREQ=MONTHLY
+                EXRULE:FREQ=HOURLY;INTERVAL=5;BYDAY=MO,TU,WE'''
     rruleset = Schedule.rrulestr(rrulestr)
     n = now()
 
-    # assert that each rule has its own dtstart
-    assert rruleset._rrule[0]._dtstart != rruleset._rrule[1]._dtstart
+    # assert that each rrule has its own dtstart
+    assert rruleset._rrule[0]._dtstart != rruleset._rrule[1]._dtstart != rruleset._rrule[2]._dtstart != rruleset._exrule[0]._dtstart
 
     # the new dtstart should be within INTERVAL amount of hours from now()
     assert n - rruleset._rrule[0]._dtstart < datetime.timedelta(hours=6)
     assert n - rruleset._rrule[1]._dtstart < datetime.timedelta(hours=8)
+    assert n - rruleset._exrule[0]._dtstart < datetime.timedelta(hours=6)
+
+    # the freq=monthly rrule's dtstart should not have changed
+    dateutil_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
+    assert rruleset._rrule[2]._dtstart == dateutil_rruleset._rrule[2]._dtstart
 
     gen = rruleset.xafter(n, count=200)
     occurrences = [i for i in gen]
@@ -79,6 +95,13 @@ def test_multiple_rrule():
     assert occurrences == orig_occurrences
 
 
+def test_future_data_not_fast_forwarded():
+    dtstart = now() + datetime.timedelta(days=30)
+    rrule = dateutil.rrule.rrule(freq=HOURLY, interval=7, dtstart=dtstart)
+    new_rrule = fast_forward_rrule(rrule)
+    assert new_rrule == rrule
+
+
 @pytest.mark.parametrize(
     'freq, interval, error',
     [
@@ -86,11 +109,15 @@ def test_multiple_rrule():
         (MONTHLY, 1, "frequency must be HOURLY or MINUTELY"),
     ],
 )
-def test_error_fast_forward_date(freq, interval, error):
+def test_error_fast_forward_rrule(freq, interval, error):
+    '''
+    Assert a couple of error states if attempting to fast forward a date that does
+    not need to be fast forwarded
+    '''
     dtstart = now() - datetime.timedelta(days=30)
-    rule = dateutil.rrule.rrule(freq=freq, interval=interval, dtstart=dtstart)
+    rrule = dateutil.rrule.rrule(freq=freq, interval=interval, dtstart=dtstart)
     if error:
         with pytest.raises(Exception) as e_info:
-            fast_forward_date(rule)
+            fast_forward_rrule(rrule)
 
         assert error in e_info.value.args[0]

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -13,11 +13,11 @@ REF_DT = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
 @pytest.mark.parametrize(
     'rrulestr',
     [
-        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5',
-        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5',
-        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=YEARLY;INTERVAL=5',
-        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYMONTHDAY=18;BYHOUR=5;BYMINUTE=35;BYSECOND=0',
-        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYHOUR=5',
+        pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5', id='every-5-min'),
+        pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5', id='every-5-hours'),
+        pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=YEARLY;INTERVAL=5', id='every-5-years'),
+        pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYMONTHDAY=18;BYHOUR=5;BYMINUTE=35;BYSECOND=0', id='every-5-minutes-at-5:35:00-am-on-the-18th-day-of-feb-or-march-with-week-starting-on-sundays'),
+        pytest.param('DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYHOUR=5', id='every-5-hours-at-5-am-in-feb-or-march-with-week-starting-on-sundays'),
     ],
 )
 def test_fast_forwarded_rrule_matches_original_occurrence(rrulestr):

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -1,61 +1,82 @@
 import pytest
 import datetime
+import dateutil
 
 from django.utils.timezone import now
 
-from awx.main.models.schedules import fast_forward_date
-from dateutil.rrule import rrule, HOURLY, MINUTELY, MONTHLY
+from awx.main.models.schedules import fast_forward_date, Schedule
+from dateutil.rrule import HOURLY, MINUTELY, MONTHLY
+
+
+@pytest.mark.parametrize(
+    'rrulestr',
+    [
+        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5',
+        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5',
+        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=YEARLY;INTERVAL=5',
+        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=MINUTELY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYMONTHDAY=18;BYHOUR=5;BYMINUTE=35;BYSECOND=0',
+        'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5;WKST=SU;BYMONTH=2,3;BYHOUR=5',
+    ],
+)
+def test_fast_forwarded_rrule_matches_original_occurrence(rrulestr):
+    '''
+    Assert that the resulting fast forwarded date is included in the original rrule
+    occurrence list
+    '''
+    rruleset = Schedule.rrulestr(rrulestr)
+    n = now()
+    gen = rruleset.xafter(n, count=200)
+    occurrences = [i for i in gen]
+
+    orig_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
+    gen = orig_rruleset.xafter(n, count=200)
+    orig_occurrences = [i for i in gen]
+
+    assert occurrences == orig_occurrences
 
 
 def test_fast_forward_date_all_hours():
     '''
+    Generate an rrule for each hour of the day
+
     Assert that the resulting fast forwarded date is included in the original rrule
     occurrence list
     '''
+    rrulestr_prefix = 'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;'
     for interval in range(1, 24):
-        dtstart = now() - datetime.timedelta(days=30)
-        rule = rrule(freq=HOURLY, interval=interval, dtstart=dtstart)
-        new_datetime = fast_forward_date(rule)
+        rrulestr = f"{rrulestr_prefix}INTERVAL={interval}"
+        rruleset = Schedule.rrulestr(rrulestr)
+        n = now()
+        gen = rruleset.xafter(n, count=200)
+        occurrences = [i for i in gen]
 
-        # get occurrences of the rrule
-        gen = rule.xafter(new_datetime - datetime.timedelta(days=1), count=100)
-        found_matching_date = False
-        for occurrence in gen:
-            if occurrence == new_datetime:
-                found_matching_date = True
-                break
+        orig_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
+        gen = orig_rruleset.xafter(n, count=200)
+        orig_occurrences = [i for i in gen]
 
-        assert found_matching_date
+        assert occurrences == orig_occurrences
 
 
-@pytest.mark.parametrize(
-    'freq, interval',
-    [
-        (MINUTELY, 15),
-        (MINUTELY, 120),
-        (MINUTELY, 60 * 24 * 3),
-        (HOURLY, 7),
-        (HOURLY, 24 * 3),
-    ],
-)
-def test_fast_forward_date(freq, interval):
-    '''
-    Assert that the resulting fast forwarded date is included in the original rrule
-    occurrence list
-    '''
-    dtstart = now() - datetime.timedelta(days=30)
-    rule = rrule(freq=freq, interval=interval, dtstart=dtstart)
-    new_datetime = fast_forward_date(rule)
+def test_multiple_rrule():
+    rrulestr = 'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;INTERVAL=5 RRULE:FREQ=HOURLY;INTERVAL=7'
+    rruleset = Schedule.rrulestr(rrulestr)
+    n = now()
 
-    # get occurrences of the rrule
-    gen = rule.xafter(new_datetime - datetime.timedelta(days=1), count=100)
-    found_matching_date = False
-    for occurrence in gen:
-        if occurrence == new_datetime:
-            found_matching_date = True
-            break
+    # assert that each rule has its own dtstart
+    assert rruleset._rrule[0]._dtstart != rruleset._rrule[1]._dtstart
 
-    assert found_matching_date
+    # the new dtstart should be within INTERVAL amount of hours from now()
+    assert n - rruleset._rrule[0]._dtstart < datetime.timedelta(hours=6)
+    assert n - rruleset._rrule[1]._dtstart < datetime.timedelta(hours=8)
+
+    gen = rruleset.xafter(n, count=200)
+    occurrences = [i for i in gen]
+
+    orig_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
+    gen = orig_rruleset.xafter(n, count=200)
+    orig_occurrences = [i for i in gen]
+
+    assert occurrences == orig_occurrences
 
 
 @pytest.mark.parametrize(
@@ -63,30 +84,13 @@ def test_fast_forward_date(freq, interval):
     [
         (MINUTELY, 15.5555, "interval is a fraction of a second"),
         (MONTHLY, 1, "frequency must be HOURLY or MINUTELY"),
-        (HOURLY, 24 * 30, "interval is greater than the fast forward amount"),
     ],
 )
 def test_error_fast_forward_date(freq, interval, error):
     dtstart = now() - datetime.timedelta(days=30)
-    rule = rrule(freq=freq, interval=interval, dtstart=dtstart)
+    rule = dateutil.rrule.rrule(freq=freq, interval=interval, dtstart=dtstart)
     if error:
         with pytest.raises(Exception) as e_info:
             fast_forward_date(rule)
 
         assert error in e_info.value.args[0]
-
-
-def test_very_old_date():
-    dtstart = now() - datetime.timedelta(days=365 * 10)
-    rule = rrule(freq=HOURLY, interval=11, dtstart=dtstart)
-    new_datetime = fast_forward_date(rule)
-
-    # get occurrences of the rrule
-    gen = rule.xafter(new_datetime - datetime.timedelta(days=1), count=100)
-    found_matching_date = False
-    for occurrence in gen:
-        if occurrence == new_datetime:
-            found_matching_date = True
-            break
-
-    assert found_matching_date

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -1,0 +1,92 @@
+import pytest
+import datetime
+
+from django.utils.timezone import now
+
+from awx.main.models.schedules import fast_forward_date
+from dateutil.rrule import rrule, HOURLY, MINUTELY, MONTHLY
+
+
+def test_fast_forward_date_all_hours():
+    '''
+    Assert that the resulting fast forwarded date is included in the original rrule
+    occurrence list
+    '''
+    for interval in range(1, 24):
+        dtstart = now() - datetime.timedelta(days=30)
+        rule = rrule(freq=HOURLY, interval=interval, dtstart=dtstart)
+        new_datetime = fast_forward_date(rule)
+
+        # get occurrences of the rrule
+        gen = rule.xafter(new_datetime - datetime.timedelta(days=1), count=100)
+        found_matching_date = False
+        for occurrence in gen:
+            if occurrence == new_datetime:
+                found_matching_date = True
+                break
+
+        assert found_matching_date
+
+
+@pytest.mark.parametrize(
+    'freq, interval',
+    [
+        (MINUTELY, 15),
+        (MINUTELY, 120),
+        (MINUTELY, 60 * 24 * 3),
+        (HOURLY, 7),
+        (HOURLY, 24 * 3),
+    ],
+)
+def test_fast_forward_date(freq, interval):
+    '''
+    Assert that the resulting fast forwarded date is included in the original rrule
+    occurrence list
+    '''
+    dtstart = now() - datetime.timedelta(days=30)
+    rule = rrule(freq=freq, interval=interval, dtstart=dtstart)
+    new_datetime = fast_forward_date(rule)
+
+    # get occurrences of the rrule
+    gen = rule.xafter(new_datetime - datetime.timedelta(days=1), count=100)
+    found_matching_date = False
+    for occurrence in gen:
+        if occurrence == new_datetime:
+            found_matching_date = True
+            break
+
+    assert found_matching_date
+
+
+@pytest.mark.parametrize(
+    'freq, interval, error',
+    [
+        (MINUTELY, 15.5555, "interval is a fraction of a second"),
+        (MONTHLY, 1, "frequency must be HOURLY or MINUTELY"),
+        (HOURLY, 24 * 30, "interval is greater than the fast forward amount"),
+    ],
+)
+def test_error_fast_forward_date(freq, interval, error):
+    dtstart = now() - datetime.timedelta(days=30)
+    rule = rrule(freq=freq, interval=interval, dtstart=dtstart)
+    if error:
+        with pytest.raises(Exception) as e_info:
+            fast_forward_date(rule)
+
+        assert error in e_info.value.args[0]
+
+
+def test_very_old_date():
+    dtstart = now() - datetime.timedelta(days=365 * 10)
+    rule = rrule(freq=HOURLY, interval=11, dtstart=dtstart)
+    new_datetime = fast_forward_date(rule)
+
+    # get occurrences of the rrule
+    gen = rule.xafter(new_datetime - datetime.timedelta(days=1), count=100)
+    found_matching_date = False
+    for occurrence in gen:
+        if occurrence == new_datetime:
+            found_matching_date = True
+            break
+
+    assert found_matching_date

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -4,8 +4,10 @@ import dateutil
 
 from django.utils.timezone import now
 
-from awx.main.models.schedules import fast_forward_rrule, Schedule
+from awx.main.models.schedules import _fast_forward_rrule, Schedule
 from dateutil.rrule import HOURLY, MINUTELY, MONTHLY
+
+REF_DT = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
 
 
 @pytest.mark.parametrize(
@@ -23,19 +25,19 @@ def test_fast_forwarded_rrule_matches_original_occurrence(rrulestr):
     Assert that the resulting fast forwarded date is included in the original rrule
     occurrence list
     '''
-    rruleset = Schedule.rrulestr(rrulestr)
-    n = now()
-    gen = rruleset.xafter(n, count=200)
+    rruleset = Schedule.rrulestr(rrulestr, ref_dt=REF_DT)
+
+    gen = rruleset.xafter(REF_DT, count=200)
     occurrences = [i for i in gen]
 
     orig_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
-    gen = orig_rruleset.xafter(n, count=200)
+    gen = orig_rruleset.xafter(REF_DT, count=200)
     orig_occurrences = [i for i in gen]
 
     assert occurrences == orig_occurrences
 
 
-def test_fast_forward_rrule_all_hours():
+def test_fast_forward_rrule_hours():
     '''
     Generate an rrule for each hour of the day
 
@@ -45,79 +47,80 @@ def test_fast_forward_rrule_all_hours():
     rrulestr_prefix = 'DTSTART;TZID=America/New_York:20201118T200000 RRULE:FREQ=HOURLY;'
     for interval in range(1, 24):
         rrulestr = f"{rrulestr_prefix}INTERVAL={interval}"
-        rruleset = Schedule.rrulestr(rrulestr)
-        n = now()
-        gen = rruleset.xafter(n, count=200)
+        rruleset = Schedule.rrulestr(rrulestr, ref_dt=REF_DT)
+
+        gen = rruleset.xafter(REF_DT, count=200)
         occurrences = [i for i in gen]
 
         orig_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
-        gen = orig_rruleset.xafter(n, count=200)
+        gen = orig_rruleset.xafter(REF_DT, count=200)
         orig_occurrences = [i for i in gen]
 
         assert occurrences == orig_occurrences
 
 
-def test_multiple_rrule():
+def test_multiple_rrules():
     '''
     Create an rruleset that contains multiple rrules and an exrule
-    - freq HOURLY interval 5, dtstart should be fast forwarded
-    - freq HOURLY interval 7, dtstart should be fast forwarded
-    - freq MONTHLY interval 1, dtstart should not be fast forwarded
-    - exrule freq HOURLY interval 5, dtstart should be fast forwarded
+    rruleA: freq HOURLY interval 5, dtstart should be fast forwarded
+    rruleB: freq HOURLY interval 7, dtstart should be fast forwarded
+    rruleC: freq MONTHLY interval 1, dtstart should not be fast forwarded
+    exruleA: freq HOURLY interval 5, dtstart should be fast forwarded
     '''
     rrulestr = '''DTSTART;TZID=America/New_York:20201118T200000
                 RRULE:FREQ=HOURLY;INTERVAL=5
                 RRULE:FREQ=HOURLY;INTERVAL=7
                 RRULE:FREQ=MONTHLY
                 EXRULE:FREQ=HOURLY;INTERVAL=5;BYDAY=MO,TU,WE'''
-    rruleset = Schedule.rrulestr(rrulestr)
-    n = now()
+    rruleset = Schedule.rrulestr(rrulestr, ref_dt=REF_DT)
+
+    rruleA, rruleB, rruleC = rruleset._rrule
+    exruleA = rruleset._exrule[0]
 
     # assert that each rrule has its own dtstart
-    assert rruleset._rrule[0]._dtstart != rruleset._rrule[1]._dtstart != rruleset._rrule[2]._dtstart != rruleset._exrule[0]._dtstart
+    assert rruleA._dtstart != rruleB._dtstart
+    assert rruleA._dtstart != rruleC._dtstart
 
-    # the new dtstart should be within INTERVAL amount of hours from now()
-    assert n - rruleset._rrule[0]._dtstart < datetime.timedelta(hours=6)
-    assert n - rruleset._rrule[1]._dtstart < datetime.timedelta(hours=8)
-    assert n - rruleset._exrule[0]._dtstart < datetime.timedelta(hours=6)
+    assert exruleA._dtstart == rruleA._dtstart
+
+    # the new dtstart should be within INTERVAL amount of hours from REF_DT
+    assert REF_DT - rruleA._dtstart < datetime.timedelta(hours=6)
+    assert REF_DT - rruleB._dtstart < datetime.timedelta(hours=8)
+    assert REF_DT - exruleA._dtstart < datetime.timedelta(hours=6)
 
     # the freq=monthly rrule's dtstart should not have changed
     dateutil_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
-    assert rruleset._rrule[2]._dtstart == dateutil_rruleset._rrule[2]._dtstart
+    assert rruleC._dtstart == dateutil_rruleset._rrule[2]._dtstart
 
-    gen = rruleset.xafter(n, count=200)
+    gen = rruleset.xafter(REF_DT, count=200)
     occurrences = [i for i in gen]
 
     orig_rruleset = dateutil.rrule.rrulestr(rrulestr, forceset=True)
-    gen = orig_rruleset.xafter(n, count=200)
+    gen = orig_rruleset.xafter(REF_DT, count=200)
     orig_occurrences = [i for i in gen]
 
     assert occurrences == orig_occurrences
 
 
-def test_future_data_not_fast_forwarded():
+def test_future_date_does_not_fast_forward():
     dtstart = now() + datetime.timedelta(days=30)
     rrule = dateutil.rrule.rrule(freq=HOURLY, interval=7, dtstart=dtstart)
-    new_rrule = fast_forward_rrule(rrule)
+    new_rrule = _fast_forward_rrule(rrule, ref_dt=REF_DT)
     assert new_rrule == rrule
 
 
 @pytest.mark.parametrize(
-    'freq, interval, error',
+    'freq, interval',
     [
-        (MINUTELY, 15.5555, "interval is a fraction of a second"),
-        (MONTHLY, 1, "frequency must be HOURLY or MINUTELY"),
+        (MINUTELY, 15.5555),
+        (MONTHLY, 1),
     ],
 )
-def test_error_fast_forward_rrule(freq, interval, error):
+def test_does_not_fast_forward(freq, interval):
     '''
-    Assert a couple of error states if attempting to fast forward a date that does
-    not need to be fast forwarded
+    Assert a couple of rrules that should not be fast forwarded
     '''
-    dtstart = now() - datetime.timedelta(days=30)
+    dtstart = REF_DT - datetime.timedelta(days=30)
     rrule = dateutil.rrule.rrule(freq=freq, interval=interval, dtstart=dtstart)
-    if error:
-        with pytest.raises(Exception) as e_info:
-            fast_forward_rrule(rrule)
 
-        assert error in e_info.value.args[0]
+    assert rrule == _fast_forward_rrule(rrule, ref_dt=REF_DT)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
By stable, we mean future occurrences of the rrule should be the same before and after the fast forward operation.

The problem before was that we were fast forwarding to *exactly* 7 days ago. For some rrules, this does not retain the old occurrences (for example, freq=HOURLY and INTERVAL=23). Thus, jobs would launch at unexpected times any time the schedule would fast forward.

This change makes sure we fast forward in increments of the rrule INTERVAL (converted to seconds), thus the new dtstart should be in the occurrence list of the old rrule.

#### DETAIL

It is important that each rrule in the rruleset gets fast forwarded independently. For example consider this rruleset

```
DTSTART;TZID=America/New_York:20201118T200000
RRULE:FREQ=HOURLY;INTERVAL=5
RRULE:FREQ=HOURLY;INTERVAL=7
```
Each of those rrules will need its own dtstart, since the occurrences from each rrule do not perfectly overlap.

the API also support exclusion rules, which are basically just rrules. So we can use the same method to fast forward those too.

#### PERFORMANCE

We want to retain the performance gains from introducing fast forwarding to begin with

create a bunch of old schedules

```
for i in range(2000):
    Schedule.objects.create(name=f's{i}', rrule='DTSTART;TZID=America/New_York:20190517T000000 RRULE:FREQ=HOURLY;INTERVAL=7', unified_job_template_id=7)
```

runit will update_computed_fields for each schedule
```
def runit():
    for sch in Schedule.objects.all():
        sch.update_computed_fields()
```

benchmark it
```
cProfile.run("runit()", "bench.txt")
```

before:
![image](https://github.com/user-attachments/assets/67eee87f-0f70-4688-a19f-21fa65d28a31)

after:
![image](https://github.com/user-attachments/assets/866b4b1c-59bf-4100-a17c-b26eec8e1b19)


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

