### PR TITLE
fix: audit record name should not be the hostname

### DIFF
--- a/awx/main/tasks/host_indirect.py
+++ b/awx/main/tasks/host_indirect.py
@@ -82,6 +82,8 @@ def build_indirect_host_data(job: Job, job_event_queries: dict[str, dict[str, st
 
             # Obtain the record based on the hashable canonical_facts now determined
             facts = data.get('facts')
+            name = data.get('name')
+
             if hashable_facts in results:
                 audit_record = results[hashable_facts]
             else:
@@ -90,7 +92,7 @@ def build_indirect_host_data(job: Job, job_event_queries: dict[str, dict[str, st
                     facts=facts,
                     job=job,
                     organization=job.organization,
-                    name=event.host_name,
+                    name=name,
                 )
                 results[hashable_facts] = audit_record
 

--- a/awx/main/tests/data/projects/host_query/extensions/audit/event_query.yml
+++ b/awx/main/tests/data/projects/host_query/extensions/audit/event_query.yml
@@ -1,4 +1,4 @@
 ---
 demo.query.example:
   query: >-
-    {canonical_facts: {host_name: .direct_host_name}, facts: {device_type: .device_type}}
+    {name: .name, canonical_facts: {host_name: .direct_host_name}, facts: {device_type: .device_type}}

--- a/awx/main/tests/data/projects/host_query/plugins/modules/example.py
+++ b/awx/main/tests/data/projects/host_query/plugins/modules/example.py
@@ -62,6 +62,7 @@ def run_module():
 
     result['direct_host_name'] = module.params['host_name']
     result['nested_host_name'] = {'host_name': module.params['host_name']}
+    result['name'] = 'vm-foo'
 
     # non-cononical facts
     result['device_type'] = 'Fake Host'

--- a/awx/main/tests/functional/tasks/test_host_indirect.py
+++ b/awx/main/tests/functional/tasks/test_host_indirect.py
@@ -17,7 +17,7 @@ from awx.main.models.indirect_managed_node_audit import IndirectManagedNodeAudit
 """These are unit tests, similar to test_indirect_host_counting in the live tests"""
 
 
-TEST_JQ = "{canonical_facts: {host_name: .direct_host_name}, facts: {another_host_name: .direct_host_name}}"
+TEST_JQ = "{name: .name, canonical_facts: {host_name: .direct_host_name}, facts: {another_host_name: .direct_host_name}}"
 
 
 @pytest.fixture
@@ -30,7 +30,7 @@ def bare_job(job_factory):
 
 
 def create_registered_event(job, task_name='demo.query.example'):
-    return job.job_events.create(event_data={'resolved_action': task_name, 'res': {'direct_host_name': 'foo_host'}})
+    return job.job_events.create(event_data={'resolved_action': task_name, 'res': {'direct_host_name': 'foo_host', 'name': 'vm-foo'}})
 
 
 @pytest.fixture
@@ -107,6 +107,7 @@ def test_save_indirect_host_entries(job_with_counted_event, event_query):
     assert host_audit.canonical_facts == {'host_name': 'foo_host'}
     assert host_audit.facts == {'another_host_name': 'foo_host'}
     assert host_audit.organization == job_with_counted_event.organization
+    assert host_audit.name == 'vm-foo'
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/live/tests/test_indirect_host_counting.py
+++ b/awx/main/tests/live/tests/test_indirect_host_counting.py
@@ -14,7 +14,7 @@ def test_indirect_host_counting(live_tmp_folder, run_job_from_playbook):
 
     # Data matches to awx/main/tests/data/projects/host_query/extensions/audit/event_query.yml
     # this just does things in-line to be a more localized test for the immediate testing
-    module_jq_str = '{canonical_facts: {host_name: .direct_host_name}, facts: {device_type: .device_type}}'
+    module_jq_str = '{name: .name, canonical_facts: {host_name: .direct_host_name}, facts: {device_type: .device_type}}'
     event_query = {'demo.query.example': {'query': module_jq_str}}
 
     # Run the task logic directly with local data


### PR DESCRIPTION
##### SUMMARY

The indirect host counting name should not record the hostname, instead it should come back from the query result.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
