### PR TITLE
fix: increase max verbosity level for constructed inventory

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1765,7 +1765,7 @@ class ConstructedInventorySerializer(InventorySerializer):
         required=False,
         allow_null=True,
         min_value=0,
-        max_value=2,
+        max_value=5,
         default=None,
         help_text=_('The verbosity level for the related auto-created inventory source, special to constructed inventory'),
     )


### PR DESCRIPTION
##### SUMMARY

Increase the max verbosity level for constructed inventories to 5. See:

![grafik](https://github.com/user-attachments/assets/5663346d-ac61-4eb9-af2a-4e269d17d21a)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
