### PR TITLE
Add option to skip credential type discovery

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -1,3 +1,5 @@
+import os
+
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 from awx.main.utils.common import bypass_in_test
@@ -61,5 +63,11 @@ class MainConfig(AppConfig):
     def ready(self):
         super().ready()
 
-        self.load_credential_types_feature()
+        """
+        Credential loading triggers database operations. There are cases we want to call
+        awx-manage collectstatic without a database. All management commands invoke the ready() code
+        path. Using settings.AWX_SKIP_CREDENTIAL_TYPES_DISCOVER _could_ invoke a database operation.
+        """
+        if not os.environ.get('AWX_SKIP_CREDENTIAL_TYPES_DISCOVER', None):
+            self.load_credential_types_feature()
         self.load_named_url_feature()


### PR DESCRIPTION


##### SUMMARY
Option to avoid database operations in django init path. Useful for running collectstatic, or other management commands, without a database.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
