### PR TITLE
AAP-12623 Do not escape non ascii in job_metadata

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -993,7 +993,7 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
             'approval_status': approval_status,
             'approval_node_name': self.workflow_approval_template.name,
             'workflow_url': workflow_url,
-            'job_metadata': json.dumps(self.notification_data(), indent=4),
+            'job_metadata': json.dumps(self.notification_data(), indent=4, ensure_ascii=False),
         }
 
     @property


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add ensure_ascii=False to json.dumps when serializing job_metadata

Fixes issue where a notification body that contains non-ASCII would be \u escaped.

Without fix:

![image](https://github.com/user-attachments/assets/f16075c2-4d1c-4fcb-89d5-10741c8bd0f9)


With fix:

![image](https://github.com/user-attachments/assets/5d20fe62-645d-4ede-a1e6-e253a5e59498)


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
