### PR TITLE
Fix bug where unrelated jobs were linked as dependencies

### DIFF
--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -389,8 +389,8 @@ class DependencyManager(TaskBase):
             if job_deps:
                 dependencies += job_deps
                 with disable_activity_stream():
-                    task.dependent_jobs.add(*dependencies)
-                logger.debug(f'Linked {[dep.log_format for dep in dependencies]} as dependencies of {task.log_format}')
+                    task.dependent_jobs.add(*job_deps)
+                logger.debug(f'Linked {[dep.log_format for dep in job_deps]} as dependencies of {task.log_format}')
 
         UnifiedJob.objects.filter(pk__in=[task.pk for task in undeped_tasks]).update(dependencies_processed=True)
 


### PR DESCRIPTION
##### SUMMARY
This used a wrong variable in a loop, where `dependencies` was a cumulative list for every `task` seen in the loop, but `job_deps` were the dependencies for the one task being looked at. The point was to simply save the job's dependencies, but using the global variable, we kind of saved every dependency seen by that single run as a dependency of the job. This was seen adding an inventory update as a dependency of itself... logically because a prior `task` in the loop had the inventory update as a dependency, and the inventory update, itself, later in the loop, produced a project update dependency. So it added the 2 dependencies, the inventory update, a dependency for some other random job, and the project update, to the dependency list of the inventory update.

Test failure without code change:

```
  File "/home/alancoding/repos/awx/awx/main/tests/functional/task_management/test_scheduler.py", line 425, in test_dependency_isolation
    assert (inv_update.dependent_jobs.count(), job.dependent_jobs.count()) == (1, 1)
AssertionError: assert (1, 2) == (1, 1)
  
  At index 1 diff: 2 != 1
  Use -v to get more diff
```

Important to note the 1st entry, `1`, which means the _first_ `task` to be processed got the correct dependencies linked.

It is only the later items in the loop, the 2nd item here, which gets linked to its own deps and erroneous deps of prior tasks processed. Giving `2`, having added its own dep to the 1 before. This is not good, both examples in the test are simple cases, totally isolated from each other, that only produce `1` dependency.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

