### PR TITLE
Remove ProtocolTypeRouter deprecation exception

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -80,9 +80,6 @@ filterwarnings =
   once:distro.linux_distribution.. is deprecated. It should only be used as a compatibility shim with Python's platform.linux_distribution... Please use distro.id.., distro.version.. and distro.name.. instead.:DeprecationWarning:awx.main.analytics.collectors
 
   # FIXME: Figure this out, fix and then delete the entry.
-  once:\nUsing ProtocolTypeRouter without an explicit "http" key is deprecated.\nGiven that you have not passed the "http" you likely should use Django's\nget_asgi_application...:DeprecationWarning:awx.main.routing
-
-  # FIXME: Figure this out, fix and then delete the entry.
   once:Channel's inbuilt http protocol AsgiHandler is deprecated. Use Django's get_asgi_application.. instead.:DeprecationWarning:channels.routing
 
   # FIXME: Use `codecs.open()` via a context manager


### PR DESCRIPTION
##### SUMMARY
* Time has passed. Channels (4.2.0) no longer raises a deprecation warning for this case. It used to (4.1.0).
* All is good. No code changes needed for this. We do NOT service http requests over daphne, just websockets. We, correctly, do NOT supply the http key so daphne does NOT service http requests.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
