### PR TITLE
cli: set non-zero return code for `canceled` status

### DIFF
--- a/awxkit/awxkit/cli/custom.py
+++ b/awxkit/awxkit/cli/custom.py
@@ -81,6 +81,8 @@ class Launchable(object):
                 response.json['status'] = status
                 if status in ('failed', 'error'):
                     setattr(response, 'rc', 1)
+                if status in ('canceled'):
+                    setattr(response, 'rc', 2)
         return response
 
     def perform(self, **kwargs):
@@ -561,6 +563,8 @@ class HasMonitor(object):
                 response.json['status'] = status
                 if status in ('failed', 'error'):
                     setattr(response, 'rc', 1)
+                if status in ('canceled'):
+                    setattr(response, 'rc', 2)
         else:
             return 'Unable to monitor finished job'
 


### PR DESCRIPTION
##### SUMMARY

This PR adds `canceled` to the list of statuses that cause `launch` commands (with `--monitor` or `--wait`) to exit non-zero.

If a job is canceled, I expect the caller to get a non-zero return code; otherwise, the caller will think that the job completed successful, even though it did not.

This is a follow-up to https://github.com/ansible/awx/pull/6081.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - CLI

##### AWX VERSION
```
awx: 0.1.dev34249+g91bb012
```

##### ADDITIONAL INFORMATION
N/A