### PR TITLE
Fix missing dependencies due to extras `-` vs `_`

### DIFF
--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,6 +1,6 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest_filters,jwt_consumer,resource_registry,rbac]
+django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac]
 awx-plugins-core @ git+https://git@github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core
 awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git


### PR DESCRIPTION
##### SUMMARY
Other PRs ran the requirement generator and dropped dependencies of DAB.

With this change, I run:

```
docker exec --user=0 -it tools_awx_1 /bin/bash
```

then

```
cd requirements/
./updater.sh run
```

With this, I get no change in the `requirements.txt` file, unlike other active PRs like https://github.com/ansible/awx/pull/15660 which incorrectly mark requests as not a requirement of DAB. It is, given the extras we select.

I don't know who introduced this problem, but this fixes it for us.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

