### PR TITLE
Remove cgi deprecation exception.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include awx/ui/Makefile
 
-PYTHON := $(notdir $(shell for i in python3.13 python3; do command -v $$i; done|sed 1q))
+PYTHON := $(notdir $(shell for i in python3.11 python3; do command -v $$i; done|sed 1q))
 SHELL := bash
 DOCKER_COMPOSE ?= docker compose
 OFFICIAL ?= no

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include awx/ui/Makefile
 
-PYTHON := $(notdir $(shell for i in python3.11 python3; do command -v $$i; done|sed 1q))
+PYTHON := $(notdir $(shell for i in python3.13 python3; do command -v $$i; done|sed 1q))
 SHELL := bash
 DOCKER_COMPOSE ?= docker compose
 OFFICIAL ?= no

--- a/pytest.ini
+++ b/pytest.ini
@@ -41,9 +41,6 @@ filterwarnings =
   # FIXME: Delete this entry once `zope` is updated.
   once:Deprecated call to `pkg_resources.declare_namespace.'zope'.`.\nImplementing implicit namespace packages .as specified in PEP 420. is preferred to `pkg_resources.declare_namespace`. See https.//setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages:DeprecationWarning:
 
-  # FIXME: Delete this entry once `coreapi` is updated.
-  once:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:_pytest.assertion.rewrite
-
   # FIXME: Delete this entry once the use of `distutils` is exterminated from the repo.
   once:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning:_pytest.assertion.rewrite
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -41,6 +41,9 @@ filterwarnings =
   # FIXME: Delete this entry once `zope` is updated.
   once:Deprecated call to `pkg_resources.declare_namespace.'zope'.`.\nImplementing implicit namespace packages .as specified in PEP 420. is preferred to `pkg_resources.declare_namespace`. See https.//setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages:DeprecationWarning:
 
+  # FIXME: Delete this entry once `coreapi` is updated.
+  once:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:_pytest.assertion.rewrite
+
   # FIXME: Delete this entry once the use of `distutils` is exterminated from the repo.
   once:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning:_pytest.assertion.rewrite
 

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -1,5 +1,6 @@
 build
 coreapi
+legacy-cgi; python_version >= '3.13'
 django-debug-toolbar==3.2.4
 django-test-migrations
 drf-yasg<1.21.10  # introduces new DeprecationWarning that is turned into error


### PR DESCRIPTION
##### SUMMARY
This module is no longer part of the Python standard library. It was [removed in Python 3.13](https://docs.python.org/3/whatsnew/3.13.html#whatsnew313-pep594) after being deprecated in Python 3.11. The removal was decided in [PEP 594](https://peps.python.org/pep-0594/).

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
