### PR TITLE
Do not evaluate coverage until all jobs finish

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,6 @@
 
 codecov:
   notify:
-    after_n_builds: 6  # Number of test matrix+lint jobs uploading coverage
     wait_for_ci: false
 
   require_ci_to_pass: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,12 +344,7 @@ jobs:
 
   finalize-codecov:
     needs:
-      - api-test
-      - api-migrations
-      - api-lint
-      - api-swagger
-      - awx-collection
-      - api-schema
+      - common-tests
       - collection-integration
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,7 @@ jobs:
           flags: >-
             CI-GHA,
             pytest,
+            awx-unit,
             OS-${{ runner.os }}
           name: ${{ github.job }}-${{ matrix.os || runner.os }}  # Unique name per job
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -254,6 +255,7 @@ jobs:
           flags: >-
             CI-GHA,
             pytest,
+            awx-sanity,
             OS-${{ runner.os }}
           name: ${{ github.job }}-${{ matrix.os || runner.os }}  # Unique name per job
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -363,7 +365,7 @@ jobs:
           flags: >-
             CI-GHA,
             ansible-test,
-            integration,
+            awx-collection-integration,
             OS-${{ runner.os }}
           name: ${{ github.job }}-${{ matrix.os || runner.os }}
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,6 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           ansible-core-version: ${{ matrix.ansible }}
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}
           collection-root: awx_collection
           pre-test-cmd: >-
             ansible-playbook
@@ -239,6 +238,46 @@ jobs:
             -e collection_version=1.0.0
             -e '{"awx_template_version": false}'
           testing-type: sanity
+
+      - name: Upload test coverage to Codecov
+        if: >-
+          !cancelled()
+          && steps.make-run.outputs.cov-report-files != ''
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: >-
+            ${{
+              toJSON(env.UPSTREAM_REPOSITORY_ID == github.repository_id)
+            }}
+          files: >-
+            ${{ steps.make-run.outputs.cov-report-files }}
+          flags: >-
+            CI-GHA,
+            pytest,
+            OS-${{ runner.os }}
+          name: ${{ github.job }}-${{ matrix.os || runner.os }}  # Unique name per job
+          token: ${{ secrets.CODECOV_TOKEN }}
+          parallel: true  # <--- ENABLE PARALLEL MODE
+
+      - name: Upload test results to Codecov
+        if: >-
+          !cancelled()
+          && steps.make-run.outputs.test-result-files != ''
+        uses: codecov/test-results-action@v1
+        with:
+          fail_ci_if_error: >-
+            ${{
+              toJSON(env.UPSTREAM_REPOSITORY_ID == github.repository_id)
+            }}
+          files: >-
+            ${{ steps.make-run.outputs.test-result-files }}
+          flags: >-
+            CI-GHA,
+            pytest,
+            OS-${{
+              runner.os
+            }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload awx jUnit test reports to the unified dashboard
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,11 @@ jobs:
           flags: >-
             CI-GHA,
             pytest,
-            OS-${{
-              runner.os
-            }}
+            OS-${{ runner.os }}
+          name: ${{ github.job }}-${{ matrix.os || runner.os }}  # Unique name per job
           token: ${{ secrets.CODECOV_TOKEN }}
+          parallel: true  # <--- ENABLE PARALLEL MODE
+
       - name: Upload test results to Codecov
         if: >-
           !cancelled()
@@ -324,10 +325,10 @@ jobs:
             CI-GHA,
             ansible-test,
             integration,
-            OS-${{
-              runner.os
-            }}
+            OS-${{ runner.os }}
+          name: ${{ github.job }}-${{ matrix.os || runner.os }}
           token: ${{ secrets.CODECOV_TOKEN }}
+          parallel: true  # <--- ENABLE PARALLEL MODE
 
       # Upload coverage report as artifact
       - uses: actions/upload-artifact@v4
@@ -340,6 +341,22 @@ jobs:
         if: always()
         with:
           log-filename: collection-integration-${{ matrix.target-regex.name }}.log
+
+  finalize-codecov:
+    needs:
+      - api-test
+      - api-migrations
+      - api-lint
+      - api-swagger
+      - awx-collection
+      - api-schema
+      - collection-integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Finalize Codecov report
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   collection-integration-coverage-combine:
     name: combine awx_collection integration coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,12 +346,14 @@ jobs:
     needs:
       - common-tests
       - collection-integration
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Finalize Codecov report
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
 
   collection-integration-coverage-combine:
     name: combine awx_collection integration coverage


### PR DESCRIPTION
##### SUMMARY
Seeing a lot of wonkiness in https://github.com/ansible/awx/pull/16017

It's wrong to give a coverage metric when the tests have not completed.

This adds flags to not finalize in each upload and then adds a finalization job that depends on the other jobs.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
