### PR TITLE
prevent multiple tasks from processing the same job events, prevent p…

### DIFF
--- a/awx/main/tasks/host_indirect.py
+++ b/awx/main/tasks/host_indirect.py
@@ -8,6 +8,7 @@ import jq
 
 from django.utils.timezone import now, timedelta
 from django.conf import settings
+from django.db import transaction
 
 # Django flags
 from flags.state import flag_enabled
@@ -147,13 +148,30 @@ def save_indirect_host_entries(job_id: int, wait_for_events: bool = True) -> Non
             logger.warning(f'Event count {current_events} < {job.emitted_events} for job_id={job_id}, delaying processing of indirect host tracking')
             return
 
+    with transaction.atomic():
+        """
+        Pre-emptively set the job marker to 'events processed'. This prevents other instances from running the
+        same task.
+        """
+        try:
+            job = Job.objects.select_for_update().get(id=job_id)
+        except job.DoesNotExist:
+            logger.debug(f'Job {job_id} seems to be deleted, bailing from save_indirect_host_entries')
+            return
+
+        if job.event_queries_processed is True:
+            # this can mean one of two things:
+            # 1. another instance has already processed the events of this job
+            # 2. the artifacts_handler has not yet been called for this job
+            return
+
+        job.event_queries_processed = True
+        job.save(update_fields=['event_queries_processed'])
+
     try:
         save_indirect_host_entries_of_job(job)
     except Exception:
         logger.traceback(f'Error processing indirect host data for job_id={job_id}')
-
-    # Mark job as processed, even if the processing failed
-    job.save(update_fields=['event_queries_processed'])
 
 
 @task(queue=get_task_queuename)
@@ -171,7 +189,7 @@ def cleanup_and_save_indirect_host_entries_fallback() -> None:
     window_end = right_now_time - timedelta(seconds=settings.INDIRECT_HOST_QUERY_FALLBACK_MINUTES)
     window_start = right_now_time - timedelta(days=settings.INDIRECT_HOST_QUERY_FALLBACK_GIVEUP_DAYS)
     for job in Job.objects.filter(event_queries_processed=False, finished__lte=window_end, finished__gte=window_start).iterator():
-        save_indirect_host_entries.delay(job.id, wait_for_events=True)
+        save_indirect_host_entries(job.id, wait_for_events=True)
         job_ct += 1
     if job_ct:
         logger.info(f'Restarted event processing for {job_ct} jobs')

--- a/awx/main/tests/functional/tasks/test_host_indirect.py
+++ b/awx/main/tests/functional/tasks/test_host_indirect.py
@@ -187,20 +187,21 @@ def test_events_not_fully_processed_no_op(bare_job):
     assert bare_job.event_queries_processed is False
 
     # Right away, the fallback processing will not run either
-    with mock.patch.object(save_indirect_host_entries, 'delay') as mock_delay:
-        cleanup_and_save_indirect_host_entries_fallback()
-    mock_delay.assert_not_called()
+    cleanup_and_save_indirect_host_entries_fallback()
     bare_job.refresh_from_db()
     assert bare_job.event_queries_processed is False
 
     # After 3 hours have passed...
     bare_job.finished = now() - timedelta(hours=3)
+
+    # Create the expected job events
+    for _ in range(12):
+        create_registered_event(bare_job)
+
     bare_job.save(update_fields=['finished'])
 
     # The fallback task will now process indirect host query data for this job
-    with mock.patch.object(save_indirect_host_entries, 'delay') as mock_delay:
-        cleanup_and_save_indirect_host_entries_fallback()
-    mock_delay.assert_called_once_with(bare_job.id, wait_for_events=True)
+    cleanup_and_save_indirect_host_entries_fallback()
 
     # Test code to process anyway, events collected or not
     save_indirect_host_entries(bare_job.id, wait_for_events=False)


### PR DESCRIPTION
##### SUMMARY
Introduce locking for flipping the `event_queries_processed` marker. We want to ensure that only ever one controller instance creates the processing task for a job.

Also prevent the periodic task from spawning additional tasks, handle everything within the same task. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
