### PR TITLE
Remove api version from hardcoded inventory url

### DIFF
--- a/awx_collection/plugins/inventory/controller.py
+++ b/awx_collection/plugins/inventory/controller.py
@@ -134,9 +134,8 @@ class InventoryModule(BaseInventoryPlugin):
                     'Invalid type for configuration option inventory_id, ' 'not integer, and cannot convert to string: {err}'.format(err=to_native(e))
                 ), e)
         inventory_id = inventory_id.replace('/', '')
-        inventory_url = '/api/v2/inventories/{inv_id}/script/'.format(inv_id=inventory_id)
 
-        inventory = module.get_endpoint(inventory_url, data={'hostvars': '1', 'towervars': '1', 'all': '1'})['json']
+        inventory = module.get_endpoint('inventories/{inv_id}/script/'.format(inv_id=inventory_id), data={'hostvars': '1', 'towervars': '1', 'all': '1'})['json']
 
         # To start with, create all the groups.
         for group_name in inventory:
@@ -169,7 +168,7 @@ class InventoryModule(BaseInventoryPlugin):
         # Fetch extra variables if told to do so
         if self.get_option('include_metadata'):
 
-            config_data = module.get_endpoint('/api/v2/config/')['json']
+            config_data = module.get_endpoint('config/')['json']
 
             server_data = {}
             server_data['license_type'] = config_data.get('license_info', {}).get('license_type', 'unknown')

--- a/awx_collection/plugins/inventory/controller.py
+++ b/awx_collection/plugins/inventory/controller.py
@@ -135,7 +135,9 @@ class InventoryModule(BaseInventoryPlugin):
                 ), e)
         inventory_id = inventory_id.replace('/', '')
 
-        inventory = module.get_endpoint('inventories/{inv_id}/script/'.format(inv_id=inventory_id), data={'hostvars': '1', 'towervars': '1', 'all': '1'})['json']
+        inventory = module.get_endpoint(
+            'inventories/{inv_id}/script/'.format(inv_id=inventory_id), data={'hostvars': '1', 'towervars': '1', 'all': '1'}
+        )['json']
 
         # To start with, create all the groups.
         for group_name in inventory:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Previously we manually included the api version for the endpoint in the inventory url but this is no longer necessary. This PR updates the endpoint to remove the "/api/v2/" specification since that is now handled automatically. 
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
