### PR TITLE
Upload container logs for live tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
       - uses: ./.github/actions/upload_awx_devel_logs
         if: always()
         with:
-          log-filename: live-tests-${{ matrix.target-regex.name }}.log
+          log-filename: live-tests.log
 
   awx-operator:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,11 @@ jobs:
       - name: Run live dev env tests
         run: docker exec tools_awx_1 /bin/bash -c "make live_test"
 
+      - uses: ./.github/actions/upload_awx_devel_logs
+        if: always()
+        with:
+          log-filename: live-tests-${{ matrix.target-regex.name }}.log
+
   awx-operator:
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
##### SUMMARY
Looking at https://github.com/ansible/awx/pull/15705, it seems the task manager isn't running, ping @jessicamack 

We need to see the logs to get hints as to what is happening, but the tests don't upload the logs.

The "live" tests are weird, sometimes server logs are emitted in the `pytest` process, which are captured in the test output. But it's split, because some work is ping-ponged to the task system, so those logs can only be obtained by asynchronous getting the server logs after the tests finish.

This is already a solved problem, but wasn't solved for these tests.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
