### PR TITLE
🧪 Hide false negative warnings by `coveragepy`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -17,6 +17,23 @@ exclude_also =
 
 [run]
 branch = True
+# NOTE: `disable_warnings` is needed when `pytest-cov` runs in tandem
+# NOTE: with `pytest-xdist`. These warnings are false negative in this
+# NOTE: context.
+#
+# NOTE: It's `coveragepy` that emits the warnings and previously they
+# NOTE: wouldn't get on the radar of `pytest`'s `filterwarnings`
+# NOTE: mechanism. This changed, however, with `pytest >= 8.4`. And
+# NOTE: since we set `filterwarnings = error`, those warnings are being
+# NOTE: raised as exceptions, cascading into `pytest`'s internals and
+# NOTE: causing tracebacks and crashes of the test sessions.
+#
+# Ref:
+# * https://github.com/pytest-dev/pytest-cov/issues/693
+# * https://github.com/pytest-dev/pytest-cov/pull/695
+# * https://github.com/pytest-dev/pytest-cov/pull/696
+disable_warnings =
+  module-not-measured
 omit =
     awx/main/migrations/*
     awx/settings/defaults.py

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,9 +15,6 @@ markers =
 filterwarnings =
   error
 
-  # Breaks coverage combined with pytest-mp, surfacing as an unhandled error outside of test scope
-  ignore:Module awx was previously imported, but not measured:coverage.exceptions.CoverageWarning
-
   # FIXME: Upgrade protobuf https://github.com/protocolbuffers/protobuf/issues/15077
   once:Type google._upb._message.* uses PyType_Spec with a metaclass that has custom tp_new:DeprecationWarning
 


### PR DESCRIPTION
They are only surfaced under pytest 8.4, with `pytest-cov` and `pytest-xdist` being both active [[1]]. Or equivalent situations.

This is a follow-up for #16015 which attempted ignoring the warning on the runtime level in pytest. Instead, the patch tells `coveragepy` not to emit said warnings in the first place.

[1]: pytest-dev/pytest-cov#693

<!--- Bug, Docs Fix or other nominal change -->