### PR TITLE
fix: invalid f-string and oidc url for insights plugin

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -21,7 +21,9 @@
 # gpg_pubkey: the GPG public key to use for validation, when enabled
 # client_id: Red Hat service account client ID; required for the 'service_account' authentication method used against the Insights API
 # client_secret: Red Hat service account client secret; required for the 'service_account' authentication method used against the Insights API
-# oidc_endpoint: OpenID Connect URL for 'service_account' authentication method.
+# authentication: The authentication method to use against the Insights API
+# client_id and client_secret are required for the 'service_account' authentication method
+# scm_username and scm_password are required for the 'basic' authentication method
 
 - hosts: localhost
   gather_facts: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The f-string added in #15742 was incorrectly declared. This fix makes sure it is correctly declared, and also adds useful info about new variables to `project_update.yml` as well as a default value for the OIDC endpoint if the user hasn't declared any.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6.2.dev232+g445b5251cc
```