### PR TITLE
Fix rsyslog permission error in github ubuntu tests from apparmor

### DIFF
--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -16,6 +16,12 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Disable apparmor for rsyslogd, first step
+      run: sudo ln -s /etc/apparmor.d/usr.sbin.rsyslogd /etc/apparmor.d/disable/
+
+    - name: Disable apparmor for rsyslogd, second step
+      run: sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.rsyslogd
+
     - name: Build awx_devel image for running checks
       uses: ./.github/actions/awx_devel_image
       with:

--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -17,9 +17,11 @@ runs:
   using: composite
   steps:
     - name: Disable apparmor for rsyslogd, first step
+      shell: bash
       run: sudo ln -s /etc/apparmor.d/usr.sbin.rsyslogd /etc/apparmor.d/disable/
 
     - name: Disable apparmor for rsyslogd, second step
+      shell: bash
       run: sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.rsyslogd
 
     - name: Build awx_devel image for running checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
           build-ui: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: get info on apparmor
+        run: sudo dmesg
+
       - name: Run live dev env tests
         run: docker exec tools_awx_1 /bin/bash -c "make live_test"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,9 +139,6 @@ jobs:
           build-ui: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: get info on apparmor
-        run: sudo dmesg
-
       - name: Run live dev env tests
         run: docker exec tools_awx_1 /bin/bash -c "make live_test"
 

--- a/awx/main/tests/live/tests/test_devel_image.py
+++ b/awx/main/tests/live/tests/test_devel_image.py
@@ -1,0 +1,10 @@
+import os
+
+RSYSLOG_CONFIG = '/var/lib/awx/rsyslog/rsyslog.conf'
+
+
+def test_rsyslog_config_readable():
+    with open(RSYSLOG_CONFIG, 'r') as f:
+        content = f.read()
+        assert '/var/lib/awx/rsyslog' in content
+    assert oct(os.stat(RSYSLOG_CONFIG).st_mode) == '0o100640'


### PR DESCRIPTION
##### SUMMARY
We see an issue in the container logs, and this test is meant to make it a failure. Something about the image build and the ubuntu runners, probably.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

