### PR TITLE
Update defaults.py receptor typo

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -870,7 +870,7 @@ AWX_RUNNER_KEEPALIVE_SECONDS = 0
 
 # Delete completed work units in receptor
 RECEPTOR_RELEASE_WORK = True
-RECPETOR_KEEP_WORK_ON_ERROR = False
+RECEPTOR_KEEP_WORK_ON_ERROR = False
 
 # K8S only. Use receptor_log_level on AWX spec to set this properly
 RECEPTOR_LOG_LEVEL = 'info'


### PR DESCRIPTION
fixing typo for  RECEPTOR_KEEP_WORK_ON_ERROR

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

fixing typo for  RECEPTOR_KEEP_WORK_ON_ERROR

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 - Other: Receptor Settings

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev34254+gcb04ad8

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
