### PR TITLE
doc: add url format option to custom credentials

### DIFF
--- a/docs/credentials/custom_credential_types.md
+++ b/docs/credentials/custom_credential_types.md
@@ -127,9 +127,9 @@ ordered fields for that type:
 
             "type": ("string" | "boolean")   # defaults to 'string'
 
-            "format": "ssh_private_key"      # optional, can be used to enforce data
-                                             # format validity for SSH private key
-                                             # data (only applicable to `type=string`)
+            "format": ("ssh_private_key" | "url") # optional, can be used to enforce data
+                                                  # format validity for SSH private key
+                                                  # data or for URL format (only applicable to `type=string`)
 
             "secret": true,                  # if true, the field value will be encrypted
 


### PR DESCRIPTION
##### SUMMARY
add the format `url` to the custom credential documentation

##### ISSUE TYPE
Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### AWX VERSION
```
N/A
```

##### ADDITIONAL INFORMATION
according to https://github.com/ansible/awx/blob/devel/awx/main/fields.py#L728 custom credential format could also be `url` not only `ssh_private_key`
