### PR TITLE
Add missing slash breaking image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -574,7 +574,7 @@ docker-compose-buildx: Dockerfile.dev
 	- docker buildx create --name docker-compose-buildx
 	docker buildx use docker-compose-buildx
 	- docker buildx build \
-		--ssh default=$(SSH_AUTH_SOCK)
+		--ssh default=$(SSH_AUTH_SOCK) \
 		--push \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
 		$(DOCKER_DEVEL_CACHE_FLAG) \


### PR DESCRIPTION
##### SUMMARY
Image builds not pushing, because

```
docker buildx create --name docker-compose-buildx
docker-compose-buildx
docker buildx use docker-compose-buildx
docker buildx build \
	--ssh default=/tmp/ssh-Mgp3py5hRV2r/agent.2859
ERROR: "docker buildx build" requires exactly 1 argument.
See 'docker buildx build --help'.

Usage:  docker buildx build [OPTIONS] PATH | URL | -

Start a build
make: [Makefile:576: docker-compose-buildx] Error 1 (ignored)
push \
	--build-arg BUILDKIT_INLINE_CACHE=1 \
	--no-cache \
	--platform=linux/amd64,linux/arm64   \
	--tag ghcr.io/ansible/awx_devel:devel \
	-f Dockerfile.dev .
bash: line 2: push: command not found
make: [Makefile:577: docker-compose-buildx] Error 127 (ignored)
docker buildx rm docker-compose-buildx
docker-compose-buildx removed
```

Bash command wasn't right, due to recent SSH auth changes in actions

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
