### PR TITLE
Fix: Remove execution_environment selection when empty value is provi…

### DIFF
--- a/awx_collection/plugins/modules/job_template.py
+++ b/awx_collection/plugins/modules/job_template.py
@@ -375,7 +375,7 @@ def update_survey(module, last_request):
     if module.params.get('survey_spec') == {}:
         response = module.delete_endpoint(spec_endpoint)
         if response['status_code'] != 200:
-            # Not sure how to make this actually return a non 200 to test what to dump in the respinse
+            # Not sure how to make this actually return a non 200 to test what to dump in the response
             module.fail_json(msg="Failed to delete survey: {0}".format(response['json']))
     else:
         response = module.post_endpoint(spec_endpoint, **{'data': module.params.get('survey_spec')})
@@ -399,7 +399,7 @@ def main():
         credential=dict(),
         vault_credential=dict(),
         credentials=dict(type='list', elements='str'),
-        execution_environment=dict(),
+        execution_environment=dict(type='str'),
         custom_virtualenv=dict(),
         instance_groups=dict(type="list", elements='str'),
         forks=dict(type='int'),
@@ -479,8 +479,11 @@ def main():
         search_fields['organization'] = new_fields['organization'] = organization_id
 
     ee = module.params.get('execution_environment')
-    if ee:
-        new_fields['execution_environment'] = module.resolve_name_to_id('execution_environments', ee)
+    if ee is not None:
+        if ee == "":
+            new_fields['execution_environment'] = None
+        elif ee:
+            new_fields['execution_environment'] = module.resolve_name_to_id('execution_environments', ee)
 
     # Attempt to look up an existing item based on the provided data
     existing_item = module.get_one('job_templates', name_or_id=name, check_exists=(state == 'exists'), **{'data': search_fields})


### PR DESCRIPTION
…ded (#14841)

##### SUMMARY
When a job template has an Execution Environment selected, but the playbook specifies `execution_environment: ""`, the selected environment should be removed to avoid incorrect configurations.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```plaintext
23.2.0
```

ADDITIONAL INFORMATION
Steps to reproduce:

- name: Get all templates from AAP
  ansible.controller.export:
    job_templates: 'all'
  register: aap_templates

- debug:
    var: aap_templates.assets.job_templates[0].execution_environment

- set_fact:
    ee: ""

- name: Create templates
  ansible.controller.job_template:
    name: "{{ aap_templates.assets.job_templates[0].name }}"
    execution_environment: "{{ ee }}"

Expected Results:
```
markdown
TASK [Create templates] ************************************************************************************************************************************
changed: [localhost]
```
Actual Results:
```
markdown
Copy code
TASK [Get all templates from AAP] **************************************************************************************************************************
ok: [localhost]

TASK [debug] ***********************************************************************************************************************************************
ok: [localhost] => {
"aap_templates.assets.job_templates[0].execution_environment": {
"name": "Automation Hub Default execution environment",
"type": "execution_environment"
}
}

TASK [set_fact] ********************************************************************************************************************************************
ok: [localhost]

TASK [Create templates] ************************************************************************************************************************************
ok: [localhost]
```