### PR TITLE
Add test to ensure bootstrap reqs are good

### DIFF
--- a/awx/main/tests/functional/test_python_requirements.py
+++ b/awx/main/tests/functional/test_python_requirements.py
@@ -5,6 +5,33 @@ import pytest
 from django.conf import settings
 
 
+def test_bootstrap_consistent():
+    with open('Makefile', 'r') as f:
+        mk_data = f.read()
+    bootstrap_reqs = None
+    for line in mk_data.split('\n'):
+        if line.startswith('VENV_BOOTSTRAP'):
+            parts = line.split()
+            bootstrap_reqs = parts[parts.index('?=') + 1 :]
+            break
+    else:
+        raise RuntimeError('Cound not find bootstrap line')
+
+    req_data = None
+    with open('requirements/requirements.txt', 'r') as f:
+        req_data = f.read()
+
+    for req in bootstrap_reqs:
+        boot_req_name, _ = req.split('=', 1)
+        for line in req_data.split('\n'):
+            if '=' not in line:
+                continue
+            req_name, _ = line.split('=', 1)
+            if req_name == boot_req_name:
+                assert req == line
+                break
+
+
 @pytest.mark.skip(reason="This test needs some love")
 def test_env_matches_requirements_txt():
     from pip.operations import freeze

--- a/awx/main/tests/functional/test_python_requirements.py
+++ b/awx/main/tests/functional/test_python_requirements.py
@@ -21,6 +21,7 @@ def test_bootstrap_consistent():
     with open('requirements/requirements.txt', 'r') as f:
         req_data = f.read()
 
+    different_requirements = []
     for req in bootstrap_reqs:
         boot_req_name, _ = req.split('=', 1)
         for line in req_data.split('\n'):
@@ -28,8 +29,10 @@ def test_bootstrap_consistent():
                 continue
             req_name, _ = line.split('=', 1)
             if req_name == boot_req_name:
-                assert req == line
+                different_requirements.append((req, line))
                 break
+
+    assert not different_requirements
 
 
 @pytest.mark.skip(reason="This test needs some love")

--- a/awx/main/tests/functional/test_python_requirements.py
+++ b/awx/main/tests/functional/test_python_requirements.py
@@ -29,7 +29,8 @@ def test_bootstrap_consistent():
                 continue
             req_name, _ = line.split('=', 1)
             if req_name == boot_req_name:
-                different_requirements.append((req, line))
+                if req != line:
+                    different_requirements.append((req, line))
                 break
 
     assert not different_requirements


### PR DESCRIPTION
##### SUMMARY
Adds a regression test for what https://github.com/ansible/awx/pull/15732 by @saito-hideki fixes

It should fail until that is merged.

This test is intended to be "lazy" and brutal in implementation. As you can see in this file, importing from libs like pip is fragile and tends to break. This should continue to work as long as we keep our file structures the same, and if someone changes it, then can come edit this test.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

