### PR TITLE
Fix test warnings that escaped somehow

### DIFF
--- a/awx/main/tests/functional/models/test_workflow.py
+++ b/awx/main/tests/functional/models/test_workflow.py
@@ -377,7 +377,7 @@ class TestWorkflowJobTemplatePrompts:
         assert workflow_job.scm_branch is None
         assert workflow_job.job_tags is None
         assert workflow_job.skip_tags is None
-        assert len(workflow_job.labels.all()) is 0
+        assert len(workflow_job.labels.all()) == 0
 
         # fields from prompts used
         workflow_job = workflow_job_template.create_unified_job(**prompts_data)

--- a/awx/main/tests/unit/utils/test_common.py
+++ b/awx/main/tests/unit/utils/test_common.py
@@ -318,7 +318,7 @@ class TestHostnameRegexValidator:
 
     def test_good_call(self, regex_expr, re_flags):
         h = HostnameRegexValidator(regex=regex_expr, flags=re_flags)
-        assert (h("192.168.56.101"), None)
+        assert h("192.168.56.101") is None
 
     def test_bad_call(self, regex_expr, re_flags):
         h = HostnameRegexValidator(regex=regex_expr, flags=re_flags)
@@ -336,4 +336,4 @@ class TestHostnameRegexValidator:
 
     def test_bad_call_with_inverse(self, regex_expr, re_flags, inverse_match=True):
         h = HostnameRegexValidator(regex=regex_expr, flags=re_flags, inverse_match=inverse_match)
-        assert (h("@#$%)$#(TUFAS_DG"), None)
+        assert h("@#$%)$#(TUFAS_DG") is None


### PR DESCRIPTION
##### SUMMARY
Looking at the output of another test:

```
awx/main/tests/functional/test_rbac_credential.py .                      [ 97%]
awx/conf/tests/test_env.py .                                             [ 97%]
awx/conf/tests/unit/test_fields.py ..................................... [ 98%]
..................                                                       [ 98%]
awx/conf/tests/unit/test_registry.py ...............                     [ 99%]
/awx_devel/awx/main/tests/functional/models/test_workflow.py:380: SyntaxWarning: "is" with a literal. Did you mean "=="?
  assert len(workflow_job.labels.all()) is 0
/awx_devel/awx/main/tests/unit/utils/test_common.py:321: SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert (h("192.168.56.101"), None)
/awx_devel/awx/main/tests/unit/utils/test_common.py:[339](https://github.com/ansible/awx/actions/runs/12396891431/job/34605975660?pr=15711#step:4:340): SyntaxWarning: assertion is always true, perhaps remove parentheses?
  assert (h("@#$%)$#(TUFAS_DG"), None)
awx/conf/tests/unit/test_settings.py ..........................          [100%]
```

Warnings were supposed to be blocking with recent @webknjaz changes, so I can't really tell you what's going on.

But the 2 issues are obviously correct and trivial to fix, so let's do it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

