### PR TITLE
Ignore warnings so people can run tests on python 3.12

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,17 @@ markers =
 filterwarnings =
   error
 
+  # NOTE: The following are introduced upgrading python 3.11 to python 3.12
+  # FIXME: Upgrade django-polymorphic https://github.com/jazzband/django-polymorphic/pull/541
+  once:Deprecated call to `pkg_resources.declare_namespace\('sphinxcontrib'\)`.\nImplementing implicit namespace packages \(as specified in PEP 420\) is preferred to `pkg_resources.declare_namespace`.:DeprecationWarning
+
+  # FIXME: Upgrade protobuf https://github.com/protocolbuffers/protobuf/issues/15077
+  once:Type google._upb._message.* uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning
+
+  # FIXME: Upgrade python-dateutil https://github.com/dateutil/dateutil/issues/1340
+  once:datetime.datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC:DeprecationWarning
+
+  # NOTE: the following are present using python 3.11
   # FIXME: Set `USE_TZ` to `True`.
   once:The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.:django.utils.deprecation.RemovedInDjango50Warning:django.conf
 


### PR DESCRIPTION
##### SUMMARY
Hit this quickly after pulling updated `devel` after https://github.com/ansible/awx/pull/15620 merged. Linking the related issues for upgrades, added here:

 - https://github.com/jazzband/django-polymorphic/issues/503
   - fix: https://github.com/jazzband/django-polymorphic/pull/541 - 
 - https://github.com/protocolbuffers/protobuf/issues/15077
   - fix: https://github.com/protocolbuffers/protobuf/pull/15999
 - https://github.com/dateutil/dateutil/issues/1340
   - fix: https://github.com/dateutil/dateutil/pull/1285 (also has backport)

Our containers run python 3.11, but it stands to reason that some people might be using python 3.12. Sure, they could make a new venv but we might as well prepare these so that they are on the agenda and to keep developer flexibility.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
