### PR TITLE
Pin drf-yasg to make api-test pass

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -2,7 +2,7 @@ build
 coreapi
 django-debug-toolbar==3.2.4
 django-test-migrations
-drf-yasg
+drf-yasg<1.21.10  # introduces new DeprecationWarning that is turned into error
 # pprofile - re-add once https://github.com/vpelletier/pprofile/issues/41 is addressed
 ipython>=7.31.1 # https://github.com/ansible/awx/security/dependabot/30
 unittest2


### PR DESCRIPTION
##### SUMMARY
Emergency fix for api-test check.

Surfaces as:

```
E   DeprecationWarning: SwaggerJSONRenderer & SwaggerYAMLRenderer's `format` has changed to not include a `.` prefix, please silence this warning by setting `SWAGGER_USE_COMPAT_RENDERERS = False` in your Django settings and ensure your application works (check your URLCONF and swagger/redoc URLs).
```

But our tests convert deprecation warnings to errors from @webknjaz's recent work. But this means that any floating pins can introduce errors like these.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

