### PR TITLE
Allow schema generation on-demand

### DIFF
--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -5,6 +5,7 @@ env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - devel


### PR DESCRIPTION
##### SUMMARY
The `api-schema` checks have been failing, and we need to trigger it. This allows manually re-triggering, so that we don't have to manually push a commit to devel to do this.

More generally, since we pin to `devel` of DAB, we are highly exposed to a changing schema due to a change in DAB. This will allow us to update the reference file without having to accept the change in an unrelated PR.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
