### PR TITLE
fix: reset state before evaluating named urls

### DIFF
--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -20,6 +20,7 @@ from awx.main import migrations
 from awx.main.utils.profiling import AWXProfiler
 from awx.main.utils.common import memoize
 from awx.urls import get_urlpatterns
+from awx.main.utils.named_url_graph import reset_counters
 
 
 logger = logging.getLogger('awx.main.middleware')
@@ -112,6 +113,7 @@ class URLModificationMiddleware(MiddlewareMixin):
     @classmethod
     def _named_url_to_pk(cls, node, resource, named_url):
         kwargs = {}
+        reset_counters()
         if node.populate_named_url_query_kwargs(kwargs, named_url):
             match = node.model.objects.filter(**kwargs).first()
             if match:

--- a/awx/main/tests/functional/test_named_url.py
+++ b/awx/main/tests/functional/test_named_url.py
@@ -265,3 +265,14 @@ class TestConvertNamedUrl:
             URLModificationMiddleware._convert_named_url(f'/api/{prefix}v2/organizations/test_org/inventories/')
             == f'/api/{prefix}v2/organizations/{test_org.pk}/inventories/'
         )
+
+    def test_named_job_template(self):
+        org = Organization.objects.create(name='test_org')
+        tpl = JobTemplate.objects.create(name='test_tpl', organization=org)
+
+        # first, cause a '404' - we want to verify that no state from previous requests is carried over when named
+        # urls are resolved
+        assert URLModificationMiddleware._convert_named_url('/api/v2/job_templates/test/tpl++test_org/') == '/api/v2/job_templates/test/tpl++test_org/'
+
+        # try to resolve a valid url - it should succeed
+        assert URLModificationMiddleware._convert_named_url('/api/v2/job_templates/test_tpl++test_org/') == f'/api/v2/job_templates/{tpl.pk}/'


### PR DESCRIPTION
##### SUMMARY

Valid named urls were failing when the previous request resulted in a 404. This change fixes this.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
