### PR TITLE
Address Lookup Plugins AttributeError

### DIFF
--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -560,7 +560,7 @@ class CredentialTypeHelper:
     @classmethod
     def get_creation_params(cls, cred_type):
         if cred_type.kind == 'external':
-            return dict(namespace=cred_type.namespace, kind=cred_type.kind, name=cred_type.name, managed=False)
+            return dict(namespace=cred_type.namespace, kind=cred_type.kind, name=cred_type.name, managed=True)
         return dict(
             namespace=cred_type.namespace,
             kind=cred_type.kind,

--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -438,11 +438,15 @@ class CredentialType(CommonModelNameNotUnique):
     @classmethod
     def from_db(cls, db, field_names, values):
         instance = super(CredentialType, cls).from_db(db, field_names, values)
-        if instance.managed and instance.namespace:
+        if instance.managed and instance.namespace and instance.kind != "external":
             native = ManagedCredentialType.registry[instance.namespace]
             instance.inputs = native.inputs
             instance.injectors = native.injectors
             instance.custom_injectors = getattr(native, 'custom_injectors', None)
+        elif instance.kind == "external":
+            native = ManagedCredentialType.registry[instance.namespace]
+            instance.inputs = native.inputs
+
         return instance
 
     def get_absolute_url(self, request=None):
@@ -544,7 +548,7 @@ class CredentialType(CommonModelNameNotUnique):
     @classmethod
     def load_plugin(cls, ns, plugin):
         # TODO: User "side-loaded" credential custom_injectors isn't supported
-        ManagedCredentialType.registry[ns] = ManagedCredentialType(namespace=ns, name=plugin.name, kind='external', inputs=plugin.inputs, injectors={})
+        ManagedCredentialType.registry[ns] = SimpleNamespace(namespace=ns, name=plugin.name, kind='external', inputs=plugin.inputs, backend=plugin.backend)
 
     def inject_credential(self, credential, env, safe_env, args, private_data_dir):
         from awx_plugins.interfaces._temporary_private_inject_api import inject_credential

--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -443,7 +443,7 @@ class CredentialType(CommonModelNameNotUnique):
             instance.inputs = native.inputs
             instance.injectors = native.injectors
             instance.custom_injectors = getattr(native, 'custom_injectors', None)
-        elif instance.kind == "external":
+        elif instance.namespace and instance.kind == "external":
             native = ManagedCredentialType.registry[instance.namespace]
             instance.inputs = native.inputs
 
@@ -559,6 +559,8 @@ class CredentialType(CommonModelNameNotUnique):
 class CredentialTypeHelper:
     @classmethod
     def get_creation_params(cls, cred_type):
+        if cred_type.kind == 'external':
+            return dict(namespace=cred_type.namespace, kind=cred_type.kind, name=cred_type.name, managed=False)
         return dict(
             namespace=cred_type.namespace,
             kind=cred_type.kind,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
We lost the `backend` function when saving lookup plugins to the registry with #15685. 

* managedcredential registry may now contain 2 different classes
* managedcredentialType and one that represents a lookup plugin
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
