### PR TITLE
Remove L10N deprecation exception

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -80,10 +80,6 @@ LANGUAGE_CODE = 'en-us'
 # to load the internationalization machinery.
 USE_I18N = True
 
-# If you set this to False, Django will not format dates, numbers and
-# calendars according to the current locale
-USE_L10N = True
-
 USE_TZ = True
 
 STATICFILES_DIRS = [

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,9 +29,6 @@ filterwarnings =
   # FIXME: Set `USE_TZ` to `True`.
   once:The default value of USE_TZ will change from False to True in Django 5.0. Set USE_TZ to False in your project settings if you want to keep the current default behavior.:django.utils.deprecation.RemovedInDjango50Warning:django.conf
 
-  # FIXME: Delete this entry once `USE_L10N` use is removed.
-  once:The USE_L10N setting is deprecated. Starting with Django 5.0, localized formatting of data will always be enabled. For example Django will display numbers and dates using the format of the current locale.:django.utils.deprecation.RemovedInDjango50Warning:django.conf
-
   # FIXME: Delete this entry once `pyparsing` is updated.
   once:module 'sre_constants' is deprecated:DeprecationWarning:_pytest.assertion.rewrite
 


### PR DESCRIPTION
##### SUMMARY
Remove deprecation error from no longer use of L10N setting (AAP-27491).

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
