### PR TITLE
fix chicken egg issue with workflow nodes and inventory sources for parents that do not exist

### DIFF
--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -230,7 +230,11 @@ def main():
     inventory_object = module.get_one('inventories', name_or_id=inventory, data=lookup_data)
 
     if not inventory_object:
-        module.fail_json(msg='The specified inventory, {0}, was not found.'.format(lookup_data))
+        # if the inventory does not exist, then it can't have sources.
+        if state == 'absent':
+            module.exit_json(**module.json_output)
+        else:
+            module.fail_json(msg='The specified inventory, {0}, was not found.'.format(lookup_data))
 
     inventory_source_object = module.get_one(
         'inventory_sources',

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -320,9 +320,13 @@ def main():
             wfjt_search_fields['organization'] = organization_id
         wfjt_data = module.get_one('workflow_job_templates', name_or_id=workflow_job_template, **{'data': wfjt_search_fields})
         if wfjt_data is None:
-            module.fail_json(
-                msg="The workflow {0} in organization {1} was not found on the controller instance server".format(workflow_job_template, organization)
-            )
+            if state == 'absent':
+                # if the workflow doesn't exist, it can't have workflow nodes.
+                module.exit_json(**module.json_output)
+            else:
+                module.fail_json(
+                    msg="The workflow {0} in organization {1} was not found on the controller instance server".format(workflow_job_template, organization)
+                )
         workflow_job_template_id = wfjt_data['id']
         search_fields['workflow_job_template'] = new_fields['workflow_job_template'] = workflow_job_template_id
 

--- a/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
@@ -121,6 +121,21 @@
         that:
           - "result is changed"
 
+    - name: Attempt to delete an inventory source from an inventory that does not exist that does not exist
+      inventory_source:
+        name: "{{ inv_source3 }}"
+        source: scm
+        state: absent
+        source_project: "{{ project_name }}"
+        source_path: inventories/create_100_hosts.ini
+        description: Source for Test inventory
+        organization: Default
+        inventory: Does not exist
+
+    - assert:
+        that:
+          - "result is not changed"
+
   always:
     - name: Delete Inventory
       inventory:

--- a/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory_source_update/tasks/main.yml
@@ -121,7 +121,7 @@
         that:
           - "result is changed"
 
-    - name: Attempt to delete an inventory source from an inventory that does not exist that does not exist
+    - name: Attempt to delete an inventory source from an inventory that does not exist
       inventory_source:
         name: "{{ inv_source3 }}"
         source: scm
@@ -131,6 +131,7 @@
         description: Source for Test inventory
         organization: Default
         inventory: Does not exist
+      register: result
 
     - assert:
         that:

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -428,6 +428,16 @@
         that:
           - "results is changed"
 
+    - name: Remove a node from a workflow that does not exist.
+      workflow_job_template_node:
+        identifier: root
+        unified_job_template: "{{ jt1_name }}"
+        workflow: Does not exist
+
+    - assert:
+        that:
+          - "results is not changed"
+
     - name: Create root node
       workflow_job_template_node:
         identifier: root

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -433,6 +433,8 @@
         identifier: root
         unified_job_template: "{{ jt1_name }}"
         workflow: Does not exist
+        state: absent
+      register: results
 
     - assert:
         that:


### PR DESCRIPTION
fix chicken egg issue with workflow nodes and inventory sources for parents that do not exist

Right now if you attempt to delete an inventory source for an inventory that has been deleted, it will fail, this will just mark as ok, as it does not exist, so it behaves as if it has been deleted. 

The same goes for workflow nodes.

##### SUMMARY
fix chicken egg issue with workflow nodes and inventory sources for p…

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### AWX VERSION


##### ADDITIONAL INFORMATION
Tests updated
