### PR TITLE
Fix dispatcherd bugs: schedule aliases, job kwargs handling, cancel handling

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -82,9 +82,22 @@ class MainConfig(AppConfig):
         super().ready()
 
         from django.conf import settings
+
         from awx.main.utils.db import get_pg_notify_params
         from awx.main.dispatch import get_task_queuename
         from awx.main.dispatch.pool import get_auto_max_workers
+        from awx.main.dispatch.publish import ALTERNATIVE_TASK_IMPLEMENTATIONS
+
+        # from dispatcherd.config import settings as dispatcher_settings
+        from dispatcherd.utils import serialize_task
+
+        dispatcherd_schedule = {}
+        for task_name, options in settings.DISPATCHER_SCHEDULE.items():
+            if task_name in ALTERNATIVE_TASK_IMPLEMENTATIONS:
+                taskd_name = serialize_task(ALTERNATIVE_TASK_IMPLEMENTATIONS[task_name])
+            else:
+                taskd_name = task_name
+            dispatcherd_schedule[taskd_name] = options
 
         dispatcher_setup(
             {
@@ -108,7 +121,7 @@ class MainConfig(AppConfig):
                     "socket": {"socket_path": settings.DISPATCHERD_DEBUGGING_SOCKFILE},
                 },
                 "producers": {
-                    "ScheduledProducer": {"task_schedule": settings.DISPATCHER_SCHEDULE},
+                    "ScheduledProducer": {"task_schedule": dispatcherd_schedule},
                     "OnStartProducer": {"task_list": {"awx.main.tasks.system.dispatch_startup": {}}},
                     "ControlProducer": {},
                 },

--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -105,7 +105,7 @@ class task:
                             logger.info(f"[DISPATCHER] Using dispatcherd implementation for task: {cls.name}")
                             return alt_impl.apply_async(args=args, kwargs=kwargs, queue=queue, uuid=uuid, **kw)
                         else:
-                            logger.info(f"[DISPATCHER] No alternative registered for {cls.name}; using original legacy method.")
+                            logger.debug(f"[DISPATCHER] No alternative registered for {cls.name}; using original legacy method.")
                 except Exception:
                     logger.warning(f"[DISPATCHER] Failed to check for alternative dispatcherd implementation for {cls.name}")
                     # Continue with original implementation if anything fails

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1363,7 +1363,30 @@ class UnifiedJob(
             traceback=self.result_traceback,
         )
 
-    def pre_start(self, **kwargs):
+    def get_start_kwargs(self):
+        needed = self.get_passwords_needed_to_start()
+
+        decrypted_start_args = decrypt_field(self, 'start_args')
+
+        if not decrypted_start_args or decrypted_start_args == '{}':
+            return None
+
+        try:
+            start_args = json.loads(decrypted_start_args)
+        except Exception:
+            logger.exception(f'Unexpected malformed start_args on unified_job={self.id}')
+            return None
+
+        opts = dict([(field, start_args.get(field, '')) for field in needed])
+
+        if not all(opts.values()):
+            missing_fields = ', '.join([k for k, v in opts.items() if not v])
+            self.job_explanation = u'Missing needed fields: %s.' % missing_fields
+            self.save(update_fields=['job_explanation'])
+
+        return opts
+
+    def pre_start(self):
         if not self.can_start:
             self.job_explanation = u'%s is not in a startable state: %s, expecting one of %s' % (self._meta.verbose_name, self.status, str(('new', 'waiting')))
             self.save(update_fields=['job_explanation'])
@@ -1384,25 +1407,10 @@ class UnifiedJob(
                 self.save(update_fields=['job_explanation'])
                 return (False, None)
 
-        needed = self.get_passwords_needed_to_start()
-        try:
-            start_args = json.loads(decrypt_field(self, 'start_args'))
-        except Exception:
-            start_args = None
-
-        if start_args in (None, ''):
-            start_args = kwargs
-
-        opts = dict([(field, start_args.get(field, '')) for field in needed])
+        opts = self.get_start_kwargs()
 
         if not all(opts.values()):
-            missing_fields = ', '.join([k for k, v in opts.items() if not v])
-            self.job_explanation = u'Missing needed fields: %s.' % missing_fields
-            self.save(update_fields=['job_explanation'])
             return (False, None)
-
-        if 'extra_vars' in kwargs:
-            self.handle_extra_data(kwargs['extra_vars'])
 
         # remove any job_explanations that may have been set while job was in pending
         if self.job_explanation != "":

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1409,7 +1409,7 @@ class UnifiedJob(
 
         opts = self.get_start_kwargs()
 
-        if not all(opts.values()):
+        if opts and (not all(opts.values())):
             return (False, None)
 
         # remove any job_explanations that may have been set while job was in pending

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -117,7 +117,8 @@ def with_path_cleanup(f):
 @task(on_duplicate='queue_one', bind=True)
 def dispatch_waiting_jobs(binder):
     for uj in UnifiedJob.objects.filter(status='waiting', controller_node=settings.CLUSTER_HOST_ID).only('id', 'status', 'polymorphic_ctype', 'celery_task_id'):
-        binder.control('run', data={'task': serialize_task(uj._get_task_class()), 'args': [uj.id], 'uuid': uj.celery_task_id})
+        kwargs = uj.get_start_kwargs()
+        binder.control('run', data={'task': serialize_task(uj._get_task_class()), 'args': [uj.id], 'kwargs': kwargs, 'uuid': uj.celery_task_id})
 
 
 class BaseTask(object):

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -68,7 +68,7 @@ from awx.main.tasks.callback import (
     RunnerCallbackForProjectUpdate,
     RunnerCallbackForSystemJob,
 )
-from awx.main.tasks.signals import with_signal_handling, signal_callback
+from awx.main.tasks.signals import with_signal_handling, signal_callback, signal_state
 from awx.main.tasks.receptor import AWXReceptorJob
 from awx.main.tasks.facts import start_fact_cache, finish_fact_cache
 from awx.main.tasks.system import update_smart_memberships_for_inventory, update_inventory_computed_fields, events_processed_hook
@@ -512,6 +512,7 @@ class BaseTask(object):
             self.build_project_dir(self.instance, private_data_dir)
             self.instance.log_lifecycle("preparing_playbook")
             if self.instance.cancel_flag or signal_callback():
+                logger.debug(f'detected pre-run cancel flag for {self.instance.log_format}')
                 self.instance = self.update_model(self.instance.pk, status='canceled')
 
             if self.instance.status != 'running':
@@ -641,6 +642,8 @@ class BaseTask(object):
             self.runner_callback.delay_update(job_explanation=str(exc))
         except DispatcherCancel:
             # dispatcher uses non-sigterm signal, and will raise this exception
+            signal_state.dispatcher_cancel_flag = True
+            logger.info(f'Caught DispatcherCancel error for {self.instance.log_format}')
             status = 'canceled'
         except Exception:
             # this could catch programming or file system errors

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -118,6 +118,8 @@ def with_path_cleanup(f):
 def dispatch_waiting_jobs(binder):
     for uj in UnifiedJob.objects.filter(status='waiting', controller_node=settings.CLUSTER_HOST_ID).only('id', 'status', 'polymorphic_ctype', 'celery_task_id'):
         kwargs = uj.get_start_kwargs()
+        if not kwargs:
+            kwargs = {}
         binder.control('run', data={'task': serialize_task(uj._get_task_class()), 'args': [uj.id], 'kwargs': kwargs, 'uuid': uj.celery_task_id})
 
 

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -510,6 +510,9 @@ class AWXReceptorJob:
                     raise SignalExit()
                 res = processor_future.result()
             except (SignalExit, DispatcherCancel):
+                if not signal_callback():
+                    # Record if this was from dispatcherd signal handling
+                    signal_state.dispatcher_cancel_flag = True
                 receptor_ctl.simple_command(f"work cancel {self.unit_id}")
                 resultsock.shutdown(socket.SHUT_RDWR)
                 resultfile.close()

--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -17,6 +17,7 @@ class SignalState:
     def reset(self):
         self.sigterm_flag = False
         self.sigint_flag = False
+        self.dispatcher_cancel_flag = False
 
         self.is_active = False  # for nested context managers
         self.original_sigterm = None
@@ -63,7 +64,7 @@ signal_state = SignalState()
 
 
 def signal_callback():
-    return bool(signal_state.sigterm_flag or signal_state.sigint_flag)
+    return bool(signal_state.sigterm_flag or signal_state.sigint_flag or signal_state.dispatcher_cancel_flag)
 
 
 def with_signal_handling(f):

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -667,7 +667,7 @@ def cluster_node_heartbeat(dispatch_time=None, worker_tasks=None):
             active_task_ids.extend(task_list)
 
         # Convert dispatch_time to datetime
-        ref_time = datetime.fromisoformat(dispatch_time) if dispatch_time else datetime.now()
+        ref_time = datetime.fromisoformat(dispatch_time) if dispatch_time else now()
 
         reaper.reap(instance=this_inst, excluded_uuids=active_task_ids, ref_time=ref_time)
 
@@ -699,7 +699,7 @@ def adispatch_cluster_node_heartbeat(binder):
         return  # Failed to get task IDs, don't attempt reaping
 
     # Run local reaper using tasks from dispatcherd
-    ref_time = datetime.now()  # No dispatch_time in dispatcherd version
+    ref_time = now()  # No dispatch_time in dispatcherd version
     logger.debug(f"Running reaper with {len(active_task_ids)} excluded UUIDs")
     reaper.reap(instance=this_inst, excluded_uuids=active_task_ids, ref_time=ref_time)
     # If waiting jobs are hanging out, resubmit them


### PR DESCRIPTION
##### SUMMARY
The ScheduledProducer thing short-circuits the publishing logic, and task "alternatives" were only put in the publish logic. So this fixes that bug, which seems to be causing many jobs stuck in "running" forever because the heartbeat, and thus the reaper, is not running due to this.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

