### PR TITLE
Add test that resource list does not server error

### DIFF
--- a/awx/main/tests/functional/dab_resource_registry/test_resource_list.py
+++ b/awx/main/tests/functional/dab_resource_registry/test_resource_list.py
@@ -1,0 +1,15 @@
+import pytest
+
+from ansible_base.lib.utils.response import get_relative_url
+
+
+@pytest.mark.django_db
+def test_users_in_resource_list(admin_user, rando, get):
+    url = get_relative_url("resource-list")
+    get(url=url, expect=200, user=admin_user)
+
+
+@pytest.mark.django_db
+def test_user_resource_detail(admin_user, rando, get):
+    url = get_relative_url("resource-detail", kwargs={'ansible_id': str(rando.resource.ansible_id)})
+    get(url=url, expect=200, user=admin_user)


### PR DESCRIPTION
##### SUMMARY
These are regression tests for what we saw with https://github.com/ansible/awx/pull/15626

Our checks were not failing when that regression happened. This adds coverage so that we will catch those errors. Before the fix, I did verify that this was failing.

I had intended for this to go in with the fix.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

