### PR TITLE
Fix git req sanitization due to underscore

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -43,7 +43,7 @@ automat==22.10.0
     # via twisted
 # awx-plugins-core @ git+https://git@github.com/ansible/awx-plugins.git@devel  # git requirements installed separately
     # via -r /awx_devel/requirements/requirements_git.txt
-awx-plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+# awx-plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git  # git requirements installed separately
     # via
     #   -r /awx_devel/requirements/requirements_git.txt
     #   awx-plugins-core

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -3,4 +3,4 @@ git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
 awx-plugins-core @ git+https://git@github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core
-awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+awx-plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git


### PR DESCRIPTION
##### SUMMARY
This is what @TheRealHaoLiu was asking about.

I'd suggest a followup change to the awx-plugins.interfaces library to also use `-`. Ping @webknjaz 

https://github.com/ansible/awx_plugins.interfaces

I believe this is the right thing to do, because:

https://github.com/python-poetry/poetry/issues/8848

> that is the correctly normalized package name, not a bug

referencing its own source

https://peps.python.org/pep-0503/#normalized-names

> This PEP references the concept of a “normalized” project name. As per [PEP 426](https://peps.python.org/pep-0426/) the only valid characters in a name are the ASCII alphabet, ASCII numbers, ., -, and _. The name should be lowercased with all runs of the characters ., -, or _ replaced with a single - character. This can be implemented in Python with the re module:

And it writes code, in case that wasn't clear enough what normalization means.

```python
import re

def normalize(name):
    return re.sub(r"[-_.]+", "-", name).lower()
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

