### PR TITLE
AAP-36604 (analytics) Thousands of zombie/orphaned Slow/Stuck DB queries in controller querying active host count

### DIFF
--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -93,8 +93,10 @@ class HostMetricTask:
 
 class HostMetricSummaryMonthlyTask:
     LOCK_KEY = 'host_metric_summary_monthly'
-    LOCK_SESSION_TIMEOUT = 30000
+    
+    LOCK_SESSION_TIMEOUT = 300000  # 5 minutes. 
     """
+    Task runs every four hours, longer lock timeout avoids premature termination due to high db load or other latency.
     This task computes last [threshold] months of HostMetricSummaryMonthly table
     [threshold] is setting CLEANUP_HOST_METRICS_HARD_THRESHOLD
     Each record in the table represents changes in HostMetric table in one month

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -11,6 +11,8 @@ from awx.main.dispatch.publish import task
 from awx.main.models.inventory import HostMetric, HostMetricSummaryMonthly
 from awx.main.tasks.helpers import is_run_threshold_reached
 from awx.conf.license import get_license
+from awx.main.utils.pglock import advisory_lock
+
 
 logger = logging.getLogger('awx.main.tasks.host_metrics')
 
@@ -90,6 +92,8 @@ class HostMetricTask:
 
 
 class HostMetricSummaryMonthlyTask:
+    LOCK_KEY = 'host_metric_summary_monthly'
+    LOCK_SESSION_TIMEOUT = 30000
     """
     This task computes last [threshold] months of HostMetricSummaryMonthly table
     [threshold] is setting CLEANUP_HOST_METRICS_HARD_THRESHOLD
@@ -115,29 +119,37 @@ class HostMetricSummaryMonthlyTask:
         self.records_to_update = []
 
     def execute(self):
-        self._load_existing_summaries()
-        self._load_hosts_added()
-        self._load_hosts_deleted()
 
-        # Get first month after last hard delete
-        month = self._get_first_month()
-        license_consumed = self._get_license_consumed_before(month)
+        with advisory_lock(
+            HostMetricSummaryMonthlyTask.LOCK_KEY, lock_session_timeout_milliseconds=HostMetricSummaryMonthlyTask.LOCK_SESSION_TIMEOUT, wait=False
+        ) as acquired:
+            if not acquired:
+                logger.info("Another instance of host_metric_summary_monthly is already running. Exiting.")
+                return
 
-        # Fill record for each month
-        while month <= datetime.date.today().replace(day=1):
-            summary = self._find_or_create_summary(month)
-            # Update summary and update license_consumed by hosts added/removed this month
-            self._update_summary(summary, month, license_consumed)
-            license_consumed = summary.license_consumed
+            self._load_existing_summaries()
+            self._load_hosts_added()
+            self._load_hosts_deleted()
 
-            month = month + relativedelta(months=1)
+            # Get first month after last hard delete
+            month = self._get_first_month()
+            license_consumed = self._get_license_consumed_before(month)
 
-        # Create/Update stats
-        HostMetricSummaryMonthly.objects.bulk_create(self.records_to_create, batch_size=1000)
-        HostMetricSummaryMonthly.objects.bulk_update(self.records_to_update, ['license_consumed', 'hosts_added', 'hosts_deleted'], batch_size=1000)
+            # Fill record for each month
+            while month <= datetime.date.today().replace(day=1):
+                summary = self._find_or_create_summary(month)
+                # Update summary and update license_consumed by hosts added/removed this month
+                self._update_summary(summary, month, license_consumed)
+                license_consumed = summary.license_consumed
 
-        # Set timestamp of last run
-        settings.HOST_METRIC_SUMMARY_TASK_LAST_TS = now()
+                month = month + relativedelta(months=1)
+
+            # Create/Update stats
+            HostMetricSummaryMonthly.objects.bulk_create(self.records_to_create, batch_size=1000)
+            HostMetricSummaryMonthly.objects.bulk_update(self.records_to_update, ['license_consumed', 'hosts_added', 'hosts_deleted'], batch_size=1000)
+
+            # Set timestamp of last run
+            settings.HOST_METRIC_SUMMARY_TASK_LAST_TS = now()
 
     def _get_license_consumed_before(self, month):
         license_consumed = 0

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -93,8 +93,7 @@ class HostMetricTask:
 
 class HostMetricSummaryMonthlyTask:
     LOCK_KEY = 'host_metric_summary_monthly'
-    
-    LOCK_SESSION_TIMEOUT = 300000  # 5 minutes. 
+    LOCK_SESSION_TIMEOUT = 300000  # 5 minutes.
     """
     Task runs every four hours, longer lock timeout avoids premature termination due to high db load or other latency.
     This task computes last [threshold] months of HostMetricSummaryMonthly table


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Related #[AAP-36604]
(analytics) Thousands of zombie/orphaned Slow/Stuck DB queries in controller querying active host count

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6.2.dev198+ge2be654df3
```


##### ADDITIONAL INFORMATION

Identified that HostMetricSummaryMonthlyTask was running once per node, but only needed to be run once, so wrapped the execution with an advisory_lock similar to how it's done in system.py 

From comment by [Elijah DeLee](https://issues.redhat.com/secure/ViewProfile.jspa?name=elijahd)  on [AAP-36604](https://issues.redhat.com/browse/AAP-36604)
```
...this one (Jira ticket) for running the analytics/hostmetrics stuff on every single node.


Note we see this exception on postgres:

2024-11-26 12:50:18.892 UTC [2431843] ERROR:  duplicate key value violates unique constraint "main_hostmetricsummarymonthly_date_key"
2024-11-26 12:50:18.892 UTC [2431843] DETAIL:  Key (date)=(2021-12-01) already exists.
2024-11-26 12:50:18.892 UTC [2431843] STATEMENT:  INSERT INTO "main_hostmetricsummarymonthly" ("date", "license_consumed", "license_capacity", "hosts_added", "hosts_deleted", "indirectly_managed_hosts") VALUES ('2021-12-01'::date, 0, 0, 0, 0, 0), ('2022-01-01'::date, 0, 0, 0, 0, 0), ('2022-02-01'::date, 0, 0, 0, 0, 0), ('2022-03-01'::date, 0, 0, 0, 0, 0), ('2022-04-01'::date, 0, 0, 0, 0, 0), ('2022-05-01'::date, 0, 0, 0, 0, 0), ('2022-06-01'::date, 0, 0, 0, 0, 0), ('2022-07-...
 
further underlining issue that we are running same task on multiple controller nodes when we really should acquire some kind of advisory lock and only run it on one for each schedule.

```

```
