### PR TITLE
Revive the logstash container for testing

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -170,12 +170,6 @@ services:
     depends_on:
       - prometheus
 {% endif %}
-  # A useful container that simply passes through log messages to the console
-  # helpful for testing awx/tower logging
-  # logstash:
-  #   build:
-  #     context: ../../docker-compose
-  #     dockerfile: Dockerfile-logstash
   postgres:
     image: quay.io/sclorg/postgresql-15-c9s
     container_name: tools_postgres_1

--- a/tools/docker-compose/docs/logstash.md
+++ b/tools/docker-compose/docs/logstash.md
@@ -2,16 +2,10 @@
 
 #### Modify the docker-compose.yml
 
-Uncomment the following lines in the `docker-compose.yml`
+You can run the logstash container by adding another compose file to the docker-compose target.
 
 ```
-#- logstash
-...
-
-#logstash:
-#  build:
-#    context: ./docker-compose
-#    dockerfile: Dockerfile-logstash
+COMPOSE_OPTS="-f tools/docker-compose/logstash-override.yaml" COMPOSE_TAG=devel make docker-compose
 ```
 
 POST the following content to `/api/v2/settings/logging/` (this uses

--- a/tools/docker-compose/logstash-override.yaml
+++ b/tools/docker-compose/logstash-override.yaml
@@ -1,3 +1,4 @@
+---
 services:
   # A useful container that simply passes through log messages to the console
   # helpful for testing awx/tower logging

--- a/tools/docker-compose/logstash-override.yaml
+++ b/tools/docker-compose/logstash-override.yaml
@@ -1,0 +1,11 @@
+services:
+  # A useful container that simply passes through log messages to the console
+  # helpful for testing awx/tower logging
+  logstash:
+    build:
+      context: ../
+      dockerfile: Dockerfile-logstash
+    container_name: tools_logstash_1
+    hostname: logstash
+    networks:
+      - awx


### PR DESCRIPTION
##### SUMMARY
Fast demo:

```
$ docker exec -i -t $(docker ps -aqf "name=tools_logstash_1") tail -n 2 /logstash.log
{"headers":{"remote_user":"awx_logger","http_accept":"*/*","content_type":"application/json; charset=utf-8","request_path":"/","http_version":"HTTP/1.1","http_authorization":"Basic YXd4X2xvZ2dlcjp3b3JrZmxvd3M=","request_method":"POST","http_host":"logstash:8085","request_uri":"/","content_length":"360"},"@timestamp":"2024-11-21T19:13:14.561Z","level":"WARNING","cluster_host_id":"awx-1","@version":"1","host":"awx-1","stack_info":null,"guid":"7ff29201","logger_name":"awx.api.generics","message":"status 404 received by user alan attempting to access /api/v2/workflow_jobs/4/workflow_nodes/ from 172.18.0.1","tower_uuid":"00000000-0000-0000-0000-000000000000"}
{"headers":{"remote_user":"awx_logger","http_accept":"*/*","content_type":"application/json; charset=utf-8","request_path":"/","http_version":"HTTP/1.1","http_authorization":"Basic YXd4X2xvZ2dlcjp3b3JrZmxvd3M=","request_method":"POST","http_host":"logstash:8085","request_uri":"/","content_length":"360"},"@timestamp":"2024-11-21T19:13:21.941Z","level":"WARNING","cluster_host_id":"awx-1","@version":"1","host":"awx-1","stack_info":null,"guid":"5492b3be","logger_name":"awx.api.generics","message":"status 404 received by user alan attempting to access /api/v2/workflow_jobs/4/workflow_nodes/ from 172.18.0.1","tower_uuid":"00000000-0000-0000-0000-000000000000"}
```

This already existed, but it wasn't working by the prior instructions. Needed container name & network. Logstash container predated other changes that made these necessary.

I also wanted to demonstrate our future direction, with the files broken out better. You could hypothetically run this completely on its own. If we could keep each compose file a full independent package, then that should be easier in the long run.

Also, the `Makefile` is nearing the point of maintenance failure, so I'm trying to dodge around changes to that. The ELK stack sure doesn't work.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
