### PR TITLE
Fix signal handling gap, hijack SIGUSR1 from dispatcherd

### DIFF
--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -2,6 +2,7 @@
 # All Rights Reserved.
 import logging
 import yaml
+import os
 
 import redis
 
@@ -47,12 +48,18 @@ class Command(BaseCommand):
             ),
         )
 
+    def verify_dispatcherd_socket(self):
+        if not os.path.exists(settings.DISPATCHERD_DEBUGGING_SOCKFILE):
+            raise CommandError('Dispatcher is not running locally')
+
     def handle(self, *arg, **options):
         if options.get('status'):
             if flag_enabled('FEATURE_DISPATCHERD_ENABLED'):
                 ctl = get_control_from_settings()
                 running_data = ctl.control_with_reply('status')
-                print(yaml.dump(running_data, default_flow_style=False))
+                if len(running_data) != 1:
+                    raise CommandError('Did not receive expected number of replies')
+                print(yaml.dump(running_data[0], default_flow_style=False))
                 return
             else:
                 print(Control('dispatcher').status())

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -69,7 +69,7 @@ from awx.main.tasks.callback import (
     RunnerCallbackForSystemJob,
 )
 from awx.main.tasks.policy import evaluate_policy
-from awx.main.tasks.signals import with_signal_handling, signal_callback, signal_state
+from awx.main.tasks.signals import with_signal_handling, signal_callback
 from awx.main.tasks.receptor import AWXReceptorJob
 from awx.main.tasks.facts import start_fact_cache, finish_fact_cache
 from awx.main.tasks.system import update_smart_memberships_for_inventory, update_inventory_computed_fields, events_processed_hook

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -31,7 +31,6 @@ from gitdb.exc import BadName as BadGitName
 
 # Dispatcherd
 from dispatcherd.publish import task
-from dispatcherd.worker.task import DispatcherCancel
 from dispatcherd.utils import serialize_task
 
 # AWX
@@ -648,11 +647,6 @@ class BaseTask(object):
             self.runner_callback.delay_update(job_explanation=str(exc), result_traceback=str(exc))
         except ReceptorNodeNotFound as exc:
             self.runner_callback.delay_update(job_explanation=str(exc))
-        except DispatcherCancel:
-            # dispatcher uses non-sigterm signal, and will raise this exception
-            signal_state.dispatcher_cancel_flag = True
-            logger.info(f'Caught DispatcherCancel error for {self.instance.log_format}')
-            status = 'canceled'
         except Exception:
             # this could catch programming or file system errors
             self.runner_callback.delay_update(result_traceback=traceback.format_exc())

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -30,7 +30,6 @@ from awx.main.utils.common import (
 )
 from awx.main.constants import MAX_ISOLATED_PATH_COLON_DELIMITER
 from awx.main.tasks.signals import signal_state, signal_callback, SignalExit
-from dispatcherd.worker.task import DispatcherCancel
 from awx.main.models import Instance, InstanceLink, UnifiedJob, ReceptorAddress
 from awx.main.dispatch import get_task_queuename
 from awx.main.dispatch.publish import task as task_awx
@@ -509,10 +508,7 @@ class AWXReceptorJob:
                 if signal_callback():
                     raise SignalExit()
                 res = processor_future.result()
-            except (SignalExit, DispatcherCancel):
-                if not signal_callback():
-                    # Record if this was from dispatcherd signal handling
-                    signal_state.dispatcher_cancel_flag = True
+            except SignalExit:
                 receptor_ctl.simple_command(f"work cancel {self.unit_id}")
                 resultsock.shutdown(socket.SHUT_RDWR)
                 resultfile.close()

--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -14,17 +14,21 @@ class SignalExit(Exception):
 
 
 class SignalState:
+    # SIGTERM: Sent by supervisord to process group on shutdown
+    # SIGUSR1: The dispatcherd cancel signal
+    signals = (signal.SIGTERM, signal.SIGINT, signal.SIGUSR1)
+
     def reset(self):
-        self.sigterm_flag = False
-        self.sigint_flag = False
-        self.dispatcher_cancel_flag = False
+        for for_signal in self.signals:
+            self.signal_flags[for_signal] = False
+            self.original_methods[for_signal] = None
 
         self.is_active = False  # for nested context managers
-        self.original_sigterm = None
-        self.original_sigint = None
         self.raise_exception = False
 
     def __init__(self):
+        self.signal_flags = {}
+        self.original_methods = {}
         self.reset()
 
     def raise_if_needed(self):
@@ -32,31 +36,28 @@ class SignalState:
             self.raise_exception = False  # so it is not raised a second time in error handling
             raise SignalExit()
 
-    def set_sigterm_flag(self, *args):
-        self.sigterm_flag = True
-        self.raise_if_needed()
-
-    def set_sigint_flag(self, *args):
-        self.sigint_flag = True
+    def set_signal_flag(self, *args, for_signal=None):
+        self.signal_flags[for_signal] = True
+        logger.info(f'Processed signal {for_signal}, set exit flag')
         self.raise_if_needed()
 
     def connect_signals(self):
-        self.original_sigterm = signal.getsignal(signal.SIGTERM)
-        self.original_sigint = signal.getsignal(signal.SIGINT)
-        signal.signal(signal.SIGTERM, self.set_sigterm_flag)
-        signal.signal(signal.SIGINT, self.set_sigint_flag)
+        for for_signal in self.signals:
+            self.original_methods[for_signal] = signal.getsignal(for_signal)
+            signal.signal(for_signal, lambda *args, for_signal=None: self.set_signal_flag(args, for_signal=for_signal))
         self.is_active = True
 
     def restore_signals(self):
-        signal.signal(signal.SIGTERM, self.original_sigterm)
-        signal.signal(signal.SIGINT, self.original_sigint)
-        # if we got a signal while context manager was active, call parent methods.
-        if self.sigterm_flag:
-            if callable(self.original_sigterm):
-                self.original_sigterm()
-        if self.sigint_flag:
-            if callable(self.original_sigint):
-                self.original_sigint()
+        for for_signal in self.signals:
+            original_method = self.original_methods[for_signal]
+            signal.signal(for_signal, original_method)
+            # if we got a signal while context manager was active, call parent methods.
+            if self.signal_flags[for_signal]:
+                if callable(original_method):
+                    try:
+                        original_method()
+                    except Exception as exc:
+                        logger.info(f'Error processing original {for_signal} signal, error: {str(exc)}')
         self.reset()
 
 
@@ -64,7 +65,7 @@ signal_state = SignalState()
 
 
 def signal_callback():
-    return bool(signal_state.sigterm_flag or signal_state.sigint_flag or signal_state.dispatcher_cancel_flag)
+    return any(signal_state.signal_flags[for_signal] for for_signal in signal_state.signals)
 
 
 def with_signal_handling(f):

--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -44,7 +44,7 @@ class SignalState:
     def connect_signals(self):
         for for_signal in self.signals:
             self.original_methods[for_signal] = signal.getsignal(for_signal)
-            signal.signal(for_signal, lambda *args, for_signal=None: self.set_signal_flag(args, for_signal=for_signal))
+            signal.signal(for_signal, lambda *args: self.set_signal_flag(*args, for_signal=for_signal))
         self.is_active = True
 
     def restore_signals(self):

--- a/awx/main/tasks/signals.py
+++ b/awx/main/tasks/signals.py
@@ -44,7 +44,7 @@ class SignalState:
     def connect_signals(self):
         for for_signal in self.signals:
             self.original_methods[for_signal] = signal.getsignal(for_signal)
-            signal.signal(for_signal, lambda *args: self.set_signal_flag(*args, for_signal=for_signal))
+            signal.signal(for_signal, lambda *args, for_signal=for_signal: self.set_signal_flag(*args, for_signal=for_signal))
         self.is_active = True
 
     def restore_signals(self):

--- a/awx/main/tests/live/tests/test_job_cancel.py
+++ b/awx/main/tests/live/tests/test_job_cancel.py
@@ -13,7 +13,7 @@ def test_cancel_and_delete_job(live_tmp_folder, run_job_from_playbook, post, del
 
     # Wait for first event so that we can be sure the job is in-progress first
     start = time.time()
-    timeout = 3.0
+    timeout = 10.0
     while not job.job_events.exists():
         time.sleep(0.2)
         if time.time() - start > timeout:

--- a/awx/main/tests/unit/tasks/test_signals.py
+++ b/awx/main/tests/unit/tasks/test_signals.py
@@ -50,7 +50,7 @@ def test_outer_inner_signal_handling():
     @with_signal_handling
     def f1():
         assert signal_callback() is False
-        signal_state.set_sigterm_flag()
+        signal_state.set_signal_flag(for_signal=signal.SIGTERM)
         assert signal_callback()
         f2()
 
@@ -74,7 +74,7 @@ def test_inner_outer_signal_handling():
     @with_signal_handling
     def f2():
         assert signal_callback() is False
-        signal_state.set_sigint_flag()
+        signal_state.set_signal_flag(for_signal=signal.SIGINT)
         assert signal_callback()
 
     @with_signal_handling


### PR DESCRIPTION
##### SUMMARY
Let me give the command I'm debugging here:

```
pytest --inventory=playbooks/inventory-docker.py tests/api/test_projects.py tests/api/inventories/test_inventory_update.py tests/api/workflows/test_workflow_jobs.py -k "test_cancel_queued_update or test_cancel_inventory_update_during_save or test_cancel_workflow_job_pre_spawn"
```

There's too much nuance with exception handling, and my prior attempts at this problem with the `DispatcherCancel` exception just were not working. At issue, specifically, we kept having that exception raised at the line:

```
tools_awx_1       |   File "/awx_devel/awx/main/tasks/jobs.py", line 500, in run
tools_awx_1       |     self.instance = self.update_model(self.instance.pk, execution_environment=self.instance.resolve_execution_environment())
tools_awx_1       |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This line might be particularly slow? But anyway, it's outside the try-except. As I wracked my brain on this problem, I could not make this work. Catching `DispatcherCancel` risks having it raised multiple times, and it's ugly, and leaky.

The fact is that there is already a fine-crafted policy about where it should and should not raise an exception. Being conservative, this brings us closer back to what the prior logic was.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

