### PR TITLE
[PoC] Catch ImagePullBackOff from receptor workunitand surface to job_explanation

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -537,6 +537,12 @@ class AWXReceptorJob:
                     self.task.update_model(self.task.instance.pk, status='pending')
                     return
 
+                if 'ImagePullBackOff' in detail:
+                    logger.warning(detail)
+                    log_name = self.task.instance.log_format
+                    logger.warning(f"Could not launch pod for {log_name}. ImagePullBackOff.")
+                    self.task.runner_callback.delay_update(job_explanation=f'{detail}')
+
                 try:
                     receptor_output = ''
                     if state_name == 'Failed' and self.task.runner_callback.event_ct == 0:


### PR DESCRIPTION
##### SUMMARY
Instead of just result traceback so we stop getting the
```
Failed to JSON parse a line from worker stream. Error: Expecting value: line 1 column 1 (char 0) Line with invalid JSON data: b''
```
for this specific case
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 
##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
