### PR TITLE
Fix misused project cache identifier

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -700,6 +700,7 @@ class SourceControlMixin(BaseTask):
             logger.debug(f'Project not available locally, {self.instance.id} will sync with remote')
             sync_needs.append(source_update_tag)
 
+        # Determine whether or not this project sync needs to populate the cache for Ansible content, roles and collections
         has_cache = os.path.exists(os.path.join(project.get_cache_path(), project.cache_id))
         # Galaxy requirements are not supported for manual projects
         if project.scm_type and ((not has_cache) or branch_override):

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -1,14 +1,18 @@
 import time
 
+import pytest
+
 # These tests are invoked from the awx/main/tests/live/ subfolder
 # so any fixtures from higher-up conftest files must be explicitly included
 from awx.main.tests.functional.conftest import *  # noqa
 
+from awx.main.models import Organization
 
-def wait_to_leave_status(job, status, timeout=25, sleep_time=0.1):
+
+def wait_to_leave_status(job, status, timeout=30, sleep_time=0.1):
     """Wait until the job does NOT have the specified status with some timeout
 
-    the default timeout of 25 if chosen because the task manager runs on a 20 second
+    the default timeout is based on the task manager running a 20 second
     schedule, and the API does not guarentee working jobs faster than this
     """
     start = time.time()
@@ -26,3 +30,11 @@ def wait_for_job(job, final_status='successful', running_timeout=800):
     wait_to_leave_status(job, 'running', timeout=running_timeout)
 
     assert job.status == final_status, f'Job was not successful id={job.id} status={job.status}'
+
+
+@pytest.fixture(scope='session')
+def default_org():
+    org = Organization.objects.filter(name='Default').first()
+    if org is None:
+        raise Exception('Tests expect Default org to already be created and it is not')
+    return org

--- a/awx/main/tests/live/tests/projects/test_requirements.py
+++ b/awx/main/tests/live/tests/projects/test_requirements.py
@@ -1,0 +1,56 @@
+import os
+import time
+
+import pytest
+
+from django.conf import settings
+
+from awx.main.tests.live.tests.conftest import wait_for_job
+
+from awx.main.models import Project, SystemJobTemplate
+
+
+@pytest.fixture(scope='session')
+def project_with_requirements(default_org):
+    project, _ = Project.objects.get_or_create(
+        name='project-with-requirements',
+        scm_url='https://github.com/ansible/test-playbooks.git',
+        scm_branch="with_requirements",
+        scm_type='git',
+        organization=default_org,
+    )
+    start = time.time()
+    while time.time() - start < 3.0:
+        if project.current_job or project.last_job or project.last_job_run:
+            break
+    assert project.current_job or project.last_job or project.last_job_run, f'Project never updated id={project.id}'
+    update = project.current_job or project.last_job
+    if update:
+        wait_for_job(update)
+    return project
+
+
+def project_cache_is_populated(project):
+    proj_cache = os.path.join(project.get_cache_path(), project.cache_id)
+    return os.path.exists(proj_cache)
+
+
+def test_cache_is_populated_after_cleanup_job(project_with_requirements):
+    assert project_with_requirements.cache_id is not None  # already updated, should be something
+    cache_path = os.path.join(settings.PROJECTS_ROOT, '.__awx_cache')
+    assert os.path.exists(cache_path)
+
+    assert project_cache_is_populated(project_with_requirements)
+
+    cleanup_sjt = SystemJobTemplate.objects.get(name='Cleanup Job Details')
+    cleanup_job = cleanup_sjt.create_unified_job(extra_vars={'days': 0})
+    cleanup_job.signal_start()
+    wait_for_job(cleanup_job)
+
+    project_with_requirements.refresh_from_db()
+    assert project_with_requirements.cache_id is not None
+    update = project_with_requirements.update()
+    wait_for_job(update)
+
+    # Now, we still have a populated cache
+    assert project_cache_is_populated(project_with_requirements)


### PR DESCRIPTION
##### SUMMARY
Requires for testing https://github.com/ansible/awx/pull/15688

This fixes an issue where we used the wrong cache id (for `requirements.yml`) for both new projects and after running cleanup_jobs.

The problem wasn't what I expected and described in conversations with @lucas-benedito, where we thought it was because the last job id was cleared (thus None) and needed to be thrown away. The problem was that for pretty much any "check" type update it was using the _last_ related project update when it should be using the _current_ update id, which would be the current job. You run a project update, and that update should save the content to the folder with its id for a name. Later "sync" updates probably got this right eventually, but only by doing an extra update. Again, because of misuse of current/last update id.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 