### PR TITLE
use server certificates for checking rhsm and satellite subscriptions

### DIFF
--- a/awx/main/tests/unit/utils/test_licensing.py
+++ b/awx/main/tests/unit/utils/test_licensing.py
@@ -11,13 +11,13 @@ def test_rhsm_licensing():
     def mocked_requests_get(*args, **kwargs):
         assert kwargs['verify'] == True
         response = Response()
-        subs = json.dumps([{'key': 'dummy'}])
+        subs = json.dumps({'body': []})
         response.status_code = HTTPStatus.OK
         response._content = bytes(subs, 'utf-8')
         return response
 
     licenser = Licenser()
-    with patch('requests.get', new=mocked_requests_get):
+    with patch('awx.main.utils.analytics_proxy.OIDCClient.make_request', new=mocked_requests_get):
         licenser.get_rhsm_subs('localhost', 'admin', 'admin')
     pass
 

--- a/awx/main/tests/unit/utils/test_licensing.py
+++ b/awx/main/tests/unit/utils/test_licensing.py
@@ -1,0 +1,37 @@
+import json
+from http import HTTPStatus
+from unittest.mock import patch
+
+from requests import Response
+
+from awx.main.utils.licensing import Licenser
+
+
+def test_rhsm_licensing():
+    def mocked_requests_get(*args, **kwargs):
+        assert kwargs['verify'] == True
+        response = Response()
+        subs = json.dumps([{'key': 'dummy'}])
+        response.status_code = HTTPStatus.OK
+        response._content = bytes(subs, 'utf-8')
+        return response
+
+    licenser = Licenser()
+    with patch('requests.get', new=mocked_requests_get):
+        licenser.get_rhsm_subs('localhost', 'admin', 'admin')
+    pass
+
+
+def test_satellite_licensing():
+    def mocked_requests_get(*args, **kwargs):
+        assert kwargs['verify'] == True
+        response = Response()
+        subs = json.dumps({'results': []})
+        response.status_code = HTTPStatus.OK
+        response._content = bytes(subs, 'utf-8')
+        return response
+
+    licenser = Licenser()
+    with patch('requests.get', new=mocked_requests_get):
+        licenser.get_satellite_subs('localhost', 'admin', 'admin')
+    pass

--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -278,9 +278,13 @@ class Licenser(object):
             host = ':'.join([host, port])
         json = []
         try:
-            orgs = requests.get('/'.join([host, 'katello/api/organizations']), verify=True, auth=(user, pw))
+            orgs = requests.get('/'.join([host, 'katello/api/organizations']), verify=verify, auth=(user, pw))
         except requests.exceptions.ConnectionError as error:
             raise error
+        except OSError as error:
+            raise OSError(
+                'Unable to open certificate bundle {}. Check that the service is running on Red Hat Enterprise Linux.'.format(verify)
+            ) from error  # noqa
         orgs.raise_for_status()
 
         for org in orgs.json()['results']:

--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -243,25 +243,18 @@ class Licenser(object):
         return []
 
     def get_rhsm_subs(self, host, client_id, client_secret):
-        verify = getattr(settings, 'REDHAT_CANDLEPIN_VERIFY', True)
-        # TODO: remove this after fixing the custom ca issue in insights.py file
-        verify = True
         try:
             client = OIDCClient(client_id, client_secret, DEFAULT_OIDC_TOKEN_ENDPOINT, ['api.console'])
             subs = client.make_request(
                 'GET',
                 host,
-                verify=verify,
+                verify=True,
                 timeout=(31, 31),
             )
         except TokenError as e:
             raise e
         except requests.exceptions.ConnectionError as error:
             raise error
-        except OSError as error:
-            raise OSError(
-                'Unable to open certificate bundle {}. Check that the service is running on Red Hat Enterprise Linux.'.format(verify)
-            ) from error  # noqa
         subs.raise_for_status()
         subs_formatted = []
         for sku in subs.json()['body']:
@@ -280,18 +273,14 @@ class Licenser(object):
             port = str(self.config.get("server", "port"))
         except Exception as e:
             logger.exception('Unable to read rhsm config to get ca_cert location. {}'.format(str(e)))
-            verify = getattr(settings, 'REDHAT_CANDLEPIN_VERIFY', True)
+            verify = True
         if port:
             host = ':'.join([host, port])
         json = []
         try:
-            orgs = requests.get('/'.join([host, 'katello/api/organizations']), verify=verify, auth=(user, pw))
+            orgs = requests.get('/'.join([host, 'katello/api/organizations']), verify=True, auth=(user, pw))
         except requests.exceptions.ConnectionError as error:
             raise error
-        except OSError as error:
-            raise OSError(
-                'Unable to open certificate bundle {}. Check that the service is running on Red Hat Enterprise Linux.'.format(verify)
-            ) from error  # noqa
         orgs.raise_for_status()
 
         for org in orgs.json()['results']:


### PR DESCRIPTION
##### SUMMARY

Don't rely on the `REDHAT_CANDLEPIN_VERIFY` certificate anymore, instead use server certificates.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
