### PR TITLE
Add client_secret and client_id to credential_input_fields

### DIFF
--- a/awxkit/awxkit/api/pages/credentials.py
+++ b/awxkit/awxkit/api/pages/credentials.py
@@ -31,6 +31,8 @@ credential_input_fields = (
     'become_password',
     'become_username',
     'client',
+    'client_id',
+    'client_secret',
     'cloud_environment',
     'domain',
     'host',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related to [https://github.com/ansible/awx-plugins/pull/71](https://github.com/ansible/awx-plugins/pull/71)
awxkit - add service account support for Insights credential type, specifically adding the fields `client_id` and `client_secret` to `credential_input_fields`
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
24.6.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
To test changes, use the following command:
`awx --conf.host <path to your awx host>    --conf.username <username> --conf.password <password>     --conf.insecure credential create --name <name of credential> --credential_type 14 --user <user ID>   --inputs '{"client_id": "foo", "client_secret": "bar"}'`

`credential_type` 14 is the insights credential. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
