### PR TITLE
Ship analytics data using service account token

### DIFF
--- a/awx/main/utils/analytics_proxy.py
+++ b/awx/main/utils/analytics_proxy.py
@@ -10,6 +10,8 @@ from typing import Optional, Any
 
 import requests
 
+DEFAULT_OIDC_ENDPOINT = 'https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token'
+
 
 class TokenError(requests.RequestException):
     '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The analytics API should use the service account token to authenticate and fall back to the previous methods.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
