### PR TITLE
By default, do not count indirect hosts

### DIFF
--- a/awx/main/migrations/0201_indirect_managed_node_audit.py
+++ b/awx/main/migrations/0201_indirect_managed_node_audit.py
@@ -11,7 +11,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AlterField(
+        migrations.AddField(
             model_name='job',
             name='event_queries_processed',
             field=models.BooleanField(default=True, help_text='Events of this job have been queried for indirect host information, or do not need processing.'),

--- a/awx/main/migrations/0201_indirect_managed_node_audit.py
+++ b/awx/main/migrations/0201_indirect_managed_node_audit.py
@@ -11,10 +11,10 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddField(
+        migrations.AlterField(
             model_name='job',
             name='event_queries_processed',
-            field=models.BooleanField(default=False, help_text='Events of this job have been queried for indirect host information'),
+            field=models.BooleanField(default=True, help_text='Events of this job have been queried for indirect host information, or do not need processing.'),
         ),
         migrations.CreateModel(
             name='EventQuery',

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -608,8 +608,8 @@ class Job(UnifiedJob, JobOptions, SurveyJobMixin, JobNotificationMixin, TaskMana
         help_text=_("If ran as part of sliced jobs, the total number of slices. If 1, job is not part of a sliced job."),
     )
     event_queries_processed = models.BooleanField(
-        default=False,
-        help_text=_("Events of this job have been queried for indirect host information"),
+        default=True,
+        help_text=_("Events of this job have been queried for indirect host information, or do not need processing."),
     )
 
     def _get_parent_field_name(self):

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -277,6 +277,7 @@ class RunnerCallback:
     def artifacts_handler(self, artifact_dir):
         success, query_file_contents = try_load_query_file(artifact_dir)
         if success:
+            self.delay_update(event_queries_processed=False)
             collections_info = collect_queries(query_file_contents)
             for collection, data in collections_info.items():
                 version = data['version']

--- a/awx/main/tests/functional/tasks/test_host_indirect.py
+++ b/awx/main/tests/functional/tasks/test_host_indirect.py
@@ -13,7 +13,6 @@ from awx.main.tasks.host_indirect import (
 )
 from awx.main.models.event_query import EventQuery
 from awx.main.models.indirect_managed_node_audit import IndirectManagedNodeAudit
-from awx.main.tests.functional.conftest import organization
 
 """These are unit tests, similar to test_indirect_host_counting in the live tests"""
 

--- a/awx/main/tests/functional/tasks/test_host_indirect.py
+++ b/awx/main/tests/functional/tasks/test_host_indirect.py
@@ -25,7 +25,8 @@ TEST_JQ = "{canonical_facts: {host_name: .direct_host_name}, facts: {another_hos
 def bare_job(job_factory):
     job = job_factory()
     job.installed_collections = {'demo.query': {'version': '1.0.1'}, 'demo2.query': {'version': '1.0.1'}}
-    job.save(update_fields=['installed_collections'])
+    job.event_queries_processed = False
+    job.save(update_fields=['installed_collections', 'event_queries_processed'])
     return job
 
 
@@ -72,11 +73,9 @@ def new_audit_record(bare_job, organization):
 
 
 @pytest.mark.django_db
-def test_build_with_no_results(job_factory):
+def test_build_with_no_results(bare_job):
     # never filled in events, should do nothing
-    job = job_factory()
-    assert job.event_queries_processed is False
-    assert build_indirect_host_data(job, {}) == []
+    assert build_indirect_host_data(bare_job, {}) == []
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
This gives me a satisfying conclusion to the dance between the control process and the event processing for indirect host processing.

I'm changing the default of our mark to process these, `event_queries_processed` to `False`, meaning that the default behavior is that it won't do anything.

Then, _if_ the control process (via the artifacts handler) finds the even_query file (in any form), it uses this field to make a note to process the data for that job.

This perhaps handles the issue better than the feature flag itself, because on a job-by-job basis, we control the task noise in the dispatcher. The big concern I had was the polling loop that was in there, because sleeping tasks can be risky in the wild, occupying workers and leading to saturation and cluster death.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

