### PR TITLE
Lost my socks

### DIFF
--- a/awx/main/dispatch/worker/base.py
+++ b/awx/main/dispatch/worker/base.py
@@ -252,7 +252,12 @@ class AWXConsumerPG(AWXConsumerBase):
             except psycopg.InterfaceError:
                 logger.warning("Stale Postgres message bus connection, reconnecting")
                 continue
-            except (db.DatabaseError, psycopg.OperationalError):
+            except (db.DatabaseError, psycopg.OperationalError) as exc:
+                # If we never connected to begin with, then be brief, no risk of losing work
+                if init is False:
+                    logger.info(f'Could not create listener connection: {exc}')
+                    time.sleep(1)  # Patience to avoid log spam
+                    sys.exit(1)
                 # If we have attained stady state operation, tolerate short-term database hickups
                 if not self.pg_is_down:
                     logger.exception(f"Error consuming new events from postgres, will retry for {self.pg_max_wait} s")

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -72,12 +72,6 @@ class Command(BaseCommand):
         exit_if_redis_down(logger)
         DispatcherMetricsServer().start()
 
-        # TODO: move to a common database checker in DAB
-        try:
-            connection.ensure_connection()
-        except Exception as e:
-            print(type(e))
-
         if not os.path.exists(RECEPTOR_SOCK_FILE):
             logger.info(f'Receptor sock file does not exist at {RECEPTOR_SOCK_FILE}')
             time.sleep(1)  # Patience to avoid log spam

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -8,7 +8,6 @@ import time
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.db import connection
 
 from awx.main.dispatch import get_task_queuename
 from awx.main.dispatch.control import Control

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -2,15 +2,21 @@
 # All Rights Reserved.
 import logging
 import yaml
+import os
+import sys
+import time
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
+from django.db import connection
 
 from awx.main.dispatch import get_task_queuename
 from awx.main.dispatch.control import Control
 from awx.main.dispatch.pool import AutoscalePool
 from awx.main.dispatch.worker import AWXConsumerPG, TaskWorker
 from awx.main.analytics.subsystem_metrics import DispatcherMetricsServer
+from awx.main.utils.redis import exit_if_redis_down
+from awx.main.tasks.receptor import RECEPTOR_SOCK_FILE
 
 logger = logging.getLogger('awx.main.dispatch')
 
@@ -63,7 +69,19 @@ class Command(BaseCommand):
 
         consumer = None
 
+        exit_if_redis_down(logger)
         DispatcherMetricsServer().start()
+
+        # TODO: move to a common database checker in DAB
+        try:
+            connection.ensure_connection()
+        except Exception as e:
+            print(type(e))
+
+        if not os.path.exists(RECEPTOR_SOCK_FILE):
+            logger.info(f'Receptor sock file does not exist at {RECEPTOR_SOCK_FILE}')
+            time.sleep(1)  # Patience to avoid log spam
+            sys.exit(1)
 
         try:
             queues = ['tower_broadcast_all', 'tower_settings_change', get_task_queuename()]

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -33,6 +33,7 @@ from awx.main.models.rbac import (
 )
 from awx.main.models.unified_jobs import UnifiedJob
 from awx.main.utils.common import get_corrected_cpu, get_cpu_effective_capacity, get_corrected_memory, get_mem_effective_capacity
+from awx.main.utils.redis import ping_redis
 from awx.main.models.mixins import RelatedJobsMixin, ResourceMixin
 from awx.main.models.receptor_address import ReceptorAddress
 
@@ -397,7 +398,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
         try:
             # if redis is down for some reason, that means we can't persist
             # playbook event data; we should consider this a zero capacity event
-            redis.Redis.from_url(settings.BROKER_URL).ping()
+            ping_redis()
         except redis.ConnectionError:
             errors = _('Failed to connect to Redis')
 

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -41,6 +41,7 @@ from filelock import FileLock
 
 logger = logging.getLogger('awx.main.tasks.receptor')
 __RECEPTOR_CONF = '/etc/receptor/receptor.conf'
+RECEPTOR_SOCK_FILE = '/var/run/receptor/receptor.sock'
 __RECEPTOR_CONF_LOCKFILE = f'{__RECEPTOR_CONF}.lock'
 RECEPTOR_ACTIVE_STATES = ('Pending', 'Running')
 
@@ -758,7 +759,7 @@ RECEPTOR_CONFIG_STARTER = (
     {'local-only': None},
     {'log-level': settings.RECEPTOR_LOG_LEVEL},
     {'node': {'firewallrules': [{'action': 'reject', 'tonode': settings.CLUSTER_HOST_ID, 'toservice': 'control'}]}},
-    {'control-service': {'service': 'control', 'filename': '/var/run/receptor/receptor.sock', 'permissions': '0660'}},
+    {'control-service': {'service': 'control', 'filename': RECEPTOR_SOCK_FILE, 'permissions': '0660'}},
     {'work-command': {'worktype': 'local', 'command': 'ansible-runner', 'params': 'worker', 'allowruntimeparams': True}},
     {'work-signing': {'privatekey': '/etc/receptor/work_private_key.pem', 'tokenexpiration': '1m'}},
     {

--- a/awx/main/utils/redis.py
+++ b/awx/main/utils/redis.py
@@ -1,0 +1,19 @@
+import sys
+import time
+
+from django.conf import settings
+
+import redis
+
+
+def ping_redis():
+    redis.Redis.from_url(settings.BROKER_URL).ping()
+
+
+def exit_if_redis_down(logger):
+    try:
+        ping_redis()
+    except redis.ConnectionError as exc:
+        logger.info(f'Redis ping error: {exc}')
+        time.sleep(1)  # Patience to avoid log spam
+        sys.exit(1)


### PR DESCRIPTION
##### SUMMARY
This scratches my own itch, since I've been looking at logs a lot.

The issue is that the installer sets up services before receptor is fully running. This results in log spam that looks like the following:

```
2025-01-15 20:37:13,710 INFO     [-] awx.main.dispatch Running worker dispatcher listening to queues ['tower_broadcast_all', 'tower_settings_change', '18.212.26.122']
2025-01-15 20:37:13,756 ERROR    [-] awx.main.dispatch Encountered unhandled error in dispatcher main loop
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/dispatch/worker/base.py", line 239, in run
    self.worker.on_start()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/dispatch/worker/task.py", line 141, in on_start
    dispatch_startup()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/system.py", line 117, in dispatch_startup
    cluster_node_heartbeat()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/system.py", line 575, in cluster_node_heartbeat
    inspect_execution_and_hop_nodes(instance_list)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/system.py", line 514, in inspect_execution_and_hop_nodes
    mesh_status = ctl.simple_command('status')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/receptorctl/socket_interface.py", line 81, in simple_command
    self.connect()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/receptorctl/socket_interface.py", line 99, in connect
    raise ValueError(f"Socket path does not exist: {path}")
ValueError: Socket path does not exist: /var/run/receptor/receptor.sock
2025-01-15 20:37:17,758 INFO     [-] awx.main.dispatch Running worker dispatcher listening to queues ['tower_broadcast_all', 'tower_settings_change', '18.212.26.122']
2025-01-15 20:37:17,822 ERROR    [-] awx.main.dispatch Encountered unhandled error in dispatcher main loop
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/dispatch/worker/base.py", line 239, in run
    self.worker.on_start()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/dispatch/worker/task.py", line 141, in on_start
    dispatch_startup()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/system.py", line 117, in dispatch_startup
    cluster_node_heartbeat()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/system.py", line 575, in cluster_node_heartbeat
    inspect_execution_and_hop_nodes(instance_list)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/system.py", line 514, in inspect_execution_and_hop_nodes
    mesh_status = ctl.simple_command('status')
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/receptorctl/socket_interface.py", line 81, in simple_command
    self.connect()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/receptorctl/socket_interface.py", line 99, in connect
    raise ValueError(f"Socket path does not exist: {path}")
```

These do come in 4 second increments, but the state persists for a long time. I just really don't want to see tracebacks in this situation, because I only want to see tracebacks when there is an actual problem. This is the _normal_ install flow.

Demo:

```
$ awx-manage run_dispatcher
2025-01-16 20:24:54,269 INFO     [-] awx.main.utils.redis Redis ping error: Error 2 connecting to unix socket: /var/run/redis/redis.sock. No such file or directory.
```

Next:

```
$ awx-manage run_dispatcher
2025-01-16 20:39:48,646 INFO     [-] awx.main.dispatch Running worker dispatcher listening to queues ['tower_broadcast_all', 'tower_settings_change', 'arominge-thinkpadp16vgen1.durham.csb']
2025-01-16 20:39:52,336 INFO     [-] awx.main.dispatch Could not create listener connection: [Errno -2] Name or service not known
```

Next:

```
$ awx-manage run_dispatcher
2025-01-16 20:35:46,234 INFO     [-] awx.main.dispatch Receptor sock file does not exist at /var/run/receptor/receptor.sock
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

