### PR TITLE
Remove zope deprecation exception

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -38,9 +38,6 @@ filterwarnings =
   # FIXME: Delete this entry once `polymorphic` is updated.
   once:pkg_resources is deprecated as an API. See https.//setuptools.pypa.io/en/latest/pkg_resources.html:DeprecationWarning:_pytest.assertion.rewrite
 
-  # FIXME: Delete this entry once `zope` is updated.
-  once:Deprecated call to `pkg_resources.declare_namespace.'zope'.`.\nImplementing implicit namespace packages .as specified in PEP 420. is preferred to `pkg_resources.declare_namespace`. See https.//setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages:DeprecationWarning:
-
   # FIXME: Delete this entry once `coreapi` is updated.
   once:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:_pytest.assertion.rewrite
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -530,9 +530,6 @@ yarl==1.18.3
     # via aiohttp
 zipp==3.21.0
     # via importlib-metadata
-zope-interface==7.2
-    # via twisted
-
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.2.4
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
Remove deprecation error for zope (AAP-27488).

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
