### PR TITLE
host_metrics date fix to make summary dates (datetime.datetime) comparable to month: datetime.date

### DIFF
--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -221,7 +221,7 @@ class HostMetricSummaryMonthlyTask:
             self.records_to_update.append(summary)
         return summary
 
-    def _find_summary(self, month):
+    def _find_summary(self, month: datetime.date):
         """
         Existing summaries are ordered by month ASC.
         This method is called with month in ascending order too => only 1 traversing is enough
@@ -229,11 +229,11 @@ class HostMetricSummaryMonthlyTask:
         summary = None
         while not summary and self.existing_summaries_idx < self.existing_summaries_cnt:
             tmp = self.existing_summaries[self.existing_summaries_idx]
-            if tmp.date < month:
+            if tmp.date.date() < month:  # Normalize tmp.date to a datetime.date object
                 self.existing_summaries_idx += 1
-            elif tmp.date == month:
+            elif tmp.date.date() == month:  # Normalize here too
                 summary = tmp
-            elif tmp.date > month:
+            elif tmp.date.date() > month:
                 break
         return summary
 

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -229,11 +229,11 @@ class HostMetricSummaryMonthlyTask:
         summary = None
         while not summary and self.existing_summaries_idx < self.existing_summaries_cnt:
             tmp = self.existing_summaries[self.existing_summaries_idx]
-            if tmp.date.date() < month:
+            if tmp.date < month:
                 self.existing_summaries_idx += 1
-            elif tmp.date.date() == month:
+            elif tmp.date == month:
                 summary = tmp
-            elif tmp.date.date() > month:
+            elif tmp.date > month:
                 break
         return summary
 

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -229,7 +229,7 @@ class HostMetricSummaryMonthlyTask:
         summary = None
         while not summary and self.existing_summaries_idx < self.existing_summaries_cnt:
             tmp = self.existing_summaries[self.existing_summaries_idx]
-            if isinstance(tmp, datetime):
+            if isinstance(tmp, datetime.datetime):
                 tmp = tmp.date()
             if tmp.date < month:
                 self.existing_summaries_idx += 1

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -229,9 +229,9 @@ class HostMetricSummaryMonthlyTask:
         summary = None
         while not summary and self.existing_summaries_idx < self.existing_summaries_cnt:
             tmp = self.existing_summaries[self.existing_summaries_idx]
-            if tmp.date.date() < month:  # Normalize tmp.date to a datetime.date object
+            if tmp.date.date() < month:
                 self.existing_summaries_idx += 1
-            elif tmp.date.date() == month:  # Normalize here too
+            elif tmp.date.date() == month:
                 summary = tmp
             elif tmp.date.date() > month:
                 break

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -229,6 +229,8 @@ class HostMetricSummaryMonthlyTask:
         summary = None
         while not summary and self.existing_summaries_idx < self.existing_summaries_cnt:
             tmp = self.existing_summaries[self.existing_summaries_idx]
+            if isinstance(tmp, datetime):
+                tmp = tmp.date()
             if tmp.date < month:
                 self.existing_summaries_idx += 1
             elif tmp.date == month:


### PR DESCRIPTION
##### SUMMARY
 Related to #36839 https://issues.redhat.com/browse/AAP-36839 
 Fixing date comparison mismatch (datetime.datetime is not compariable to datetime.date)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Other 

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6.2.dev194+g75f17857c0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
