### PR TITLE
feat: Add http_headers param

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -51,6 +51,10 @@ options:
     - If provided, the other locations for config files will not be considered.
     type: path
     aliases: [tower_config_file]
+  http_headers:
+    description:
+    - Arbitrary headers to add to every HTTP request
+    type: dict
 
 notes:
 - If no I(config_file) is provided we will attempt to use the tower-cli library

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -56,6 +56,7 @@ class ControllerModule(AnsibleModule):
         validate_certs=dict(type='bool', aliases=['tower_verify_ssl'], required=False, fallback=(env_fallback, ['CONTROLLER_VERIFY_SSL', 'TOWER_VERIFY_SSL'])),
         request_timeout=dict(type='float', required=False, fallback=(env_fallback, ['CONTROLLER_REQUEST_TIMEOUT'])),
         controller_config_file=dict(type='path', aliases=['tower_config_file'], required=False, default=None),
+        http_headers=dict(type='dict', required=False, default={}),
     )
     # Associations of these types are ordered and have special consideration in the modified associations function
     ordered_associations = ['instance_groups', 'galaxy_credentials', 'input_inventories']
@@ -473,6 +474,8 @@ class ControllerAPIModule(ControllerModule):
 
         # Extract the headers, this will be used in a couple of places
         headers = kwargs.get('headers', {})
+        if self.params.get('http_headers'):
+            headers.update(self.params['http_headers'])
 
         # Authenticate to AWX (if not already done so)
         if not self.authenticated:
@@ -626,16 +629,19 @@ class ControllerAPIModule(ControllerModule):
         if self.username and self.password:
             # use api url /api/v2/me to get current user info as a testing request
             me_url = self.build_url("me").geturl()
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": self._get_basic_authorization_header(),
+            }
+            if self.params.get('http_headers'):
+                headers.update(self.params['http_headers'])
             self.session.open(
                 "GET",
                 me_url,
                 validate_certs=self.verify_ssl,
                 timeout=self.request_timeout,
                 follow_redirects=True,
-                headers={
-                    "Content-Type": "application/json",
-                    "Authorization": self._get_basic_authorization_header(),
-                },
+                headers=headers,
             )
 
     def authenticate(self, **kwargs):


### PR DESCRIPTION
##### SUMMARY

We deploy AWX inside a secure environment where every HTTP call has to go through a gateway responsible for authenticating every micro service, even if the software behind has its own authentication mechanism. In order to authenticate against this gateway, we need to provide additional non-conflicting HTTP headers. This pull request allows to provide an arbitrary list of HTTP headers to every requests made by the Ansible collection, that we use to configure AWX. By default, no custom header is provided.

##### ISSUE TYPE

 - New or Enhanced Feature

##### COMPONENT NAME

 - Collection

Example of usage:
```yaml
- name: Configure execution environments
  awx.awx.execution_environment:
    http_headers:
      X-Gateway-Source: "{{ awx_gw_uservice.id }}"
      X-Gateway-Token: "{{ awx_gw_uservice.secret }}"
      X-Gateway-Region: "{{ awx_gw_uservice.region }}"
      X-Gateway-Service-Name: "awx"
    name: "{{ item.value.name }}"
    image: "{{ item.value.image }}:{{ item.value.image_tag }}"
    validate_certs: "{{ awx_validate_cert | default('yes') }}"
  loop: "{{ lookup('dict', awx_common_ee | combine(awx_specific_ee | default({})), wantlist=True) }}"
  tags: ['ee', 'execution_environment']
```
