### PR TITLE
Fix dependency upgrades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==69.0.2 setuptools_scm[toml]==8.0.4 wheel==0.42.0 cython==0.29.37
+VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==72.1.0 setuptools_scm[toml]==8.1.0 wheel==0.45.1 cython==3.0.11
 
 NAME ?= awx
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==72.1.0 setuptools_scm[toml]==8.1.0 wheel==0.45.1 cython==3.0.11
+VENV_BOOTSTRAP ?= pip==21.2.4 setuptools==70.3.0 setuptools_scm[toml]==8.1.0 wheel==0.45.1 cython==3.0.11
 
 NAME ?= awx
 

--- a/requirements/README.md
+++ b/requirements/README.md
@@ -62,6 +62,8 @@ If modifying these libraries make sure testing with the offline build is perform
 Versions need to match the versions used in the pip bootstrapping step
 in the top-level Makefile.
 
+Verify ansible-runner's build dependency doesn't conflict with the changes made.
+
 ### cryptography
 
 If modifying this library make sure testing with the offline build is performed to confirm it is functionally working.

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -33,7 +33,7 @@ JSON-log-formatter
 jsonschema
 Markdown  # used for formatting API help
 maturin  # pydantic-core build dep
-msgpack<1.0.6  # 1.0.6+ requires cython>=3
+msgpack
 msrestazure
 openshift
 opentelemetry-api~=1.24     # new y streams can be drastically different, in a good way

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -8,7 +8,7 @@ boto3
 botocore
 channels
 channels-redis
-cryptography>=41.0.7  # CVE-2023-49083
+cryptography<42.0.0  # next version requires OPENSSL 3
 Cython
 daphne
 distro

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -8,7 +8,7 @@ boto3
 botocore
 channels
 channels-redis
-cryptography<42.0.0  # next version requires OPENSSL 3
+cryptography<42.0.0  # investigation is needed for 42+ to work with OpenSSL v3.0.x (RHEL 9.4) and v3.2.x (RHEL 9.5)
 Cython
 daphne
 distro

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -63,7 +63,7 @@ uWSGI
 uwsgitop
 wheel>=0.38.1  # CVE-2022-40898
 pip==21.2.4  # see UPGRADE BLOCKERs
-setuptools  # see UPGRADE BLOCKERs
+setuptools<71.0.0  # see UPGRADE BLOCKERs, path hack in v71 breaks irc deps
 setuptools_scm[toml]  # see UPGRADE BLOCKERs, xmlsec build dep
 setuptools-rust>=0.11.4  # cryptography build dep
 pkgconfig>=1.5.1  # xmlsec build dep - needed for offline build

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -522,7 +522,7 @@ zope-interface==7.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
     # via -r /awx_devel/requirements/requirements.in
-setuptools==72.1.0
+setuptools==70.3.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   asciichartpy

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -268,7 +268,7 @@ msal==1.31.1
     #   msal-extensions
 msal-extensions==1.2.0
     # via azure-identity
-msgpack==1.0.5
+msgpack==1.1.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels-redis
@@ -522,7 +522,7 @@ zope-interface==7.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
     # via -r /awx_devel/requirements/requirements.in
-setuptools==75.6.0
+setuptools==72.1.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   asciichartpy

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -92,7 +92,7 @@ click==8.1.7
     # via receptorctl
 constantly==23.10.4
     # via twisted
-cryptography==44.0.0
+cryptography==41.0.7
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   adal

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -92,7 +92,7 @@ click==8.1.8
     # via receptorctl
 constantly==23.10.4
     # via twisted
-cryptography==44.0.0
+cryptography==41.0.7
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   adal

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ adal==1.2.7
     # via msrestazure
 aiohappyeyeballs==2.4.4
     # via aiohttp
-aiohttp==3.11.10
+aiohttp==3.11.11
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   aiohttp-retry
@@ -63,9 +63,9 @@ azure-keyvault-secrets==4.9.0
     # via azure-keyvault
 backports-tarfile==1.2.0
     # via jaraco-context
-boto3==1.35.82
+boto3==1.35.96
     # via -r /awx_devel/requirements/requirements.in
-botocore==1.35.82
+botocore==1.35.96
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   boto3
@@ -86,13 +86,13 @@ channels==4.2.0
     #   channels-redis
 channels-redis==4.2.1
     # via -r /awx_devel/requirements/requirements.in
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via receptorctl
 constantly==23.10.4
     # via twisted
-cryptography==41.0.7
+cryptography==44.0.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   adal
@@ -173,9 +173,9 @@ frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-gitdb==4.0.11
+gitdb==4.0.12
     # via gitpython
-gitpython==3.1.43
+gitpython==3.1.44
     # via -r /awx_devel/requirements/requirements.in
 google-auth==2.37.0
     # via kubernetes
@@ -183,7 +183,7 @@ googleapis-common-protos==1.66.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.68.1
+grpcio==1.69.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -201,7 +201,7 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
-importlib-resources==6.4.5
+importlib-resources==6.5.2
     # via irc
 incremental==24.7.2
     # via twisted
@@ -232,7 +232,7 @@ jaraco-text==4.0.0
     # via
     #   irc
     #   jaraco-collections
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r /awx_devel/requirements/requirements.in
 jmespath==1.0.1
     # via
@@ -254,7 +254,7 @@ markdown==3.7
     # via -r /awx_devel/requirements/requirements.in
 markupsafe==3.0.2
     # via jinja2
-maturin==1.7.8
+maturin==1.8.1
     # via -r /awx_devel/requirements/requirements.in
 more-itertools==10.5.0
     # via
@@ -345,11 +345,11 @@ propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-protobuf==5.29.1
+protobuf==5.29.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==6.1.0
+psutil==6.1.1
     # via -r /awx_devel/requirements/requirements.in
 psycopg==3.2.3
     # via -r /awx_devel/requirements/requirements.in
@@ -462,20 +462,20 @@ six==1.17.0
     #   openshift
     #   pygerduty
     #   python-dateutil
-slack-sdk==3.33.5
+slack-sdk==3.34.0
     # via -r /awx_devel/requirements/requirements.in
-smmap==5.0.1
+smmap==5.0.2
     # via gitdb
 sqlparse==0.5.3
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django
     #   django-ansible-base
-tempora==5.7.0
+tempora==5.8.0
     # via
     #   irc
     #   jaraco-logging
-twilio==9.4.1
+twilio==9.4.2
     # via -r /awx_devel/requirements/requirements.in
 twisted[tls]==24.11.0
     # via
@@ -494,7 +494,7 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   psycopg
     #   twisted
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   botocore
     #   django-ansible-base


### PR DESCRIPTION
##### SUMMARY
This includes
 - https://github.com/ansible/awx/pull/15732
 - https://github.com/simaishi/awx/pull/1
 - and more

just want to put this up to document

For people visiting from the future, https://github.com/pypa/setuptools/pull/4457 is the setuptools PR that causes the pin added here. It modifies `sys.path` and this causes import errors, because the irc lib has dependencies overlapping with setuptools _vendor directory, and they conflict, functionally.

Next https://github.com/pallets/markupsafe/pull/478 put a minimum pin on setuptools, but this is non-conflicting with our other needs because there is a version range that satisfies markupsafe's new requirement while still pre-dating the `sys.path` hack.

I don't have a particularly good reference for the cryptography situation, other than general release notes, which make a ton of notes about specific OpenSSL versions.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

