### PR TITLE
Bugfix: adjust incorrectly passed keywords with exclude-strings argument

### DIFF
--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -360,7 +360,7 @@ def _convert_args_to_cli(vargs):
     args = ['cleanup']
     for option in ('exclude_strings', 'remove_images'):
         if vargs.get(option):
-            args.append('--{} {}'.format(option.replace('_', '-'), ' '.join(vargs.get(option))))
+            args.append('--{} {}'.format(option.replace('_', '-'), ' '.join(f'"{item}"' for item in vargs.get(option))))
     for option in ('file_pattern', 'image_prune', 'process_isolation_executable', 'grace_period'):
         if vargs.get(option) is True:
             args.append('--{}'.format(option.replace('_', '-')))

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -360,7 +360,7 @@ def _convert_args_to_cli(vargs):
     args = ['cleanup']
     for option in ('exclude_strings', 'remove_images'):
         if vargs.get(option):
-            args.append('--{}="{}"'.format(option.replace('_', '-'), ' '.join(vargs.get(option))))
+            args.append('--{} {}'.format(option.replace('_', '-'), ' '.join(vargs.get(option))))
     for option in ('file_pattern', 'image_prune', 'process_isolation_executable', 'grace_period'):
         if vargs.get(option) is True:
             args.append('--{}'.format(option.replace('_', '-')))

--- a/awx/main/tests/unit/utils/test_receptor.py
+++ b/awx/main/tests/unit/utils/test_receptor.py
@@ -3,7 +3,7 @@ from awx.main.tasks.receptor import _convert_args_to_cli
 
 def test_file_cleanup_scenario():
     args = _convert_args_to_cli({'exclude_strings': ['awx_423_', 'awx_582_'], 'file_pattern': '/tmp/awx_*_*'})
-    assert ' '.join(args) == 'cleanup --exclude-strings="awx_423_ awx_582_" --file-pattern=/tmp/awx_*_*'
+    assert ' '.join(args) == 'cleanup --exclude-strings awx_423_ awx_582_ --file-pattern=/tmp/awx_*_*'
 
 
 def test_image_cleanup_scenario():

--- a/awx/main/tests/unit/utils/test_receptor.py
+++ b/awx/main/tests/unit/utils/test_receptor.py
@@ -3,7 +3,7 @@ from awx.main.tasks.receptor import _convert_args_to_cli
 
 def test_file_cleanup_scenario():
     args = _convert_args_to_cli({'exclude_strings': ['awx_423_', 'awx_582_'], 'file_pattern': '/tmp/awx_*_*'})
-    assert ' '.join(args) == 'cleanup --exclude-strings awx_423_ awx_582_ --file-pattern=/tmp/awx_*_*'
+    assert ' '.join(args) == 'cleanup --exclude-strings "awx_423_" "awx_582_" --file-pattern=/tmp/awx_*_*'
 
 
 def test_image_cleanup_scenario():
@@ -17,5 +17,6 @@ def test_image_cleanup_scenario():
         }
     )
     assert (
-        ' '.join(args) == 'cleanup --remove-images="quay.invalid/foo/bar:latest quay.invalid/foo/bar:devel" --image-prune --process-isolation-executable=podman'
+        ' '.join(args)
+        == 'cleanup --remove-images "quay.invalid/foo/bar:latest" "quay.invalid/foo/bar:devel" --image-prune --process-isolation-executable=podman'
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR addresses an issue with how the `--exclude-strings` argument is passed to `ansible-runner` during the cleanup task.

##### Issue
When `--exclude-strings` is passed with quotes, such as:
- `--exclude-strings="awx_1, awx_2"`
- `--exclude-strings="awx_1 awx_2"`

The argument is treated as a single string, and `ansible-runner` receives it as: `["awx_1 awx_2"]` or `["awx_1, awx_2"]`.
This causes the exclusion logic to fail and as a result, directories or files specified in `--exclude-strings` are not excluded from cleanup.

##### Impact
Due to this bug, the `ansible-runner worker cleanup` command removes directories and files that are intended to be excluded by the `--exclude-strings` argument.
In our case, this bug results in running jobs being killed by the cleanup task triggered by another job on the same execution node.
**I suspect this issue may have contributed to the "JSON error" problems that have been frequently reported.** (like [14693](https://github.com/ansible/awx/issues/14693), [15657](https://github.com/ansible/awx/issues/15657), [15122](https://github.com/ansible/awx/issues/15122))
##### Expected Behavior:
When `--exclude-strings` is passed without quotes and the `=` sign, like: `--exclude-strings awx_1 awx_2`, `ansible-runner` correctly parses it into a list of separate strings: `["awx_1", "awx_2"]`.
This allows the cleanup process to properly exclude the specified directories or files.
<!--- 
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.6.2.dev205+g3d7a4b20f1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
