### PR TITLE
AAP-35805 cleanup EE test

### DIFF
--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -1,3 +1,4 @@
+import subprocess
 import time
 
 import pytest
@@ -59,3 +60,20 @@ def default_org():
 def demo_inv(default_org):
     inventory, _ = Inventory.objects.get_or_create(name='Demo Inventory', defaults={'organization': default_org})
     return inventory
+
+
+@pytest.fixture
+def podman_image_generator():
+    """
+    Generate a tagless podman image from awx base EE
+    """
+
+    def fn():
+        dockerfile = """
+        FROM quay.io/ansible/awx-ee:latest
+        RUN echo "Hello, Podman!" > /tmp/hello.txt
+        """
+        cmd = ['podman', 'build', '-f', '-']  # Create an image without a tag
+        subprocess.run(cmd, capture_output=True, input=dockerfile, text=True, check=True)
+
+    return fn


### PR DESCRIPTION
##### SUMMARY

This test uses the new live tests to give confidence in our container cleanup code. We have function and unit test code for container cleanup, but it stops at the interface to runner. We verify the command line parameters that we construct, but our assumption in what the command-line params _should_ look like was wrong. This test is not susceptible to that because it's an end to end test. This test is not perfect. 

At the time of opening this draft PR the test is not _exactly_ like production. To be like production we would need a control/hybrid + an execution node. We do not have that capability in our testing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - APIr

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
