### PR TITLE
feat: update insights action plugin to handle oauth

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -19,6 +19,9 @@
 # awx_version: Current running version of the awx or tower as a string
 # awx_license_type: "open" for AWX; else presume Tower
 # gpg_pubkey: the GPG public key to use for validation, when enabled
+# client_id: Red Hat service account client ID; required for the 'service_account' authentication method used against the Insights API
+# client_secret: Red Hat service account client secret; required for the 'service_account' authentication method used against the Insights API
+# oidc_endpoint: OpenID Connect URL for 'service_account' authentication method.
 
 - hosts: localhost
   gather_facts: false
@@ -95,11 +98,14 @@
         - name: Fetch Insights Playbook(s)
           insights:
             insights_url: "{{ insights_url }}"
-            username: "{{ scm_username }}"
-            password: "{{ scm_password }}"
+            username: "{{ scm_username | default(omit) }}"
+            password: "{{ scm_password | default(omit) }}"
             project_path: "{{ project_path }}"
             awx_license_type: "{{ awx_license_type }}"
             awx_version: "{{ awx_version }}"
+            client_id: "{{ client_id | default(omit) }}"
+            client_secret: "{{ client_secret | default(omit) }}"
+            authentication: "{{ authentication | default(omit) }}"
           register: results
 
         - name: Save Insights Version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for the `service_account` login type for the insights action plugin. First, get the valid authentication URL from the configured OIDC endpoint, then get the token for all API calls to the insights URL.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6.2.dev215+gf2aee7ba06
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Implementation based in the RH Developer docs from the Insights API as well as the current implementation to obtain the token from [Ansible Collection for Insights](https://github.com/RedHatInsights/ansible-collections-insights/blob/master/plugins/inventory/insights.py#L200)
<!--- Paste verbatim command output below, e.g. before and after your change -->