### PR TITLE
AAP-36536 Send job_lifecycle logs to external loggers

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -592,7 +592,7 @@ register(
 register(
     'LOG_AGGREGATOR_LOGGERS',
     field_class=fields.StringListField,
-    default=['awx', 'activity_stream', 'job_events', 'system_tracking', 'broadcast_websocket'],
+    default=['awx', 'activity_stream', 'job_events', 'system_tracking', 'broadcast_websocket', 'job_lifecycle'],
     label=_('Loggers Sending Data to Log Aggregator Form'),
     help_text=_(
         'List of loggers that will send HTTP logs to the collector, these can '
@@ -602,6 +602,7 @@ register(
         'job_events - callback data from Ansible job events\n'
         'system_tracking - facts gathered from scan jobs\n'
         'broadcast_websocket - errors pertaining to websockets broadcast metrics\n'
+        'job_lifecycle - logs related to processing of a job\n'
     ),
     category=_('Logging'),
     category_slug='logging',

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1625,7 +1625,7 @@ class UnifiedJob(
         elif state == "execution_node_chosen":
             extra["execution_node"] = self.execution_node or "NOT_SET"
 
-        logger_job_lifecycle.info(f"{msg} {json.dumps(extra)}", extra={'lifecycle_data': extra})
+        logger_job_lifecycle.info(f"{msg} {json.dumps(extra)}", extra={'lifecycle_data': extra, 'organization_id': self.organization_id})
 
     @property
     def launched_by(self):

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1625,7 +1625,7 @@ class UnifiedJob(
         elif state == "execution_node_chosen":
             extra["execution_node"] = self.execution_node or "NOT_SET"
 
-        logger_job_lifecycle.info(f"{msg} {json.dumps(extra)}")
+        logger_job_lifecycle.info(f"{msg} {json.dumps(extra)}", extra={'lifecycle_data': extra})
 
     @property
     def launched_by(self):

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -160,6 +160,9 @@ class LogstashFormatter(LogstashFormatterBase):
             data = json.loads(data)
         data_for_log = {}
 
+        if 'lifecycle_data' in raw_data:
+            data_for_log['lifecycle_data'] = raw_data['lifecycle_data']
+
         if kind == 'job_events' and raw_data.get('python_objects', {}).get('job_event'):
             job_event = raw_data['python_objects']['job_event']
             guid = job_event.event_data.pop('guid', None)

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -160,6 +160,7 @@ class LogstashFormatter(LogstashFormatterBase):
             data = json.loads(data)
         data_for_log = {}
 
+        # For the job_lifecycle logger
         if 'lifecycle_data' in raw_data:
             data_for_log['lifecycle_data'] = raw_data['lifecycle_data']
 

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -160,9 +160,10 @@ class LogstashFormatter(LogstashFormatterBase):
             data = json.loads(data)
         data_for_log = {}
 
-        # For the job_lifecycle logger
-        if 'lifecycle_data' in raw_data:
-            data_for_log['lifecycle_data'] = raw_data['lifecycle_data']
+        # For the job_lifecycle logger, copy some raw data fields directly
+        for key in ('lifecycle_data', 'organization_id'):
+            if key in raw_data:
+                data_for_log[key] = raw_data[key]
 
         if kind == 'job_events' and raw_data.get('python_objects', {}).get('job_event'):
             job_event = raw_data['python_objects']['job_event']

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -783,7 +783,7 @@ LOGGING = {
         'awx.analytics': {'handlers': ['external_logger'], 'level': 'INFO', 'propagate': False},
         'awx.analytics.broadcast_websocket': {'handlers': ['console', 'file', 'wsrelay', 'external_logger'], 'level': 'INFO', 'propagate': False},
         'awx.analytics.performance': {'handlers': ['console', 'file', 'tower_warnings', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
-        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle'], 'level': 'DEBUG', 'propagate': False},
+        'awx.analytics.job_lifecycle': {'handlers': ['console', 'job_lifecycle', 'external_logger'], 'level': 'DEBUG', 'propagate': False},
         'social': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},

--- a/tools/docker-compose/docs/logstash.md
+++ b/tools/docker-compose/docs/logstash.md
@@ -22,7 +22,8 @@ authentication set up inside of the logstash configuration file).
         "awx",
         "activity_stream",
         "job_events",
-        "system_tracking"
+        "system_tracking",
+        "job_lifecycle"
     ],
     "LOG_AGGREGATOR_INDIVIDUAL_FACTS": false,
     "LOG_AGGREGATOR_TOWER_UUID": "991ac7e9-6d68-48c8-bbde-7ca1096653c6",


### PR DESCRIPTION
##### SUMMARY
Steps to reproduce, run the server

```
COMPOSE_OPTS="-f tools/docker-compose/logstash-override.yaml" COMPOSE_TAG=devel make docker-compose
```

Now set up the logging according to the instructions in `tools/docker-compose/docs/logstash.md`

Launch the Demo JT, wait for it to finish, then check for a specific log with this:

```
docker exec -i -t $(docker ps -aqf "name=tools_logstash_1") grep wrapup /logstash.log
```

Initially, this returns no results.

Now, apply this patch, launch Demo JT again, wait for finish, re-run same:

```
$ docker exec -i -t $(docker ps -aqf "name=tools_logstash_1") grep wrapup /logstash.log
{"headers":{"remote_user":"awx_logger","http_accept":"*/*","content_type":"application/json; charset=utf-8","request_path":"/","http_version":"HTTP/1.1","http_authorization":"Basic YXd4X2xvZ2dlcjp3b3JrZmxvd3M=","request_method":"POST","http_host":"logstash:8085","request_uri":"/","content_length":"394"},"@timestamp":"2024-12-11T15:55:22.808Z","level":"INFO","cluster_host_id":"awx-1","@version":"1","host":"awx-1","logger_name":"awx.analytics.job_lifecycle","message":"job-6 stats wrapup finished {\"type\": \"job\", \"task_id\": 6, \"state\": \"stats_wrapup_finished\", \"work_unit_id\": \"awx1x2f2sPdQ\", \"task_name\": \"Demo Job Template\"}","tower_uuid":"00000000-0000-0000-0000-000000000000"}
```

So right there, we get a job_lifecycle log sent to logstash. The end.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
