### PR TITLE
Do not fast forward rrule if count is set

### DIFF
--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -64,6 +64,9 @@ def _fast_forward_rrule(rrule, ref_dt=None):
     if rrule._freq not in {dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY}:
         return rrule
 
+    if rrule._count:
+        return rrule
+
     if ref_dt is None:
         ref_dt = now()
 

--- a/awx/main/tests/unit/utils/test_schedule_fast_forward.py
+++ b/awx/main/tests/unit/utils/test_schedule_fast_forward.py
@@ -115,6 +115,12 @@ def test_future_date_does_not_fast_forward():
     assert new_rrule == rrule
 
 
+def test_rrule_with_count_does_not_fast_forward():
+    rrule = dateutil.rrule.rrule(freq=MINUTELY, interval=5, count=1, dtstart=REF_DT)
+
+    assert rrule == _fast_forward_rrule(rrule, ref_dt=REF_DT)
+
+
 @pytest.mark.parametrize(
     ('freq', 'interval'),
     [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes a bug where a schedule that was created to run only once will continue to run repeatedly.

e.g. an rrule with
dtstart 20240730; count 1; freq MINUTELY

This job will run on 20240730, and should never run again.

However, the next time the schedule update_computed_fields runs, the dtstart will fast forward to today's date, and next_run will be computed from that. This will trigger the job to run again, which is not intended.

If count is set, we just should not fast forward the rrule and always calculate next_run based on original dtstart.

I missed this conditional when making the fast forwarded changes https://github.com/ansible/awx/pull/15601/files#diff-4e2b0c51faca14c32936465e8d8ce1d88673c02b45b684970f0df2aeb5091f46L220

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

