### PR TITLE
Complete dispatcherd integration & job cancellation (AAP-43033)

### DIFF
--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -106,7 +106,7 @@ class task:
                             return alt_impl.apply_async(args=args, kwargs=kwargs, queue=queue, uuid=uuid, **kw)
                         else:
                             logger.info(f"[DISPATCHER] No alternative registered for {cls.name}; using original legacy method.")
-                except Exception as e:
+                except Exception:
                     logger.warning(f"[DISPATCHER] Failed to check for alternative dispatcherd implementation for {cls.name}")
                     # Continue with original implementation if anything fails
                     pass

--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -96,19 +96,18 @@ class task:
 
             @classmethod
             def apply_async(cls, args=None, kwargs=None, queue=None, uuid=None, **kw):
-                # Entry point debug logging
                 try:
                     from flags.state import flag_enabled
 
                     if flag_enabled('FEATURE_NEW_DISPATCHER'):
                         if cls.name in ALTERNATIVE_TASK_IMPLEMENTATIONS:
                             alt_impl = ALTERNATIVE_TASK_IMPLEMENTATIONS[cls.name]
-                            logger.info(f"Using dispatcherd implementation for task: {cls.name}")
+                            logger.info(f"[DISPATCHER] Using dispatcherd implementation for task: {cls.name}")
                             return alt_impl.apply_async(args=args, kwargs=kwargs, queue=queue, uuid=uuid, **kw)
                         else:
-                            logger.info(f"⚠Task {cls.name} is not registered for dispatcherd, using original method")
+                            logger.info(f"[DISPATCHER] No alternative registered for {cls.name}; using original legacy method.")
                 except Exception as e:
-                    logger.warning(f"Failed to check for dispatcherd implementation: {e}")
+                    logger.warning(f"[DISPATCHER] Failed to check for alternative dispatcherd implementation for {cls.name}")
                     # Continue with original implementation if anything fails
                     pass
 

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -76,19 +76,24 @@ class Command(BaseCommand):
             else:
                 return Control('dispatcher').control({'control': 'reload'})
         if options.get('cancel'):
+            cancel_str = options.get('cancel')
+            try:
+                cancel_data = yaml.safe_load(cancel_str)
+            except Exception:
+                cancel_data = [cancel_str]
+            if not isinstance(cancel_data, list):
+                cancel_data = [cancel_str]
+
             if flag_enabled('FEATURE_NEW_DISPATCHER'):
                 ctl = get_control_from_settings()
-                running_data = ctl.control_with_reply('running')
-                print(yaml.dump(running_data, default_flow_style=False))
+                results = []
+                for task_id in cancel_data:
+                    # For each task UUID, send an individual cancel command
+                    result = ctl.control_with_reply('cancel', data={'uuid': task_id})
+                    results.append(result)
+                print(yaml.dump(results, default_flow_style=False))
                 return
             else:
-                cancel_str = options.get('cancel')
-                try:
-                    cancel_data = yaml.safe_load(cancel_str)
-                except Exception:
-                    cancel_data = [cancel_str]
-                if not isinstance(cancel_data, list):
-                    cancel_data = [cancel_str]
                 print(Control('dispatcher').cancel(cancel_data))
                 return
 

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -23,6 +23,7 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.timezone import now
 from django.utils.encoding import smart_str
 from django.contrib.contenttypes.models import ContentType
+from flags.state import flag_enabled
 
 # REST Framework
 from rest_framework.exceptions import ParseError
@@ -1463,21 +1464,44 @@ class UnifiedJob(
     def cancel_dispatcher_process(self):
         """Returns True if dispatcher running this job acknowledged request and sent SIGTERM"""
         if not self.celery_task_id:
-            return
+            return False
+
         canceled = []
+        # Special case for task manager (used during workflow job cancellation)
         if not connection.get_autocommit():
-            # this condition is purpose-written for the task manager, when it cancels jobs in workflows
-            ControlDispatcher('dispatcher', self.controller_node).cancel([self.celery_task_id], with_reply=False)
+            if flag_enabled('FEATURE_NEW_DISPATCHER'):
+                try:
+                    from dispatcherd.factories import get_control_from_settings
+
+                    ctl = get_control_from_settings()
+                    ctl.control('cancel', data={'uuid': self.celery_task_id})
+                except Exception:
+                    logger.exception("Error sending cancel command to new dispatcher")
+            else:
+                try:
+                    ControlDispatcher('dispatcher', self.controller_node).cancel([self.celery_task_id], with_reply=False)
+                except Exception:
+                    logger.exception("Error sending cancel command to legacy dispatcher")
             return True  # task manager itself needs to act under assumption that cancel was received
 
+        # Standard case with reply
         try:
-            # Use control and reply mechanism to cancel and obtain confirmation
             timeout = 5
-            canceled = ControlDispatcher('dispatcher', self.controller_node).cancel([self.celery_task_id])
+            if flag_enabled('FEATURE_NEW_DISPATCHER'):
+                from dispatcherd.factories import get_control_from_settings
+
+                ctl = get_control_from_settings()
+                results = ctl.control_with_reply('cancel', data={'uuid': self.celery_task_id}, expected_replies=1, timeout=timeout)
+                # Check if cancel was successful by checking if we got any results
+                return bool(results and len(results) > 0)
+            else:
+                # Original implementation
+                canceled = ControlDispatcher('dispatcher', self.controller_node).cancel([self.celery_task_id])
         except socket.timeout:
             logger.error(f'could not reach dispatcher on {self.controller_node} within {timeout}s')
         except Exception:
             logger.exception("error encountered when checking task status")
+
         return bool(self.celery_task_id in canceled)  # True or False, whether confirmation was obtained
 
     def cancel(self, job_explanation=None, is_chain=False):

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -161,17 +161,27 @@ def dispatch_startup():
 
 
 def inform_cluster_of_shutdown():
+    """
+    Clean system shutdown that marks the current instance offline.
+    In legacy mode, it also reaps waiting jobs.
+    In dispatcherd mode, it relies on dispatcherd's built-in cleanup.
+    """
     try:
-        this_inst = Instance.objects.get(hostname=settings.CLUSTER_HOST_ID)
-        this_inst.mark_offline(update_last_seen=True, errors=_('Instance received normal shutdown signal'))
-        if not flag_enabled('FEATURE_NEW_DISPATCHER'):
-            try:
-                reaper.reap_waiting(this_inst, grace_period=0)
-            except Exception:
-                logger.exception('failed to reap waiting jobs for {}'.format(this_inst.hostname))
-        logger.warning('Normal shutdown signal for instance {}, removed self from capacity pool.'.format(this_inst.hostname))
-    except Exception:
-        logger.exception('Encountered problem with normal shutdown signal.')
+        inst = Instance.objects.get(hostname=settings.CLUSTER_HOST_ID)
+        inst.mark_offline(update_last_seen=True, errors=_('Instance received normal shutdown signal'))
+    except Instance.DoesNotExist:
+        logger.exception("Cluster host not found: %s", settings.CLUSTER_HOST_ID)
+        return
+
+    if flag_enabled('FEATURE_NEW_DISPATCHER'):
+        logger.debug("Dispatcherd mode: no extra reaping required for instance %s", inst.hostname)
+    else:
+        try:
+            logger.debug("Legacy mode: reaping waiting jobs for instance %s", inst.hostname)
+            reaper.reap_waiting(inst, grace_period=0)
+        except Exception:
+            logger.exception("Failed to reap waiting jobs for %s", inst.hostname)
+    logger.warning("Normal shutdown processed for instance %s; instance removed from capacity pool.", inst.hostname)
 
 
 @task(queue=get_task_queuename)

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -184,7 +184,7 @@ def inform_cluster_of_shutdown():
     logger.warning("Normal shutdown processed for instance %s; instance removed from capacity pool.", inst.hostname)
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def migrate_jsonfield(table, pkfield, columns):
     batchsize = 10000
     with advisory_lock(f'json_migration_{table}', wait=False) as acquired:
@@ -230,7 +230,7 @@ def migrate_jsonfield(table, pkfield, columns):
         logger.warning(f"Migration of {table} to jsonb is finished.")
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def apply_cluster_membership_policies():
     from awx.main.signals import disable_activity_stream
 
@@ -342,7 +342,7 @@ def apply_cluster_membership_policies():
         logger.debug('Cluster policy computation finished in {} seconds'.format(time.time() - started_compute))
 
 
-@task(queue='tower_settings_change')
+@task_awx(queue='tower_settings_change')
 def clear_setting_cache(setting_keys):
     # log that cache is being cleared
     logger.info(f"clear_setting_cache of keys {setting_keys}")
@@ -355,7 +355,7 @@ def clear_setting_cache(setting_keys):
     cache.delete_many(cache_keys)
 
 
-@task(queue='tower_broadcast_all')
+@task_awx(queue='tower_broadcast_all')
 def delete_project_files(project_path):
     # TODO: possibly implement some retry logic
     lock_file = project_path + '.lock'
@@ -373,7 +373,7 @@ def delete_project_files(project_path):
             logger.exception('Could not remove lock file {}'.format(lock_file))
 
 
-@task(queue='tower_broadcast_all')
+@task_awx(queue='tower_broadcast_all')
 def profile_sql(threshold=1, minutes=1):
     if threshold <= 0:
         cache.delete('awx-profile-sql-threshold')
@@ -383,7 +383,7 @@ def profile_sql(threshold=1, minutes=1):
         logger.error('SQL QUERIES >={}s ENABLED FOR {} MINUTE(S)'.format(threshold, minutes))
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def send_notifications(notification_list, job_id=None):
     if not isinstance(notification_list, list):
         raise TypeError("notification_list should be of type list")
@@ -428,13 +428,13 @@ def events_processed_hook(unified_job):
             save_indirect_host_entries.delay(unified_job.id)
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def gather_analytics():
     if is_run_threshold_reached(getattr(settings, 'AUTOMATION_ANALYTICS_LAST_GATHER', None), settings.AUTOMATION_ANALYTICS_GATHER_INTERVAL):
         analytics.gather()
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def purge_old_stdout_files():
     nowtime = time.time()
     for f in os.listdir(settings.JOBOUTPUT_ROOT):
@@ -496,18 +496,18 @@ class CleanupImagesAndFiles:
         cls.run_remote(this_inst, **kwargs)
 
 
-@task(queue='tower_broadcast_all')
+@task_awx(queue='tower_broadcast_all')
 def handle_removed_image(remove_images=None):
     """Special broadcast invocation of this method to handle case of deleted EE"""
     CleanupImagesAndFiles.run(remove_images=remove_images, file_pattern='')
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def cleanup_images_and_files():
     CleanupImagesAndFiles.run(image_prune=True)
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def cluster_node_health_check(node):
     """
     Used for the health check endpoint, refreshes the status of the instance, but must be ran on target node
@@ -526,7 +526,7 @@ def cluster_node_health_check(node):
     this_inst.local_health_check()
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def execution_node_health_check(node):
     if node == '':
         logger.warning('Remote health check incorrectly called with blank string')
@@ -681,8 +681,6 @@ def adispatch_cluster_node_heartbeat(binder):
     Dispatcherd implementation.
     Uses Control API to get running tasks.
     """
-    logger.info("Running cluster_node_heartbeat using dispatcherd implementation")
-
     # Run common instance management logic
     this_inst, instance_list, lost_instances = _heartbeat_instance_management()
     if this_inst is None:
@@ -746,16 +744,12 @@ def _get_active_task_ids_from_dispatcherd(binder):
         return None
 
 
-# NOTE: This approach of registering alternative dispatcher implementations is a targeted solution
-# for specific functions (currently only cluster_node_heartbeat) and is not a general
-# solution for all tasks.
+# NOTE: This approach of registering alternative dispatcher implementations is a targeted solution for specific functions.
 try:
-    # Import and use the registry from publish module
-    from awx.main.dispatch.publish import ALTERNATIVE_TASK_IMPLEMENTATIONS
+    from awx.main.dispatch.publish import serialize_task, ALTERNATIVE_TASK_IMPLEMENTATIONS
 
     # Register the alternative implementation
-    ALTERNATIVE_TASK_IMPLEMENTATIONS[cluster_node_heartbeat.name] = adispatch_cluster_node_heartbeat
-    logger.info(f"Successfully registered dispatcherd method for {cluster_node_heartbeat.name}")
+    ALTERNATIVE_TASK_IMPLEMENTATIONS[serialize_task(cluster_node_heartbeat)] = adispatch_cluster_node_heartbeat
 except Exception:
     logger.exception("Failed to register dispatcherd method for cluster_node_heartbeat")
 
@@ -857,7 +851,7 @@ def _heartbeat_handle_lost_instances(lost_instances, this_inst):
                 logger.exception('No SQL state available.  Error marking {} as lost'.format(other_inst.hostname))
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def awx_receptor_workunit_reaper():
     """
     When an AWX job is launched via receptor, files such as status, stdin, and stdout are created
@@ -895,7 +889,7 @@ def awx_receptor_workunit_reaper():
     administrative_workunit_reaper(receptor_work_list)
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def awx_k8s_reaper():
     if not settings.RECEPTOR_RELEASE_WORK:
         return
@@ -918,7 +912,7 @@ def awx_k8s_reaper():
                 logger.exception("Failed to delete orphaned pod {} from {}".format(job.log_format, group))
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def awx_periodic_scheduler():
     lock_session_timeout_milliseconds = settings.TASK_MANAGER_LOCK_TIMEOUT * 1000
     with advisory_lock('awx_periodic_scheduler_lock', lock_session_timeout_milliseconds=lock_session_timeout_milliseconds, wait=False) as acquired:
@@ -977,7 +971,7 @@ def awx_periodic_scheduler():
             emit_channel_notification('schedules-changed', dict(id=schedule.id, group_name="schedules"))
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def handle_failure_notifications(task_ids):
     """A task-ified version of the method that sends notifications."""
     found_task_ids = set()
@@ -992,7 +986,7 @@ def handle_failure_notifications(task_ids):
         logger.warning(f'Could not send notifications for {deleted_tasks} because they were not found in the database')
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def update_inventory_computed_fields(inventory_id):
     """
     Signal handler and wrapper around inventory.update_computed_fields to
@@ -1042,7 +1036,7 @@ def update_smart_memberships_for_inventory(smart_inventory):
     return False
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def update_host_smart_inventory_memberships():
     smart_inventories = Inventory.objects.filter(kind='smart', host_filter__isnull=False, pending_deletion=False)
     changed_inventories = set([])
@@ -1058,7 +1052,7 @@ def update_host_smart_inventory_memberships():
         smart_inventory.update_computed_fields()
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def delete_inventory(inventory_id, user_id, retries=5):
     # Delete inventory as user
     if user_id is None:
@@ -1120,7 +1114,7 @@ def _reconstruct_relationships(copy_mapping):
         new_obj.save()
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def deep_copy_model_obj(model_module, model_name, obj_pk, new_obj_pk, user_pk, permission_check_func=None):
     logger.debug('Deep copy {} from {} to {}.'.format(model_name, obj_pk, new_obj_pk))
 
@@ -1175,7 +1169,7 @@ def deep_copy_model_obj(model_module, model_name, obj_pk, new_obj_pk, user_pk, p
         update_inventory_computed_fields.delay(new_obj.id)
 
 
-@task(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename)
 def periodic_resource_sync():
     if not getattr(settings, 'RESOURCE_SERVER', None):
         logger.debug("Skipping periodic resource_sync, RESOURCE_SERVER not configured")

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -82,7 +82,12 @@ Try upgrading OpenSSH or providing your private key in an different format. \
 '''
 
 
-def dispatch_startup():
+def _run_dispatch_startup_common():
+    """
+    Execute the common startup initialization steps.
+    This includes updating schedules, syncing instance membership, and starting
+    local reaping and resetting metrics.
+    """
     startup_logger = logging.getLogger('awx.main.tasks')
 
     # TODO: Enable this on VM installs
@@ -92,14 +97,14 @@ def dispatch_startup():
     try:
         convert_jsonfields()
     except Exception:
-        logger.exception("Failed json field conversion, skipping.")
+        logger.exception("Failed JSON field conversion, skipping.")
 
-    startup_logger.debug("Syncing Schedules")
+    startup_logger.debug("Syncing schedules")
     for sch in Schedule.objects.all():
         try:
             sch.update_computed_fields()
         except Exception:
-            logger.exception("Failed to rebuild schedule {}.".format(sch))
+            logger.exception("Failed to rebuild schedule %s.", sch)
 
     #
     # When the dispatcher starts, if the instance cannot be found in the database,
@@ -119,14 +124,40 @@ def dispatch_startup():
     apply_cluster_membership_policies()
     cluster_node_heartbeat()
     reaper.startup_reaping()
-    if flag_enabled('FEATURE_NEW_DISPATCHER'):
-        from awx.main.tasks.jobs import dispatch_waiting_jobs
-
-        dispatch_waiting_jobs.apply_async(queue=get_task_queuename())
-    else:
-        reaper.reap_waiting(grace_period=0)
     m = DispatcherMetrics()
     m.reset_values()
+
+
+def _legacy_dispatch_startup():
+    """
+    Legacy branch for startup: simply performs reaping of waiting jobs with a zero grace period.
+    """
+    logger.debug("Legacy dispatcher: calling reaper.reap_waiting with grace_period=0")
+    reaper.reap_waiting(grace_period=0)
+
+
+def _dispatcherd_dispatch_startup():
+    """
+    New dispatcherd branch for startup: uses the control API to re-submit waiting jobs.
+    """
+    logger.debug("Dispatcherd enabled: dispatching waiting jobs via control channel")
+    from awx.main.tasks.jobs import dispatch_waiting_jobs
+
+    dispatch_waiting_jobs.apply_async(queue=get_task_queuename())
+
+
+def dispatch_startup():
+    """
+    System initialization at startup.
+    First, execute the common logic.
+    Then, if FEATURE_NEW_DISPATCHER is enabled, re-submit waiting jobs via the control API;
+    otherwise, fall back to legacy reaping of waiting jobs.
+    """
+    _run_dispatch_startup_common()
+    if flag_enabled('FEATURE_NEW_DISPATCHER'):
+        _dispatcherd_dispatch_startup()
+    else:
+        _legacy_dispatch_startup()
 
 
 def inform_cluster_of_shutdown():


### PR DESCRIPTION
## Summary

Change Type: New or Enhanced Feature

This PR completes the integration of the feature-flagged `dispatcherd` library in AWX by migrating all task decorators to be dispatcherd-aware and implementing job cancellation that works with both the legacy dispatcher and the new `dispatcherd` library based on the `FEATURE_NEW_DISPATCHER` flag.

This work builds on PR #15911, which established the registry pattern for task decorators, by applying that pattern across all relevant tasks and implementing the missing cancellation functionality.

## Changes

### Task Migration and Testing
- Migrated all 22 task decorators to use `@task_awx` for dispatcher-compatibility (`task_awx` comes from legacy dispatcher)
- Tested each task - turns out only cluster_node_heartbeat needed special handling
- All other tasks work fine with the registry pattern from PR #15911

### Code Cleanup

- Split dispatch_startup() into shared and branch-specific logic
- Did the same for inform_cluster_of_shutdown()
- Added clearer feature flag branching

### Job Cancellation
- Updated `cancel_dispatcher_process()` to handle both dispatcher types
- Made it work for regular cancellations and workflow cancellations
- Fixed `run_dispatcher.py` to properly handle cancel commands in new dispatcher mode

## Testing Methodology
Each task was tested to verify compatibility with both dispatcher implementations:

1. With shell:
   ```
   awx-manage shell -c "from awx.main.tasks.system import <task_name>; <task_name>.delay()"
   ```

2. With scripts for more complex tasks (e.g.):
   ```
   awx-manage shell -c "exec(open('test_send_notifications.py').read())"
   ```

## Note: Expected Behavior - RuntimeError during Startup (Cancellation)

Mentioned: https://github.com/ansible/awx/pull/15930

On a startup you may see a RuntimeError similar to:

```
RuntimeError: Not starting canceled task pk=75 because its status "canceled" is not "waiting"
```

This is **expected behavior** and validates that our cancellation flow is working correctly. 
The error traceback confirms that this safety mechanism is working as designed:
```
  raise RuntimeError(f'Not starting {self.instance.status} task pk={pk} because its status "{self.instance.status}" is not "waiting"')
RuntimeError: Not starting canceled task pk=75 because its status "canceled" is not "waiting"
```

## Related Work
This PR completes the work started in #15911 by applying the registry pattern to all tasks and adding the missing cancellation functionality required for full feature compatibility.