### PR TITLE
Put duplicate plugin location in error message

### DIFF
--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -653,8 +653,8 @@ def load_credentials():
             setattr(cred_plugin, 'injectors', {})
         if ns in ManagedCredentialType.registry:
             raise ValueError(
-                'a ManagedCredentialType with namespace={} is already defined in {}'.format(
-                    ns, inspect.getsourcefile(ManagedCredentialType.registry[ns].__class__)
+                'a ManagedCredentialType with namespace={} was defined in {}, but also defined in {}'.format(
+                    ns, ep.value, inspect.getsourcefile(ManagedCredentialType.registry[ns].__class__)
                 )
             )
         ManagedCredentialType.registry[ns] = cred_plugin


### PR DESCRIPTION
##### SUMMARY
I was trying to adjust some things in our testing suite, and I was getting very frustrated due to this error message, and the lack of actionable information that it gives me.

Before:

```
E               ValueError: a ManagedCredentialType with namespace=controller is already defined in /awx_devel/awx/main/models/credential.py
```

You say that the controller credential type is already defined... but why are you telling me this? I don't have prior context, why does it matter that it is already defined? I would hope that it should be defined, yes. That definition sounds like a perfectly good way to define it. Why is this a problem? I see there is a hint that we have a conflicting definition... I know nothing about this other definition.

After:

```
E               ValueError: a ManagedCredentialType with namespace=controller was defined in awx_plugins.credentials.plugins:controller, but also defined in /awx_devel/awx/main/models/credential.py
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
