### PR TITLE
fix: azure credential awxkit client_id collision

### DIFF
--- a/awxkit/awxkit/api/pages/credentials.py
+++ b/awxkit/awxkit/api/pages/credentials.py
@@ -134,6 +134,8 @@ def get_payload_field_and_value_from_kwargs_or_config_cred(field, kind, kwargs, 
         config_field = 'ad_user'
     elif field == 'client':
         config_field = 'client_id'
+    elif field == 'client_id' and 'azure' in kind:  # Needed to avoid service account client_id collision
+        config_field = ''
     elif field == 'authorize_password':
         config_field = 'authorize'
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
After #15734, when an Azure credential is created using awxkit, the creation fails because the parameter `client_id` is added to the input fields while the API is not expecting it. 

This fix makes sure the field is not added if we're working with Azure credentials, as the `config_cred` value for `client` in the case of Azure is `client_id`; this caused the input to include both the fields `client` and `client_id`, yielding an error.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6.2.dev232+g9c5b6805e4.d20250121
```