### PR TITLE
Do not apply ANSIBLE_STANDARD_SETTINGS_FILES to job environment variables

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -305,6 +305,8 @@ class BaseTask(object):
         # Add ANSIBLE_* settings to the subprocess environment.
         for attr in dir(settings):
             if attr == attr.upper() and attr.startswith('ANSIBLE_') and not attr.startswith('ANSIBLE_BASE_'):
+                if attr == 'ANSIBLE_STANDARD_SETTINGS_FILES':
+                    continue  # special case intended only for dynaconf use
                 env[attr] = str(getattr(settings, attr))
         # Also set environment variables configured in AWX_TASK_ENV setting.
         for key, value in settings.AWX_TASK_ENV.items():


### PR DESCRIPTION
##### SUMMARY
this was added in django-ansible-base, but its meaning was never as an ansible-core setting. In AWX, it is assumed that the naming `ANSIBLE_` indicates an ansible-core setting that should be applied to the job environment variables, and that's just not the case with this.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
