### PR TITLE
Add full api restriction setting (#15656)

### DIFF
--- a/awx/conf/tests/unit/test_validators.py
+++ b/awx/conf/tests/unit/test_validators.py
@@ -1,0 +1,23 @@
+import pytest
+from rest_framework import serializers
+
+from awx.api.conf import allowed_urls_validate
+from awx.settings.defaults import ANONYMOUS_ACCESS_API_ALLOWED_PATHS as DEFAULT_ALLOWED_PATHS
+
+
+class TestAllowedUrlsValidator:
+
+    def test_ok_validator(self):
+        attrs = {'ANONYMOUS_ACCESS_API_ALLOWED_PATHS': DEFAULT_ALLOWED_PATHS}
+        allowed_urls_validate(None, attrs)
+
+    def test_all_validator(self):
+        attrs = {'ANONYMOUS_ACCESS_API_ALLOWED_PATHS': []}
+        allowed_urls_validate(None, attrs)
+        assert attrs.get('ANONYMOUS_ACCESS_API_ALLOWED_PATHS') == DEFAULT_ALLOWED_PATHS
+
+    def test_wrong_path_validator(self):
+        attrs = {'ANONYMOUS_ACCESS_API_ALLOWED_PATHS': DEFAULT_ALLOWED_PATHS + ['not_a_path']}
+
+        with pytest.raises(serializers.ValidationError):
+            allowed_urls_validate(None, attrs)

--- a/awx/main/tests/unit/test_middleware.py
+++ b/awx/main/tests/unit/test_middleware.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import patch
+
+from django.contrib.auth.models import AnonymousUser
+from django.http import JsonResponse, HttpResponse
+from rest_framework.test import APIRequestFactory
+
+from awx.main.middleware import AnonymousAccessRestrictionMiddleware
+
+
+@pytest.fixture
+def access_restriction_middleware():
+    return AnonymousAccessRestrictionMiddleware(lambda request: HttpResponse())
+
+
+@pytest.fixture
+def mock_user(is_authenticated):
+    return type("User", (), {"is_authenticated": is_authenticated})()
+
+
+class TestAnonymousAccessRestrictionMiddleware:
+    @pytest.mark.parametrize(
+        "is_authenticated,expected_response",
+        [
+            (False, JsonResponse),  # Anonymous user, restricted path
+            (True, None),  # Authenticated user, not restricted
+        ],
+    )
+    @patch("django.conf.settings.RESTRICT_API_ANONYMOUS_ACCESS", True)
+    @patch("django.conf.settings.ANONYMOUS_ACCESS_API_ALLOWED_PATHS", ["/api/public"])
+    def test_restricted_access_to_authenticated_only_path(self, access_restriction_middleware, mock_user, is_authenticated, expected_response):
+        request = APIRequestFactory().get("/api/secure-data")
+        request.user = mock_user
+        response = access_restriction_middleware.process_request(request)
+
+        if expected_response:
+            assert isinstance(response, expected_response)
+            assert response.status_code == 401
+        else:
+            assert response is None
+
+    @patch("django.conf.settings.RESTRICT_API_ANONYMOUS_ACCESS", True)
+    @patch("django.conf.settings.ANONYMOUS_ACCESS_API_ALLOWED_PATHS", ["/api/public"])
+    def test_allowed_path_for_anonymous_user(self, access_restriction_middleware):
+        """Test that anonymous users can access paths in the allowed list."""
+        request = APIRequestFactory().get("/api/public")
+        request.user = AnonymousUser()
+
+        response = access_restriction_middleware.process_request(request)
+        assert response is None
+
+    @patch("django.conf.settings.RESTRICT_API_ANONYMOUS_ACCESS", False)
+    def test_anonymous_access_when_restriction_disabled(self, access_restriction_middleware):
+        """Test that anonymous access is allowed when the restriction is disabled."""
+        request = APIRequestFactory().get("/api/secure-data")
+        request.user = AnonymousUser()  # Anonymous user
+
+        response = access_restriction_middleware.process_request(request)
+        assert response is None
+
+    def test_non_api_path_is_skipped(self, access_restriction_middleware):
+        """Test that non-API paths are skipped by the middleware."""
+        request = APIRequestFactory().get("/")
+        request.user = AnonymousUser()
+
+        response = access_restriction_middleware.process_request(request)
+        assert response is None

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -893,6 +893,7 @@ MIDDLEWARE = [
     'crum.CurrentRequestUserMiddleware',
     'awx.main.middleware.URLModificationMiddleware',
     'awx.main.middleware.SessionTimeoutMiddleware',
+    'awx.main.middleware.AnonymousAccessRestrictionMiddleware',
 ]
 
 # Secret header value to exchange for websockets responsible for distributing websocket messages.
@@ -1057,3 +1058,9 @@ SYSTEM_USERNAME = None
 
 # feature flags
 FLAGS = {}
+
+# Restrict access to all endpoints with exception for ANONYMOUS_ACCESS_API_ALLOWED_PATHS
+RESTRICT_API_ANONYMOUS_ACCESS = False
+
+# These are the essential endpoints required for authentication and token management for RESTRICT_API_ANONYMOUS_ACCESS.
+ANONYMOUS_ACCESS_API_ALLOWED_PATHS = ['/api/login/']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR introduces a new configuration option, RESTRICT_API_ANONYMOUS_ACCESS, to enhance security by allowing administrators to restrict unauthorized access to all AWX API endpoints, with the exception of those specified in ANONYMOUS_ACCESS_API_ALLOWED_PATHS. This feature is especially important for environments with strict security policies that require more control over which endpoints can be accessed without authentication. By default, this feature is disabled to ensure backward compatibility with existing setups.

This is related to https://github.com/ansible/awx/issues/15656, but more flexible

Proposal:

- Add a new setting RESTRICT_API_ANONYMOUS_ACCESS to enable or disable the restriction of anonymous access to the API.
- Introduce ANONYMOUS_ACCESS_API_ALLOWED_PATHS to define which paths can be accessed without authentication.
- Modify the middleware to enforce these restrictions, returning a 401 Unauthorized response for any unauthorized API access attempts.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
- The feature ensures that current installations remain unaffected by default, and administrators can opt-in based on their security needs.
