### PR TITLE
Clean up logging for receptor down & unregistered cases

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -599,7 +599,11 @@ def inspect_execution_and_hop_nodes(instance_list):
         except FileNotFoundError:
             logger.error('Receptor daemon not running, skipping execution node check')
             return
-        mesh_status = ctl.simple_command('status')
+        try:
+            mesh_status = ctl.simple_command('status')
+        except ValueError as exc:
+            logger.error(f'Error running receptorctl status command, error: {str(exc)}')
+            return
 
         inspect_established_receptor_connections(mesh_status)
 

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -876,9 +876,13 @@ def awx_receptor_workunit_reaper():
     try:
         receptor_ctl = get_receptor_ctl()
     except FileNotFoundError:
-        logger.error('Receptor daemon not found, skipping work unit reaper')
+        logger.info('Receptorctl sockfile not found for workunit reaper, doing nothing')
         return
-    receptor_work_list = receptor_ctl.simple_command("work list")
+    try:
+        receptor_work_list = receptor_ctl.simple_command("work list")
+    except ValueError as exc:
+        logger.info(f'Error getting work list for workunit reaper, error: {str(exc)}')
+        return
 
     unit_ids = [id for id in receptor_work_list]
     jobs_with_unreleased_receptor_units = UnifiedJob.objects.filter(work_unit_id__in=unit_ids).exclude(status__in=ACTIVE_STATES)

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -594,7 +594,11 @@ def inspect_established_receptor_connections(mesh_status):
 def inspect_execution_and_hop_nodes(instance_list):
     with advisory_lock('inspect_execution_and_hop_nodes_lock', wait=False):
         node_lookup = {inst.hostname: inst for inst in instance_list}
-        ctl = get_receptor_ctl()
+        try:
+            ctl = get_receptor_ctl()
+        except FileNotFoundError:
+            logger.error('Receptor daemon not running, skipping execution node check')
+            return
         mesh_status = ctl.simple_command('status')
 
         inspect_established_receptor_connections(mesh_status)
@@ -864,7 +868,11 @@ def awx_receptor_workunit_reaper():
     if not settings.RECEPTOR_RELEASE_WORK:
         return
     logger.debug("Checking for unreleased receptor work units")
-    receptor_ctl = get_receptor_ctl()
+    try:
+        receptor_ctl = get_receptor_ctl()
+    except FileNotFoundError:
+        logger.error('Receptor daemon not found, skipping work unit reaper')
+        return
     receptor_work_list = receptor_ctl.simple_command("work list")
 
     unit_ids = [id for id in receptor_work_list]

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -788,7 +788,8 @@ def _heartbeat_instance_management():
                 logger.warning(f'Recreated instance record {this_inst.hostname} after unexpected removal')
             this_inst.local_health_check()
         else:
-            raise RuntimeError("Cluster Host Not Found: {}".format(settings.CLUSTER_HOST_ID))
+            logger.error("Cluster Host Not Found: {}".format(settings.CLUSTER_HOST_ID))
+            return None, None, None
 
     return this_inst, instance_list, lost_instances
 


### PR DESCRIPTION
##### SUMMARY
I've been having to inspect test runs a lot lately, and this is one of the most verbose remaining things after my prior redis fix.

I haven't tested yet, and I don't want to until the dispatcherd work is in which has its own improvements.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

