### PR TITLE
Move plugin loading to dispatcher startup

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -120,7 +120,7 @@ from awx.main.utils.named_url_graph import reset_counters
 from awx.main.utils.inventory_vars import update_group_variables
 from awx.main.scheduler.task_manager_models import TaskManagerModels
 from awx.main.redact import UriCleaner, REPLACE_STR
-from awx.main.signals import update_inventory_computed_fields
+from awx.main.tasks.system import update_inventory_computed_fields
 
 from awx.main.validators import vars_validate_or_raise
 

--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -1,16 +1,10 @@
-import os
-
 from dispatcherd.config import setup as dispatcher_setup
 
 from django.apps import AppConfig
 from django.db import connection
 from django.utils.translation import gettext_lazy as _
-from awx.main.utils.common import bypass_in_test, load_all_entry_points_for
-from awx.main.utils.migration import is_database_synchronized
 from awx.main.utils.named_url_graph import _customize_graph, generate_graph
 from awx.conf import register, fields
-
-from awx_plugins.interfaces._temporary_private_licensing_api import detect_server_product_name
 
 
 class MainConfig(AppConfig):
@@ -43,42 +37,6 @@ class MainConfig(AppConfig):
             category_slug='named-url',
         )
 
-    def _load_credential_types_feature(self):
-        """
-        Create CredentialType records for any discovered credentials.
-
-        Note that Django docs advise _against_ interacting with the database using
-        the ORM models in the ready() path. Specifically, during testing.
-        However, we explicitly use the @bypass_in_test decorator to avoid calling this
-        method during testing.
-
-        Django also advises against running pattern because it runs everywhere i.e.
-        every management command. We use an advisory lock to ensure correctness and
-        we will deal performance if it becomes an issue.
-        """
-        from awx.main.models.credential import CredentialType
-
-        if is_database_synchronized():
-            CredentialType.setup_tower_managed_defaults(app_config=self)
-
-    @bypass_in_test
-    def load_credential_types_feature(self):
-        from awx.main.models.credential import load_credentials
-
-        load_credentials()
-        return self._load_credential_types_feature()
-
-    def load_inventory_plugins(self):
-        from awx.main.models.inventory import InventorySourceOptions
-
-        is_awx = detect_server_product_name() == 'AWX'
-        extra_entry_point_groups = () if is_awx else ('inventory.supported',)
-        entry_points = load_all_entry_points_for(['inventory', *extra_entry_point_groups])
-
-        for entry_point_name, entry_point in entry_points.items():
-            cls = entry_point.load()
-            InventorySourceOptions.injectors[entry_point_name] = cls
-
     def configure_dispatcherd(self):
         """This implements the default configuration for dispatcherd
 
@@ -100,13 +58,4 @@ class MainConfig(AppConfig):
         super().ready()
 
         self.configure_dispatcherd()
-
-        """
-        Credential loading triggers database operations. There are cases we want to call
-        awx-manage collectstatic without a database. All management commands invoke the ready() code
-        path. Using settings.AWX_SKIP_CREDENTIAL_TYPES_DISCOVER _could_ invoke a database operation.
-        """
-        if not os.environ.get('AWX_SKIP_CREDENTIAL_TYPES_DISCOVER', None):
-            self.load_credential_types_feature()
         self.load_named_url_feature()
-        self.load_inventory_plugins()

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -52,7 +52,6 @@ from awx.main.models import (
 )
 from awx.main.utils import model_instance_diff, model_to_dict, camelcase_to_underscore, get_current_apps
 from awx.main.utils import ignore_inventory_computed_fields, ignore_inventory_group_removal, _inventory_updates
-from awx.main.tasks.system import update_inventory_computed_fields, handle_removed_image
 from awx.main.fields import is_implicit_parent
 
 from awx.main import consumers
@@ -98,6 +97,8 @@ def emit_update_inventory_on_created_or_deleted(sender, **kwargs):
         pass
     else:
         if inventory is not None:
+            from awx.main.tasks.system import update_inventory_computed_fields
+
             connection.on_commit(lambda: update_inventory_computed_fields.delay(inventory.id))
 
 
@@ -555,6 +556,8 @@ def deny_orphaned_approvals(sender, instance, **kwargs):
 def _handle_image_cleanup(removed_image, pk):
     if (not removed_image) or ExecutionEnvironment.objects.filter(image=removed_image).exclude(pk=pk).exists():
         return  # if other EE objects reference the tag, then do not purge it
+    from awx.main.tasks.system import handle_removed_image
+
     handle_removed_image.delay(remove_images=[removed_image])
 
 

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -71,8 +71,11 @@ from awx.main.models import (
 from awx.main.tasks.helpers import is_run_threshold_reached
 from awx.main.tasks.host_indirect import save_indirect_host_entries
 from awx.main.tasks.receptor import administrative_workunit_reaper, get_receptor_ctl, worker_cleanup, worker_info, write_receptor_config
-from awx.main.utils.common import ignore_inventory_computed_fields, ignore_inventory_group_removal
+from awx.main.utils.common import ignore_inventory_computed_fields, ignore_inventory_group_removal, load_all_entry_points_for
+from awx.main.utils.migration import is_database_synchronized
 from awx.main.utils.reload import stop_local_services
+
+from awx_plugins.interfaces._temporary_private_licensing_api import detect_server_product_name
 
 logger = logging.getLogger('awx.main.tasks.system')
 
@@ -81,6 +84,40 @@ It looks like you're trying to use a private key in OpenSSH format, which \
 isn't supported by the installed version of OpenSSH on this instance. \
 Try upgrading OpenSSH or providing your private key in an different format. \
 '''
+
+
+def load_inventory_plugins():
+    from awx.main.models.inventory import InventorySourceOptions
+
+    with advisory_lock('load_inventory_plugins', wait=False) as acquired:
+        if not acquired:
+            return
+
+        is_awx = detect_server_product_name() == 'AWX'
+        extra_entry_point_groups = () if is_awx else ('inventory.supported',)
+        entry_points = load_all_entry_points_for(['inventory', *extra_entry_point_groups])
+
+        for entry_point_name, entry_point in entry_points.items():
+            cls = entry_point.load()
+            InventorySourceOptions.injectors[entry_point_name] = cls
+
+
+def load_credential_types_feature():
+    from django.apps import apps
+
+    from awx.main.models.credential import CredentialType, load_credentials
+
+    if os.environ.get('AWX_SKIP_CREDENTIAL_TYPES_DISCOVER', None):
+        logger.info('Credential type loading disabled, skipping')
+        return
+
+    with advisory_lock('load_credential_types', wait=False) as acquired:
+        if not acquired:
+            return
+
+        load_credentials()
+        if is_database_synchronized():
+            CredentialType.setup_tower_managed_defaults(app_config=apps.get_app_config('main'))
 
 
 def _run_dispatch_startup_common():
@@ -99,9 +136,11 @@ def _run_dispatch_startup_common():
             logger.exception("Failed to write receptor config, skipping.")
 
     try:
+        load_inventory_plugins()
+        load_credential_types_feature()
         convert_jsonfields()
     except Exception:
-        logger.exception("Failed JSON field conversion, skipping.")
+        logger.exception("Failed plugin loading or JSON field conversion, skipping.")
 
     startup_logger.debug("Syncing schedules")
     for sch in Schedule.objects.all():

--- a/awx/main/tests/functional/models/test_context_managers.py
+++ b/awx/main/tests/functional/models/test_context_managers.py
@@ -1,7 +1,8 @@
 import pytest
 
 # AWX context managers for testing
-from awx.main.signals import disable_activity_stream, disable_computed_fields, update_inventory_computed_fields
+from awx.main.signals import disable_activity_stream, disable_computed_fields
+from awx.main.tasks.system import update_inventory_computed_fields
 
 # AWX models
 from awx.main.models.organization import Organization

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -150,14 +150,6 @@ def is_testing(argv=None):
     return False
 
 
-def bypass_in_test(func):
-    def fn(*args, **kwargs):
-        if not is_testing():
-            return func(*args, **kwargs)
-
-    return fn
-
-
 class RequireDebugTrueOrTest(logging.Filter):
     """
     Logging filter to output when in DEBUG mode or running tests.


### PR DESCRIPTION
##### SUMMARY
If you read some of the comments of the methods moved here, it was very clear even when implemented that you're not supposed to be interacting with the database in the `.ready` method.

To summarize some discussion:
 - the dispatcher startup is the "middle-ground" solution, not too often, not too infrequently
   - the migration hook would be much more infrequent, but awx-operator does not reliably call it every startup
   - the ready method calls every time ever service or any other script using Django starts
 - The remaining concern is that you could have a race condition, expecting a `CredentialType` for configuration-as-code, which is technically possible
   - This is not actually realistic in my opinion
   - If there is a problem, scripts can poll until the `capacity` of instances reaches a non-zero value, which happens after these methods in the startup method
 - I am very opinionated to move away from standard Django practices, as I have another patch up at https://github.com/ansible/awx/pull/15463 to remove another case where another query-on-import was performed. Why?
   - Log maintenance becomes a nightmare because these categorically front-run any other database errors, which I spend a _lot_ of time debugging
   - People will find it more and more difficult to work with AWX because it doesn't use Django out-of-the-box. If there were a really strong reason to break standard practice, I won't resist, we may have to do. This does not appear to be a strong reason.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

