### PR TITLE
cli: fix `TypeError` in `HelpfulArgumentParser` for python 3.12.8 and 3.13.1

### DIFF
--- a/awxkit/awxkit/cli/utils.py
+++ b/awxkit/awxkit/cli/utils.py
@@ -40,14 +40,6 @@ class HelpfulArgumentParser(ArgumentParser):
         self._print_message('\n')
         self.exit(2, '%s: %s\n' % (self.prog, message))
 
-    def _parse_known_args(self, args, ns):
-        for arg in ('-h', '--help'):
-            # the -h argument is extraneous; if you leave it off,
-            # awx-cli will just print usage info
-            if arg in args:
-                args.remove(arg)
-        return super(HelpfulArgumentParser, self)._parse_known_args(args, ns)
-
 
 def color_enabled():
     return _color.enabled


### PR DESCRIPTION
##### SUMMARY

This PR removes the `_parse_known_args` override from `HelpfulArgumentParser`, since it raises a `TypeError` in Python 3.12.8 and 3.13.1 and above. Removing this override was suggested in https://github.com/ansible/awx/pull/15692#pullrequestreview-2847468322.

Resolves https://github.com/ansible/awx/issues/15687.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI

##### AWX VERSION
```
awx: 0.1.dev34249+g91bb012
```


##### ADDITIONAL INFORMATION
N/A