### PR TITLE
[dispatcherd] Dispatcher socket-based `--status` demo working

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -104,13 +104,17 @@ class MainConfig(AppConfig):
                         "sync_connection_factory": "awx.main.utils.db.psycopg_connection_from_django",
                         "channels": ['tower_broadcast_all', 'tower_settings_change', get_task_queuename()],
                         "default_publish_channel": settings.CLUSTER_HOST_ID,  # used for debugging commands
-                    }
+                    },
+                    "socket": {"socket_path": settings.DISPATCHERD_DEBUGGING_SOCKFILE},
                 },
                 "producers": {
                     "ScheduledProducer": {"task_schedule": settings.DISPATCHER_SCHEDULE},
                     "OnStartProducer": {"task_list": {"awx.main.tasks.system.dispatch_startup": {}}},
                 },
-                "publish": {"default_broker": "pg_notify"},
+                "publish": {
+                    "default_control_broker": "socket",
+                    "default_broker": "pg_notify",
+                },
             }
         )
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -426,6 +426,9 @@ DISPATCHER_DB_DOWNTIME_TOLERANCE = 40
 # sqlite3 based tests will use this
 DISPATCHER_MOCK_PUBLISH = False
 
+# Debugging sockfile for the --status command
+DISPATCHERD_DEBUGGING_SOCKFILE = os.path.join(BASE_DIR, 'dispatcherd.sock')
+
 BROKER_URL = 'unix:///var/run/redis/redis.sock'
 CELERYBEAT_SCHEDULE = {
     'tower_scheduler': {'task': 'awx.main.tasks.system.awx_periodic_scheduler', 'schedule': timedelta(seconds=30), 'options': {'expires': 20}},
@@ -750,7 +753,7 @@ LOGGING = {
         'simple': {'format': '%(asctime)s %(levelname)-8s [%(guid)s] %(name)s %(message)s'},
         'json': {'()': 'awx.main.utils.formatters.LogstashFormatter'},
         'timed_import': {'()': 'awx.main.utils.formatters.TimeFormatter', 'format': '%(relativeSeconds)9.3f %(levelname)-8s %(message)s'},
-        'dispatcherd': {'format': '%(asctime)s %(levelname)-8s [%(guid)s] %(name)s PID:%(process)d %(message)s'},
+        'dispatcher': {'format': '%(asctime)s %(levelname)-8s [%(guid)s] %(name)s PID:%(process)d %(message)s'},
     },
     # Extended below based on install scenario. You probably don't want to add something directly here.
     # See 'handler_config' below.
@@ -804,7 +807,7 @@ LOGGING = {
         'social': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'dispatcherd': {'handlers': ['console'], 'level': 'INFO'},
+        'dispatcherd': {'handlers': ['dispatcher'], 'level': 'INFO'},
     },
 }
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -807,7 +807,7 @@ LOGGING = {
         'social': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'system_tracking_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
         'rbac_migrations': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'DEBUG'},
-        'dispatcherd': {'handlers': ['dispatcher'], 'level': 'INFO'},
+        'dispatcherd': {'handlers': ['dispatcher', 'console'], 'level': 'INFO'},
     },
 }
 


### PR DESCRIPTION
##### SUMMARY
Small patch to adopt the `ctl` broker type from https://github.com/ansible/dispatcherd/pull/125

Verified working

```
In [1]: from dispatcherd.factories import get_control_from_settings

In [2]: ctl = get_control_from_settings()

In [3]: ctl.control_with_reply('workers')
2025-03-27 18:37:15,505 INFO     [-] awx.main.dispatch.control control-and-reply message returned in 0.002811908721923828 seconds
Out[3]: 
[{'worker-2': {'worker_id': 2,
   'pid': 883,
   'status': 'ready',
   'finished_count': 13,
   'current_task': None,
   'current_task_uuid': None,
   'active_cancel': False,
   'age': 207.06849504902493},
...

In [39]: ctl.__dict__
Out[39]: 
{'queuename': None,
 'broker_name': 'socket',
 'broker_config': {'socket_path': '/awx_devel/awx/dispatcherd.sock'}}

```

Background:

By moving the dispatcher to another library, we can't paste our status to redis for later retrieval. This shows our desired alternative working, just basically proving we can do this and the library split won't completely blow up in our face because we didn't think of this.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
