### PR TITLE
Use api_base_path from awxkit envioronment AWXKIT_API_BASE_PATH

### DIFF
--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -9,6 +9,7 @@ try:
     from awxkit.api.client import Connection
     from awxkit.api.pages.api import ApiV2
     from awxkit.api import get_registered_page
+    from awxkit.config import config
 
     HAS_AWX_KIT = True
 except ImportError:
@@ -42,7 +43,7 @@ class ControllerAWXKitModule(ControllerModule):
         if not self.apiV2Ref:
             if not self.authenticated:
                 self.authenticate()
-            v2_index = get_registered_page('/api/v2/')(self.connection).get()
+            v2_index = get_registered_page(config.api_base_path + 'v2/')(self.connection).get()
             self.api_ref = ApiV2(connection=self.connection, **{'json': v2_index})
         return self.api_ref
 


### PR DESCRIPTION
Change  base path call to api_base_path from config in export operation

##### SUMMARY

When someon want to use `export` module to export anything from controller placed on custom base path with usage env `AWXKIT_API_BASE_PATH` module not properly handle it. It still use hardcoded `/api/v2/` base path

Change allows user to use custom api base path for export operation, for example call AAP controller api


##### COMPONENT NAME
 - Collection