### PR TITLE
Allow exporting constructed inventories separately

### DIFF
--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -71,6 +71,11 @@ options:
         - inventory names, IDs, or named URLs to export
       type: list
       elements: str
+    constructed_inventory:
+      description:
+        - constructed inventory names, IDs, or named URLs to export
+      type: list
+      elements: str
     projects:
       description:
         - project names, IDs, or named URLs to export

--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -21,6 +21,7 @@ EXPORTABLE_RESOURCES = [
     'notification_templates',
     'projects',
     'inventory',
+    'constructed_inventory',
     'inventory_sources',
     'job_templates',
     'workflow_job_templates',


### PR DESCRIPTION
##### SUMMARY
Allow exporting constructed inventories with their specific fields

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection

##### AWX VERSION
```
4.6.2
```


##### ADDITIONAL INFORMATION
Constructed inventories have specific fields such as *limit* and *source_vars* which are exposed via /api/v2/constructed_inventories/ but not via /api/v2/inventories/

As an end user I'd like to be able to export constructed inventories with their unique fields so that I don't need to make additional API calls (or export auto-generated inventory sources) after exporting inventories using existing *inventory* parameter.
