### PR TITLE
Install awx collection from branch for operator ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,8 @@ jobs:
         working-directory: awx-operator
         run: |
           python3 -m pip install -r molecule/requirements.txt
+          python3 -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
+          $(realpath ../awx/tools/scripts/rewrite-awx-operator-requirements.py) molecule/requirements.yml $(realpath ../awx)
           ansible-galaxy collection install -r molecule/requirements.yml
           sudo rm -f $(which kustomize)
           make kustomize

--- a/tools/scripts/rewrite-awx-operator-requirements.py
+++ b/tools/scripts/rewrite-awx-operator-requirements.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+import yaml
+import sys
+
+
+AWX_ENTRY = 'https://github.com/ansible/awx.git#/awx_collection/'
+
+
+def load_yaml_file(fname):
+    with open(fname, 'r') as file:
+        data = yaml.safe_load(file)
+    return data
+
+
+def write_yaml_file(fname, data):
+    with open(fname, 'w') as file:
+        yaml.dump(data, file)
+
+
+def replace_awx(data, path):
+    for entry in data['collections']:
+        if entry['name'] == AWX_ENTRY or entry['name'] == 'awx.awx':
+            entry['name'] = f'file://{path}#/awx_collection/'
+            entry['type'] = 'git'
+            entry.pop('version', None)
+            return data
+
+    raise ValueError(f"Failed to find {AWX_ENTRY} in {data}")
+
+
+def run(fname, awx_path):
+    write_yaml_file(fname, replace_awx(load_yaml_file(fname), awx_path))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 3:
+        run(sys.argv[1], sys.argv[2])
+    else:
+        print(f"Usage: {sys.argv[0]} <awx-operator-molecule-requirements.yml> <awx-git-path>", file=sys.stderr)


### PR DESCRIPTION
##### SUMMARY
Install awx collection from current branch for operator ci test

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

_How do I know this is installing the branch version of the awx collection?_
https://github.com/ansible/awx/actions/runs/11695232281/job/32570297454?pr=15616 <-- here is a run where I put an error in `awx_collection/galaxy.yml` file to make the awx collection install fail. This shows that the collection install is running against the branch.
![image](https://github.com/user-attachments/assets/7d6518f4-7fb2-4d30-a8c5-435a56b8738b)

A successful run with the error in `awx_collection/galaxy.yml` removed https://github.com/ansible/awx/actions/runs/11695303693/job/32570502882?pr=15616


