### PR TITLE
Make dev script work in combined environment

### DIFF
--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -30,12 +30,12 @@ if [ ! -d "/awx_devel/awx/ui/build/awx" ]; then
     cp /awx_devel/awx/ui/placeholder_index_awx.html /awx_devel/awx/ui/build/awx/index_awx.html
 fi
 
-if output=$(awx-manage createsuperuser --noinput --username=admin --email=admin@localhost 2> /dev/null); then
+if output=$(ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage createsuperuser --noinput --username=admin --email=admin@localhost 2> /dev/null); then
     echo $output
 fi
 echo "Admin password: ${DJANGO_SUPERUSER_PASSWORD}"
 
-awx-manage create_preload_data
+ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage create_preload_data
 awx-manage register_default_execution_environments
 
 awx-manage provision_instance --hostname="$(hostname)" --node_type="$MAIN_NODE_TYPE"


### PR DESCRIPTION
##### SUMMARY
This adds the env var from DAB so that it won't sync the changes to the resource server. This is the accepted, canonical, way to run the bootstrap commands. But the dev bootstrap script is just a low-priority item so we never got around to this.

But I hit this debugging other problems so wanted to get this cleanup in.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
