### PR TITLE
AAP-47771 Rename github_app credential namespace

### DIFF
--- a/awx/main/migrations/0203_rename_github_app_credential_type.py
+++ b/awx/main/migrations/0203_rename_github_app_credential_type.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+from awx.main.models import CredentialType
+
+
+def update_github_app_namespace(apps, schema_editor):
+    CredentialType.setup_tower_managed_defaults(apps)
+    apps.get_model('main', 'CredentialType').objects.filter(namespace='github_app').update(namespace='github_app_lookup')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('main', '0202_squashed_deletions.py'),
+    ]
+
+    operations = [migrations.RunPython(update_github_app_namespace)]


### PR DESCRIPTION
##### SUMMARY
Renaming the github_app to github_app_lookup as per the packaging change

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
