### PR TITLE
fix: invalid response type on post request

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -13,7 +13,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.db import connection, transaction
 from django.db.models.fields.related import OneToOneRel
-from django.http import QueryDict
+from django.http import QueryDict, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
@@ -81,6 +81,7 @@ analytics_logger = logging.getLogger('awx.analytics.performance')
 
 
 class LoggedLoginView(auth_views.LoginView):
+
     def get(self, request, *args, **kwargs):
         if is_proxied_request():
             next = request.GET.get('next', "")
@@ -105,7 +106,7 @@ class LoggedLoginView(auth_views.LoginView):
     def post(self, request, *args, **kwargs):
         if is_proxied_request():
             # Give a message, saying to login via AAP
-            return Response(
+            return JsonResponse(
                 {
                     'detail': _('Please log in via Platform Authentication.'),
                 },

--- a/awx/main/tests/functional/api/test_auth.py
+++ b/awx/main/tests/functional/api/test_auth.py
@@ -1,12 +1,16 @@
 import pytest
 
 from django.contrib import auth
+from django.http import JsonResponse
+
 from django.test import Client
 
 from rest_framework.test import APIRequestFactory
 
-from awx.api.generics import LoggedLoginView
+import awx.api.generics
 from rest_framework.reverse import reverse as drf_reverse
+
+from pytest_mock import MockerFixture
 
 
 @pytest.mark.django_db
@@ -21,6 +25,25 @@ def test_invalid_login():
     request = factory.post(url, data)
     request.user = anon
 
-    response = LoggedLoginView.as_view()(request)
+    response = awx.api.generics.LoggedLoginView.as_view()(request)
 
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_invalid_post(mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch):
+    url = drf_reverse('api:login')
+    factory = APIRequestFactory()
+    request = factory.post(url)
+
+    is_proxied_request_mock = mocker.Mock(
+        autospec=True,
+        name='is_proxied_request',
+        return_value=True,
+    )
+    monkeypatch.setattr(awx.api.generics, 'is_proxied_request', is_proxied_request_mock)
+    response = awx.api.generics.LoggedLoginView.as_view()(request)
+
+    assert isinstance(response, JsonResponse)
+    assert b'Please log in via Platform Authentication.' in response.content
     assert response.status_code == 401


### PR DESCRIPTION
##### SUMMARY

Fix the 500 response when sending an unauthenticated `POST` request to `/api/controller/login`. Using a django `JsonResponse` avoids the error.

Verified by running this on OpenShift with Gateway.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
