### PR TITLE
Add option 'bitbucket_dc' to 'webhook_service'

### DIFF
--- a/awx_collection/plugins/modules/job_template.py
+++ b/awx_collection/plugins/modules/job_template.py
@@ -274,6 +274,7 @@ options:
       type: str
       choices:
         - ''
+        - 'bitbucket_dc'
         - 'github'
         - 'gitlab'
     webhook_credential:
@@ -436,7 +437,7 @@ def main():
         scm_branch=dict(),
         ask_scm_branch_on_launch=dict(type='bool'),
         job_slice_count=dict(type='int'),
-        webhook_service=dict(choices=['github', 'gitlab', '']),
+        webhook_service=dict(choices=['github', 'gitlab', 'bitbucket_dc', '']),
         webhook_credential=dict(),
         labels=dict(type="list", elements='str'),
         notification_templates_started=dict(type="list", elements='str'),


### PR DESCRIPTION
##### SUMMARY
Add option 'bitbucket_dc' to 'webhook_service' in job-template module, since webhooks from Bitbucket Data Center are already implemented and configurable using the GUI but not using the module

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection

##### ADDITIONAL INFORMATION
