### PR TITLE
Configure the pull policy for EE images.

### DIFF
--- a/awx/main/management/commands/register_default_execution_environments.py
+++ b/awx/main/management/commands/register_default_execution_environments.py
@@ -118,7 +118,7 @@ class Command(BaseCommand):
                 defaults={
                     'image': ee["image"],
                     'credential': registry_cred,
-                    'pull': ee["pull"]
+                    'pull': ee.get("pull", "missing")
                 }
             )
             if ee_created:
@@ -130,6 +130,9 @@ class Command(BaseCommand):
                     changed = True
                 if _this_ee.credential != registry_cred:
                     _this_ee.credential = registry_cred
+                    changed = True
+                if _this_ee.pull != ee.get("pull", "missing"):
+                    _this_ee.pull = ee.get("pull", "missing")
                     changed = True
             if changed:
                 _this_ee.save()

--- a/awx/main/management/commands/register_default_execution_environments.py
+++ b/awx/main/management/commands/register_default_execution_environments.py
@@ -113,7 +113,14 @@ class Command(BaseCommand):
 
         # Create default globally available Execution Environments
         for ee in reversed(settings.GLOBAL_JOB_EXECUTION_ENVIRONMENTS):
-            _this_ee, ee_created = ExecutionEnvironment.objects.get_or_create(name=ee["name"], defaults={'image': ee["image"], 'credential': registry_cred, 'pull': ee["pull"]})
+            _this_ee, ee_created = ExecutionEnvironment.objects.get_or_create(
+                name=ee["name"],
+                defaults={
+                    'image': ee["image"],
+                    'credential': registry_cred,
+                    'pull': ee["pull"]
+                }
+            )
             if ee_created:
                 changed = True
                 print(f"'{ee['name']}' Default Execution Environment registered.")

--- a/awx/main/management/commands/register_default_execution_environments.py
+++ b/awx/main/management/commands/register_default_execution_environments.py
@@ -113,7 +113,7 @@ class Command(BaseCommand):
 
         # Create default globally available Execution Environments
         for ee in reversed(settings.GLOBAL_JOB_EXECUTION_ENVIRONMENTS):
-            _this_ee, ee_created = ExecutionEnvironment.objects.get_or_create(name=ee["name"], defaults={'image': ee["image"], 'credential': registry_cred})
+            _this_ee, ee_created = ExecutionEnvironment.objects.get_or_create(name=ee["name"], defaults={'image': ee["image"], 'credential': registry_cred, 'pull': ee["pull"]})
             if ee_created:
                 changed = True
                 print(f"'{ee['name']}' Default Execution Environment registered.")

--- a/awx/main/tests/functional/utils/test_execution_environments.py
+++ b/awx/main/tests/functional/utils/test_execution_environments.py
@@ -20,10 +20,11 @@ def test_default_to_jobs_default(set_up_defaults, organization):
     """
     # Fill in some other unrelated EEs
     ExecutionEnvironment.objects.create(name='Steves environment', image='quay.io/ansible/awx-ee')
-    ExecutionEnvironment(name=settings.GLOBAL_JOB_EXECUTION_ENVIRONMENTS[0]['name'], image='quay.io/ansible/awx-ee', organization=organization)
+    ExecutionEnvironment(name=settings.GLOBAL_JOB_EXECUTION_ENVIRONMENTS[0]['name'], image='quay.io/ansible/awx-ee', organization=organization, pull='missing')
     default_ee = get_default_execution_environment()
     assert default_ee.image == settings.GLOBAL_JOB_EXECUTION_ENVIRONMENTS[0]['image']
     assert default_ee.name == settings.GLOBAL_JOB_EXECUTION_ENVIRONMENTS[0]['name']
+    assert default_ee.pull == settings.GLOBAL_JOB_EXECUTION_ENVIRONMENTS[0]['pull']
 
 
 @pytest.mark.django_db

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -180,7 +180,7 @@ DEFAULT_EXECUTION_ENVIRONMENT = None
 # Should be ordered from highest to lowest precedence.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE(s)
 # If a registry credential is needed to pull the image, that can be provided to the awx-manage command
-GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE (latest)', 'image': 'quay.io/ansible/awx-ee:latest', 'pull': 'missing'}]
+GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE (latest)', 'image': 'quay.io/ansible/awx-ee:latest'}]
 # This setting controls which EE will be used for project updates.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE
 # This image is distinguished from others by having "managed" set to True and users have limited

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -180,7 +180,7 @@ DEFAULT_EXECUTION_ENVIRONMENT = None
 # Should be ordered from highest to lowest precedence.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE(s)
 # If a registry credential is needed to pull the image, that can be provided to the awx-manage command
-GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE (latest)', 'image': 'quay.io/ansible/awx-ee:latest'}]
+GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE (latest)', 'image': 'quay.io/ansible/awx-ee:latest', 'pull': 'missing'}]
 # This setting controls which EE will be used for project updates.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE
 # This image is distinguished from others by having "managed" set to True and users have limited

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -180,7 +180,7 @@ DEFAULT_EXECUTION_ENVIRONMENT = None
 # Should be ordered from highest to lowest precedence.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE(s)
 # If a registry credential is needed to pull the image, that can be provided to the awx-manage command
-GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE (latest)', 'image': 'quay.io/ansible/awx-ee:latest'}]
+GLOBAL_JOB_EXECUTION_ENVIRONMENTS = [{'name': 'AWX EE (latest)', 'image': 'quay.io/ansible/awx-ee:latest', 'pull': ''}]
 # This setting controls which EE will be used for project updates.
 # The awx-manage register_default_execution_environments command reads this setting and registers the EE
 # This image is distinguished from others by having "managed" set to True and users have limited


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Configure the pull policy for EE images.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
related https://github.com/ansible/awx-operator/issues/1490

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
latest
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default execution environments now include and initialize the image pull value when created, and existing global environments are updated if their pull value differs.

* **Tests**
  * Added assertions to verify the pull value for default execution environments.

* **Chores**
  * Updated default configuration for global execution environments to include a pull field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->