### PR TITLE
AAP-37381 Password validators from settings.AUTH_PASSWORD_VALIDATORS were not applied.

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -625,6 +625,30 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
         exclusions.extend([field.name for field in opts.many_to_many])
         return exclusions
 
+    def full_clean(self, obj, attrs):
+        """
+        This is called after the HTML form has been submitted, but before the
+        model instance is saved to the database.
+
+        Extend this method of you need the model instance for validation.
+        Otherwise you may consider directly extending `validate`.
+
+        :param obj: The Meta model instance.
+        :param attrs: The names and values of the filled form fields.
+        :return: None.
+        :raise ValidationError: if the validation fails.
+        """
+        # The purpose of this method is kind of overlapping with the purpose of
+        # `Model.full_clean`. But since we have most of our validation logic in
+        # the serializers, utilizing this method allows for keeping related code
+        # in the same module.
+        #
+        # See also the [Django REST Framework
+        # docs](https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform)
+        # on this, and also [this
+        # discussion](https://stackoverflow.com/q/32834026).
+        return
+
     def validate(self, attrs):
         attrs = super(BaseSerializer, self).validate(attrs)
         try:
@@ -641,6 +665,10 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
             for k in attrs.keys():
                 if k not in exclusions:
                     attrs[k] = getattr(obj, k)
+            # After the model instance is available, run the serializers
+            # full_clean() method to apply validations which are not implemented
+            # at model level.
+            self.full_clean(obj, attrs)
         except DjangoValidationError as exc:
             # DjangoValidationError may contain a list or dict; normalize into a
             # dict where the keys are the field name and the values are a list
@@ -984,7 +1012,7 @@ class UserSerializer(BaseSerializer):
         return ret
 
     def validate_password(self, value):
-        django_validate_password(value)
+        logger.error(f"validate_password(): {value=}")  # DJDEBUG
         if not self.instance and value in (None, ''):
             raise serializers.ValidationError(_('Password required for new User.'))
 
@@ -1008,6 +1036,7 @@ class UserSerializer(BaseSerializer):
         return value
 
     def _update_password(self, obj, new_password):
+        logger.error(f"_update_password(): {new_password=} {obj.password=}")  # DJDEBUG
         if new_password and new_password != '$encrypted$':
             obj.set_password(new_password)
             obj.save(update_fields=['password'])
@@ -1025,6 +1054,7 @@ class UserSerializer(BaseSerializer):
 
     def create(self, validated_data):
         new_password = validated_data.pop('password', None)
+        logger.error(f"create(): {new_password=}")  # DJDEBUG
         is_system_auditor = validated_data.pop('is_system_auditor', None)
         obj = super(UserSerializer, self).create(validated_data)
         self._update_password(obj, new_password)
@@ -1034,12 +1064,54 @@ class UserSerializer(BaseSerializer):
 
     def update(self, obj, validated_data):
         new_password = validated_data.pop('password', None)
+        logger.error(f"update(): {new_password=}")  # DJDEBUG
         is_system_auditor = validated_data.pop('is_system_auditor', None)
         obj = super(UserSerializer, self).update(obj, validated_data)
         self._update_password(obj, new_password)
         if is_system_auditor is not None:
             obj.is_system_auditor = is_system_auditor
         return obj
+
+    def full_clean(self, obj, attrs):
+        """
+        Called after the HTML form for creating a new user or editing an
+        existing user has been submitted.
+
+        Password validation according to settings.AUTH_PASSWORD_VALIDATORS
+        happens here.
+
+        :param obj: The User model instance.
+        :param attrs: The names and values of the filled form fields.
+        :return: None.
+        :raise ValidationError: if at least on of the configured validators
+            failed.
+        """
+        # We validate the password here, because some validators may need the
+        # User object which is neither available in `validate_password` nor in
+        # `validate` which otherwise would be logical places for this operation.
+        #
+        # If we try to instantiate a User object in `validate` for passing it to
+        # the validators, as recommended in the [Django REST Framework
+        # documentation](https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform),
+        # ValidationError is raised, but the user is saved into the database
+        # anyways!
+        #
+        # Another seemingly good location to apply password validation would be
+        # `_update_password`, covering `create` and `update`, but this would
+        # actually be too late because on these calls the Django Rest Framework
+        # has already saved the User instance and no longer catches
+        # ValidationError, thereby reporting an internal server error in the
+        # HTML GUI.
+        #
+        # Since the HTML form allows for saving a user with empty password field
+        # to indicate that the existing password is untouched, we have to skip
+        # password validation for that case.
+        password = attrs.get("password")
+        if password and password != '$encrypted$':
+            # Apply validators from settings.AUTH_PASSWORD_VALIDATORS.
+            django_validate_password(password, user=obj)
+        #
+        super(UserSerializer, self).full_clean(obj, attrs)
 
     def get_related(self, obj):
         res = super(UserSerializer, self).get_related(obj)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -635,6 +635,9 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
             for k, v in attrs.items():
                 if k not in exclusions and k != 'canonical_address_port':
                     setattr(obj, k, v)
+            # Call validators which need the model object for validation.
+            self.validate_with_obj(attrs, obj)
+            #
             obj.full_clean(exclude=exclusions)
             # full_clean may modify values on the instance; copy those changes
             # back to attrs so they are saved.
@@ -662,6 +665,23 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
                 d[k] = list(map(force_str, v2))
             raise ValidationError(d)
         return attrs
+
+    def validate_with_obj(self, attrs, obj):
+        """
+        Overwrite this if you need the model instance for your validation.
+
+        :param dict attrs: The names and values of the model form fields.
+        :raise django.core.exceptionsValidationError: Raise this if your
+            validation fails.
+
+            To make the error shown at the respective form field, instantiate
+            the Exception with a dict containing the field name as key and the
+            error message as value.
+
+            Example: ``ValidationError({"password": "Not good enough!"})``
+        :return: None
+        """
+        return
 
     def reverse(self, *args, **kwargs):
         kwargs['request'] = self.context.get('request')
@@ -1006,15 +1026,15 @@ class UserSerializer(BaseSerializer):
 
         return value
 
-    def validate(self, attrs):
+    def validate_with_obj(self, attrs, obj):
         """
-        Validate the form input against the Django password validators.
+        Validate the password with the Django password validators
 
-        To enable this, configure the Django password validators in
+        To enable the Django password validators, configure
         `settings.AUTH_PASSWORD_VALIDATORS` as described in the [Django
         docs](https://docs.djangoproject.com/en/5.1/topics/auth/passwords/#enabling-password-validation)
 
-        :param attrs: The User form field names and their values as a dict.
+        :param dict attrs: The User form field names and their values as a dict.
             Example::
 
                 {
@@ -1024,34 +1044,31 @@ class UserSerializer(BaseSerializer):
                     'password': 'secret123'
                 }
 
-        :type attrs: dict
-        :raises ValidationError: If at least one Django password validator
-            fails.
-        :return: The unmodified input attrs dict.
-        :rtype: dict
+        :param obj: The User model instance.
+        :raises django.core.exceptions.ValidationError: Raise this if at least
+            one Django password validator fails.
+
+            The exception contains a dict ``{"password": <error-message>``}
+            which indicates that the password field has failed validation, and
+            the reason for failure.
+        :return: None.
         """
         # We must do this here instead of in `validate_password` bacause some
         # django password validators need access to other model instance fields,
-        # e.g. ``username`` for similarity validation.
+        # e.g. ``username`` for the ``UserAttributeSimilarityValidator``.
         password = attrs.get("password")
+        # Skip validation if no password has been entered. This may happen when
+        # an existing User is edited.
         if password and password != '$encrypted$':
-            # Create a User instance and set its attributes according to the
-            # form fields and their values.
-            #
-            # Note that we cannot simply do ``obj = User(**attrs)``, because
-            # then the user instance is written into the database before the
-            # validation is passed! See also
-            # https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform
-            exclusions = self.get_validation_exclusions(self.instance)
-            obj = self.instance or self.Meta.model()
-            for k, v in attrs.items():
-                if k not in exclusions and k != 'canonical_address_port':
-                    setattr(obj, k, v)
             # Apply validators from settings.AUTH_PASSWORD_VALIDATORS. This may
             # raise ValidationError.
-            django_validate_password(password, user=obj)
-        #
-        return super().validate(attrs)
+            #
+            # If the validation fails, re-raise the exception with adjusted
+            # content to make the error appear near the password field.
+            try:
+                django_validate_password(password, user=obj)
+            except DjangoValidationError as exc:
+                raise DjangoValidationError({"password": exc.messages})
 
     def _update_password(self, obj, new_password):
         if new_password and new_password != '$encrypted$':

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -625,30 +625,6 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
         exclusions.extend([field.name for field in opts.many_to_many])
         return exclusions
 
-    def full_clean(self, obj, attrs):
-        """
-        This is called after the HTML form has been submitted, but before the
-        model instance is saved to the database.
-
-        Extend this method of you need the model instance for validation.
-        Otherwise you may consider directly extending `validate`.
-
-        :param obj: The Meta model instance.
-        :param attrs: The names and values of the filled form fields.
-        :return: None.
-        :raise ValidationError: if the validation fails.
-        """
-        # The purpose of this method is kind of overlapping with the purpose of
-        # `Model.full_clean`. But since we have most of our validation logic in
-        # the serializers, utilizing this method allows for keeping related code
-        # in the same module.
-        #
-        # See also the [Django REST Framework
-        # docs](https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform)
-        # on this, and also [this
-        # discussion](https://stackoverflow.com/q/32834026).
-        return
-
     def validate(self, attrs):
         attrs = super(BaseSerializer, self).validate(attrs)
         try:
@@ -665,10 +641,6 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
             for k in attrs.keys():
                 if k not in exclusions:
                     attrs[k] = getattr(obj, k)
-            # After the model instance is available, run the serializers
-            # full_clean() method to apply validations which are not implemented
-            # at model level.
-            self.full_clean(obj, attrs)
         except DjangoValidationError as exc:
             # DjangoValidationError may contain a list or dict; normalize into a
             # dict where the keys are the field name and the values are a list
@@ -1034,6 +1006,53 @@ class UserSerializer(BaseSerializer):
 
         return value
 
+    def validate(self, attrs):
+        """
+        Validate the form input against the Django password validators.
+
+        To enable this, configure the Django password validators in
+        `settings.AUTH_PASSWORD_VALIDATORS` as described in the [Django
+        docs](https://docs.djangoproject.com/en/5.1/topics/auth/passwords/#enabling-password-validation)
+
+        :param attrs: The User form field names and their values as a dict.
+            Example::
+
+                {
+                    'username': 'TestUsername', 'first_name': 'FirstName',
+                    'last_name': 'LastName', 'email': 'First.Last@my.org',
+                    'is_superuser': False, 'is_system_auditor': False,
+                    'password': 'secret123'
+                }
+
+        :type attrs: dict
+        :raises ValidationError: If at least one Django password validator
+            fails.
+        :return: The unmodified input attrs dict.
+        :rtype: dict
+        """
+        # We must do this here instead of in `validate_password` bacause some
+        # django password validators need access to other model instance fields,
+        # e.g. ``username`` for similarity validation.
+        password = attrs.get("password")
+        if password and password != '$encrypted$':
+            # Create a User instance and set its attributes according to the
+            # form fields and their values.
+            #
+            # Note that we cannot simply do ``obj = User(**attrs)``, because
+            # then the user instance is written into the database before the
+            # validation is passed! See also
+            # https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform
+            exclusions = self.get_validation_exclusions(self.instance)
+            obj = self.instance or self.Meta.model()
+            for k, v in attrs.items():
+                if k not in exclusions and k != 'canonical_address_port':
+                    setattr(obj, k, v)
+            # Apply validators from settings.AUTH_PASSWORD_VALIDATORS. This may
+            # raise ValidationError.
+            django_validate_password(password, user=obj)
+        #
+        return super().validate(attrs)
+
     def _update_password(self, obj, new_password):
         if new_password and new_password != '$encrypted$':
             obj.set_password(new_password)
@@ -1067,47 +1086,6 @@ class UserSerializer(BaseSerializer):
         if is_system_auditor is not None:
             obj.is_system_auditor = is_system_auditor
         return obj
-
-    def full_clean(self, obj, attrs):
-        """
-        Called after the HTML form for creating a new user or editing an
-        existing user has been submitted.
-
-        Password validation according to settings.AUTH_PASSWORD_VALIDATORS
-        happens here.
-
-        :param obj: The User model instance.
-        :param attrs: The names and values of the filled form fields.
-        :return: None.
-        :raise ValidationError: if at least on of the configured validators
-            failed.
-        """
-        # We validate the password here, because some validators may need the
-        # User object which is neither available in `validate_password` nor in
-        # `validate` which otherwise would be logical places for this operation.
-        #
-        # If we try to instantiate a User object in `validate` for passing it to
-        # the validators, as recommended in the [Django REST Framework
-        # documentation](https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform),
-        # ValidationError is raised, but the user is saved into the database
-        # anyways!
-        #
-        # Another seemingly good location to apply password validation would be
-        # `_update_password`, covering `create` and `update`, but this would
-        # actually be too late because on these calls the Django Rest Framework
-        # has already saved the User instance and no longer catches
-        # ValidationError, thereby reporting an internal server error in the
-        # HTML GUI.
-        #
-        # Since the HTML form allows for saving a user with empty password field
-        # to indicate that the existing password is untouched, we have to skip
-        # password validation for that case.
-        password = attrs.get("password")
-        if password and password != '$encrypted$':
-            # Apply validators from settings.AUTH_PASSWORD_VALIDATORS.
-            django_validate_password(password, user=obj)
-        #
-        super(UserSerializer, self).full_clean(obj, attrs)
 
     def get_related(self, obj):
         res = super(UserSerializer, self).get_related(obj)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1036,7 +1036,6 @@ class UserSerializer(BaseSerializer):
 
     def _update_password(self, obj, new_password):
         if new_password and new_password != '$encrypted$':
-            # django_validate_password(new_password, user=obj)
             obj.set_password(new_password)
             obj.save(update_fields=['password'])
 

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -626,18 +626,41 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
         return exclusions
 
     def validate(self, attrs):
+        """
+        Apply serializer validation. Called by DRF.
+
+        Can be extended by subclasses. Or consider overwriting
+        `validate_with_obj` in subclasses, which provides access to the model
+        object and exception handling for field validation.
+
+        :param dict attrs: The names and values of the model form fields.
+        :raise rest_framework.exceptions.ValidationError: If the validation
+            fails.
+
+            The exception must contain a dict with the names of the form fields
+            which failed validation as keys, and a list of error messages as
+            values. This ensures that the error messages are rendered near the
+            relevant fields.
+        :return: The names and values from the model form fields, possibly
+            modified by the validations.
+        :rtype: dict
+        """
         attrs = super(BaseSerializer, self).validate(attrs)
+        # Create/update a model instance and run its full_clean() method to
+        # do any validation implemented on the model class.
+        exclusions = self.get_validation_exclusions(self.instance)
+        # Create a new model instance or take the existing one if it exists,
+        # and update its attributes with the respective field values from
+        # attrs.
+        obj = self.instance or self.Meta.model()
+        for k, v in attrs.items():
+            if k not in exclusions and k != 'canonical_address_port':
+                setattr(obj, k, v)
         try:
-            # Create/update a model instance and run its full_clean() method to
-            # do any validation implemented on the model class.
-            exclusions = self.get_validation_exclusions(self.instance)
-            obj = self.instance or self.Meta.model()
-            for k, v in attrs.items():
-                if k not in exclusions and k != 'canonical_address_port':
-                    setattr(obj, k, v)
-            # Call validators which need the model object for validation.
+            # Run serializer validators which need the model object for
+            # validation.
             self.validate_with_obj(attrs, obj)
-            #
+            # Apply any validations implemented on the model class.
             obj.full_clean(exclude=exclusions)
             # full_clean may modify values on the instance; copy those changes
             # back to attrs so they are saved.
@@ -671,14 +694,23 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
         Overwrite this if you need the model instance for your validation.
 
         :param dict attrs: The names and values of the model form fields.
+        :param obj: An instance of the class's meta model.
+
+            If the serializer runs on a newly created object, obj contains only
+            the attrs from its serializer. If the serializer runs because an
+            object has been edited, obj is the existing model instance with all
+            attributes and values available.
         :raise django.core.exceptionsValidationError: Raise this if your
             validation fails.
 
-            To make the error shown at the respective form field, instantiate
+            To make the error appear at the respective form field, instantiate
             the Exception with a dict containing the field name as key and the
             error message as value.
 
             Example: ``ValidationError({"password": "Not good enough!"})``
+
+            If the exception contains just a string, the message cannot be
+            related to a field and is rendered at the top of the model form.
         :return: None
         """
         return

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -625,6 +625,30 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
         exclusions.extend([field.name for field in opts.many_to_many])
         return exclusions
 
+    def full_clean(self, obj, attrs):
+        """
+        This is called after the HTML form has been submitted, but before the
+        model instance is saved to the database.
+
+        Extend this method of you need the model instance for validation.
+        Otherwise you may consider directly extending `validate`.
+
+        :param obj: The Meta model instance.
+        :param attrs: The names and values of the filled form fields.
+        :return: None.
+        :raise ValidationError: if the validation fails.
+        """
+        # The purpose of this method is kind of overlapping with the purpose of
+        # `Model.full_clean`. But since we have most of our validation logic in
+        # the serializers, utilizing this method allows for keeping related code
+        # in the same module.
+        #
+        # See also the [Django REST Framework
+        # docs](https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform)
+        # on this, and also [this
+        # discussion](https://stackoverflow.com/q/32834026).
+        return
+
     def validate(self, attrs):
         attrs = super(BaseSerializer, self).validate(attrs)
         try:
@@ -641,6 +665,10 @@ class BaseSerializer(serializers.ModelSerializer, metaclass=BaseSerializerMetacl
             for k in attrs.keys():
                 if k not in exclusions:
                     attrs[k] = getattr(obj, k)
+            # After the model instance is available, run the serializers
+            # full_clean() method to apply validations which are not implemented
+            # at model level.
+            self.full_clean(obj, attrs)
         except DjangoValidationError as exc:
             # DjangoValidationError may contain a list or dict; normalize into a
             # dict where the keys are the field name and the values are a list
@@ -984,7 +1012,7 @@ class UserSerializer(BaseSerializer):
         return ret
 
     def validate_password(self, value):
-        django_validate_password(value)
+        logger.error(f"validate_password(): {value=}")  # DJDEBUG
         if not self.instance and value in (None, ''):
             raise serializers.ValidationError(_('Password required for new User.'))
 
@@ -1008,7 +1036,9 @@ class UserSerializer(BaseSerializer):
         return value
 
     def _update_password(self, obj, new_password):
+        logger.error(f"_update_password(): {new_password=} {obj.password=}")  # DJDEBUG
         if new_password and new_password != '$encrypted$':
+            # django_validate_password(new_password, user=obj)
             obj.set_password(new_password)
             obj.save(update_fields=['password'])
 
@@ -1025,6 +1055,7 @@ class UserSerializer(BaseSerializer):
 
     def create(self, validated_data):
         new_password = validated_data.pop('password', None)
+        logger.error(f"create(): {new_password=}")  # DJDEBUG
         is_system_auditor = validated_data.pop('is_system_auditor', None)
         obj = super(UserSerializer, self).create(validated_data)
         self._update_password(obj, new_password)
@@ -1034,12 +1065,54 @@ class UserSerializer(BaseSerializer):
 
     def update(self, obj, validated_data):
         new_password = validated_data.pop('password', None)
+        logger.error(f"update(): {new_password=}")  # DJDEBUG
         is_system_auditor = validated_data.pop('is_system_auditor', None)
         obj = super(UserSerializer, self).update(obj, validated_data)
         self._update_password(obj, new_password)
         if is_system_auditor is not None:
             obj.is_system_auditor = is_system_auditor
         return obj
+
+    def full_clean(self, obj, attrs):
+        """
+        Called after the HTML form for creating a new user or editing an
+        existing user has been submitted.
+
+        Password validation according to settings.AUTH_PASSWORD_VALIDATORS
+        happens here.
+
+        :param obj: The User model instance.
+        :param attrs: The names and values of the filled form fields.
+        :return: None.
+        :raise ValidationError: if at least on of the configured validators
+            failed.
+        """
+        # We validate the password here, because some validators may need the
+        # User object which is neither available in `validate_password` nor in
+        # `validate` which otherwise would be logical places for this operation.
+        #
+        # If we try to instantiate a User object in `validate` for passing it to
+        # the validators, as recommended in the [Django REST Framework
+        # documentation](https://www.django-rest-framework.org/community/3.0-announcement/#differences-between-modelserializer-validation-and-modelform),
+        # ValidationError is raised, but the user is saved into the database
+        # anyways!
+        #
+        # Another seemingly good location to apply password validation would be
+        # `_update_password`, covering `create` and `update`, but this would
+        # actually be too late because on these calls the Django Rest Framework
+        # has already saved the User instance and no longer catches
+        # ValidationError, thereby reporting an internal server error in the
+        # HTML GUI.
+        #
+        # Since the HTML form allows for saving a user with empty password field
+        # to indicate that the existing password is untouched, we have to skip
+        # password validation for that case.
+        password = attrs.get("password")
+        if password and password != '$encrypted$':
+            # Apply validators from settings.AUTH_PASSWORD_VALIDATORS.
+            django_validate_password(password, user=obj)
+        #
+        super(UserSerializer, self).full_clean(obj, attrs)
 
     def get_related(self, obj):
         res = super(UserSerializer, self).get_related(obj)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1012,7 +1012,6 @@ class UserSerializer(BaseSerializer):
         return ret
 
     def validate_password(self, value):
-        logger.error(f"validate_password(): {value=}")  # DJDEBUG
         if not self.instance and value in (None, ''):
             raise serializers.ValidationError(_('Password required for new User.'))
 
@@ -1036,7 +1035,6 @@ class UserSerializer(BaseSerializer):
         return value
 
     def _update_password(self, obj, new_password):
-        logger.error(f"_update_password(): {new_password=} {obj.password=}")  # DJDEBUG
         if new_password and new_password != '$encrypted$':
             # django_validate_password(new_password, user=obj)
             obj.set_password(new_password)
@@ -1055,7 +1053,6 @@ class UserSerializer(BaseSerializer):
 
     def create(self, validated_data):
         new_password = validated_data.pop('password', None)
-        logger.error(f"create(): {new_password=}")  # DJDEBUG
         is_system_auditor = validated_data.pop('is_system_auditor', None)
         obj = super(UserSerializer, self).create(validated_data)
         self._update_password(obj, new_password)
@@ -1065,7 +1062,6 @@ class UserSerializer(BaseSerializer):
 
     def update(self, obj, validated_data):
         new_password = validated_data.pop('password', None)
-        logger.error(f"update(): {new_password=}")  # DJDEBUG
         is_system_auditor = validated_data.pop('is_system_auditor', None)
         obj = super(UserSerializer, self).update(obj, validated_data)
         self._update_password(obj, new_password)

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -57,6 +57,199 @@ def test_user_create(post, admin):
 
 
 @pytest.mark.django_db
+# Disable local password checks to ensure that any ValidationError originates from the Django validators.
+@override_settings(
+    LOCAL_PASSWORD_MIN_LENGTH=1,
+    LOCAL_PASSWORD_MIN_DIGITS=0,
+    LOCAL_PASSWORD_MIN_UPPER=0,
+    LOCAL_PASSWORD_MIN_SPECIAL=0,
+)
+def test_user_create_with_django_password_validation_basic(post, admin):
+    """Test if the Django password validators are applied correctly."""
+    with override_settings(
+        AUTH_PASSWORD_VALIDATORS=[
+            {
+                'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+                'OPTIONS': {
+                    'min_length': 3,
+                },
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+            },
+        ],
+    ):
+        # This user should fail the UserAttrSimilarity, MinLength and CommonPassword validators.
+        user_attrs = (
+            {
+                "password": "Password",
+                "username": "Password",
+                "is_superuser": False,
+            },
+        )
+        print(f"Create user with invalid password {user_attrs=}")
+        response = post(reverse('api:user_list'), user_attrs, admin, middleware=SessionMiddleware(mock.Mock()))
+        assert response.status_code == 400
+        # This user should pass all Django validators.
+        user_attrs = {
+            "password": "r$TyKiOCb#ED",
+            "username": "TestUser",
+            "is_superuser": False,
+        }
+        print(f"Create user with valid password {user_attrs=}")
+        response = post(reverse('api:user_list'), user_attrs, admin, middleware=SessionMiddleware(mock.Mock()))
+        assert response.status_code == 201
+
+
+@pytest.mark.django_db
+# Disable local password checks to ensure that any ValidationError originates from the Django validators.
+@override_settings(
+    LOCAL_PASSWORD_MIN_LENGTH=1,
+    LOCAL_PASSWORD_MIN_DIGITS=0,
+    LOCAL_PASSWORD_MIN_UPPER=0,
+    LOCAL_PASSWORD_MIN_SPECIAL=0,
+)
+def test_user_create_with_django_password_validation_ext(post, delete, admin):
+    """Test the functionality of the single Django password validators."""
+    #
+    default_fixtures = {
+        # Keys in `fixtures` override `default_fixtures` if they exist and their
+        # value is not 'None'.
+        "user_attrs": {
+            "password": "r$TyKiOCb#ED",
+            "username": "DefaultUser",
+            "is_superuser": False,
+        },
+        "password_validators": [
+            {
+                'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+                'OPTIONS': {
+                    'min_length': 8,
+                },
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+            },
+            {
+                'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+            },
+        ],
+    }
+    # The list of fixture dicts which constitute the test cases.
+    fixtures_list = [
+        # Test password similarity with username.
+        {
+            "user_attrs": {
+                "password": "TestUser1",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [
+                {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
+            ],
+            "expected_status_code": 400,
+        },
+        {
+            "user_attrs": {
+                "password": "abc",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [
+                {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
+            ],
+            "expected_status_code": 201,
+        },
+        # Test password min length criterion.
+        {
+            "user_attrs": {
+                "password": "TooShort",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [
+                {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator', 'OPTIONS': {'min_length': 9}},
+            ],
+            "expected_status_code": 400,
+        },
+        {
+            "user_attrs": {
+                "password": "LongEnough",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [
+                {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator', 'OPTIONS': {'min_length': 9}},
+            ],
+            "expected_status_code": 201,
+        },
+        # Test password is too common criterion.
+        {
+            "user_attrs": {
+                "password": "Password",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [
+                {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
+            ],
+            "expected_status_code": 400,
+        },
+        {
+            "user_attrs": {
+                "password": "Password",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [],
+            "expected_status_code": 201,
+        },
+        # Test if password is only numeric.
+        {
+            "user_attrs": {
+                "password": "1234567890",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [
+                {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
+            ],
+            "expected_status_code": 400,
+        },
+        {
+            "user_attrs": {
+                "password": "1234567890",
+                "username": "TestUser1",
+                "is_superuser": False,
+            },
+            "password_validators": [],
+            "expected_status_code": 201,
+        },
+    ]
+    for i, fixtures in enumerate(fixtures_list):
+        user_attrs = fixtures.setdefault("user_attrs", default_fixtures["user_attrs"])
+        password_validators = fixtures.setdefault("password_validators", default_fixtures["password_validators"])
+        expected_status_code = fixtures["expected_status_code"]
+        print(f"Testing fixtures {i}: {expected_status_code=} {user_attrs=}")
+        with override_settings(AUTH_PASSWORD_VALIDATORS=password_validators):
+            response = post(reverse('api:user_list'), user_attrs, admin, middleware=SessionMiddleware(mock.Mock()))
+            assert response.status_code == expected_status_code
+            # Delete user if it was created succesfully.
+            if response.status_code == 201:
+                response = delete(reverse('api:user_detail', kwargs={'pk': response.data['id']}), admin, middleware=SessionMiddleware(mock.Mock()))
+                assert response.status_code == 204
+
+
+@pytest.mark.django_db
 def test_fail_double_create_user(post, admin):
     response = post(reverse('api:user_list'), EXAMPLE_USER_DATA, admin, middleware=SessionMiddleware(mock.Mock()))
     assert response.status_code == 201

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -88,7 +88,7 @@ def test_user_create_with_django_password_validation_basic(post, admin):
         # This user should fail the UserAttrSimilarity, MinLength and CommonPassword validators.
         user_attrs = (
             {
-                "password": "Password",
+                "password": "Password",  # NOSONAR
                 "username": "Password",
                 "is_superuser": False,
             },
@@ -98,7 +98,7 @@ def test_user_create_with_django_password_validation_basic(post, admin):
         assert response.status_code == 400
         # This user should pass all Django validators.
         user_attrs = {
-            "password": "r$TyKiOCb#ED",
+            "password": "r$TyKiOCb#ED",  # NOSONAR
             "username": "TestUser",
             "is_superuser": False,
         }
@@ -122,7 +122,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         # Keys in `fixtures` override `default_fixtures` if they exist and their
         # value is not 'None'.
         "user_attrs": {
-            "password": "r$TyKiOCb#ED",
+            "password": "r$TyKiOCb#ED",  # NOSONAR
             "username": "DefaultUser",
             "is_superuser": False,
         },
@@ -149,7 +149,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         # Test password similarity with username.
         {
             "user_attrs": {
-                "password": "TestUser1",
+                "password": "TestUser1",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },
@@ -160,7 +160,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         },
         {
             "user_attrs": {
-                "password": "abc",
+                "password": "abc",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },
@@ -172,7 +172,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         # Test password min length criterion.
         {
             "user_attrs": {
-                "password": "TooShort",
+                "password": "TooShort",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },
@@ -183,7 +183,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         },
         {
             "user_attrs": {
-                "password": "LongEnough",
+                "password": "LongEnough",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },
@@ -195,7 +195,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         # Test password is too common criterion.
         {
             "user_attrs": {
-                "password": "Password",
+                "password": "Password",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },
@@ -206,7 +206,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         },
         {
             "user_attrs": {
-                "password": "Password",
+                "password": "Password",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },
@@ -216,7 +216,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         # Test if password is only numeric.
         {
             "user_attrs": {
-                "password": "1234567890",
+                "password": "1234567890",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },
@@ -227,7 +227,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         },
         {
             "user_attrs": {
-                "password": "1234567890",
+                "password": "1234567890",  # NOSONAR
                 "username": "TestUser1",
                 "is_superuser": False,
             },

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -56,7 +56,6 @@ def test_user_create(post, admin):
     assert not response.data['is_system_auditor']
 
 
-@pytest.mark.django_db
 # Disable local password checks to ensure that any ValidationError originates from the Django validators.
 @override_settings(
     LOCAL_PASSWORD_MIN_LENGTH=1,
@@ -64,6 +63,7 @@ def test_user_create(post, admin):
     LOCAL_PASSWORD_MIN_UPPER=0,
     LOCAL_PASSWORD_MIN_SPECIAL=0,
 )
+@pytest.mark.django_db
 def test_user_create_with_django_password_validation_basic(post, admin):
     """Test if the Django password validators are applied correctly."""
     with override_settings(
@@ -107,7 +107,71 @@ def test_user_create_with_django_password_validation_basic(post, admin):
         assert response.status_code == 201
 
 
-@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "user_attrs,validators,expected_status_code",
+    [
+        # Test password similarity with username.
+        (
+            {"password": "TestUser1", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
+            ],
+            400,
+        ),
+        (
+            {"password": "abc", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
+            ],
+            201,
+        ),
+        # Test password min length criterion.
+        (
+            {"password": "TooShort", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator', 'OPTIONS': {'min_length': 9}},
+            ],
+            400,
+        ),
+        (
+            {"password": "LongEnough", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator', 'OPTIONS': {'min_length': 9}},
+            ],
+            201,
+        ),
+        # Test password is too common criterion.
+        (
+            {"password": "Password", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
+            ],
+            400,
+        ),
+        (
+            {"password": "aEArV$5Vkdw", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
+            ],
+            201,
+        ),
+        # Test if password is only numeric.
+        (
+            {"password": "1234567890", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
+            ],
+            400,
+        ),
+        (
+            {"password": "abc4567890", "username": "TestUser1", "is_superuser": False},  # NOSONAR
+            [
+                {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
+            ],
+            201,
+        ),
+    ],
+)
 # Disable local password checks to ensure that any ValidationError originates from the Django validators.
 @override_settings(
     LOCAL_PASSWORD_MIN_LENGTH=1,
@@ -115,18 +179,18 @@ def test_user_create_with_django_password_validation_basic(post, admin):
     LOCAL_PASSWORD_MIN_UPPER=0,
     LOCAL_PASSWORD_MIN_SPECIAL=0,
 )
-def test_user_create_with_django_password_validation_ext(post, delete, admin):
+@pytest.mark.django_db
+def test_user_create_with_django_password_validation_ext(post, delete, admin, user_attrs, validators, expected_status_code):
     """Test the functionality of the single Django password validators."""
     #
-    default_fixtures = {
-        # Keys in `fixtures` override `default_fixtures` if they exist and their
-        # value is not 'None'.
+    default_parameters = {
+        # Default values for input parameters which are None.
         "user_attrs": {
             "password": "r$TyKiOCb#ED",  # NOSONAR
             "username": "DefaultUser",
             "is_superuser": False,
         },
-        "password_validators": [
+        "validators": [
             {
                 'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
             },
@@ -144,116 +208,21 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
             },
         ],
     }
-    # The list of fixture dicts which constitute the test cases.
-    fixtures_list = [
-        # Test password similarity with username.
-        {
-            "user_attrs": {
-                "password": "TestUser1",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [
-                {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
-            ],
-            "expected_status_code": 400,
-        },
-        {
-            "user_attrs": {
-                "password": "abc",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [
-                {'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator'},
-            ],
-            "expected_status_code": 201,
-        },
-        # Test password min length criterion.
-        {
-            "user_attrs": {
-                "password": "TooShort",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [
-                {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator', 'OPTIONS': {'min_length': 9}},
-            ],
-            "expected_status_code": 400,
-        },
-        {
-            "user_attrs": {
-                "password": "LongEnough",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [
-                {'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator', 'OPTIONS': {'min_length': 9}},
-            ],
-            "expected_status_code": 201,
-        },
-        # Test password is too common criterion.
-        {
-            "user_attrs": {
-                "password": "Password",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [
-                {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator'},
-            ],
-            "expected_status_code": 400,
-        },
-        {
-            "user_attrs": {
-                "password": "Password",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [],
-            "expected_status_code": 201,
-        },
-        # Test if password is only numeric.
-        {
-            "user_attrs": {
-                "password": "1234567890",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [
-                {'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator'},
-            ],
-            "expected_status_code": 400,
-        },
-        {
-            "user_attrs": {
-                "password": "1234567890",  # NOSONAR
-                "username": "TestUser1",
-                "is_superuser": False,
-            },
-            "password_validators": [],
-            "expected_status_code": 201,
-        },
-    ]
-    for i, fixtures in enumerate(fixtures_list):
-        user_attrs = fixtures.setdefault("user_attrs", default_fixtures["user_attrs"])
-        password_validators = fixtures.setdefault("password_validators", default_fixtures["password_validators"])
-        expected_status_code = fixtures["expected_status_code"]
-        print(f"Testing fixtures {i}: {expected_status_code=} {user_attrs=}")
-        with override_settings(AUTH_PASSWORD_VALIDATORS=password_validators):
-            response = post(reverse('api:user_list'), user_attrs, admin, middleware=SessionMiddleware(mock.Mock()))
-            assert response.status_code == expected_status_code, (i, fixtures)
-            # Delete user if it was created succesfully.
-            if response.status_code == 201:
-                response = delete(reverse('api:user_detail', kwargs={'pk': response.data['id']}), admin, middleware=SessionMiddleware(mock.Mock()))
-                assert response.status_code == 204
-            else:
-                # Catch the unexpected behavour that sometimes the user is
-                # written into the database before the validation fails. This
-                # actually can happen if UserSerializer.validate instantiates
-                # User(**attrs)!
-                username = fixtures['user_attrs']['username']
-                assert not User.objects.filter(username=username)
+    user_attrs = user_attrs if user_attrs is not None else default_parameters["user_attrs"]
+    validators = validators if validators is not None else default_parameters["validators"]
+    with override_settings(AUTH_PASSWORD_VALIDATORS=validators):
+        response = post(reverse('api:user_list'), user_attrs, admin, middleware=SessionMiddleware(mock.Mock()))
+        assert response.status_code == expected_status_code
+        # Delete user if it was created succesfully.
+        if response.status_code == 201:
+            response = delete(reverse('api:user_detail', kwargs={'pk': response.data['id']}), admin, middleware=SessionMiddleware(mock.Mock()))
+            assert response.status_code == 204
+        else:
+            # Catch the unexpected behavior that sometimes the user is written
+            # into the database before the validation fails. This actually can
+            # happen if UserSerializer.validate instantiates User(**attrs)!
+            username = user_attrs['username']
+            assert not User.objects.filter(username=username)
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -242,11 +242,18 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin):
         print(f"Testing fixtures {i}: {expected_status_code=} {user_attrs=}")
         with override_settings(AUTH_PASSWORD_VALIDATORS=password_validators):
             response = post(reverse('api:user_list'), user_attrs, admin, middleware=SessionMiddleware(mock.Mock()))
-            assert response.status_code == expected_status_code
+            assert response.status_code == expected_status_code, (i, fixtures)
             # Delete user if it was created succesfully.
             if response.status_code == 201:
                 response = delete(reverse('api:user_detail', kwargs={'pk': response.data['id']}), admin, middleware=SessionMiddleware(mock.Mock()))
                 assert response.status_code == 204
+            else:
+                # Catch the unexpected behavour that sometimes the user is
+                # written into the database before the validation fails. This
+                # actually can happen if UserSerializer.validate instantiates
+                # User(**attrs)!
+                username = fixtures['user_attrs']['username']
+                assert not User.objects.filter(username=username)
 
 
 @pytest.mark.django_db
@@ -275,6 +282,10 @@ def test_updating_own_password_refreshes_session(patch, admin):
     Updating your own password should refresh the session id.
     '''
     with mock.patch('awx.api.serializers.update_session_auth_hash') as update_session_auth_hash:
+        # Attention: If the Django password validator `CommonPasswordValidator`
+        # is active, this test case will fail because this validator raises on
+        # password 'newpassword'. Consider changing the hard-coded password to
+        # something uncommon.
         patch(reverse('api:user_detail', kwargs={'pk': admin.pk}), {'password': 'newpassword'}, admin, middleware=SessionMiddleware(mock.Mock()))
         assert update_session_auth_hash.called
 


### PR DESCRIPTION
[AAP-37381](https://issues.redhat.com/browse/AAP-37381)

##### SUMMARY
Fixed application of Django password validators.

The Django password validator UserAttributeSimilarityValidator did not work because it didn't have access to the object's attributes. This is fixed now.

Also added some functional tests for this.


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
```
devel
```


##### ADDITIONAL INFORMATION
