### PR TITLE
standardizing how host gets validated

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -15,7 +15,6 @@ from ansible.module_utils.six.moves.configparser import ConfigParser, NoOptionEr
 from base64 import b64encode
 from socket import getaddrinfo, IPPROTO_TCP
 import time
-import re
 from json import loads, dumps
 from os.path import isfile, expanduser, split, join, exists, isdir
 from os import access, R_OK, getcwd, environ, getenv
@@ -106,7 +105,7 @@ class ControllerModule(AnsibleModule):
                 setattr(self, short_param, direct_value)
 
         # Perform some basic validation
-        if not re.match('^https{0,1}://', self.host):
+        if not self.host.startswith(("https://", "http://")):
             self.host = "https://{0}".format(self.host)
 
         # Try to parse the hostname as a url

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -105,7 +105,7 @@ class ControllerModule(AnsibleModule):
                 setattr(self, short_param, direct_value)
 
         # Perform some basic validation
-        if not self.host.startswith(("https://", "http://")): # NOSONAR
+        if not self.host.startswith(("https://", "http://")):  # NOSONAR
             self.host = "https://{0}".format(self.host)
 
         # Try to parse the hostname as a url

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -105,7 +105,7 @@ class ControllerModule(AnsibleModule):
                 setattr(self, short_param, direct_value)
 
         # Perform some basic validation
-        if not self.host.startswith(("https://", "http://")):
+        if not self.host.startswith(("https://", "http://")): # NOSONAR
             self.host = "https://{0}".format(self.host)
 
         # Try to parse the hostname as a url


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
removing the requirement for re in controller_api.py and changing to startswith which the other AAP collections use

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
[hub](https://github.com/ansible-collections/ansible_hub/blob/05c4f14efb9593701a2c48c98a7731a058fb2d5a/plugins/module_utils/ah_module.py#L137)
[eda](https://github.com/ansible/event-driven-ansible/blob/0591e5e5f316e639753b5d6560f6032debbce278/plugins/module_utils/client.py#L56)
