### PR TITLE
Collect coverage for live tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Run live dev env tests
         id: make-run
-        run: docker exec tools_awx_1 /bin/bash -c "GITHUB_ACTIONS=${GITHUB_ACTIONS} PYTEST_ADDOPTS='--cov=awx --cov-report=xml --junitxml=../../../../reports/junit.xml --no-cov-on-fail' make live_test"
+        run: docker exec tools_awx_1 /bin/bash -c "GITHUB_ACTIONS=${GITHUB_ACTIONS} GITHUB_OUTPUT=${GITHUB_OUTPUT} PYTEST_ADDOPTS='--cov=awx --cov-report=xml --junitxml=../../../../reports/junit.xml --no-cov-on-fail' make live_test"
 
       - name: Upload test coverage to Codecov
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           private-github-key: ${{ secrets.PRIVATE_GITHUB_KEY }}
 
       - name: Run live dev env tests
+        id: make-run
         run: docker exec tools_awx_1 /bin/bash -c "PYTEST_ADDOPTS='--cov=awx --cov-report=xml --junitxml=../../../../reports/junit.xml --no-cov-on-fail' make live_test"
 
       - name: Upload test coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Run live dev env tests
         id: make-run
-        run: docker exec tools_awx_1 /bin/bash -c "PYTEST_ADDOPTS='--cov=awx --cov-report=xml --junitxml=../../../../reports/junit.xml --no-cov-on-fail' make live_test"
+        run: docker exec tools_awx_1 /bin/bash -c "GITHUB_ACTIONS=${GITHUB_ACTIONS} PYTEST_ADDOPTS='--cov=awx --cov-report=xml --junitxml=../../../../reports/junit.xml --no-cov-on-fail' make live_test"
 
       - name: Upload test coverage to Codecov
         if: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,46 @@ jobs:
           private-github-key: ${{ secrets.PRIVATE_GITHUB_KEY }}
 
       - name: Run live dev env tests
-        run: docker exec tools_awx_1 /bin/bash -c "make live_test"
+        run: docker exec tools_awx_1 /bin/bash -c "PYTEST_ADDOPTS='--cov=awx --cov-report=xml --junitxml=../../../../reports/junit.xml --no-cov-on-fail' make live_test"
+
+      - name: Upload test coverage to Codecov
+        if: >-
+          !cancelled()
+          && steps.make-run.outputs.cov-report-files != ''
+        uses: codecov/codecov-action@v4
+        with:
+          fail_ci_if_error: >-
+            ${{
+              toJSON(env.UPSTREAM_REPOSITORY_ID == github.repository_id)
+            }}
+          files: >-
+            ${{ steps.make-run.outputs.cov-report-files }}
+          flags: >-
+            CI-GHA,
+            pytest,
+            OS-${{
+              runner.os
+            }}
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload test results to Codecov
+        if: >-
+          !cancelled()
+          && steps.make-run.outputs.test-result-files != ''
+        uses: codecov/test-results-action@v1
+        with:
+          fail_ci_if_error: >-
+            ${{
+              toJSON(env.UPSTREAM_REPOSITORY_ID == github.repository_id)
+            }}
+          files: >-
+            ${{ steps.make-run.outputs.test-result-files }}
+          flags: >-
+            CI-GHA,
+            pytest,
+            OS-${{
+              runner.os
+            }}
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - uses: ./.github/actions/upload_awx_devel_logs
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,11 @@ test:
 
 live_test:
 	cd awx/main/tests/live && py.test tests/
+	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
+	then \
+	  echo 'cov-report-files=reports/coverage.xml' >> "${GITHUB_OUTPUT}"; \
+	  echo 'test-result-files=reports/junit.xml' >> "${GITHUB_OUTPUT}"; \
+	fi
 
 ## Run all API unit tests with coverage enabled.
 test_coverage:


### PR DESCRIPTION
##### SUMMARY
Obligatory gripe:

This doesn't collect server-side coverage, which is the key mechanistic thing happening here. This only collects coverage from the pytest process, which is superficial, client-side stuff in most cases. It might go a little deeper on how the test is written, but totally case-by-case. I generally expect the interesting stuff happens via background tasks in the dispatcher.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
