### PR TITLE
[AAP-39138] - Add DAB Feature Flag common API

### DIFF
--- a/awx/main/tests/functional/dab_feature_flags/test_feature_flags_api.py
+++ b/awx/main/tests/functional/dab_feature_flags/test_feature_flags_api.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
 import pytest
 from django.test import override_settings
 
-from awx.main.models import (  # noqa
-    User,
-)
+from awx.main.models import User
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/test_feature_flags_api.py
+++ b/awx/main/tests/functional/test_feature_flags_api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+from django.test import override_settings
 
 from awx.main.models import (  # noqa
     User,
@@ -10,6 +11,28 @@ from awx.main.models import (  # noqa
 def test_feature_flags_list_endpoint(get):
     bob = User.objects.create(username='bob', password='test_user', is_superuser=False)
 
-    url = "/api/v2/feature_flags_definition/"
+    url = "/api/v2/feature_flags_state/"
     response = get(url, user=bob, expect=200)
     assert len(response.data) == 1
+
+
+@override_settings(
+    FLAGS={
+        "FEATURE_SOME_PLATFORM_FLAG_ENABLED": [
+            {"condition": "boolean", "value": False},
+            {"condition": "before date", "value": "2022-06-01T12:00Z"},
+        ],
+        "FEATURE_SOME_PLATFORM_FLAG_FOO_ENABLED": [
+            {"condition": "boolean", "value": True},
+        ],
+    }
+)
+@pytest.mark.django_db
+def test_feature_flags_list_endpoint_override(get):
+    bob = User.objects.create(username='bob', password='test_user', is_superuser=False)
+
+    url = "/api/v2/feature_flags_state/"
+    response = get(url, user=bob, expect=200)
+    assert len(response.data) == 2
+    assert response.data["FEATURE_SOME_PLATFORM_FLAG_ENABLED"] is False
+    assert response.data["FEATURE_SOME_PLATFORM_FLAG_FOO_ENABLED"] is True

--- a/awx/main/tests/functional/test_feature_flags_api.py
+++ b/awx/main/tests/functional/test_feature_flags_api.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from awx.main.models import (  # noqa
+    User,
+)
+
+
+@pytest.mark.django_db
+def test_feature_flags_list_endpoint(get):
+    bob = User.objects.create(username='bob', password='test_user', is_superuser=False)
+
+    url = "/api/v2/feature_flags_definition/"
+    response = get(url, user=bob, expect=200)
+    assert len(response.data) == 1

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -358,6 +358,7 @@ INSTALLED_APPS = [
     'ansible_base.jwt_consumer',
     'ansible_base.resource_registry',
     'ansible_base.rbac',
+    'ansible_base.feature_flags',
     'flags',
 ]
 

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,6 +1,6 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac]
+django-ansible-base @ git+https://github.com/zkayyali812/django-ansible-base@zk/feature-flag/api#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac,feature-flags]
 awx-plugins-core @ git+https://github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core
 awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,6 +1,6 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 # Remove pbr from requirements.in when moving ansible-runner to requirements.in
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
-django-ansible-base @ git+https://github.com/zkayyali812/django-ansible-base@zk/feature-flag/api#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac,feature-flags]
+django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac,feature-flags]
 awx-plugins-core @ git+https://github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core
 awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git


### PR DESCRIPTION
##### SUMMARY
Adds common feature flagging API endpoints from the DAB to AWX.

This endpoint is intended to be used for ATF enablement.
Requires - https://github.com/ansible/django-ansible-base/pull/685 to be merged in first

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
