### PR TITLE
🧪 Recover full-source coverage in `pytest-cov`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ COLLECTION_SANITY_ARGS ?= --docker
 # collection unit testing directories
 COLLECTION_TEST_DIRS ?= awx_collection/test/awx
 # pytest added args to collect coverage
-COVERAGE_ARGS ?= --cov=awx --cov-report=xml --junitxml=reports/junit.xml
+COVERAGE_ARGS ?= --cov --cov-report=xml --junitxml=reports/junit.xml
 # pytest test directories
 TEST_DIRS ?= awx/main/tests/unit awx/main/tests/functional awx/conf/tests
 # pytest args to run tests in parallel


### PR DESCRIPTION
`--cov=$thing` overrides what's in `.coveagerc` and breaks what's collected on the `coveragepy` level, cascading into Codecov not seeing coverage for a bunch of files in repo. This change attempts to fix that.

<!--- Bug, Docs Fix or other nominal change -->