### PR TITLE
bump sqlparse to meet DAB requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -470,7 +470,7 @@ slack-sdk==3.27.0
     # via -r /awx_devel/requirements/requirements.in
 smmap==5.0.1
     # via gitdb
-sqlparse==0.5.1
+sqlparse==0.5.3
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
CI failing with

```
#19 71.13 The conflict is caused by:
#19 71.13     The user requested sqlparse==0.5.1
#19 71.13     django 4.2.16 depends on sqlparse>=0.3.1
#19 71.13     django-ansible-base[jwt-consumer,rbac,resource-registry,rest-filters] 2024.12.10.0.dev55+gefb0855 depends on sqlparse>=0.5.2
```

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


