### PR TITLE
Restore basic auth for subscriptions API

### DIFF
--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -243,14 +243,23 @@ class Licenser(object):
         return []
 
     def get_rhsm_subs(self, host, client_id, client_secret):
-        client = OIDCClient(client_id, client_secret)
-        subs = client.make_request(
-            'GET',
-            host,
-            verify=True,
-            timeout=(31, 31),
-        )
-
+        try:
+            client = OIDCClient(client_id, client_secret)
+            subs = client.make_request(
+                'GET',
+                host,
+                verify=True,
+                timeout=(31, 31),
+            )
+        except requests.RequestException:
+            logger.warning("Failed to connect to console.redhat.com using Service Account credentials. Falling back to basic auth.")
+            subs = requests.request(
+                'GET',
+                host,
+                auth=(client_id, client_secret),
+                verify=True,
+                timeout=(31, 31),
+            )
         subs.raise_for_status()
         subs_formatted = []
         for sku in subs.json()['body']:

--- a/awx/main/utils/licensing.py
+++ b/awx/main/utils/licensing.py
@@ -249,7 +249,7 @@ class Licenser(object):
                 'GET',
                 host,
                 verify=True,
-                timeout=(31, 31),
+                timeout=(5, 20),
             )
         except requests.RequestException:
             logger.warning("Failed to connect to console.redhat.com using Service Account credentials. Falling back to basic auth.")
@@ -258,7 +258,7 @@ class Licenser(object):
                 host,
                 auth=(client_id, client_secret),
                 verify=True,
-                timeout=(31, 31),
+                timeout=(5, 20),
             )
         subs.raise_for_status()
         subs_formatted = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If service account auth doesn't work, fall back to using basic auth.

This allows users to continue to use basic auth credentials in the client ID / secret fields.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


