### PR TITLE
Cleanup in-memory data from test that randomly causes other failures

### DIFF
--- a/awx/main/tests/functional/test_inventory_source_migration.py
+++ b/awx/main/tests/functional/test_inventory_source_migration.py
@@ -31,8 +31,15 @@ def test_apply_new_instance_id(inventory_source):
     assert host2.instance_id == 'bad_user'
 
 
+def cleanup_cloudforms():
+    if 'cloudforms' in ManagedCredentialType.registry:
+        del ManagedCredentialType.registry['cloudforms']
+    assert 'cloudforms' not in CredentialType.defaults
+
+
 @pytest.mark.django_db
-def test_cloudforms_inventory_removal(inventory):
+def test_cloudforms_inventory_removal(request, inventory):
+    request.addfinalizer(cleanup_cloudforms)
     ManagedCredentialType(
         name='Red Hat CloudForms',
         namespace='cloudforms',


### PR DESCRIPTION
##### SUMMARY
Discovered in https://github.com/ansible/awx/pull/15711 that did nothing at all related to this

this is a test ordering bug, because the test added to the registry.

This patch removes the test data from the registry.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

