### PR TITLE
Remove AsgiHandler deprecation exception

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -79,9 +79,6 @@ filterwarnings =
   # FIXME: in `awx/main/analytics/collectors.py` and then delete the entry.
   once:distro.linux_distribution.. is deprecated. It should only be used as a compatibility shim with Python's platform.linux_distribution... Please use distro.id.., distro.version.. and distro.name.. instead.:DeprecationWarning:awx.main.analytics.collectors
 
-  # FIXME: Figure this out, fix and then delete the entry.
-  once:Channel's inbuilt http protocol AsgiHandler is deprecated. Use Django's get_asgi_application.. instead.:DeprecationWarning:channels.routing
-
   # FIXME: Use `codecs.open()` via a context manager
   # FIXME: in `awx/main/utils/ansible.py` to close hanging file descriptors
   # FIXME: and then delete the entry.


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
* Time has passed. Channels (4.2.0) no longer raises a deprecation warning for this case. It used to (4.1.0).
* We do NOT serve http requests over daphne, this is the default behavior of ProtocolTypeRouter() when the http param is NOT included

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
