### PR TITLE
fix: keep processing events, even if previous event data cannot be pa…

### DIFF
--- a/awx/main/tasks/host_indirect.py
+++ b/awx/main/tasks/host_indirect.py
@@ -81,7 +81,7 @@ def build_indirect_host_data(job: Job, job_event_queries: dict[str, dict[str, st
         try:
             data_source = compiled_jq.input(event.event_data['res']).all()
         except Exception as e:
-            logger.error(f'error for module {resolved_action} and data {event.event_data["res"]}: {e}')
+            logger.warning(f'error for module {resolved_action} and data {event.event_data["res"]}: {e}')
             continue
 
         for data in data_source:

--- a/awx/main/tasks/host_indirect.py
+++ b/awx/main/tasks/host_indirect.py
@@ -77,7 +77,14 @@ def build_indirect_host_data(job: Job, job_event_queries: dict[str, dict[str, st
         if jq_str_for_event not in compiled_jq_expressions:
             compiled_jq_expressions[resolved_action] = jq.compile(jq_str_for_event)
         compiled_jq = compiled_jq_expressions[resolved_action]
-        for data in compiled_jq.input(event.event_data['res']).all():
+
+        try:
+            data_source = compiled_jq.input(event.event_data['res']).all()
+        except Exception as e:
+            logger.error(f'error for module {resolved_action} and data {event.event_data["res"]}: {e}')
+            continue
+
+        for data in data_source:
             # From this jq result (specific to a single Ansible module), get index information about this host record
             if not data.get('canonical_facts'):
                 if not facts_missing_logged:


### PR DESCRIPTION
##### SUMMARY

For indirect host counting, we want to make sure that processing continues, even if one event contained invalid data that can't be parsed by jq.

This PR adds exception handling to just continue the outer loop in this case.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
