### PR TITLE
Update dependencies to fix offline build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==69.0.2 setuptools_scm[toml]==8.0.4 wheel==0.42.0 cython==0.29.37
+VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==72.1.0 setuptools_scm[toml]==8.1.0 wheel==0.45.1 cython==3.0.11
 
 NAME ?= awx
 

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -62,6 +62,8 @@ If modifying these libraries make sure testing with the offline build is perform
 Versions need to match the versions used in the pip bootstrapping step
 in the top-level Makefile.
 
+Verify ansible-runner's build dependency doesn't conflict with the changes made.
+
 ### cryptography
 
 If modifying this library make sure testing with the offline build is performed to confirm it is functionally working.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,7 @@ JSON-log-formatter
 jsonschema
 Markdown  # used for formatting API help
 maturin  # pydantic-core build dep
-msgpack<1.0.6  # 1.0.6+ requires cython>=3
+msgpack
 msrestazure
 openshift
 opentelemetry-api~=1.24     # new y streams can be drastically different, in a good way

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -268,7 +268,7 @@ msal==1.31.1
     #   msal-extensions
 msal-extensions==1.2.0
     # via azure-identity
-msgpack==1.0.5
+msgpack==1.1.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels-redis
@@ -522,7 +522,7 @@ zope-interface==7.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
     # via -r /awx_devel/requirements/requirements.in
-setuptools==75.6.0
+setuptools==72.1.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   asciichartpy

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -92,7 +92,7 @@ click==8.1.7
     # via receptorctl
 constantly==23.10.4
     # via twisted
-cryptography==44.0.0
+cryptography==41.0.7
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   adal


### PR DESCRIPTION
##### SUMMARY
Follow-up for #15705 to fix offline build

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

- Updated `VENV_BOOTSTRAP` to match updates made in #15705 
- Downgraded setuptools to meet ansible-runner's build requirement
- Updated msgpack as cython is updated to >=3 and the existing version requires <3