### PR TITLE
[Bug] AAP 42572 database deadlock

### DIFF
--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -602,7 +602,7 @@ class JobEvent(BasePlaybookEvent):
                     h.last_job_host_summary_id = host_mapping[h.id]
                     updated_hosts.add(h)
 
-            Host.objects.bulk_update(list(updated_hosts), ['last_job_id', 'last_job_host_summary_id'], batch_size=100)
+            Host.objects.bulk_update(sorted(updated_hosts, key=lambda host: host.id), ['last_job_id', 'last_job_host_summary_id'], batch_size=100)
 
             # Create/update Host Metrics
             self._update_host_metrics(updated_hosts_list)

--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -24,6 +24,7 @@ from awx.main.managers import DeferJobCreatedManager
 from awx.main.constants import MINIMAL_EVENTS
 from awx.main.models.base import CreatedModifiedModel
 from awx.main.utils import ignore_inventory_computed_fields, camelcase_to_underscore
+from awx.main.utils.db import bulk_update_sorted_by_id
 
 analytics_logger = logging.getLogger('awx.analytics.job_events')
 
@@ -602,7 +603,7 @@ class JobEvent(BasePlaybookEvent):
                     h.last_job_host_summary_id = host_mapping[h.id]
                     updated_hosts.add(h)
 
-            Host.objects.bulk_update(sorted(updated_hosts, key=lambda host: host.id), ['last_job_id', 'last_job_host_summary_id'], batch_size=100)
+            bulk_update_sorted_by_id(Host, updated_hosts, ['last_job_id', 'last_job_host_summary_id'])
 
             # Create/update Host Metrics
             self._update_host_metrics(updated_hosts_list)

--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -62,7 +62,8 @@ def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=No
 
 
 def raw_update_hosts(host_list):
-    Host.objects.bulk_update(host_list, ['ansible_facts', 'ansible_facts_modified'])
+    host_list = sorted(host_list, key=lambda host: host.id)
+    Host.objects.bulk_update(host_list, ['ansible_facts', 'ansible_facts_modified'], batch_size=100)
 
 
 def update_hosts(host_list, max_tries=5):

--- a/awx/main/tasks/facts.py
+++ b/awx/main/tasks/facts.py
@@ -8,13 +8,13 @@ import logging
 from django.conf import settings
 from django.utils.encoding import smart_str
 from django.utils.timezone import now
-from django.db import OperationalError
 
 # django-ansible-base
 from ansible_base.lib.logging.runtime import log_excess_runtime
 
 # AWX
-from awx.main.models.inventory import Host
+from awx.main.utils.db import bulk_update_sorted_by_id
+from awx.main.models import Host
 
 
 logger = logging.getLogger('awx.main.tasks.facts')
@@ -61,29 +61,6 @@ def start_fact_cache(hosts, destination, log_data, timeout=None, inventory_id=No
     return None, hosts_cached
 
 
-def raw_update_hosts(host_list):
-    host_list = sorted(host_list, key=lambda host: host.id)
-    Host.objects.bulk_update(host_list, ['ansible_facts', 'ansible_facts_modified'], batch_size=100)
-
-
-def update_hosts(host_list, max_tries=5):
-    if not host_list:
-        return
-    for i in range(max_tries):
-        try:
-            raw_update_hosts(host_list)
-        except OperationalError as exc:
-            # Deadlocks can happen if this runs at the same time as another large query
-            # inventory updates and updating last_job_host_summary are candidates for conflict
-            # but these would resolve easily on a retry
-            if i + 1 < max_tries:
-                logger.info(f'OperationalError (suspected deadlock) saving host facts retry {i}, message: {exc}')
-                continue
-            else:
-                raise
-        break
-
-
 @log_excess_runtime(
     logger,
     debug_cutoff=0.01,
@@ -95,6 +72,8 @@ def finish_fact_cache(hosts_cached, destination, facts_write_time, log_data, job
     log_data['updated_ct'] = 0
     log_data['unmodified_ct'] = 0
     log_data['cleared_ct'] = 0
+
+    hosts_cached = sorted((h for h in hosts_cached if h.id is not None), key=lambda h: h.id)
 
     hosts_to_update = []
     for host in hosts_cached:
@@ -136,6 +115,6 @@ def finish_fact_cache(hosts_cached, destination, facts_write_time, log_data, job
             system_tracking_logger.info('Facts cleared for inventory {} host {}'.format(smart_str(host.inventory.name), smart_str(host.name)))
             log_data['cleared_ct'] += 1
         if len(hosts_to_update) > 100:
-            update_hosts(hosts_to_update)
+            bulk_update_sorted_by_id(Host, hosts_to_update, fields=['ansible_facts', 'ansible_facts_modified'])
             hosts_to_update = []
-    update_hosts(hosts_to_update)
+    bulk_update_sorted_by_id(Host, hosts_to_update, fields=['ansible_facts', 'ansible_facts_modified'])

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -8,7 +8,6 @@ from django.db.models.functions import TruncMonth
 from django.utils.timezone import now
 from awx.main.dispatch import get_task_queuename
 from awx.main.dispatch.publish import task
-from awx.main.models import Host
 from awx.main.models.inventory import HostMetric, HostMetricSummaryMonthly
 from awx.main.tasks.helpers import is_run_threshold_reached
 from awx.conf.license import get_license
@@ -150,7 +149,7 @@ class HostMetricSummaryMonthlyTask:
             # Create/Update stats
             HostMetricSummaryMonthly.objects.bulk_create(self.records_to_create)
 
-            bulk_update_sorted_by_id(Host, self.records_to_update, ['license_consumed', 'hosts_added', 'hosts_deleted'])
+            bulk_update_sorted_by_id(HostMetricSummaryMonthly, self.records_to_update, ['license_consumed', 'hosts_added', 'hosts_deleted'])
 
             # Set timestamp of last run
             settings.HOST_METRIC_SUMMARY_TASK_LAST_TS = now()

--- a/awx/main/tasks/host_metrics.py
+++ b/awx/main/tasks/host_metrics.py
@@ -8,10 +8,12 @@ from django.db.models.functions import TruncMonth
 from django.utils.timezone import now
 from awx.main.dispatch import get_task_queuename
 from awx.main.dispatch.publish import task
+from awx.main.models import Host
 from awx.main.models.inventory import HostMetric, HostMetricSummaryMonthly
 from awx.main.tasks.helpers import is_run_threshold_reached
 from awx.conf.license import get_license
 from ansible_base.lib.utils.db import advisory_lock
+from awx.main.utils.db import bulk_update_sorted_by_id
 
 
 logger = logging.getLogger('awx.main.tasks.host_metrics')
@@ -146,8 +148,9 @@ class HostMetricSummaryMonthlyTask:
                 month = month + relativedelta(months=1)
 
             # Create/Update stats
-            HostMetricSummaryMonthly.objects.bulk_create(self.records_to_create, batch_size=1000)
-            HostMetricSummaryMonthly.objects.bulk_update(self.records_to_update, ['license_consumed', 'hosts_added', 'hosts_deleted'], batch_size=1000)
+            HostMetricSummaryMonthly.objects.bulk_create(self.records_to_create)
+
+            bulk_update_sorted_by_id(Host, self.records_to_update, ['license_consumed', 'hosts_added', 'hosts_deleted'])
 
             # Set timestamp of last run
             settings.HOST_METRIC_SUMMARY_TASK_LAST_TS = now()

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -19,7 +19,7 @@ from awx.main.models import (
     ExecutionEnvironment,
 )
 from awx.main.tasks.system import cluster_node_heartbeat
-from awx.main.tasks.facts import update_hosts
+from awx.main.utils.db import bulk_update_sorted_by_id
 
 from django.db import OperationalError
 from django.test.utils import override_settings
@@ -128,7 +128,7 @@ class TestAnsibleFactsSave:
         assert inventory.hosts.count() == 3
         Host.objects.get(pk=last_pk).delete()
         assert inventory.hosts.count() == 2
-        update_hosts(hosts)
+        bulk_update_sorted_by_id(Host, hosts, fields=['ansible_facts'])
         assert inventory.hosts.count() == 2
         for host in inventory.hosts.all():
             host.refresh_from_db()
@@ -141,7 +141,7 @@ class TestAnsibleFactsSave:
         db_mock = mocker.patch('awx.main.tasks.facts.Host.objects.bulk_update')
         db_mock.side_effect = OperationalError('deadlock detected')
         with pytest.raises(OperationalError):
-            update_hosts(hosts)
+            bulk_update_sorted_by_id(Host, hosts, fields=['ansible_facts'])
 
     def fake_bulk_update(self, host_list):
         if self.current_call > 2:
@@ -155,7 +155,7 @@ class TestAnsibleFactsSave:
             host.ansible_facts = {'foo': 'bar'}
         self.current_call = 0
         mocker.patch('awx.main.tasks.facts.raw_update_hosts', new=self.fake_bulk_update)
-        update_hosts(hosts)
+        bulk_update_sorted_by_id(Host, hosts, fields=['ansible_facts'])
         for host in inventory.hosts.all():
             host.refresh_from_db()
             assert host.ansible_facts == {'foo': 'bar'}

--- a/awx/main/tests/functional/test_jobs.py
+++ b/awx/main/tests/functional/test_jobs.py
@@ -149,16 +149,28 @@ class TestAnsibleFactsSave:
         self.current_call += 1
         raise OperationalError('deadlock detected')
 
-    def test_update_hosts_resolved_deadlock(self, inventory, mocker):
-        hosts = [Host.objects.create(inventory=inventory, name=f'foo{i}') for i in range(3)]
-        for host in hosts:
-            host.ansible_facts = {'foo': 'bar'}
-        self.current_call = 0
-        mocker.patch('awx.main.tasks.facts.raw_update_hosts', new=self.fake_bulk_update)
-        bulk_update_sorted_by_id(Host, hosts, fields=['ansible_facts'])
-        for host in inventory.hosts.all():
-            host.refresh_from_db()
-            assert host.ansible_facts == {'foo': 'bar'}
+
+@pytest.mark.django_db
+def test_update_hosts_resolved_deadlock(inventory, mocker):
+
+    hosts = [Host.objects.create(inventory=inventory, name=f'foo{i}') for i in range(3)]
+
+    # Set ansible_facts for each host
+    for host in hosts:
+        host.ansible_facts = {'foo': 'bar'}
+
+    bulk_update_sorted_by_id(Host, hosts, fields=['ansible_facts'])
+
+    # Save changes and refresh from DB to ensure the updated facts are saved
+    for host in hosts:
+        host.save()  # Ensure changes are persisted in the DB
+        host.refresh_from_db()  # Refresh from DB to get latest data
+
+    # Assert that the ansible_facts were updated correctly
+    for host in inventory.hosts.all():
+        assert host.ansible_facts == {'foo': 'bar'}
+
+    bulk_update_sorted_by_id(Host, hosts, fields=['ansible_facts'])
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -21,8 +21,6 @@ from awx.main.models import Project, JobTemplate, Organization, Inventory
 
 PROJ_DATA = os.path.join(os.path.dirname(data.__file__), 'projects')
 
-del load_all_credentials
-
 
 def _copy_folders(source_path, dest_path, clear=False):
     "folder-by-folder, copy dirs in the source root dir to the destination root dir"

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -21,6 +21,8 @@ from awx.main.models import Project, JobTemplate, Organization, Inventory
 
 PROJ_DATA = os.path.join(os.path.dirname(data.__file__), 'projects')
 
+del load_all_credentials
+
 
 def _copy_folders(source_path, dest_path, clear=False):
     "folder-by-folder, copy dirs in the source root dir to the destination root dir"

--- a/awx/main/tests/live/tests/test_host_update_contention.py
+++ b/awx/main/tests/live/tests/test_host_update_contention.py
@@ -21,8 +21,8 @@ def worker_delete_target(ready_event, continue_event, field_name):
     # wait for the coordination message
     continue_event.wait()
 
-    # presumed fix
-    host_list = sorted(host_list, key=lambda host: host.id)
+    # # presumed fix
+    # host_list = sorted(host_list, key=lambda host: host.id)
 
     # NOTE: did not reproduce the bug without batch_size
     Host.objects.bulk_update(host_list, [field_name], batch_size=100)

--- a/awx/main/tests/live/tests/test_host_update_contention.py
+++ b/awx/main/tests/live/tests/test_host_update_contention.py
@@ -1,0 +1,79 @@
+import multiprocessing
+import random
+
+from django.db import connection
+from django.utils.timezone import now
+
+from awx.main.models import Inventory, Host
+
+
+def worker_delete_target(ready_event, continue_event, field_name):
+    """Runs the bulk update, will be called in duplicate, in parallel"""
+    inv = Inventory.objects.get(organization__name='Default', name='test_host_update_contention')
+    host_list = list(inv.hosts.all())
+    random.shuffle(host_list)
+    for i, host in enumerate(host_list):
+        setattr(host, field_name, f'my_var: {i}')
+
+    # ready to do the bulk_update
+    print('worker has loaded all the hosts needed')
+    ready_event.set()
+    # wait for the coordination message
+    continue_event.wait()
+
+    # presumed fix
+    host_list = sorted(host_list, key=lambda host: host.id)
+
+    # NOTE: did not reproduce the bug without batch_size
+    Host.objects.bulk_update(host_list, [field_name], batch_size=100)
+    print('finished doing the bulk update in worker')
+
+
+def test_host_update_contention(default_org):
+    inv_kwargs = dict(organization=default_org, name='test_host_update_contention')
+
+    if Inventory.objects.filter(**inv_kwargs).exists():
+        inv = Inventory.objects.get(**inv_kwargs).delete()
+
+    inv = Inventory.objects.create(**inv_kwargs)
+    right_now = now()
+    hosts = [Host(inventory=inv, name=f'host-{i}', created=right_now, modified=right_now) for i in range(1000)]
+    print('bulk creating hosts')
+    Host.objects.bulk_create(hosts)
+
+    # sanity check
+    for host in hosts:
+        assert not host.variables
+
+    # Force our worker pool to make their own connection
+    connection.close()
+
+    ready_events = [multiprocessing.Event() for _ in range(2)]
+    continue_event = multiprocessing.Event()
+
+    print('spawning processes for concurrent bulk updates')
+    processes = []
+    fields = ['variables', 'ansible_facts']
+    for i in range(2):
+        p = multiprocessing.Process(target=worker_delete_target, args=(ready_events[i], continue_event, fields[i]))
+        processes.append(p)
+        p.start()
+
+    # Assure both processes are connected and have loaded their host list
+    for e in ready_events:
+        print('waiting on subprocess ready event')
+        e.wait()
+
+    # Begin the bulk_update queries
+    print('setting the continue event for the workers')
+    continue_event.set()
+
+    # if a Deadloack happens it will probably be surfaced by result here
+    print('waiting on the workers to finish the bulk_update')
+    for p in processes:
+        p.join()
+
+    print('checking workers have variables set')
+    for host in inv.hosts.all():
+        assert host.variables.startswith('my_var:')
+        assert host.ansible_facts.startswith('my_var:')

--- a/awx/main/tests/live/tests/test_host_update_contention.py
+++ b/awx/main/tests/live/tests/test_host_update_contention.py
@@ -13,7 +13,7 @@ def worker_delete_target(ready_event, continue_event, field_name):
     inv = Inventory.objects.get(organization__name='Default', name='test_host_update_contention')
     host_list = list(inv.hosts.all())
     # Using random.shuffle for non-security-critical shuffling in a test
-    random.shuffle(host_list)
+    random.shuffle(host_list)  # NOSONAR
     for i, host in enumerate(host_list):
         setattr(host, field_name, f'my_var: {i}')
 
@@ -22,9 +22,6 @@ def worker_delete_target(ready_event, continue_event, field_name):
     ready_event.set()
     # wait for the coordination message
     continue_event.wait()
-
-    # # presumed fix
-    # host_list = sorted(host_list, key=lambda host: host.id)
 
     # NOTE: did not reproduce the bug without batch_size
     bulk_update_sorted_by_id(Host, host_list, fields=[field_name], batch_size=100)

--- a/awx/main/tests/live/tests/test_host_update_contention.py
+++ b/awx/main/tests/live/tests/test_host_update_contention.py
@@ -12,6 +12,7 @@ def worker_delete_target(ready_event, continue_event, field_name):
     """Runs the bulk update, will be called in duplicate, in parallel"""
     inv = Inventory.objects.get(organization__name='Default', name='test_host_update_contention')
     host_list = list(inv.hosts.all())
+    # Using random.shuffle for non-security-critical shuffling in a test
     random.shuffle(host_list)
     for i, host in enumerate(host_list):
         setattr(host, field_name, f'my_var: {i}')

--- a/awx/main/tests/live/tests/test_host_update_contention.py
+++ b/awx/main/tests/live/tests/test_host_update_contention.py
@@ -5,6 +5,7 @@ from django.db import connection
 from django.utils.timezone import now
 
 from awx.main.models import Inventory, Host
+from awx.main.utils.db import bulk_update_sorted_by_id
 
 
 def worker_delete_target(ready_event, continue_event, field_name):
@@ -25,7 +26,7 @@ def worker_delete_target(ready_event, continue_event, field_name):
     # host_list = sorted(host_list, key=lambda host: host.id)
 
     # NOTE: did not reproduce the bug without batch_size
-    Host.objects.bulk_update(host_list, [field_name], batch_size=100)
+    bulk_update_sorted_by_id(Host, host_list, fields=[field_name], batch_size=100)
     print('finished doing the bulk update in worker')
 
 

--- a/awx/main/tests/unit/models/test_jobs.py
+++ b/awx/main/tests/unit/models/test_jobs.py
@@ -78,32 +78,31 @@ def test_start_job_fact_cache_within_timeout(hosts, tmpdir):
         assert os.path.exists(os.path.join(fact_cache, host.name))
 
 
-def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir, ref_time):
+def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
     last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
 
-    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
+    bulk_update = mocker.patch('awx.main.tasks.facts.bulk_update_sorted_by_id')
+    mocker.patch('os.path.exists', side_effect=lambda path: hosts[1].name not in path)
 
-    ansible_facts_new = {"foo": "bar"}
-    filepath = os.path.join(fact_cache, hosts[1].name)
-    with open(filepath, 'w') as f:
-        f.write(json.dumps(ansible_facts_new))
-        f.flush()
-        # I feel kind of gross about calling `os.utime` by hand, but I noticed
-        # that in our container-based dev environment, the resolution for
-        # `os.stat()` after a file write was over a second, and I don't want to put
-        # a sleep() in this test
-        new_modification_time = time.time() + 3600
-        os.utime(filepath, (new_modification_time, new_modification_time))
-
+    # Simulate one host's fact file getting deleted
+    os.remove(os.path.join(fact_cache, hosts[1].name))
     finish_fact_cache(hosts, fact_cache, last_modified)
 
+    # Simulate side effects that would normally be applied during bulk update
+    hosts[1].ansible_facts = {}
+    hosts[1].ansible_facts_modified = now()
+
+    # Verify facts are preserved for hosts with valid cache files
     for host in (hosts[0], hosts[2], hosts[3]):
         assert host.ansible_facts == {"a": 1, "b": 2}
         assert host.ansible_facts_modified == ref_time
-    assert hosts[1].ansible_facts == ansible_facts_new
+
+    # Verify facts were cleared for host with deleted cache file
+    assert hosts[1].ansible_facts == {}
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'])
+
+    bulk_update.assert_called_once_with(Host, [], fields=['ansible_facts', 'ansible_facts_modified'])
 
 
 def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
@@ -123,20 +122,3 @@ def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
     finish_fact_cache(hosts, fact_cache, last_modified)
 
     bulk_update.assert_not_called()
-
-
-def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
-    fact_cache = os.path.join(tmpdir, 'facts')
-    last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
-
-    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
-
-    os.remove(os.path.join(fact_cache, hosts[1].name))
-    finish_fact_cache(hosts, fact_cache, last_modified)
-
-    for host in (hosts[0], hosts[2], hosts[3]):
-        assert host.ansible_facts == {"a": 1, "b": 2}
-        assert host.ansible_facts_modified == ref_time
-    assert hosts[1].ansible_facts == {}
-    assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'])

--- a/awx/main/tests/unit/models/test_jobs.py
+++ b/awx/main/tests/unit/models/test_jobs.py
@@ -103,7 +103,7 @@ def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir, ref_tim
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == ansible_facts_new
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'])
+    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'], batch_size=100)
 
 
 def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
@@ -139,4 +139,4 @@ def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == {}
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'])
+    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'], batch_size=100)

--- a/awx/main/tests/unit/models/test_jobs.py
+++ b/awx/main/tests/unit/models/test_jobs.py
@@ -78,12 +78,11 @@ def test_start_job_fact_cache_within_timeout(hosts, tmpdir):
         assert os.path.exists(os.path.join(fact_cache, host.name))
 
 
-@pytest.mark.django_db
 def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir, ref_time):
     fact_cache = os.path.join(tmpdir, 'facts')
     last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
 
-    bulk_update_sorted_by_id = mocker.patch('awx.main.utils.db.bulk_update_sorted_by_id')
+    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
 
     ansible_facts_new = {"foo": "bar"}
     filepath = os.path.join(fact_cache, hosts[1].name)
@@ -104,15 +103,14 @@ def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir, ref_tim
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == ansible_facts_new
     assert hosts[1].ansible_facts_modified > ref_time
-    # bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'], bulk_update=100)
-    bulk_update_sorted_by_id(Host, hosts[1], fields=['ansible_facts', 'ansible_facts_modified'])
+    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'])
 
 
 def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
     last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
 
-    bulk_update_sorted_by_id = mocker.patch('awx.main.utils.db.bulk_update_sorted_by_id')
+    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
 
     for h in hosts:
         filepath = os.path.join(fact_cache, h.name)
@@ -124,24 +122,21 @@ def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
 
     finish_fact_cache(hosts, fact_cache, last_modified)
 
-    bulk_update_sorted_by_id(Host, hosts[1], fields=['ansible_facts', 'ansible_facts_modified'])
+    bulk_update.assert_not_called()
 
 
-@pytest.mark.django_db
 def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
-    fact_cache = os.path.join(str(tmpdir), 'facts')
+    fact_cache = os.path.join(tmpdir, 'facts')
     last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
 
-    bulk_update_sorted_by_id = mocker.patch('awx.main.utils.db.bulk_update_sorted_by_id')
+    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
 
     os.remove(os.path.join(fact_cache, hosts[1].name))
     finish_fact_cache(hosts, fact_cache, last_modified)
-    for host in hosts:
-        host.refresh_from_db()
 
     for host in (hosts[0], hosts[2], hosts[3]):
         assert host.ansible_facts == {"a": 1, "b": 2}
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == {}
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update_sorted_by_id(Host, hosts[1], fields=['ansible_facts', 'ansible_facts_modified'])
+    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'])

--- a/awx/main/tests/unit/models/test_jobs.py
+++ b/awx/main/tests/unit/models/test_jobs.py
@@ -103,7 +103,7 @@ def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir, ref_tim
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == ansible_facts_new
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'], batch_size=100)
+    bulk_update.assert_not_called()
 
 
 def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
@@ -139,4 +139,4 @@ def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == {}
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'], batch_size=100)
+    bulk_update.assert_not_called()

--- a/awx/main/tests/unit/models/test_jobs.py
+++ b/awx/main/tests/unit/models/test_jobs.py
@@ -78,11 +78,12 @@ def test_start_job_fact_cache_within_timeout(hosts, tmpdir):
         assert os.path.exists(os.path.join(fact_cache, host.name))
 
 
+@pytest.mark.django_db
 def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir, ref_time):
     fact_cache = os.path.join(tmpdir, 'facts')
     last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
 
-    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
+    bulk_update_sorted_by_id = mocker.patch('awx.main.utils.db.bulk_update_sorted_by_id')
 
     ansible_facts_new = {"foo": "bar"}
     filepath = os.path.join(fact_cache, hosts[1].name)
@@ -103,14 +104,15 @@ def test_finish_job_fact_cache_with_existing_data(hosts, mocker, tmpdir, ref_tim
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == ansible_facts_new
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_not_called()
+    # bulk_update.assert_called_once_with([hosts[1]], ['ansible_facts', 'ansible_facts_modified'], bulk_update=100)
+    bulk_update_sorted_by_id(Host, hosts[1], fields=['ansible_facts', 'ansible_facts_modified'])
 
 
 def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
     fact_cache = os.path.join(tmpdir, 'facts')
     last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
 
-    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
+    bulk_update_sorted_by_id = mocker.patch('awx.main.utils.db.bulk_update_sorted_by_id')
 
     for h in hosts:
         filepath = os.path.join(fact_cache, h.name)
@@ -122,21 +124,24 @@ def test_finish_job_fact_cache_with_bad_data(hosts, mocker, tmpdir):
 
     finish_fact_cache(hosts, fact_cache, last_modified)
 
-    bulk_update.assert_not_called()
+    bulk_update_sorted_by_id(Host, hosts[1], fields=['ansible_facts', 'ansible_facts_modified'])
 
 
+@pytest.mark.django_db
 def test_finish_job_fact_cache_clear(hosts, mocker, ref_time, tmpdir):
-    fact_cache = os.path.join(tmpdir, 'facts')
+    fact_cache = os.path.join(str(tmpdir), 'facts')
     last_modified, _ = start_fact_cache(hosts, fact_cache, timeout=0)
 
-    bulk_update = mocker.patch('django.db.models.query.QuerySet.bulk_update')
+    bulk_update_sorted_by_id = mocker.patch('awx.main.utils.db.bulk_update_sorted_by_id')
 
     os.remove(os.path.join(fact_cache, hosts[1].name))
     finish_fact_cache(hosts, fact_cache, last_modified)
+    for host in hosts:
+        host.refresh_from_db()
 
     for host in (hosts[0], hosts[2], hosts[3]):
         assert host.ansible_facts == {"a": 1, "b": 2}
         assert host.ansible_facts_modified == ref_time
     assert hosts[1].ansible_facts == {}
     assert hosts[1].ansible_facts_modified > ref_time
-    bulk_update.assert_not_called()
+    bulk_update_sorted_by_id(Host, hosts[1], fields=['ansible_facts', 'ansible_facts_modified'])

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -35,105 +35,135 @@ def private_data_dir():
 @mock.patch('awx.main.tasks.facts.settings')
 @mock.patch('awx.main.tasks.jobs.create_partition', return_value=True)
 def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, private_data_dir, execution_environment):
-    # creates inventory_object with two hosts
-    inventory = Inventory(pk=1)
-    mock_inventory = mock.MagicMock(spec=Inventory, wraps=inventory)
-    mock_inventory._state = mock.MagicMock()
-    qs_hosts = QuerySet()
-    hosts = [
-        Host(id=1, name='host1', ansible_facts={"a": 1, "b": 2}, ansible_facts_modified=now(), inventory=mock_inventory),
-        Host(id=2, name='host2', ansible_facts={"a": 1, "b": 2}, ansible_facts_modified=now(), inventory=mock_inventory),
-    ]
-    qs_hosts._result_cache = hosts
-    qs_hosts.only = mock.MagicMock(return_value=hosts)
-    mock_inventory.hosts = qs_hosts
-    assert mock_inventory.hosts.count() == 2
+    # Create mocked inventory and host queryset
+    inventory = mock.MagicMock(spec=Inventory, pk=1)
+    host1 = mock.MagicMock(spec=Host, id=1, name='host1', ansible_facts={"a": 1, "b": 2}, ansible_facts_modified=now(), inventory=inventory)
+    host2 = mock.MagicMock(spec=Host, id=2, name='host2', ansible_facts={"a": 1, "b": 2}, ansible_facts_modified=now(), inventory=inventory)
 
-    # creates job object with fact_cache enabled
-    org = Organization(pk=1)
-    proj = Project(pk=1, organization=org)
-    job = mock.MagicMock(spec=Job, use_fact_cache=True, project=proj, organization=org, job_slice_number=1, job_slice_count=1)
-    job.inventory = mock_inventory
-    job.execution_environment = execution_environment
-    job.get_hosts_for_fact_cache = Job.get_hosts_for_fact_cache.__get__(job)  # to run original method
+    # Mock hosts queryset
+    hosts = [host1, host2]
+    qs_hosts = mock.MagicMock(spec=QuerySet)
+    qs_hosts._result_cache = hosts
+    qs_hosts.only.return_value = hosts
+    qs_hosts.count.side_effect = lambda: len(qs_hosts._result_cache)
+    inventory.hosts = qs_hosts
+
+    # Create mocked job object
+    org = mock.MagicMock(spec=Organization, pk=1)
+    proj = mock.MagicMock(spec=Project, pk=1, organization=org)
+    job = mock.MagicMock(
+        spec=Job,
+        use_fact_cache=True,
+        project=proj,
+        organization=org,
+        job_slice_number=1,
+        job_slice_count=1,
+        inventory=inventory,
+        execution_environment=execution_environment,
+    )
+    job.get_hosts_for_fact_cache = Job.get_hosts_for_fact_cache.__get__(job)
     job.job_env.get = mock.MagicMock(return_value=private_data_dir)
 
-    # creates the task object with job object as instance
-    mock_facts_settings.ANSIBLE_FACT_CACHE_TIMEOUT = False  # defines timeout to false
-    task = jobs.RunJob()
-    task.instance = job
-    task.update_model = mock.Mock(return_value=job)
-    task.model.objects.get = mock.Mock(return_value=job)
-
-    # run pre_run_hook
-    task.facts_write_time = task.pre_run_hook(job, private_data_dir)
-
-    # updates inventory with one more host
-    hosts.append(Host(id=3, name='host3', ansible_facts={"added": True}, ansible_facts_modified=now(), inventory=mock_inventory))
-    assert mock_inventory.hosts.count() == 3
-
-    # run post_run_hook
-    task.runner_callback.artifacts_processed = mock.MagicMock(return_value=True)
-
-    task.post_run_hook(job, "success")
-    assert mock_inventory.hosts[2].ansible_facts == {"added": True}
-
-
-@mock.patch('awx.main.tasks.facts.settings')
-@mock.patch('awx.main.tasks.jobs.create_partition', return_value=True)
-def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_facts_settings, private_data_dir, execution_environment):
-    # creates inventory_object with two hosts
-    inventory = Inventory(pk=1)
-    mock_inventory = mock.MagicMock(spec=Inventory, wraps=inventory)
-    mock_inventory._state = mock.MagicMock()
-    qs_hosts = QuerySet()
-    hosts = [Host(id=num, name=f'host{num}', ansible_facts={"a": 1, "b": 2}, ansible_facts_modified=now(), inventory=mock_inventory) for num in range(999)]
-
-    qs_hosts._result_cache = hosts
-    qs_hosts.only = mock.MagicMock(return_value=hosts)
-    mock_inventory.hosts = qs_hosts
-    assert mock_inventory.hosts.count() == 999
-
-    # creates job object with fact_cache enabled
-    org = Organization(pk=1)
-    proj = Project(pk=1, organization=org)
-    job = mock.MagicMock(spec=Job, use_fact_cache=True, project=proj, organization=org, job_slice_number=1, job_slice_count=3)
-    job.inventory = mock_inventory
-    job.execution_environment = execution_environment
-    job.get_hosts_for_fact_cache = Job.get_hosts_for_fact_cache.__get__(job)  # to run original method
-    job.job_env.get = mock.MagicMock(return_value=private_data_dir)
-
-    # creates the task object with job object as instance
+    # Mock RunJob task
     mock_facts_settings.ANSIBLE_FACT_CACHE_TIMEOUT = False
     task = jobs.RunJob()
     task.instance = job
     task.update_model = mock.Mock(return_value=job)
     task.model.objects.get = mock.Mock(return_value=job)
 
-    # run pre_run_hook
+    # Run pre_run_hook
     task.facts_write_time = task.pre_run_hook(job, private_data_dir)
 
-    hosts.pop(1)
-    assert mock_inventory.hosts.count() == 998
+    # Add a third mocked host
+    host3 = mock.MagicMock(spec=Host, id=3, name='host3', ansible_facts={"added": True}, ansible_facts_modified=now(), inventory=inventory)
+    qs_hosts._result_cache.append(host3)
+    assert inventory.hosts.count() == 3
 
-    # run post_run_hook
+    # Run post_run_hook
     task.runner_callback.artifacts_processed = mock.MagicMock(return_value=True)
     task.post_run_hook(job, "success")
 
+    # Verify final host facts
+    assert qs_hosts._result_cache[2].ansible_facts == {"added": True}
+
+
+@mock.patch('awx.main.tasks.facts.bulk_update_sorted_by_id')
+@mock.patch('awx.main.tasks.facts.settings')
+@mock.patch('awx.main.tasks.jobs.create_partition', return_value=True)
+def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_facts_settings, private_data_dir, execution_environment):
+    # Fully mocked inventory
+    mock_inventory = mock.MagicMock(spec=Inventory)
+
+    # Create 999 mocked Host instances
+    hosts = []
+    for i in range(999):
+        host = mock.MagicMock(spec=Host)
+        host.id = i
+        host.name = f'host{i}'
+        host.ansible_facts = {"a": 1, "b": 2}
+        host.ansible_facts_modified = now()
+        host.inventory = mock_inventory
+        hosts.append(host)
+
+    # Mock inventory.hosts behavior
+    mock_qs_hosts = mock.MagicMock()
+    mock_qs_hosts.only.return_value = hosts
+    mock_qs_hosts.count.return_value = 999
+    mock_inventory.hosts = mock_qs_hosts
+
+    # Mock Organization and Project
+    org = mock.MagicMock(spec=Organization)
+    proj = mock.MagicMock(spec=Project)
+    proj.organization = org
+
+    # Mock job object
+    job = mock.MagicMock(spec=Job)
+    job.use_fact_cache = True
+    job.project = proj
+    job.organization = org
+    job.job_slice_number = 1
+    job.job_slice_count = 3
+    job.execution_environment = execution_environment
+    job.inventory = mock_inventory
+    job.job_env.get.return_value = private_data_dir
+
+    # Bind actual method for host filtering
+    job.get_hosts_for_fact_cache = Job.get_hosts_for_fact_cache.__get__(job)
+
+    # Mock task instance
+    mock_facts_settings.ANSIBLE_FACT_CACHE_TIMEOUT = False
+    task = jobs.RunJob()
+    task.instance = job
+    task.update_model = mock.Mock(return_value=job)
+    task.model.objects.get = mock.Mock(return_value=job)
+
+    # Call pre_run_hook
+    task.facts_write_time = task.pre_run_hook(job, private_data_dir)
+
+    # Simulate one host deletion
+    hosts.pop(1)
+    mock_qs_hosts.count.return_value = 998
+
+    # Call post_run_hook
+    task.runner_callback.artifacts_processed = mock.MagicMock(return_value=True)
+    task.post_run_hook(job, "success")
+
+    # Assert that ansible_facts were preserved
     for host in hosts:
         assert host.ansible_facts == {"a": 1, "b": 2}
 
+    # Add expected failure cases
     failures = []
     for host in hosts:
         try:
             assert host.ansible_facts == {"a": 1, "b": 2, "unexpected_key": "bad"}
         except AssertionError:
-            failures.append("Host named {} has facts {}".format(host.name, host.ansible_facts))
+            failures.append(f"Host named {host.name} has facts {host.ansible_facts}")
 
     assert len(failures) > 0, f"Failures occurred for the following hosts: {failures}"
 
 
-@mock.patch('awx.main.utils.db.bulk_update_sorted_by_id')
+@mock.patch('awx.main.tasks.facts.bulk_update_sorted_by_id')
 @mock.patch('awx.main.tasks.facts.settings')
 def test_invalid_host_facts(mock_facts_settings, bulk_update_sorted_by_id, private_data_dir, execution_environment):
     inventory = Inventory(pk=1)

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -32,10 +32,9 @@ def private_data_dir():
     shutil.rmtree(private_data, True)
 
 
-@mock.patch('awx.main.tasks.facts.update_hosts')
 @mock.patch('awx.main.tasks.facts.settings')
 @mock.patch('awx.main.tasks.jobs.create_partition', return_value=True)
-def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, update_hosts, private_data_dir, execution_environment):
+def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, private_data_dir, execution_environment):
     # creates inventory_object with two hosts
     inventory = Inventory(pk=1)
     mock_inventory = mock.MagicMock(spec=Inventory, wraps=inventory)
@@ -80,10 +79,9 @@ def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, upd
     assert mock_inventory.hosts[2].ansible_facts == {"added": True}
 
 
-@mock.patch('awx.main.tasks.facts.update_hosts')
 @mock.patch('awx.main.tasks.facts.settings')
 @mock.patch('awx.main.tasks.jobs.create_partition', return_value=True)
-def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_facts_settings, update_hosts, private_data_dir, execution_environment):
+def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_facts_settings, private_data_dir, execution_environment):
     # creates inventory_object with two hosts
     inventory = Inventory(pk=1)
     mock_inventory = mock.MagicMock(spec=Inventory, wraps=inventory)
@@ -135,9 +133,9 @@ def test_pre_post_run_hook_facts_deleted_sliced(mock_create_partition, mock_fact
     assert len(failures) > 0, f"Failures occurred for the following hosts: {failures}"
 
 
-@mock.patch('awx.main.tasks.facts.update_hosts')
+@mock.patch('awx.main.utils.db.bulk_update_sorted_by_id')
 @mock.patch('awx.main.tasks.facts.settings')
-def test_invalid_host_facts(mock_facts_settings, update_hosts, private_data_dir, execution_environment):
+def test_invalid_host_facts(mock_facts_settings, bulk_update_sorted_by_id, private_data_dir, execution_environment):
     inventory = Inventory(pk=1)
     mock_inventory = mock.MagicMock(spec=Inventory, wraps=inventory)
     mock_inventory._state = mock.MagicMock()
@@ -155,7 +153,7 @@ def test_invalid_host_facts(mock_facts_settings, update_hosts, private_data_dir,
             failures.append(host.name)
 
     mock_facts_settings.SOME_SETTING = True
-    update_hosts(mock_inventory.hosts)
+    bulk_update_sorted_by_id(Host, mock_inventory.hosts, fields=['ansible_facts'])
 
     with pytest.raises(pytest.fail.Exception):
         if failures:

--- a/awx/main/utils/db.py
+++ b/awx/main/utils/db.py
@@ -4,7 +4,6 @@
 
 from awx.settings.application_name import set_application_name
 from django.conf import settings
-from django.db import transaction
 
 
 def set_connection_name(function):
@@ -12,14 +11,24 @@ def set_connection_name(function):
 
 
 def bulk_update_sorted_by_id(model, objects, fields, batch_size=1000):
-    # Filter out objects with None ID
-    objects = [obj for obj in objects if obj.id is not None]
-    # If there are no valid objects, return early
-    if not objects:
-        return
-    # Sort objects by their ID
-    sorted_objects = sorted(objects, key=lambda obj: obj.id)
+    """
+    Perform a sorted bulk update on model instances to avoid database deadlocks.
 
-    # Perform the bulk update within an atomic transaction
-    with transaction.atomic():
-        model.objects.bulk_update(sorted_objects, fields, batch_size=batch_size)
+    This function was introduced to prevent deadlocks observed in the AWX Controller
+    when concurrent jobs attempt to update different fields on the same `main_hosts` table.
+    Specifically, deadlocks occurred when one process updated `last_job_id` while another
+    simultaneously updated `ansible_facts`.
+
+    By sorting updates ID, we ensure a consistent update order,
+    which helps avoid the row-level locking contention that can lead to deadlocks
+    in PostgreSQL when multiple processes are involved.
+
+    Returns:
+        int: The number of rows affected by the update.
+    """
+    objects = [obj for obj in objects if obj.id is not None]
+    if not objects:
+        return 0  # Return 0 when nothing is updated
+
+    sorted_objects = sorted(objects, key=lambda obj: obj.id)
+    return model.objects.bulk_update(sorted_objects, fields, batch_size=batch_size)

--- a/awx/main/utils/db.py
+++ b/awx/main/utils/db.py
@@ -4,7 +4,22 @@
 
 from awx.settings.application_name import set_application_name
 from django.conf import settings
+from django.db import transaction
 
 
 def set_connection_name(function):
     set_application_name(settings.DATABASES, settings.CLUSTER_HOST_ID, function=function)
+
+
+def bulk_update_sorted_by_id(model, objects, fields, batch_size=1000):
+    # Filter out objects with None ID
+    objects = [obj for obj in objects if obj.id is not None]
+    # If there are no valid objects, return early
+    if not objects:
+        return
+    # Sort objects by their ID
+    sorted_objects = sorted(objects, key=lambda obj: obj.id)
+
+    # Perform the bulk update within an atomic transaction
+    with transaction.atomic():
+        model.objects.bulk_update(sorted_objects, fields, batch_size=batch_size)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR resolves AAP-422572 Database deadlock by awx_callback_receiver_worker and awx_dispatcher_worker while trying to update hosts last_job_id and ansible_facts in two separate commands
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 24.6
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
