### PR TITLE
use subproject url prefix

### DIFF
--- a/docs/docsite/conf.py
+++ b/docs/docsite/conf.py
@@ -39,7 +39,7 @@ extensions = [
     'swagger',
 ]
 
-notfound_urls_prefix = "/en/latest/"
+notfound_urls_prefix = "/projects/awx/en/latest/"
 notfound_template = "404.rst"
 
 html_theme = 'sphinx_ansible_theme'

--- a/docs/docsite/rst/404.rst
+++ b/docs/docsite/rst/404.rst
@@ -10,7 +10,10 @@ The page you are looking for is not in the current AWX documentation.
    :alt: Cowsay 404
 
 You can find different versions of the AWX documentation by opening the Read the Docs fly out menu at the bottom right.
-Here is a link to the `AWX 24.6.1 <https://ansible.readthedocs.io/projects/awx/en/24.6.1/>`_ documentation.
+For your convenience, here are some links:
+
+* `AWX latest <https://ansible.readthedocs.io/projects/awx/en/latest/>`_ documentation, includes release notes and known issues, contributor's guide, and API reference.
+* `AWX 24.6.1 <https://ansible.readthedocs.io/projects/awx/en/24.6.1/>`_ documentation, includes release notes, contributor's guide, AWX quickstart, user guide, API reference, and administrator guide.
 
 If you have more questions or still can't find the docs you're looking for, join the `Ansible Forum <https://forum.ansible.com>`_.
 Here are some useful links for AWX users:


### PR DESCRIPTION
##### SUMMARY
Follows up on https://github.com/ansible/awx/pull/15680

Adds the `/projects/awx` subproject url so the custom AWX 404 page loads correctly.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### AWX VERSION
n/a


##### ADDITIONAL INFORMATION
n/a
