### PR TITLE
Fix parenthesis order in notification message building exception handling

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -488,13 +488,13 @@ class JobNotificationMixin(object):
             try:
                 msg = env.from_string(msg_template).render(**context)
             except (TemplateSyntaxError, UndefinedError, SecurityError) as e:
-                msg = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__).replace('\n', '\r\n'))])
+                msg = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__)).replace('\n', '\r\n')])
 
         if body_template:
             try:
                 body = env.from_string(body_template).render(**context)
             except (TemplateSyntaxError, UndefinedError, SecurityError) as e:
-                body = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__).replace('\n', '\r\n'))])
+                body = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__)).replace('\n', '\r\n')])
 
         # https://datatracker.ietf.org/doc/html/rfc2822#section-2.2
         # Body should have at least 2 CRLF, some clients will interpret


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR fixes an issue in the notification message rendering logic where an `AttributeError` was raised due to an incorrect method call on a list. Specifically, when formatting exception tracebacks for notifications, the code was attempting to call `.replace()` on the result of `traceback.format_exception()`, which returns a list rather than a string. This led to the following error:

    msg = '\r\n'.join([e.message, ''.join(traceback.format_exception(None, e, e.__traceback__).replace('\n', '\r\n'))])
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: 'list' object has no attribute 'replace'

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API