### PR TITLE
AAP-44381 Make dispatcherd config loading more lazy

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -81,57 +81,9 @@ class MainConfig(AppConfig):
     def ready(self):
         super().ready()
 
-        from django.conf import settings
+        from awx.main.dispatch.config import get_dispatcherd_config
 
-        from ansible_base.lib.utils.db import get_pg_notify_params
-        from awx.main.dispatch import get_task_queuename
-        from awx.main.dispatch.pool import get_auto_max_workers
-        from awx.main.dispatch.publish import ALTERNATIVE_TASK_IMPLEMENTATIONS
-
-        # from dispatcherd.config import settings as dispatcher_settings
-        from dispatcherd.utils import serialize_task
-
-        dispatcherd_schedule = {}
-        for task_name, options in settings.DISPATCHER_SCHEDULE.items():
-            if task_name in ALTERNATIVE_TASK_IMPLEMENTATIONS:
-                taskd_name = serialize_task(ALTERNATIVE_TASK_IMPLEMENTATIONS[task_name])
-            else:
-                taskd_name = task_name
-            dispatcherd_schedule[taskd_name] = options
-
-        dispatcher_setup(
-            {
-                "version": 2,
-                "service": {
-                    "pool_kwargs": {
-                        "min_workers": settings.JOB_EVENT_WORKERS,
-                        "max_workers": get_auto_max_workers(),
-                    },
-                    "main_kwargs": {"node_id": settings.CLUSTER_HOST_ID},
-                    "process_manager_cls": "ForkServerManager",
-                    "process_manager_kwargs": {"preload_modules": ['awx.main.dispatch.hazmat']},
-                },
-                "brokers": {
-                    "pg_notify": {
-                        "config": get_pg_notify_params(),
-                        "sync_connection_factory": "ansible_base.lib.utils.db.psycopg_connection_from_django",
-                        "channels": ['tower_broadcast_all', 'tower_settings_change', get_task_queuename()],
-                        "default_publish_channel": settings.CLUSTER_HOST_ID,  # used for debugging commands
-                    },
-                    "socket": {"socket_path": settings.DISPATCHERD_DEBUGGING_SOCKFILE},
-                },
-                "producers": {
-                    "ScheduledProducer": {"task_schedule": dispatcherd_schedule},
-                    "OnStartProducer": {"task_list": {"awx.main.tasks.system.dispatch_startup": {}}},
-                    "ControlProducer": {},
-                },
-                "publish": {
-                    "default_control_broker": "socket",
-                    "default_broker": "pg_notify",
-                },
-                "worker": {"worker_cls": "awx.main.dispatch.worker.dispatcherd.AWXTaskWorker"},
-            }
-        )
+        dispatcher_setup(get_dispatcherd_config())
 
         """
         Credential loading triggers database operations. There are cases we want to call

--- a/awx/main/dispatch/config.py
+++ b/awx/main/dispatch/config.py
@@ -1,0 +1,62 @@
+from django.conf import settings
+
+from ansible_base.lib.utils.db import get_pg_notify_params
+from awx.main.dispatch import get_task_queuename
+from awx.main.dispatch.pool import get_auto_max_workers
+from awx.main.dispatch.publish import ALTERNATIVE_TASK_IMPLEMENTATIONS
+
+# from dispatcherd.config import settings as dispatcher_settings
+from dispatcherd.utils import serialize_task
+
+
+def get_dispatcherd_config(for_service: bool = False) -> dict:
+    """Return a dictionary config for dispatcherd
+
+    Parameters:
+    for_service: if True, include dynamic options needed for running the dispatcher service
+      this will require database access, you should delay evaluation until after app setup
+    """
+    config = {
+        "version": 2,
+        "service": {
+            "pool_kwargs": {
+                "min_workers": settings.JOB_EVENT_WORKERS,
+                "max_workers": get_auto_max_workers(),
+            },
+            "main_kwargs": {"node_id": settings.CLUSTER_HOST_ID},
+            "process_manager_cls": "ForkServerManager",
+            "process_manager_kwargs": {"preload_modules": ['awx.main.dispatch.hazmat']},
+        },
+        "brokers": {
+            "pg_notify": {
+                "config": get_pg_notify_params(),
+                "sync_connection_factory": "ansible_base.lib.utils.db.psycopg_connection_from_django",
+                "default_publish_channel": settings.CLUSTER_HOST_ID,  # used for debugging commands
+            },
+            "socket": {"socket_path": settings.DISPATCHERD_DEBUGGING_SOCKFILE},
+        },
+        "publish": {
+            "default_control_broker": "socket",
+            "default_broker": "pg_notify",
+        },
+        "worker": {"worker_cls": "awx.main.dispatch.worker.dispatcherd.AWXTaskWorker"},
+    }
+
+    if for_service:
+        dispatcherd_schedule = {}
+        for task_name, options in settings.DISPATCHER_SCHEDULE.items():
+            if task_name in ALTERNATIVE_TASK_IMPLEMENTATIONS:
+                taskd_name = serialize_task(ALTERNATIVE_TASK_IMPLEMENTATIONS[task_name])
+            else:
+                taskd_name = task_name
+            dispatcherd_schedule[taskd_name] = options
+
+        config["producers"] = {
+            "ScheduledProducer": {"task_schedule": dispatcherd_schedule},
+            "OnStartProducer": {"task_list": {"awx.main.tasks.system.dispatch_startup": {}}},
+            "ControlProducer": {},
+        }
+
+        config["brokers"]["pg_notify"]["channels"] = ['tower_broadcast_all', 'tower_settings_change', get_task_queuename()]
+
+    return config

--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -110,7 +110,7 @@ class task:
                             logger.debug(f"[DISPATCHER] No alternative registered for {cls.name}; using original legacy method.")
                         return submit_task(alt_impl, args=args, kwargs=kwargs, queue=queue, uuid=uuid, **kw)
                 except Exception:
-                    logger.warning(f"[DISPATCHER] Failed to check for alternative dispatcherd implementation for {cls.name}")
+                    logger.exception(f"[DISPATCHER] Failed to check for alternative dispatcherd implementation for {cls.name}")
                     # Continue with original implementation if anything fails
                     pass
 

--- a/awx/main/dispatch/publish.py
+++ b/awx/main/dispatch/publish.py
@@ -5,6 +5,7 @@ import time
 from uuid import uuid4
 
 from dispatcherd.publish import submit_task
+from dispatcherd.utils import resolve_callable
 
 from django_guid import get_guid
 from django.conf import settings
@@ -108,7 +109,9 @@ class task:
                         else:
                             alt_impl = cls.name
                             logger.debug(f"[DISPATCHER] No alternative registered for {cls.name}; using original legacy method.")
-                        return submit_task(alt_impl, args=args, kwargs=kwargs, queue=queue, uuid=uuid, **kw)
+                        # At this point we have the import string, and submit_task wants the method, so back to that
+                        actual_task = resolve_callable(alt_impl)
+                        return submit_task(actual_task, args=args, kwargs=kwargs, queue=queue, uuid=uuid, **kw)
                 except Exception:
                     logger.exception(f"[DISPATCHER] Failed to check for alternative dispatcherd implementation for {cls.name}")
                     # Continue with original implementation if anything fails

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -102,7 +102,7 @@ class Command(BaseCommand):
                 return
 
         if flag_enabled('FEATURE_DISPATCHERD_ENABLED'):
-            dispatcher_setup(get_dispatcherd_config())
+            dispatcher_setup(get_dispatcherd_config(for_service=True))
             run_service()
         else:
             consumer = None

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -12,8 +12,10 @@ from flags.state import flag_enabled
 
 from dispatcherd.factories import get_control_from_settings
 from dispatcherd import run_service
+from dispatcherd.config import setup as dispatcher_setup
 
 from awx.main.dispatch import get_task_queuename
+from awx.main.dispatch.config import get_dispatcherd_config
 from awx.main.dispatch.control import Control
 from awx.main.dispatch.pool import AutoscalePool
 from awx.main.dispatch.worker import AWXConsumerPG, TaskWorker
@@ -100,6 +102,7 @@ class Command(BaseCommand):
                 return
 
         if flag_enabled('FEATURE_DISPATCHERD_ENABLED'):
+            dispatcher_setup(get_dispatcherd_config())
             run_service()
         else:
             consumer = None

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -25,14 +25,6 @@ Prevent logger.<warn, debug, error> calls from triggering database operations
 '''
 
 
-@pytest.fixture(autouse=True, scope='module')
-def _disable_dispatcherd():
-    ffs = deepcopy(settings.FLAGS)
-    ffs['FEATURE_DISPATCHERD_ENABLED'][0]['value'] = False
-    with override_settings(FLAGS=ffs):
-        yield
-
-
 @pytest.fixture(autouse=True)
 def _disable_database_settings(mocker):
     m = mocker.patch('awx.conf.settings.SettingsWrapper.all_supported_settings', new_callable=mock.PropertyMock)
@@ -311,6 +303,13 @@ class TestTaskDispatcher:
 
 
 class TestTaskPublisher:
+    @pytest.fixture(autouse=True)
+    def _disable_dispatcherd(self):
+        ffs = deepcopy(settings.FLAGS)
+        ffs['FEATURE_DISPATCHERD_ENABLED'][0]['value'] = False
+        with override_settings(FLAGS=ffs):
+            yield
+
     def test_function_callable(self):
         assert add(2, 2) == 4
 

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -5,8 +5,11 @@ import signal
 import time
 import yaml
 from unittest import mock
+from copy import deepcopy
 
 from django.utils.timezone import now as tz_now
+from django.conf import settings
+from django.test.utils import override_settings
 import pytest
 
 from awx.main.models import Job, WorkflowJob, Instance
@@ -20,6 +23,14 @@ from awx.main.dispatch.periodic import Scheduler
 '''
 Prevent logger.<warn, debug, error> calls from triggering database operations
 '''
+
+
+@pytest.fixture(autouse=True, scope='module')
+def _disable_dispatcherd():
+    ffs = deepcopy(settings.FLAGS)
+    ffs['FEATURE_DISPATCHERD_ENABLED'][0]['value'] = False
+    with override_settings(FLAGS=ffs):
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -128,7 +128,7 @@ deprecated==1.2.15
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-semantic-conventions
     #   pygithub
-dispatcherd==2025.5.7
+dispatcherd==2025.5.12
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
This is to finally fix the awx-operator failures.

The patch is untested as of opening. This was written speculatively based on a stack trace I got using the kind operator locally to get the logs from the container in the restart loop, which I couldn't get from github actions for the life of me.

That trace is:

```
  File "/awx_devel/awx/asgi.py", line 38, in <module>
    django.setup()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/apps/registry.py", line 124, in populate
    app_config.ready()
  File "/awx_devel/awx/main/apps.py", line 118, in ready
    "channels": ['tower_broadcast_all', 'tower_settings_change', get_task_queuename()],
                                                                 ^^^^^^^^^^^^^^^^^^^^
  File "/awx_devel/awx/main/dispatch/__init__.py", line 34, in get_task_queuename
    .first()
     ^^^^^^^
...snip...
django.db.utils.ProgrammingError: relation "main_instance" does not exist
LINE 1: ...n_instance"."id", "main_instance"."hostname" FROM "main_inst...
                                                             ^
make: *** [Makefile:227: collectstatic] Error 1
2025-05-12 13:07:44,942 WARN exited: uwsgi (exit status 2; not expected)
```

I was not able to reproduce this on my own using

```
make docker-compose-sources
docker compose -f tools/docker-compose/_sources/docker-compose.yml run --rm awx_1 bash
```

So I'm still left with a head-scratcher not knowing exactly what the operator is doing. But anyway, the _patch_ that results is entirely coherent. We were loading some things too early, that's all.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

