### PR TITLE
🧪 Bump the expected Codecov uploads number to 9

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,7 +2,7 @@
 
 codecov:
   notify:
-    after_n_builds: 6  # Number of test matrix+lint jobs uploading coverage
+    after_n_builds: 9  # Number of test matrix+lint jobs uploading coverage
     wait_for_ci: false
 
   require_ci_to_pass: false


### PR DESCRIPTION
It should ideally match perfectly or at least come close, for best responsiveness. This setting is currently used to prevent Codecov from publishing incomplete coverage metrics too early.

<!--- Bug, Docs Fix or other nominal change -->