### PR TITLE
Do not add env vars if they do not add content

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -981,6 +981,10 @@ class RunJob(SourceControlMixin, BaseTask):
         config_values = read_ansible_config(os.path.join(private_data_dir, 'project'), list(map(lambda x: x[1], path_vars)))
 
         for env_key, config_setting, folder, default in path_vars:
+            local_folder = os.path.join(private_data_dir, folder)
+            if (not os.path.exists(local_folder)) or (os.listdir(local_folder) == []):
+                # If there is no content populated in the additional content folder, do not set the env var
+                continue
             paths = default.split(':')
             if env_key in env:
                 for path in env[env_key].split(':'):


### PR DESCRIPTION
##### SUMMARY
This cleans up the `job_env` of a job.

```json
"job_env": {
        "JOB_ID": "25",
        "AWX_HOST": "https://platformhost/",
        "INVENTORY_ID": "3",
        "MAX_EVENT_RES": "700000",
        "PROJECT_REVISION": "347e44fea036c94d5f60e544de006453ee5c71ad",
        "RUNNER_OMIT_EVENTS": "False",
        "ANSIBLE_FORCE_COLOR": "True",
        "AWX_PRIVATE_DATA_DIR": "/tmp/awx_25_4v0h263v",
        "ANSIBLE_UNSAFE_WRITES": "1",
        "AWX_ISOLATED_DATA_DIR": "/runner/artifacts/25",
        "ANSIBLE_STDOUT_CALLBACK": "awx_display",
        "ANSIBLE_CALLBACK_PLUGINS": "/runner/artifacts/25/callback",
        "ANSIBLE_HOST_KEY_CHECKING": "False",
        "RUNNER_ONLY_FAILED_EVENTS": "False",
        "ANSIBLE_RETRY_FILES_ENABLED": "False",
        "ANSIBLE_SSH_CONTROL_PATH_DIR": "/runner/cp",
        "ANSIBLE_INVENTORY_UNPARSED_FAILED": "True",
        "ANSIBLE_PARAMIKO_RECORD_HOST_KEYS": "False"
    },
```

No longer will we set the `ANSIBLE_ROLES_PATH` and others every time. They should only get set if the actually downloaded some collections or roles from the user `requirements.yml`. Since `build_env` runs after the project update run, this should be valid, but this still needs verification that it doesn't break playbooks with this content.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
