### PR TITLE
Allow blank DB host value, reuse backend code

### DIFF
--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -9,6 +9,7 @@ from awx.settings.application_name import get_application_name
 
 from django.conf import settings
 from django.db import connection as pg_connection
+from django.db.backends.postgresql.base import DatabaseWrapper as PsycopgDatabaseWrapper
 
 NOT_READY = ([], [], [])
 
@@ -95,24 +96,25 @@ class PubSub(object):
 
 
 def create_listener_connection():
-    conf = deepcopy(settings.DATABASES['default'])
-    conf['OPTIONS'] = deepcopy(conf.get('OPTIONS', {}))
+    # Variable is called settings_dict to correspond to internal use in Django itself
+    settings_dict = deepcopy(settings.DATABASES['default'])
+    settings_dict['OPTIONS'] = deepcopy(settings_dict.get('OPTIONS', {}))
+
     # Modify the application name to distinguish from other connections the process might use
-    conf['OPTIONS']['application_name'] = get_application_name(settings.CLUSTER_HOST_ID, function='listener')
+    settings_dict['OPTIONS']['application_name'] = get_application_name(settings.CLUSTER_HOST_ID, function='listener')
 
     # Apply overrides specifically for the listener connection
     for k, v in settings.LISTENER_DATABASES.get('default', {}).items():
         if k != 'OPTIONS':
-            conf[k] = v
+            settings_dict[k] = v
     for k, v in settings.LISTENER_DATABASES.get('default', {}).get('OPTIONS', {}).items():
-        conf['OPTIONS'][k] = v
+        settings_dict['OPTIONS'][k] = v
 
-    # Allow password-less authentication
-    if 'PASSWORD' in conf:
-        conf['OPTIONS']['password'] = conf.pop('PASSWORD')
+    # Reuse the Django postgres DB backend to create params for the psycopg library
+    psycopg_conn_params = PsycopgDatabaseWrapper(settings_dict).get_connection_params()
+    psycopg_conn_params['autocommit'] = True
 
-    connection_data = f"dbname={conf['NAME']} host={conf['HOST']} user={conf['USER']} port={conf['PORT']}"
-    return psycopg.connect(connection_data, autocommit=True, **conf['OPTIONS'])
+    return psycopg.connect(**psycopg_conn_params)
 
 
 @contextmanager

--- a/awx/main/dispatch/__init__.py
+++ b/awx/main/dispatch/__init__.py
@@ -1,15 +1,13 @@
 import os
 import psycopg
 import select
-from copy import deepcopy
 
 from contextlib import contextmanager
 
-from awx.settings.application_name import get_application_name
+from awx.main.utils.db import get_listener_params
 
 from django.conf import settings
 from django.db import connection as pg_connection
-from django.db.backends.postgresql.base import DatabaseWrapper as PsycopgDatabaseWrapper
 
 NOT_READY = ([], [], [])
 
@@ -96,23 +94,7 @@ class PubSub(object):
 
 
 def create_listener_connection():
-    # Variable is called settings_dict to correspond to internal use in Django itself
-    settings_dict = deepcopy(settings.DATABASES['default'])
-    settings_dict['OPTIONS'] = deepcopy(settings_dict.get('OPTIONS', {}))
-
-    # Modify the application name to distinguish from other connections the process might use
-    settings_dict['OPTIONS']['application_name'] = get_application_name(settings.CLUSTER_HOST_ID, function='listener')
-
-    # Apply overrides specifically for the listener connection
-    for k, v in settings.LISTENER_DATABASES.get('default', {}).items():
-        if k != 'OPTIONS':
-            settings_dict[k] = v
-    for k, v in settings.LISTENER_DATABASES.get('default', {}).get('OPTIONS', {}).items():
-        settings_dict['OPTIONS'][k] = v
-
-    # Reuse the Django postgres DB backend to create params for the psycopg library
-    psycopg_conn_params = PsycopgDatabaseWrapper(settings_dict).get_connection_params()
-    psycopg_conn_params['autocommit'] = True
+    psycopg_conn_params = get_listener_params()
 
     return psycopg.connect(**psycopg_conn_params)
 

--- a/awx/main/tests/functional/utils/test_db_utils.py
+++ b/awx/main/tests/functional/utils/test_db_utils.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+from awx.main.utils.db import get_listener_params
+
+
+def test_get_listener_params():
+    params = get_listener_params()
+    assert params['autocommit'] == True
+    assert params['dbname'] == settings.DATABASES['default']['NAME']  # artifical, is sqlite3
+    assert 'application_name' in params

--- a/awx/main/utils/db.py
+++ b/awx/main/utils/db.py
@@ -1,10 +1,35 @@
 # Copyright (c) 2017 Ansible by Red Hat
 # All Rights Reserved.
 
+from copy import deepcopy
 
-from awx.settings.application_name import set_application_name
+from django.db.backends.postgresql.base import DatabaseWrapper as PsycopgDatabaseWrapper
 from django.conf import settings
+from django.db.utils import DEFAULT_DB_ALIAS
+
+from awx.settings.application_name import set_application_name, get_application_name
 
 
 def set_connection_name(function):
     set_application_name(settings.DATABASES, settings.CLUSTER_HOST_ID, function=function)
+
+
+def get_listener_params(alias=DEFAULT_DB_ALIAS):
+    settings_dict = deepcopy(settings.DATABASES[alias])
+    settings_dict['OPTIONS'] = deepcopy(settings_dict.get('OPTIONS', {}))
+
+    # Modify the application name to distinguish from other connections the process might use
+    settings_dict['OPTIONS']['application_name'] = get_application_name(settings.CLUSTER_HOST_ID, function='listener')
+
+    # Apply overrides specifically for the listener connection
+    for k, v in settings.LISTENER_DATABASES.get(alias, {}).items():
+        if k != 'OPTIONS':
+            settings_dict[k] = v
+    for k, v in settings.LISTENER_DATABASES.get(alias, {}).get('OPTIONS', {}).items():
+        settings_dict['OPTIONS'][k] = v
+
+    # Reuse the Django postgres DB backend to create params for the psycopg library
+    psycopg_params = PsycopgDatabaseWrapper(settings_dict).get_connection_params()
+    psycopg_params['autocommit'] = True
+
+    return psycopg_params

--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -2,7 +2,6 @@ import json
 import logging
 import asyncio
 from typing import Dict
-from copy import deepcopy
 
 import ipaddress
 
@@ -21,6 +20,7 @@ from awx.main.analytics.broadcast_websocket import (
     RelayWebsocketStats,
     RelayWebsocketStatsManager,
 )
+from awx.main.utils.db import get_listener_params
 
 logger = logging.getLogger('awx.main.wsrelay')
 
@@ -308,27 +308,10 @@ class WebSocketRelayManager(object):
         self.stats_mgr = RelayWebsocketStatsManager(self.local_hostname)
         self.stats_mgr.start()
 
-        database_conf = deepcopy(settings.DATABASES['default'])
-        database_conf['OPTIONS'] = deepcopy(database_conf.get('OPTIONS', {}))
+        psycopg_params = get_listener_params()
 
-        for k, v in settings.LISTENER_DATABASES.get('default', {}).items():
-            if k != 'OPTIONS':
-                database_conf[k] = v
-        for k, v in settings.LISTENER_DATABASES.get('default', {}).get('OPTIONS', {}).items():
-            database_conf['OPTIONS'][k] = v
+        async_conn = await psycopg.AsyncConnection.connect(**psycopg_params)
 
-        if 'PASSWORD' in database_conf:
-            database_conf['OPTIONS']['password'] = database_conf.pop('PASSWORD')
-
-        async_conn = await psycopg.AsyncConnection.connect(
-            dbname=database_conf['NAME'],
-            host=database_conf['HOST'],
-            user=database_conf['USER'],
-            port=database_conf['PORT'],
-            **database_conf.get("OPTIONS", {}),
-        )
-
-        await async_conn.set_autocommit(True)
         on_ws_heartbeat_task = asyncio.get_running_loop().create_task(
             self.on_ws_heartbeat(async_conn),
             name="WebSocketRelayManager.on_ws_heartbeat",


### PR DESCRIPTION
##### SUMMARY
This avoids us create a "connection string" which was already believed to be brittle and undesirable.

Here are some research links of various value:

https://github.com/django/django/blob/main/django/db/backends/base/base.py#L30

https://github.com/django/django/blob/main/django/db/backends/postgresql/base.py

This create the same thing as `django.db.connection`, but using that object specifically comes with a lot of baggage. It's much cleaner to just create it, as what we need is set up in its `__init__`. This avoids touching the _already active_ connection, which is being used for other stuff. The `deepcopy` we already had still seems like a good idea.

The idea is that `"HOST"` in the DATABASES setting may be an empty string. Instead of handling this specifically, I'm trying to do it the "right" way finally here. Presumably this works for password-less auth which we were already trying to allow.

Essentially, we have to "translate" the Django database settings into the psycopg parameters, and instead of doing it manually we will use the logic already written in Django.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

