### PR TITLE
feat: install awx collection from source

### DIFF
--- a/tools/docker-compose/ansible/requirements.yml
+++ b/tools/docker-compose/ansible/requirements.yml
@@ -1,5 +1,6 @@
 ---
 collections:
-  - awx.awx
+  - source: ./awx_collection
+    type: dir
   - flowerysong.hvault
   - community.docker


### PR DESCRIPTION
##### SUMMARY

Install the awx collection from source when starting the docker compose environment.

Note: if you have currently symlinked the collection source, you may have to remove it manually:

```
rm -rf ~/.ansible/collections/ansible_collections/awx/
```

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
