### PR TITLE
docs: Fix schedule documentation

### DIFF
--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -166,7 +166,7 @@ EXAMPLES = '''
     name: "{{ sched1 }}"
     state: present
     unified_job_template: "Demo Job Template"
-    rrule: "{{ query('awx.awx.schedule_rrule', 'week', start_date='2019-12-19 13:05:51') }}"
+    rrule: "{{ query('awx.awx.schedule_rrule', 'week', start_date='2019-12-19 13:05:51') | first }}"
   register: result
 
 - name: Build a complex schedule for every day except sunday using the rruleset plugin
@@ -174,14 +174,14 @@ EXAMPLES = '''
     name: "{{ sched1 }}"
     state: present
     unified_job_template: "Demo Job Template"
-    rrule: "{{ query(awx.awx.schedule_rruleset, '2022-04-30 10:30:45', rules=rrules, timezone='UTC' ) }}"
+    rrule: "{{ query(awx.awx.schedule_rruleset, '2022-04-30 10:30:45', rules=rrules, timezone='UTC' ) | first }}"
   vars:
     rrules:
       - frequency: 'day'
-        every: 1
+        interval: 1
       - frequency: 'day'
-        every: 1
-        on_days: 'sunday'
+        interval: 1
+        byweekday: 'sunday'
         include: false
 
 - name: Delete 'my_schedule' schedule for my_workflow


### PR DESCRIPTION
##### SUMMARY
With the "recent" changes making the lookup plugin `awx.awx.schedule_rrule` and `awx.awx.schedule_rruleset` returning a list instead of string (see #15625), the returned list (which will *always* carry only 1 item) needs to be transformed to a string either adding `| join` or `| first`. I found `first` to be more fitting as the list will *always* return a list with 1 item.

Additionally, the documentation that references `awx.awx.schedule_rruleset` in the `awx.awx.schedule` module was wrong, which is also fixed by this PR.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection
 - Docs

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```
awx: 0.1.dev34396+g0b908fc
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
