### PR TITLE
Fix deadlock error and other cleanup errors

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -466,6 +466,31 @@ class BaseTask(object):
     def should_use_fact_cache(self):
         return False
 
+    def transition_status(self, pk: int) -> bool:
+        """Atomically transition status to running, if False returned, another process got it"""
+        with transaction.atomic():
+            # Explanation of parts for the fetch:
+            # .values - avoid loading a full object, this is known to lead to deadlocks due to signals
+            #   the signals load other related rows which another process may be locking, and happens in practice
+            # of=('self',) - keeps FK tables out of the lock list, another way deadlocks can happen
+            # .get - just load the single job
+            instance_data = UnifiedJob.objects.select_for_update(of=('self',)).values('status', 'cancel_flag').get(pk=pk)
+
+            # If status is not waiting (obtained under lock) then this process does not have clearence to run
+            if instance_data['status'] == 'waiting':
+                if instance_data['cancel_flag']:
+                    updated_status = 'canceled'
+                else:
+                    updated_status = 'running'
+                # Explanation of the update:
+                # .filter - again, do not load the full object
+                # .update - a bulk update on just that one row, avoid loading unintended data
+                UnifiedJob.objects.filter(pk=pk).update(status=updated_status, start_args='')
+            elif instance_data['status'] == 'running':
+                logger.info(f'Job {pk} is being ran by another process, exiting')
+                return False
+        return True
+
     @with_path_cleanup
     @with_signal_handling
     def run(self, pk, **kwargs):
@@ -473,30 +498,15 @@ class BaseTask(object):
         Run the job/task and capture its output.
         """
         if not self.instance:  # Used to skip fetch for local runs
-            with transaction.atomic():
-                self.instance = self.model.objects.select_for_update().get(pk=pk)
+            if not self.transition_status(pk):
+                logger.info(f'Job {pk} is being ran by another process, exiting')
+                return
 
-                # If status is not waiting (obtained under lock) then this process does not have clearence to run
-                if self.instance.status == 'waiting':
-                    self.instance.start_args = ''  # blank field to remove encrypted passwords
-                    if self.instance.cancel_flag is True:
-                        self.instance.status = 'canceled'
-                    else:
-                        # self.instance because of the update_model pattern and when it's used in callback handlers
-                        self.instance.status = 'running'
-                    self.instance.save(update_fields=['start_args', 'status'])
-                elif self.instance.status == 'running':
-                    logger.info(f'Job {self.instance.log_format} is being ran by another process, exiting')
-                    return
-
+        # Load the instance
+        self.instance = self.update_model(pk)
         if self.instance.status != 'running':
-            raise RuntimeError(f'Not starting {self.instance.status} task pk={pk} because its status "{self.instance.status}" is not expected')
-
-        if self.instance.execution_environment_id is None:
-            from awx.main.signals import disable_activity_stream
-
-            with disable_activity_stream():
-                self.instance = self.update_model(self.instance.pk, execution_environment=self.instance.resolve_execution_environment())
+            logger.error(f'Not starting {self.instance.status} task pk={pk} because its status "{self.instance.status}" is not expected')
+            return
 
         self.instance.websocket_emit_status("running")
         status, rc = 'error', None
@@ -510,6 +520,12 @@ class BaseTask(object):
         private_data_dir = None
 
         try:
+            if self.instance.execution_environment_id is None:
+                from awx.main.signals import disable_activity_stream
+
+                with disable_activity_stream():
+                    self.instance = self.update_model(self.instance.pk, execution_environment=self.instance.resolve_execution_environment())
+
             self.instance.send_notification_templates("running")
             private_data_dir = self.build_private_data_dir(self.instance)
             self.pre_run_hook(self.instance, private_data_dir)
@@ -666,6 +682,9 @@ class BaseTask(object):
             logger.exception('{} Post run hook errored.'.format(self.instance.log_format))
 
         self.instance = self.update_model(pk)
+        if not self.instance:
+            logger.error(f'Unified job pk={pk} appears to be deleted while running')
+            return
         self.instance = self.update_model(pk, status=status, select_for_update=True, **self.runner_callback.get_delayed_update_fields())
 
         # Field host_status_counts is used as a metric to check if event processing is finished

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -682,13 +682,13 @@ class BaseTask(object):
             logger.exception('{} Post run hook errored.'.format(self.instance.log_format))
 
         self.instance = self.update_model(pk)
-        if not self.instance:
-            logger.error(f'Unified job pk={pk} appears to be deleted while running')
-            return
         self.instance = self.update_model(pk, status=status, select_for_update=True, **self.runner_callback.get_delayed_update_fields())
 
         # Field host_status_counts is used as a metric to check if event processing is finished
         # we send notifications if it is, if not, callback receiver will send them
+        if not self.instance:
+            logger.error(f'Unified job pk={pk} appears to be deleted while running')
+            return
         if (self.instance.host_status_counts is not None) or (not self.runner_callback.wrapup_event_dispatched):
             events_processed_hook(self.instance)
 

--- a/awx/main/tests/functional/tasks/test_tasks_jobs.py
+++ b/awx/main/tests/functional/tasks/test_tasks_jobs.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from awx.main.tasks.jobs import RunJob
@@ -18,16 +20,14 @@ def test_does_not_run_reaped_job(mocker, mock_me):
 
 
 @pytest.mark.django_db
-def test_cancel_flag_on_start(jt_linked):
+def test_cancel_flag_on_start(jt_linked, caplog):
     job = jt_linked.create_unified_job()
     job.status = 'waiting'
     job.cancel_flag = True
     job.save()
 
     task = RunJob()
-    with pytest.raises(RuntimeError) as exc:
-        task.run(job.id)
-    assert 'because its status "canceled" is not expected' in str(exc)
+    task.run(job.id)
 
     job = Job.objects.get(id=job.id)
     assert job.status == 'canceled'

--- a/awx/main/tests/functional/tasks/test_tasks_jobs.py
+++ b/awx/main/tests/functional/tasks/test_tasks_jobs.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from awx.main.tasks.jobs import RunJob


### PR DESCRIPTION
##### SUMMARY
This is an issue I discovered from test logs.

```
2025-05-14 18:02:32,048 ERROR    [-] dispatcherd.worker.task PID:457508 Worker failed to run task awx.main.tasks.jobs.RunJob(*[1789], **{}
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
psycopg.errors.DeadlockDetected: deadlock detected
DETAIL:  Process 489991 waits for ShareLock on transaction 153973; blocked by process 489953.
Process 489953 waits for ShareLock on transaction 153982; blocked by process 489991.
HINT:  See server log for query details.
CONTEXT:  while locking tuple (79,4) in relation "main_unifiedjob"

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/dispatcherd/worker/task.py", line 173, in perform_work
    result = self.run_callable(message)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/dispatcherd/worker/task.py", line 144, in run_callable
    return _call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/jobs.py", line 103, in _wrapped
    return f(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/signals.py", line 83, in _wrapped
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/tasks/jobs.py", line 477, in run
    self.instance = self.model.objects.select_for_update().get(pk=pk)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 633, in get
    num = len(clone)
          ^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 380, in __len__
    self._fetch_all()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 1881, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/polymorphic/query.py", line 58, in _polymorphic_iterator
    o = next(base_iter)
        ^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/models/sql/compiler.py", line 1562, in execute_sql
    cursor.execute(sql, params)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 84, in _execute
    with self.db.wrap_database_errors:
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/psycopg/cursor.py", line 97, in execute
    raise ex.with_traceback(None)
django.db.utils.OperationalError: deadlock detected
DETAIL:  Process 489991 waits for ShareLock on transaction 153973; blocked by process 489953.
Process 489953 waits for ShareLock on transaction 153982; blocked by process 489991.
HINT:  See server log for query details.
CONTEXT:  while locking tuple (79,4) in relation "main_unifiedjob"
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

