### PR TITLE
Make awx/main/tests/live dramatically faster

### DIFF
--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -5,9 +5,9 @@ import time
 from uuid import uuid4
 
 from django_guid import get_guid
+from django.conf import settings
 
 from . import pg_bus_conn
-from awx.main.utils import is_testing
 
 logger = logging.getLogger('awx.main.dispatch')
 
@@ -101,7 +101,7 @@ class task:
                 obj = cls.get_async_body(args=args, kwargs=kwargs, uuid=uuid, **kw)
                 if callable(queue):
                     queue = queue()
-                if not is_testing():
+                if not settings.DISPATCHER_MOCK_PUBLISH:
                     with pg_bus_conn() as conn:
                         conn.notify(queue, json.dumps(obj))
                 return (obj, queue)

--- a/awx/main/tests/settings_for_test.py
+++ b/awx/main/tests/settings_for_test.py
@@ -8,7 +8,7 @@ from awx.settings.development import *  # NOQA
 SETTINGS_MODULE = 'awx.settings.development'
 
 # Turn off task submission, because sqlite3 does not have pg_notify
-DISPATCHER_MOCK_PUBLISH = False
+DISPATCHER_MOCK_PUBLISH = True
 
 # Use SQLite for unit tests instead of PostgreSQL.  If the lines below are
 # commented out, Django will create the test_awx-dev database in PostgreSQL to

--- a/awx/main/tests/settings_for_test.py
+++ b/awx/main/tests/settings_for_test.py
@@ -7,6 +7,9 @@ from awx.settings.development import *  # NOQA
 # Some things make decisions based on settings.SETTINGS_MODULE, so this is done for that
 SETTINGS_MODULE = 'awx.settings.development'
 
+# Turn off task submission, because sqlite3 does not have pg_notify
+DISPATCHER_MOCK_PUBLISH = False
+
 # Use SQLite for unit tests instead of PostgreSQL.  If the lines below are
 # commented out, Django will create the test_awx-dev database in PostgreSQL to
 # run unit tests.

--- a/awx/main/tests/unit/test_settings.py
+++ b/awx/main/tests/unit/test_settings.py
@@ -11,6 +11,7 @@ LOCAL_SETTINGS = (
     'CACHES',
     'DEBUG',
     'NAMED_URL_GRAPH',
+    'DISPATCHER_MOCK_PUBLISH',
 )
 
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -424,6 +424,11 @@ EXECUTION_NODE_REMEDIATION_CHECKS = 60 * 30  # once every 30 minutes check if an
 # Amount of time dispatcher will try to reconnect to database for jobs and consuming new work
 DISPATCHER_DB_DOWNTIME_TOLERANCE = 40
 
+# If you set this, nothing will ever be sent to pg_notify
+# this is not practical to use, although periodic schedules may still run slugish but functional tasks
+# sqlite3 based tests will use this
+DISPATCHER_MOCK_PUBLISH = False
+
 BROKER_URL = 'unix:///var/run/redis/redis.sock'
 CELERYBEAT_SCHEDULE = {
     'tower_scheduler': {'task': 'awx.main.tasks.system.awx_periodic_scheduler', 'schedule': timedelta(seconds=30), 'options': {'expires': 20}},


### PR DESCRIPTION
##### SUMMARY
I noticed a lot of slowdown running the "live" tests, particularly related to projects which do a lot of syncing and running of jobs. When I cross-referenced against the UI I saw a lot of things hanging out in "pending" status. That's strange... even stranger that they wind up passing.

Turns out, when "pytest" is in `sys.argv` we just don't send any messages to pg_notify. Well there's you're slowdown! To do anything, the tests were waiting for the once-ever-20-seconds periodic task.

 - before: 5 passed, 5 warnings in 167.92s (0:02:47)
 - after: 1 failed, 4 passed, 5 warnings in 17.58s (think the failure is a local problem)

That 17 seconds is :kissing_closed_eyes: 

This is still not implemented in the separate dispatcher library. I still haven't dived into the details, but having this as a dispatcher config-like property is probably the best path forward, so this patch should help make changes in that area as well.

We may still have friction in some other checks, because this is going to move us in the direction of sending messages by default (which will error if not configured right). While this is more risky for development, I consider it _less_ risky for production purposes.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
