### PR TITLE
Remove cgi deprecation exception from pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -34,9 +34,6 @@ filterwarnings =
   # FIXME: Delete this entry once `zope` is updated.
   once:Deprecated call to `pkg_resources.declare_namespace.'zope'.`.\nImplementing implicit namespace packages .as specified in PEP 420. is preferred to `pkg_resources.declare_namespace`. See https.//setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages:DeprecationWarning:
 
-  # FIXME: Delete this entry once `coreapi` is updated.
-  once:'cgi' is deprecated and slated for removal in Python 3.13:DeprecationWarning:_pytest.assertion.rewrite
-
   # FIXME: Delete this entry once the use of `distutils` is exterminated from the repo.
   once:The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives:DeprecationWarning:_pytest.assertion.rewrite
 


### PR DESCRIPTION
##### SUMMARY
This module is no longer part of the Python standard library. It was [removed in Python 3.13](https://docs.python.org/3/whatsnew/3.13.html#whatsnew313-pep594) after being deprecated in Python 3.11. The removal was decided in [PEP 594](https://peps.python.org/pep-0594/).
Resolves AAP-2749.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
Since coreapi was addressed in PR https://github.com/ansible/awx/pull/15804, the removal of the cgi deprecation exception should be able to proceed without issue.
