### PR TITLE
AAP-38528 Make default state passing for coverage targets

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -28,7 +28,7 @@ coverage:
           - MyPy
     project:
       default:
-        target: 72%
+        target: 75%
       lib:
         flags:
           - pytest
@@ -48,7 +48,7 @@ coverage:
             **/test/**
           - >-
             **/tests/**
-        target: 90%
+        target: 95%
       typing:
         flags:
           - MyPy

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,9 +18,9 @@ coverage:
   status:
     patch:
       default:
-        target: 100%
+        target: 89%
       pytest:
-        target: 100%
+        target: 89%
         flags:
           - pytest
       typing:
@@ -28,7 +28,7 @@ coverage:
           - MyPy
     project:
       default:
-        target: 100%
+        target: 72%
       lib:
         flags:
           - pytest

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -18,9 +18,9 @@ coverage:
   status:
     patch:
       default:
-        target: 89%
+        target: 100%
       pytest:
-        target: 89%
+        target: 100%
         flags:
           - pytest
       typing:
@@ -48,7 +48,7 @@ coverage:
             **/test/**
           - >-
             **/tests/**
-        target: 95%
+        target: 90%
       typing:
         flags:
           - MyPy


### PR DESCRIPTION
##### SUMMARY
Reference:

https://github.com/ansible/awx/pull/15753

That PR literally _moves test files_ and it fails checks

![Screenshot from 2025-01-23 21-20-49](https://github.com/user-attachments/assets/0b90a82d-0f80-4149-b8e9-777dbb676e0d)

And it seems to be some dissonance between present coverage values, and the coverage of the diff. I'm not sure if we should have a metric for coverage in the first place, but I digress.

For merges

![Screenshot from 2025-01-23 21-19-52](https://github.com/user-attachments/assets/fd21f54b-1c31-4939-8b82-338929fe9aba)

This adjusts 3 values, corresponding to those 3 :x: s so that we may be X-free for the happy path. Hopefully. Soon.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
