### PR TITLE
Move to Runtime Platform Flags

### DIFF
--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -5,11 +5,8 @@ import signal
 import time
 import yaml
 from unittest import mock
-from copy import deepcopy
-
+from flags.state import disable_flag, enable_flag
 from django.utils.timezone import now as tz_now
-from django.conf import settings
-from django.test.utils import override_settings
 import pytest
 
 from awx.main.models import Job, WorkflowJob, Instance
@@ -302,13 +299,14 @@ class TestTaskDispatcher:
         assert str(result) == "No module named 'awx.foo'"  # noqa
 
 
+@pytest.mark.django_db
 class TestTaskPublisher:
     @pytest.fixture(autouse=True)
     def _disable_dispatcherd(self):
-        ffs = deepcopy(settings.FLAGS)
-        ffs['FEATURE_DISPATCHERD_ENABLED'][0]['value'] = False
-        with override_settings(FLAGS=ffs):
-            yield
+        flag_name = "FEATURE_DISPATCHERD_ENABLED"
+        disable_flag(flag_name)
+        yield
+        enable_flag(flag_name)
 
     def test_function_callable(self):
         assert add(2, 2) == 4

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -461,6 +461,7 @@ class TestExtraVarSanitation(TestJobExecution):
 
 
 class TestGenericRun:
+    @pytest.mark.django_db(reset_sequences=True)
     def test_generic_failure(self, patch_Job, execution_environment, mock_me, mock_create_partition):
         job = Job(status='running', inventory=Inventory(), project=Project(local_path='/projects/_23_foo'))
         job.websocket_emit_status = mock.Mock()
@@ -545,6 +546,7 @@ class TestGenericRun:
         private_data_dir, extra_vars, safe_dict = call_args
         assert extra_vars['super_secret'] == "CLASSIFIED"
 
+    @pytest.mark.django_db
     def test_awx_task_env(self, patch_Job, private_data_dir, execution_environment, mock_me):
         job = Job(project=Project(), inventory=Inventory())
         job.execution_environment = execution_environment
@@ -845,6 +847,7 @@ class TestJobCredentials(TestJobExecution):
             [None, '0'],
         ],
     )
+    @pytest.mark.django_db
     def test_net_credentials(self, authorize, expected_authorize, job, private_data_dir, mock_me):
         task = jobs.RunJob()
         task.instance = job
@@ -901,6 +904,7 @@ class TestJobCredentials(TestJobExecution):
 
         assert safe_env['AZURE_PASSWORD'] == HIDDEN_PASSWORD
 
+    @pytest.mark.django_db
     def test_awx_task_env(self, settings, private_data_dir, job, mock_me):
         settings.AWX_TASK_ENV = {'FOO': 'BAR'}
         task = jobs.RunJob()

--- a/awx/resource_api.py
+++ b/awx/resource_api.py
@@ -1,6 +1,11 @@
 from ansible_base.resource_registry.registry import ParentResource, ResourceConfig, ServiceAPIConfig, SharedResource
-from ansible_base.resource_registry.shared_types import OrganizationType, TeamType, UserType
-
+from ansible_base.resource_registry.shared_types import (
+    FeatureFlagType,
+    OrganizationType,
+    TeamType,
+    UserType,
+)
+from ansible_base.feature_flags.models import AAPFlag
 from awx.main import models
 
 
@@ -18,5 +23,9 @@ RESOURCE_LIST = (
         models.Team,
         shared_resource=SharedResource(serializer=TeamType, is_provider=False),
         parent_resources=[ParentResource(model=models.Organization, field_name="organization")],
+    ),
+    ResourceConfig(
+        AAPFlag,
+        shared_resource=SharedResource(serializer=FeatureFlagType, is_provider=False),
     ),
 )

--- a/awx/settings/__init__.py
+++ b/awx/settings/__init__.py
@@ -8,7 +8,6 @@ from ansible_base.lib.dynamic_config import (
     load_envvars,
     load_python_file_with_injected_context,
     load_standard_settings_files,
-    toggle_feature_flags,
 )
 from .functions import (
     assert_production_settings,
@@ -68,13 +67,6 @@ load_envvars(DYNACONF)
 DYNACONF.update(
     merge_application_name(DYNACONF),
     loader_identifier="awx.settings:merge_application_name",
-    merge=True,
-)
-
-# Toggle feature flags based on installer settings
-DYNACONF.update(
-    toggle_feature_flags(DYNACONF),
-    loader_identifier="awx.settings:toggle_feature_flags",
     merge=True,
 )
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1106,11 +1106,8 @@ OPA_REQUEST_TIMEOUT = 1.5  # The number of seconds after which the connection to
 OPA_REQUEST_RETRIES = 2  # The number of retry attempts for connecting to the OPA server. Default is 2.
 
 # feature flags
-FLAG_SOURCES = ('flags.sources.SettingsFlagsSource',)
-FLAGS = {
-    'FEATURE_INDIRECT_NODE_COUNTING_ENABLED': [{'condition': 'boolean', 'value': False}],
-    'FEATURE_DISPATCHERD_ENABLED': [{'condition': 'boolean', 'value': False}],
-}
+FEATURE_INDIRECT_NODE_COUNTING_ENABLED = False
+FEATURE_DISPATCHERD_ENABLED = False
 
 # Dispatcher worker lifetime. If set to None, workers will never be retired
 # based on age. Note workers will finish their last task before retiring if

--- a/awx/settings/development_defaults.py
+++ b/awx/settings/development_defaults.py
@@ -11,8 +11,6 @@ import socket
 # /usr/lib64/python/mimetypes.py
 import mimetypes
 
-from dynaconf import post_hook
-
 # awx-manage shell_plus --notebook
 NOTEBOOK_ARGUMENTS = ['--NotebookApp.token=', '--ip', '0.0.0.0', '--port', '9888', '--allow-root', '--no-browser']
 
@@ -67,11 +65,5 @@ AWX_DISABLE_TASK_MANAGERS = False
 # Needed for launching runserver in debug mode
 # ======================!!!!!!! FOR DEVELOPMENT ONLY !!!!!!!=================================
 
-
-# This modifies FLAGS set by defaults, must be deferred to run later
-@post_hook
-def set_dev_flags(settings):
-    defaults_flags = settings.get("FLAGS", {})
-    defaults_flags['FEATURE_INDIRECT_NODE_COUNTING_ENABLED'] = [{'condition': 'boolean', 'value': True}]
-    defaults_flags['FEATURE_DISPATCHERD_ENABLED'] = [{'condition': 'boolean', 'value': True}]
-    return {'FLAGS': defaults_flags}
+FEATURE_INDIRECT_NODE_COUNTING_ENABLED = True
+FEATURE_DISPATCHERD_ENABLED = True

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 awx-plugins-core @ git+https://github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core[credentials-github-app]
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac,feature-flags]
+django-ansible-base @ git+https://github.com/zkayyali812/django-ansible-base@phase2/feature-flags/poc#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac,feature-flags]
 awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git


### PR DESCRIPTION
##### Move to Runtime Platform Flags

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION

This PR moves the source of truth for feature flags from components to the platform, inheriting and leveraging platform flags.
This PR requires - https://github.com/ansible/django-ansible-base/pull/736 to be merged in first.

