### PR TITLE
Fix error with CLI monitor of ad hoc output

### DIFF
--- a/awxkit/awxkit/cli/custom.py
+++ b/awxkit/awxkit/cli/custom.py
@@ -72,13 +72,11 @@ class Launchable(object):
     def monitor(self, response, **kwargs):
         mon = monitor_workflow if response.type == 'workflow_job' else monitor
         if kwargs.get('monitor') or kwargs.get('wait'):
-            status = mon(
-                response,
-                self.page.connection.session,
-                print_stdout=not kwargs.get('wait'),
-                action_timeout=kwargs.get('action_timeout'),
-                interval=kwargs.get('interval'),
-            )
+            monitor_kwargs = {'print_stdout': bool(not kwargs.get('wait'))}
+            for key in ('action_timeout', 'interval'):
+                if key in kwargs:
+                    monitor_kwargs[key] = kwargs[key]
+            status = mon(response, self.page.connection.session, **monitor_kwargs)
             if status:
                 response.json['status'] = status
                 if status in ('failed', 'error'):


### PR DESCRIPTION
##### SUMMARY
Debugging deep into test runner failures, it's hard to rule anything out, and I saw a failure from this bug was being ignored. I thought it might be related to "worker was found in a dead state" error. Unlikely, but I'm running out of options.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

