### PR TITLE
Enable policy as code feature by default

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1079,7 +1079,7 @@ INDIRECT_HOST_AUDIT_RECORD_MAX_AGE_DAYS = 7
 
 
 # setting for Policy as Code feature
-FEATURE_POLICY_AS_CODE_ENABLED = False
+FEATURE_POLICY_AS_CODE_ENABLED = True
 
 OPA_HOST = ''  # The hostname used to connect to the OPA server. If empty, policy enforcement will be disabled.
 OPA_PORT = 8181  # The port used to connect to the OPA server. Defaults to 8181.
@@ -1098,5 +1098,5 @@ OPA_REQUEST_RETRIES = 2  # The number of retry attempts for connecting to the OP
 FLAG_SOURCES = ('flags.sources.SettingsFlagsSource',)
 FLAGS = {
     'FEATURE_INDIRECT_NODE_COUNTING_ENABLED': [{'condition': 'boolean', 'value': False}],
-    'FEATURE_POLICY_AS_CODE_ENABLED': [{'condition': 'boolean', 'value': False}],
+    'FEATURE_POLICY_AS_CODE_ENABLED': [{'condition': 'boolean', 'value': True}],
 }

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -93,6 +93,9 @@ needs_development = ['inventory_script', 'instance']
 needs_param_development = {
     'host': ['instance_id'],
     'workflow_approval': ['description', 'execution_environment'],
+    'inventory': ['opa_query_path'],
+    'job_template': ['opa_query_path'],
+    'organization': ['opa_query_path'],
 }
 # -----------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
##### SUMMARY
- Enable policy as code feature by default
- Skip awx-collection completeness test for opa_query_path field

TODO: implement opa_query_path field in awx-collection after feature is no longer gated behind feature flag

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
