### PR TITLE
AAP-38230 Fix metrics pipe vs send buffering race condition

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -300,15 +300,15 @@ class Metrics(MetricsNamespace):
             return
         try:
             current_time = time.time()
+            serialized_metrics = self.serialize_local_metrics()
+            payload = {
+                'instance': self.instance_name,
+                'metrics': serialized_metrics,
+                'metrics_namespace': self._namespace,
+            }
+            # store the serialized data locally as well, so that load_other_metrics will read it
+            self.conn.set(root_key + '-' + self._namespace + '_instance_' + self.instance_name, serialized_metrics)
             if current_time - self.previous_send_metrics.decode(self.conn) > self.send_metrics_interval:
-                serialized_metrics = self.serialize_local_metrics()
-                payload = {
-                    'instance': self.instance_name,
-                    'metrics': serialized_metrics,
-                    'metrics_namespace': self._namespace,
-                }
-                # store the serialized data locally as well, so that load_other_metrics will read it
-                self.conn.set(root_key + '-' + self._namespace + '_instance_' + self.instance_name, serialized_metrics)
                 emit_channel_notification("metrics", payload)
 
                 self.previous_send_metrics.set(current_time)


### PR DESCRIPTION
##### SUMMARY
I believe this is a fix for test failures we've been seeing. I'll do a dump of notes here.

The failing test is `tests.api.external_data.test_metrics.TestMetrics.test_subsystem_metrics_counts_incremented_accurately`, and it fails because the `/api/v2/metrics/` count of metric `callback_receiver_events_insert_db` is the same before running an ad hoc command, as after it runs (flaky). This should not be the case! I have managed to manually confirm what it is saying - yes, the count _should_ update because we ran a command, and it produces events. But the count _fails_ to update, and this is a legitimate bug.

With the test ruled out, I dug deeper into what was going on, and I would start with observing these settings:

```python
# Interval in seconds for sending local metrics to other nodes
SUBSYSTEM_METRICS_INTERVAL_SEND_METRICS = 3

# Interval in seconds for saving local metrics to redis
SUBSYSTEM_METRICS_INTERVAL_SAVE_TO_REDIS = 2
```

These are essentially the buffering time frames for 2 different buffering loops. Let's look at that failure again:

```
py.test --inventory=playbooks/inventory-docker.py tests/api/external_data/test_metrics.py -k test_subsystem_metrics_counts_incremented_accurately -rsx --repeat=20
```

gives

```
7 failed, 13 passed, 300 deselected, 425 warnings in 262.38s (0:04:22)
```

Notice anything interesting about the pass/fail ratio? It seems to fail about... 1 out of 3 times? Let's look at those buffering loops, here is the logic with the send / don't-send logic for what I'll call the "pipe" loop:

https://github.com/ansible/awx/blob/9a5ed20ed5c9e90ffde2e014885f616ac9606b52/awx/main/analytics/subsystem_metrics.py#L265-L271

And the same send / don't-send logic for what I'll call the "send" loop:

https://github.com/ansible/awx/blob/9a5ed20ed5c9e90ffde2e014885f616ac9606b52/awx/main/analytics/subsystem_metrics.py#L298

You'll see that both of these gate based on the current time compared to a breadcrumb of the last time it ran. The bug here is when that breadcrumb gets set, like `self.last_pipe_execute = time.time()`. It sets that timestamp, but it _doesn't apply the settings to redis_.

The callback receiver calls `pipe_execute` which calls `send_metrics`. These represent the outer and inner buffering loops. Yet code inside of the inner loop takes both actions

1. apply local settings to local redis
2. send a websocket message to apply those to redis in other nodes

But (1) needs to be done whenever the `last_pipe_execute` time is set, and if you don't, then you'll get a bug where the local data fails to be purged on the last event of something. This is how we get the 1-out-of-3 probability. There is a 2/3rd chance that the inner and outer loops refresh at the same point-in-time. The 1/3rd chance has `pipe_execute` call `send_metrics` and then it evaluates that we shouldn't send metrics, and records nothing into redis.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
