### PR TITLE
Set coverage limits so we do not have current failures

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -34,7 +34,7 @@ coverage:
           - pytest
         paths:
           - awx/
-        target: 100%
+        target: 75%
       tests:
         flags:
           - pytest
@@ -48,7 +48,7 @@ coverage:
             **/test/**
           - >-
             **/tests/**
-        target: 100%
+        target: 95%
       typing:
         flags:
           - MyPy

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@
 
 codecov:
   notify:
-    after_n_builds: 5  # Number of test matrix+lint jobs uploading coverage
+    after_n_builds: 6  # Number of test matrix+lint jobs uploading coverage
     wait_for_ci: false
 
   require_ci_to_pass: false


### PR DESCRIPTION
##### SUMMARY
We have 2 checks always failing, and I'd rather them not.

```
@codecov
codecov/project/lib — 79.67% (target 100.00%)
[Details](https://github.com/ansible/awx/pull/15625/checks?check_run_id=32807836738)
@codecov
codecov/project/tests — 97.76% (target 100.00%)
[Details](https://github.com/ansible/awx/pull/15625/checks?check_run_id=32807837299)
```

Ping @webknjaz


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

