### PR TITLE
Bump django to 4.2.21

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -14,7 +14,7 @@ cryptography<42.0.0  # investigation is needed for 42+ to work with OpenSSL v3.0
 Cython
 daphne
 distro
-django==4.2.20  # CVE-2025-26699
+django==4.2.21  # CVE-2025-32873
 django-cors-headers
 django-crum
 django-extensions

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -132,7 +132,7 @@ dispatcherd==2025.5.21
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in
-django==4.2.20
+django==4.2.21
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels


### PR DESCRIPTION
##### SUMMARY
Bump django to 4.2.21 due to bump in django-ansible-base (https://github.com/ansible/django-ansible-base/pull/730)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
