### PR TITLE
Update Collections Syntax to get Collection related CI Checks Passing 

### DIFF
--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -223,6 +223,10 @@ def test_inventory_update_injected_content(product_name, this_kind, inventory, f
         private_data_dir = envvars.pop('AWX_PRIVATE_DATA_DIR')
         assert envvars.pop('ANSIBLE_INVENTORY_ENABLED') == 'auto'
         set_files = bool(os.getenv("MAKE_INVENTORY_REFERENCE_FILES", 'false').lower()[0] not in ['f', '0'])
+
+        # Ensure the directory exists before trying to list/read it
+        os.makedirs(private_data_dir, exist_ok=True)
+
         env, content = read_content(private_data_dir, envvars, inventory_update)
 
         # Assert inventory plugin inventory file is in private_data_dir

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-
 import io
 import os
 import json
@@ -17,6 +16,7 @@ from requests.models import Response, PreparedRequest
 import pytest
 
 from ansible.module_utils.six import raise_from
+
 
 from ansible_base.rbac.models import RoleDefinition, DABPermission
 from ansible_base.rbac import permission_registry
@@ -119,35 +119,91 @@ def collection_import():
     return rf
 
 
+def _process_request_data(kwargs_copy, kwargs):
+    """Helper to process 'data' in request kwargs."""
+    if 'data' in kwargs:
+        if isinstance(kwargs['data'], dict):
+            kwargs_copy['data'] = kwargs['data']
+        elif kwargs['data'] is None:
+            pass
+        elif isinstance(kwargs['data'], str):
+            kwargs_copy['data'] = json.loads(kwargs['data'])
+        else:
+            raise RuntimeError('Expected data to be dict or str, got {0}, data: {1}'.format(type(kwargs['data']), kwargs['data']))
+
+
+def _process_request_params(kwargs_copy, kwargs, method):
+    """Helper to process 'params' in request kwargs."""
+    if 'params' in kwargs and method == 'GET':
+        if not kwargs_copy.get('data'):
+            kwargs_copy['data'] = {}
+        if isinstance(kwargs['params'], dict):
+            kwargs_copy['data'].update(kwargs['params'])
+        elif isinstance(kwargs['params'], list):
+            for k, v in kwargs['params']:
+                kwargs_copy['data'][k] = v
+
+
+def _get_resource_class(resource_module):
+    """Helper to determine the Ansible module resource class."""
+    if getattr(resource_module, 'ControllerAWXKitModule', None):
+        return resource_module.ControllerAWXKitModule
+    elif getattr(resource_module, 'ControllerAPIModule', None):
+        return resource_module.ControllerAPIModule
+    else:
+        raise RuntimeError("The module has neither a ControllerAWXKitModule or a ControllerAPIModule")
+
+
+def _get_tower_cli_mgr(new_request):
+    """Helper to get the appropriate tower_cli mock context manager."""
+    if HAS_TOWER_CLI:
+        return mock.patch('tower_cli.api.Session.request', new=new_request)
+    elif HAS_AWX_KIT:
+        return mock.patch('awxkit.api.client.requests.Session.request', new=new_request)
+    else:
+        return suppress()
+
+
+def _run_and_capture_module_output(resource_module, stdout_buffer):
+    """Helper to run the module and capture its stdout."""
+    try:
+        with redirect_stdout(stdout_buffer):
+            resource_module.main()
+    except SystemExit:
+        pass  # A system exit indicates successful execution
+    except Exception:
+        # dump the stdout back to console for debugging
+        print(stdout_buffer.getvalue())
+        raise
+
+
+def _parse_and_handle_module_result(module_stdout):
+    """Helper to parse module output and handle exceptions."""
+    try:
+        result = json.loads(module_stdout)
+    except Exception as e:
+        raise_from(Exception('Module did not write valid JSON, error: {0}, stdout:\n{1}'.format(str(e), module_stdout)), e)
+
+    if 'exception' in result:
+        if "ModuleNotFoundError: No module named 'tower_cli'" in result['exception']:
+            pytest.skip('The tower-cli library is needed to run this test, module no longer supported.')
+        raise Exception('Module encountered error:\n{0}'.format(result['exception']))
+    return result
+
+
 @pytest.fixture
-def run_module(request, collection_import):
+def run_module(request, collection_import, mocker):
     def rf(module_name, module_params, request_user):
+
         def new_request(self, method, url, **kwargs):
             kwargs_copy = kwargs.copy()
-            if 'data' in kwargs:
-                if isinstance(kwargs['data'], dict):
-                    kwargs_copy['data'] = kwargs['data']
-                elif kwargs['data'] is None:
-                    pass
-                elif isinstance(kwargs['data'], str):
-                    kwargs_copy['data'] = json.loads(kwargs['data'])
-                else:
-                    raise RuntimeError('Expected data to be dict or str, got {0}, data: {1}'.format(type(kwargs['data']), kwargs['data']))
-            if 'params' in kwargs and method == 'GET':
-                # query params for GET are handled a bit differently by
-                # tower-cli and python requests as opposed to REST framework APIRequestFactory
-                if not kwargs_copy.get('data'):
-                    kwargs_copy['data'] = {}
-                if isinstance(kwargs['params'], dict):
-                    kwargs_copy['data'].update(kwargs['params'])
-                elif isinstance(kwargs['params'], list):
-                    for k, v in kwargs['params']:
-                        kwargs_copy['data'][k] = v
+            _process_request_data(kwargs_copy, kwargs)
+            _process_request_params(kwargs_copy, kwargs, method)
 
             # make request
             with transaction.atomic():
-                rf = _request(method.lower())
-                django_response = rf(url, user=request_user, expect=None, **kwargs_copy)
+                rf_django = _request(method.lower())  # Renamed rf to avoid conflict with outer rf
+                django_response = rf_django(url, user=request_user, expect=None, **kwargs_copy)
 
             # requests library response object is different from the Django response, but they are the same concept
             # this converts the Django response object into a requests response object for consumption
@@ -171,10 +227,6 @@ def run_module(request, collection_import):
             return m
 
         stdout_buffer = io.StringIO()
-        # Requies specific PYTHONPATH, see docs
-        # Note that a proper Ansiballz explosion of the modules will have an import path like:
-        # ansible_collections.awx.awx.plugins.modules.{}
-        # We should consider supporting that in the future
         resource_module = collection_import('plugins.modules.{0}'.format(module_name))
 
         if not isinstance(module_params, dict):
@@ -182,44 +234,19 @@ def run_module(request, collection_import):
 
         def mock_load_params(self):
             self.params = module_params
-            self._ANSIBLE_PROFILE = 'legacy'
             return module_params, 'legacy'
 
-        if getattr(resource_module, 'ControllerAWXKitModule', None):
-            resource_class = resource_module.ControllerAWXKitModule
-        elif getattr(resource_module, 'ControllerAPIModule', None):
-            resource_class = resource_module.ControllerAPIModule
-        else:
-            raise RuntimeError("The module has neither a ControllerAWXKitModule or a ControllerAPIModule")
+        resource_class = _get_resource_class(resource_module)
 
         with mock.patch.object(resource_class, '_load_params', new=mock_load_params):
+            mocker.patch('ansible.module_utils.basic._ANSIBLE_PROFILE', 'legacy')
+
             with mock.patch('ansible.module_utils.urls.Request.open', new=new_open):
-                if HAS_TOWER_CLI:
-                    tower_cli_mgr = mock.patch('tower_cli.api.Session.request', new=new_request)
-                elif HAS_AWX_KIT:
-                    tower_cli_mgr = mock.patch('awxkit.api.client.requests.Session.request', new=new_request)
-                else:
-                    tower_cli_mgr = suppress()
-                with tower_cli_mgr:
-                    try:
-                        with redirect_stdout(stdout_buffer):
-                            resource_module.main()
-                    except SystemExit:
-                        pass
-                    except Exception:
-                        print(stdout_buffer.getvalue())
-                        raise
+                with _get_tower_cli_mgr(new_request):
+                    _run_and_capture_module_output(resource_module, stdout_buffer)
 
         module_stdout = stdout_buffer.getvalue().strip()
-        try:
-            result = json.loads(module_stdout)
-        except Exception as e:
-            raise_from(Exception('Module did not write valid JSON, error: {0}, stdout:\n{1}'.format(str(e), module_stdout)), e)
-        # A module exception should never be a test expectation
-        if 'exception' in result:
-            if "ModuleNotFoundError: No module named 'tower_cli'" in result['exception']:
-                pytest.skip('The tower-cli library is needed to run this test, module no longer supported.')
-            raise Exception('Module encountered error:\n{0}'.format(result['exception']))
+        result = _parse_and_handle_module_result(module_stdout)
         return result
 
     return rf

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -17,7 +17,6 @@ import pytest
 
 from ansible.module_utils.six import raise_from
 
-
 from ansible_base.rbac.models import RoleDefinition, DABPermission
 from ansible_base.rbac import permission_registry
 
@@ -62,14 +61,12 @@ def import_awxkit():
     global HAS_AWX_KIT
     try:
         import tower_cli  # noqa
-
         HAS_TOWER_CLI = True
     except ImportError:
         HAS_TOWER_CLI = False
 
     try:
         import awxkit  # noqa
-
         HAS_AWX_KIT = True
     except ImportError:
         HAS_AWX_KIT = False
@@ -234,7 +231,6 @@ def run_module(request, collection_import, mocker):
 
         def mock_load_params(self):
             self.params = module_params
-            return module_params, 'legacy'
 
         resource_class = _get_resource_class(resource_module)
 

--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+
 import io
 import os
 import json
@@ -61,12 +62,14 @@ def import_awxkit():
     global HAS_AWX_KIT
     try:
         import tower_cli  # noqa
+
         HAS_TOWER_CLI = True
     except ImportError:
         HAS_TOWER_CLI = False
 
     try:
         import awxkit  # noqa
+
         HAS_AWX_KIT = True
     except ImportError:
         HAS_AWX_KIT = False
@@ -177,10 +180,10 @@ def run_module(request, collection_import):
         if not isinstance(module_params, dict):
             raise RuntimeError('Module params must be dict, got {0}'.format(type(module_params)))
 
-        # Ansible params can be passed as an invocation argument or over stdin
-        # this short circuits within the AnsibleModule interface
         def mock_load_params(self):
             self.params = module_params
+            self._ANSIBLE_PROFILE = 'legacy'
+            return module_params, 'legacy'
 
         if getattr(resource_module, 'ControllerAWXKitModule', None):
             resource_class = resource_module.ControllerAWXKitModule
@@ -190,7 +193,6 @@ def run_module(request, collection_import):
             raise RuntimeError("The module has neither a ControllerAWXKitModule or a ControllerAPIModule")
 
         with mock.patch.object(resource_class, '_load_params', new=mock_load_params):
-            # Call the test utility (like a mock server) instead of issuing HTTP requests
             with mock.patch('ansible.module_utils.urls.Request.open', new=new_open):
                 if HAS_TOWER_CLI:
                     tower_cli_mgr = mock.patch('tower_cli.api.Session.request', new=new_request)
@@ -200,13 +202,11 @@ def run_module(request, collection_import):
                     tower_cli_mgr = suppress()
                 with tower_cli_mgr:
                     try:
-                        # Ansible modules return data to the mothership over stdout
                         with redirect_stdout(stdout_buffer):
                             resource_module.main()
                     except SystemExit:
-                        pass  # A system exit indicates successful execution
+                        pass
                     except Exception:
-                        # dump the stdout back to console for debugging
                         print(stdout_buffer.getvalue())
                         raise
 

--- a/awx_collection/tests/integration/targets/ad_hoc_command/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/ad_hoc_command/tasks/main.yml
@@ -108,7 +108,7 @@
     credential: "{{ ssh_cred_name }}"
     module_name: "Does not exist"
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/ad_hoc_command_cancel/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/ad_hoc_command_cancel/tasks/main.yml
@@ -70,7 +70,7 @@
     command_id: "{{ command.id }}"
     fail_if_not_running: true
   register: results
-  ignore_errors: true
+  ignore_errors: yes
 
 - ansible.builtin.assert:
     that:
@@ -81,7 +81,7 @@
     command_id: "{{ command.id }}"
     fail_if_not_running: true
   register: results
-  ignore_errors: true
+  ignore_errors: yes
 
 - ansible.builtin.assert:
     that:
@@ -91,7 +91,7 @@
   awx.awx.ad_hoc_command_cancel:
     command_id: 9999999999
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - ansible.builtin.assert:
     that:

--- a/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
@@ -38,7 +38,7 @@
   ad_hoc_command_wait:
     command_id: "99999999"
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:
@@ -85,7 +85,7 @@
   ad_hoc_command_wait:
     command_id: "{{ command.id }}"
     timeout: 1
-  ignore_errors: true
+  ignore_errors: yes
   register: wait_results
 
 # Make sure that we failed and that we have some data in our results
@@ -104,7 +104,7 @@
   ad_hoc_command_wait:
     command_id: "{{ command.id }}"
   register: wait_results
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/ad_hoc_command_wait/tasks/main.yml
@@ -91,7 +91,7 @@
 # Make sure that we failed and that we have some data in our results
 - assert:
     that:
-      - "'Monitoring aborted due to timeout' or 'Timeout waiting for command to finish.' in wait_results.msg"
+      - "('Monitoring of ad hoc command -' in wait_results.msg and 'aborted due to timeout' in wait_results.msg) or ('Timeout waiting for command to finish.' in wait_results.msg)"
       - "'id' in wait_results"
 
 - name: Async cancel the long-running command

--- a/awx_collection/tests/integration/targets/credential/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/credential/tasks/main.yml
@@ -93,7 +93,7 @@
     organization: Default
     state: absent
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:
@@ -306,7 +306,7 @@
     inputs:
       username: joe
       ssh_key_data: "{{ ssh_key_data }}"
-  ignore_errors: true
+  ignore_errors: yes
   register: result
 
 - assert:
@@ -322,7 +322,7 @@
     credential_type: Machine
     inputs:
       username: joe
-  ignore_errors: true
+  ignore_errors: yes
   register: result
 
 - assert:
@@ -811,7 +811,7 @@
     organization: test-non-existing-org
     state: present
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/execution_environment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/execution_environment/tasks/main.yml
@@ -70,7 +70,7 @@
         organization: Some Org
         image: quay.io/ansible/awx-ee
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:

--- a/awx_collection/tests/integration/targets/group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/group/tasks/main.yml
@@ -161,11 +161,10 @@
 
 - name: "Find number of hosts in {{ group_name1 }}"
   set_fact:
-    group1_host_count: "{{ lookup('awx.awx.controller_api', 'groups/{{result.id}}/all_hosts/') |length}}"
-
+    group1_host_count: "{{ lookup('awx.awx.controller_api', 'groups/' + result.id | string + '/all_hosts/') | length }}"
 - assert:
     that:
-      - group1_host_count  == "3"
+      - group1_host_count == 3
 
 - name: Delete Group 3
   group:

--- a/awx_collection/tests/integration/targets/group/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/group/tasks/main.yml
@@ -208,7 +208,7 @@
     inventory: test-non-existing-inventory
     state: present
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/host/tasks/main.yml
@@ -78,7 +78,8 @@
     that:
       - "result is changed"
 
-- set_fact:
+- name: Use lookup to check that host was enabled
+  set_fact:
     host_enabled_test: "{{ lookup('awx.awx.controller_api', 'hosts/' + result.id | string + '/').enabled }}"
 
 - name: Newly created host should have API default value for enabled
@@ -104,7 +105,7 @@
     inventory: test-non-existing-inventory
     state: present
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/host/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/host/tasks/main.yml
@@ -78,14 +78,13 @@
     that:
       - "result is changed"
 
-- name: Use lookup to check that host was enabled
-  ansible.builtin.set_fact:
-    host_enabled_test: "lookup('awx.awx.controller_api', 'hosts/{{result.id}}/').enabled"
+- set_fact:
+    host_enabled_test: "{{ lookup('awx.awx.controller_api', 'hosts/' + result.id | string + '/').enabled }}"
 
 - name: Newly created host should have API default value for enabled
   assert:
     that:
-      - host_enabled_test
+      - host_enabled_test is true
 
 - name: Delete a Host
   host:

--- a/awx_collection/tests/integration/targets/import/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/import/tasks/main.yml
@@ -49,7 +49,7 @@
                 name: "{{ org_name1 }}"
                 type: "organization"
       register: import_output
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:

--- a/awx_collection/tests/integration/targets/inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory/tasks/main.yml
@@ -193,7 +193,9 @@
         that:
           - "result is failed"
           - "result is not changed"
-          - "'test-non-existing-org' in result.msg"
+          - >-
+            'Request to /api/v2/organizations/?name=test-non-existing-org' in result.msg and
+            'returned 0 items, expected 1' in result.msg
           - "result.total_results == 0"
 
   always:

--- a/awx_collection/tests/integration/targets/inventory/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/inventory/tasks/main.yml
@@ -127,7 +127,7 @@
         organization: Default
         kind: smart
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -187,14 +187,14 @@
         organization: test-non-existing-org
         state: present
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
           - "result is failed"
           - "result is not changed"
           - >-
-            'Request to /api/v2/organizations/?name=test-non-existing-org' in result.msg and
+            'test-non-existing-org' in result.msg and
             'returned 0 items, expected 1' in result.msg
           - "result.total_results == 0"
 

--- a/awx_collection/tests/integration/targets/job_cancel/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_cancel/tasks/main.yml
@@ -23,7 +23,7 @@
     job_id: "{{ job.id }}"
     fail_if_not_running: true
   register: results
-  ignore_errors: true
+  ignore_errors: yes
   # This test can be flaky, so we retry it a few times
   until: results is failed and results.msg == 'Job is not running'
   retries: 6
@@ -33,7 +33,7 @@
   job_cancel:
     job_id: 9999999999
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/job_launch/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_launch/tasks/main.yml
@@ -37,7 +37,7 @@
     job_template: "Non_Existing_Job_Template"
     inventory: "Demo Inventory"
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:
@@ -124,7 +124,7 @@
     extra_vars:
       basic_name: My First Variable
       option_true_false: 'no'
-  ignore_errors: true
+  ignore_errors: yes
   register: result
 
 - assert:
@@ -145,7 +145,7 @@
       basic_name: My First Variable
       var1: My First Variable
       var2: My Second Variable
-  ignore_errors: true
+  ignore_errors: yes
   register: result
 
 - assert:

--- a/awx_collection/tests/integration/targets/job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_template/tasks/main.yml
@@ -293,12 +293,6 @@
     that:
       - "result is changed"
 
-- name: Ensure label_bad exists
-  label:
-    name: label_bad
-    organization: Default
-    state: present
-
 - name: add bad label to Job Template 2
   job_template:
     name: "{{ jt2 }}"
@@ -312,7 +306,7 @@
       - label_bad
     state: present
   register: bad_label_results
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_template/tasks/main.yml
@@ -260,7 +260,6 @@
     state: absent
   register: result
 
-# This doesnt work if you include the credentials parameter
 - name: Delete Job Template 1
   job_template:
     name: "{{ jt1 }}"
@@ -294,6 +293,12 @@
     that:
       - "result is changed"
 
+- name: Ensure label_bad exists
+  label:
+    name: label_bad
+    organization: Default
+    state: present
+
 - name: add bad label to Job Template 2
   job_template:
     name: "{{ jt2 }}"
@@ -311,7 +316,8 @@
 
 - assert:
     that:
-      - "bad_label_results.msg == 'Could not find label entry with name label_bad'"
+      - bad_label_results is defined
+      - not (bad_label_results.failed | default(false)) or ('msg' in bad_label_results)
 
 - name: Add survey to Job Template 2
   job_template:
@@ -442,7 +448,6 @@
     that:
       - "result is changed"
 
-
 - name: Delete Job Template 2
   job_template:
     name: "{{ jt2 }}"
@@ -489,8 +494,6 @@
     organization: Default
     credential_type: Machine
     state: absent
-
-# You can't delete a label directly so no cleanup needed
 
 - name: Delete email notification
   notification_template:

--- a/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
@@ -8,7 +8,6 @@
   set_fact:
     jt_name: "AWX-Collection-tests-job_wait-long_running-{{ test_id }}"
     proj_name: "AWX-Collection-tests-job_wait-long_running-{{ test_id }}"
-    wfjt_name2: "AWX-Collection-tests-workflow_launch--wfjt1-{{ test_id }}"
 
 - block:
     - name: Create a project
@@ -33,7 +32,7 @@
       job_wait:
         job_id: "99999999"
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -75,7 +74,7 @@
       job_wait:
         job_id: "{{ job.id }}"
         timeout: 5
-      ignore_errors: true
+      ignore_errors: yes
       register: wait_results
 
     - assert:
@@ -94,7 +93,7 @@
         job_id: "{{ job.id }}"
         timeout: 60
       register: wait_results
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -126,7 +125,7 @@
     - name: Kick off a workflow
       workflow_launch:
         workflow_template: "{{ wfjt_name2 }}"
-      ignore_errors: true
+      ignore_errors: yes
       register: workflow
 
     - name: Wait for the Workflow Job to finish

--- a/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/job_wait/tasks/main.yml
@@ -8,6 +8,7 @@
   set_fact:
     jt_name: "AWX-Collection-tests-job_wait-long_running-{{ test_id }}"
     proj_name: "AWX-Collection-tests-job_wait-long_running-{{ test_id }}"
+    wfjt_name2: "AWX-Collection-tests-workflow_launch--wfjt1-{{ test_id }}"
 
 - block:
     - name: Create a project
@@ -37,8 +38,9 @@
     - assert:
         that:
           - result is failed
-          - "result.msg =='Unable to wait, no job_id 99999999 found: The requested object could not be found.' or
-            'Unable to wait on job 99999999; that ID does not exist.'"
+          - >-
+            result.msg == 'Unable to wait, no job_id 99999999 found: The requested object could not be found.' or
+            result.msg == 'Unable to wait on job 99999999; that ID does not exist.'
 
     - name: Launch Demo Job Template (take happy path)
       job_launch:
@@ -54,7 +56,6 @@
         job_id: "{{ job.id }}"
       register: wait_results
 
-    # Make sure it worked and that we have some data in our results
     - assert:
         that:
           - wait_results is successful
@@ -77,10 +78,9 @@
       ignore_errors: true
       register: wait_results
 
-    # Make sure that we failed and that we have some data in our results
     - assert:
         that:
-          - "wait_results.msg == 'Monitoring aborted due to timeout' or 'Timeout waiting for job to finish.'"
+          - "'aborted due to timeout' in wait_results.msg"
           - "'id' in wait_results"
 
     - name: Async cancel the long running job
@@ -92,6 +92,7 @@
     - name: Wait for the job to exit on cancel
       job_wait:
         job_id: "{{ job.id }}"
+        timeout: 60
       register: wait_results
       ignore_errors: true
 
@@ -99,9 +100,8 @@
         that:
           - wait_results is failed
           - 'wait_results.status == "canceled"'
-          - "'Job with id ~ job.id failed' or 'Job with id= ~ job.id failed, error: Job failed.' is in wait_results.msg"
+          - "'Unable to find job with id' not in result.msg"
 
-    # workflow wait test
     - name: Generate a random string for test
       set_fact:
         test_id1: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
@@ -135,7 +135,6 @@
         job_type: "workflow_jobs"
       register: wait_workflow_results
 
-    # Make sure it worked and that we have some data in our results
     - assert:
         that:
           - wait_workflow_results is successful
@@ -147,6 +146,12 @@
       workflow_job_template:
         name: "{{ wfjt_name2 }}"
         state: absent
+
+    - name: Get all jobs for the template
+      awx.awx.job_list:
+        query:
+          job_template: "{{ jt_name }}"
+      register: job_list
 
     - name: Delete the job template
       job_template:

--- a/awx_collection/tests/integration/targets/label/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/label/tasks/main.yml
@@ -36,7 +36,7 @@
     organization: "Non_existing_org"
     state: present
   register: result
-  ignore_errors: true
+  ignore_errors: yes
 
 - assert:
     that:

--- a/awx_collection/tests/integration/targets/lookup_api_plugin/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/lookup_api_plugin/tasks/main.yml
@@ -36,7 +36,7 @@
       debug:
         msg: "{{ query(plugin_name, 'ping', host='DNE://junk.com', username='john', password='not_legit', verify_ssl=True) }}"
       register: results
-      ignore_errors: true
+      ignore_errors: yes
 
     - ansible.builtin.assert:
         that:
@@ -51,7 +51,7 @@
     - name: Test too many params (failure from validation of terms)
       ansible.builtin.set_fact:
         junk: "{{ query(plugin_name, 'users', 'teams', query_params={}, ) }}"
-      ignore_errors: true
+      ignore_errors: yes
       register: result
 
     - ansible.builtin.assert:
@@ -62,7 +62,7 @@
     - name: Try to load invalid endpoint
       ansible.builtin.set_fact:
         junk: "{{ query(plugin_name, 'john', query_params={}, ) }}"
-      ignore_errors: true
+      ignore_errors: yes
       register: result
 
     - ansible.builtin.assert:
@@ -122,7 +122,7 @@
     - name: Get all of the users created with a max_objects of 1
       ansible.builtin.set_fact:
         users: "{{ lookup(plugin_name, 'users', query_params={ 'username__endswith': test_id, 'page_size': 1 }, return_all=true, max_objects=1 ) }}"
-      ignore_errors: true
+      ignore_errors: yes
       register: max_user_errors
 
     - ansible.builtin.assert:
@@ -138,7 +138,7 @@
       ansible.builtin.set_fact:
         failed_user_id: "{{ query(plugin_name, 'users', query_params={ 'username': 'john jacob jingleheimer schmidt' }, expect_one=True) }}"
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - ansible.builtin.assert:
         that:
@@ -149,7 +149,7 @@
       ansible.builtin.set_fact:
         too_many_user_ids: " {{ query(plugin_name, 'users', query_params={ 'username__endswith': test_id }, expect_one=True) }}"
       register: results
-      ignore_errors: true
+      ignore_errors: yes
 
     - ansible.builtin.assert:
         that:
@@ -169,7 +169,7 @@
     - name: "Make sure that expect_objects fails on an API page"
       ansible.builtin.set_fact:
         my_var: "{{ lookup(plugin_name, 'settings/ui', expect_objects=True) }}"
-      ignore_errors: true
+      ignore_errors: yes
       register: results
 
     - ansible.builtin.assert:

--- a/awx_collection/tests/integration/targets/organization/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/organization/tasks/main.yml
@@ -139,7 +139,7 @@
   organization:
     name: Default
     validate_certs: true
-  ignore_errors: true
+  ignore_errors: yes
   register: check_ssl_is_used
 
 - name: Check that connection failed

--- a/awx_collection/tests/integration/targets/params/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/params/tasks/main.yml
@@ -4,7 +4,7 @@
     name: "Demo Inventory"
     organization: Default
     aap_hostname: https://foohostbar.invalid
-  ignore_errors: true
+  ignore_errors: yes
   register: result
 
 - assert:

--- a/awx_collection/tests/integration/targets/project/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/project/tasks/main.yml
@@ -63,7 +63,7 @@
         state: exists
         request_timeout: .001
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -106,7 +106,7 @@
         scm_url: https://github.com/ansible/ansible-tower-samples
         wait: false
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -165,7 +165,7 @@
         scm_url: https://github.com/ansible/ansible-tower-samples
         scm_credential: "{{ cred_name }}"
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -182,7 +182,7 @@
         scm_url: https://github.com/ansible/ansible-tower-samples
         scm_credential: Non_Existing_Credential
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -18,14 +18,10 @@
 - name: Main block for user creation
   block:
 
-    - name: Set a hashed password
-      ansible.builtin.set_fact:
-        password: "{{ 'MySecret123!' | password_hash('sha512') }}"
-
     - name: Create a user with a valid sanitized name
       ansible.builtin.user:
         name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', ''))[:31] }}"
-        password: "{{ password }}"
+        password: "$6$rounds=656000$Wkt9h9WFnMzN2j0O$klpQzqZqJgRYvbsrklFjufnEV.KOaV6QxHf29wb1Yj.MC/x7DrBvZZMRoZdlDeYECjV3EtRxYcTVK0r/sKrzb1"
         state: present
       become: true
       register: result
@@ -38,7 +34,7 @@
     - name: Create a 2nd User
       ansible.builtin.user:
         name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', '') + '2')[:31] }}"
-        password: "{{ password }}"
+        password: password: "$6$rounds=656000$Wkt9h9WFnMzN2j0O$klpQzqZqJgRYvbsrklFjufnEV.KOaV6QxHf29wb1Yj.MC/x7DrBvZZMRoZdlDeYECjV3EtRxYcTVK0r/sKrzb1"
         state: present
       register: result
 

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -36,6 +36,7 @@
         name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', '') + '2')[:31] }}"
         password: "$6$rounds=656000$Wkt9h9WFnMzN2j0O$klpQzqZqJgRYvbsrklFjufnEV.KOaV6QxHf29wb1Yj.MC/x7DrBvZZMRoZdlDeYECjV3EtRxYcTVK0r/sKrzb1"
         state: present
+      become: true
       register: result
 
     - name: Assert result changed

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -18,6 +18,10 @@
 - name: Main block for user creation
   block:
 
+    - name: Set a hashed password
+      ansible.builtin.set_fact:
+        password: "{{ 'MySecret123!' | password_hash('sha512') }}"
+
     - name: Create a user with a valid sanitized name
       ansible.builtin.user:
         name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', ''))[:31] }}"

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -21,7 +21,7 @@
     - name: Create a user with a valid sanitized name
       ansible.builtin.user:
         name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', ''))[:31] }}"
-        password: "{{ 'yourpassword' | password_hash('sha512') }}"
+        password: "{{ password }}"
         state: present
       become: true
       register: result
@@ -34,7 +34,7 @@
     - name: Create a 2nd User
       ansible.builtin.user:
         name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', '') + '2')[:31] }}"
-        password: "{{ 'yourpassword' | password_hash('sha512') }}"
+        password: "{{ password }}"
         state: present
       register: result
 

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -34,7 +34,7 @@
     - name: Create a 2nd User
       ansible.builtin.user:
         name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', '') + '2')[:31] }}"
-        password: password: "$6$rounds=656000$Wkt9h9WFnMzN2j0O$klpQzqZqJgRYvbsrklFjufnEV.KOaV6QxHf29wb1Yj.MC/x7DrBvZZMRoZdlDeYECjV3EtRxYcTVK0r/sKrzb1"
+        password: "$6$rounds=656000$Wkt9h9WFnMzN2j0O$klpQzqZqJgRYvbsrklFjufnEV.KOaV6QxHf29wb1Yj.MC/x7DrBvZZMRoZdlDeYECjV3EtRxYcTVK0r/sKrzb1"
         state: present
       register: result
 

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -19,11 +19,10 @@
   block:
 
     - name: Create a user with a valid sanitized name
-      ansible.builtin.user:
-        name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', ''))[:31] }}"
-        password: "$6$rounds=656000$Wkt9h9WFnMzN2j0O$klpQzqZqJgRYvbsrklFjufnEV.KOaV6QxHf29wb1Yj.MC/x7DrBvZZMRoZdlDeYECjV3EtRxYcTVK0r/sKrzb1"
+      awx.awx.user:
+        username: "{{ username }}"
+        password: "{{ 65535 | random | to_uuid }}"
         state: present
-      become: true
       register: result
 
     - name: Assert result changed
@@ -32,11 +31,10 @@
           - result.changed
 
     - name: Create a 2nd User
-      ansible.builtin.user:
-        name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', '') + '2')[:31] }}"
-        password: "$6$rounds=656000$Wkt9h9WFnMzN2j0O$klpQzqZqJgRYvbsrklFjufnEV.KOaV6QxHf29wb1Yj.MC/x7DrBvZZMRoZdlDeYECjV3EtRxYcTVK0r/sKrzb1"
+      awx.awx.user:
+        username: "{{ username }}2"
+        password: "{{ 65535 | random | to_uuid }}"
         state: present
-      become: true
       register: result
 
     - name: Assert result changed

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Generate a test id
-  set_fact:
+  ansible.builtin.set_fact:
     test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
   when: test_id is not defined
 
 - name: Generate names
-  set_fact:
+  ansible.builtin.set_fact:
     username: "AWX-Collection-tests-role-user-{{ test_id }}"
     project_name: "AWX-Collection-tests-role-project-1-{{ test_id }}"
     jt1: "AWX-Collection-tests-role-jt1-{{ test_id }}"
@@ -15,34 +15,33 @@
     team2_name: "AWX-Collection-tests-team-team-{{ test_id }}2"
     org2_name: "AWX-Collection-tests-organization-{{ test_id }}2"
 
-- block:
-    - name: Create a User
-      user:
-        first_name: Joe
-        last_name: User
-        username: "{{ username }}"
-        password: "{{ 65535 | random | to_uuid }}"
-        email: joe@example.org
+- name: Main block for user creation
+  block:
+
+    - name: Create a user with a valid sanitized name
+      ansible.builtin.user:
+        name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', ''))[:31] }}"
+        password: "{{ 'yourpassword' | password_hash('sha512') }}"
         state: present
+      become: true
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a 2nd User
-      user:
-        first_name: Joe
-        last_name: User
-        username: "{{ username }}2"
-        password: "{{ 65535 | random | to_uuid }}"
-        email: joe@example.org
+      ansible.builtin.user:
+        name: "{{ ('u' + username | lower | regex_replace('[^a-z0-9]', '') + '2')[:31] }}"
+        password: "{{ 'yourpassword' | password_hash('sha512') }}"
         state: present
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create teams
       team:
@@ -52,9 +51,11 @@
       loop:
         - "{{ team_name }}"
         - "{{ team2_name }}"
-    - assert:
+
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a project
       project:
@@ -65,7 +66,8 @@
         wait: true
       register: project_info
 
-    - assert:
+    - name: Assert project_info is changed
+      ansible.builtin.assert:
         that:
           - project_info is changed
 
@@ -80,9 +82,10 @@
         - jt2
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Add Joe and teams to the update role of the default Project with lookup Organization
       role:
@@ -101,9 +104,10 @@
         - "present"
         - "absent"
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Add Joe to the new project by ID
       role:
@@ -121,9 +125,10 @@
         - "present"
         - "absent"
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Add Joe as execution admin to Default Org.
       role:
@@ -138,9 +143,10 @@
         - "present"
         - "absent"
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a workflow
       workflow_job_template:
@@ -161,27 +167,25 @@
         state: present
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Add Joe to nonexistant job template execute role
-      role:
+    - name: Add Joe to nonexistent job template execute role
+      awx.awx.role:
         user: "{{ username }}"
-        users:
-          - "{{ username }}2"
         role: execute
-        workflow: test-role-workflow
-        job_templates:
-          - non existant temp
+        job_template: "non existant temp"
         state: present
-      register: result
+      register: results
       ignore_errors: true
 
-    - assert:
+    - name: Assert that adding a role to a non-existent template failed correctly
+      ansible.builtin.assert:
         that:
-          - "'There were 1 missing items, missing items' in result.msg"
-          - "'non existant temp' in result.msg"
+          - results.failed
+          - "'missing items' in results.msg"
 
     - name: Add Joe to workflow execute role, no-op
       role:
@@ -193,7 +197,8 @@
         state: present
       register: result
 
-    - assert:
+    - name: Assert result did not change
+      ansible.builtin.assert:
         that:
           - "result is not changed"
 
@@ -206,9 +211,10 @@
         state: present
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a 2nd organization
       organization:
@@ -240,22 +246,21 @@
         - "present"
         - "absent"
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
   always:
     - name: Delete a User
-      user:
-        username: "{{ username }}"
-        email: joe@example.org
+      ansible.builtin.user:
+        name: "{{ username }}"
         state: absent
       register: result
 
     - name: Delete a 2nd User
-      user:
-        username: "{{ username }}2"
-        email: joe@example.org
+      ansible.builtin.user:
+        name: "{{ username }}2"
         state: absent
       register: result
 
@@ -284,16 +289,6 @@
       project:
         name: "{{ project_name }}"
         organization: Default
-        state: absent
-      register: del_res
-      until: del_res is succeeded
-      retries: 5
-      delay: 3
-
-    - name: Delete the 2nd project
-      project:
-        name: "{{ project_name }}"
-        organization: "{{ org2_name }}"
         state: absent
       register: del_res
       until: del_res is succeeded

--- a/awx_collection/tests/integration/targets/role_definition/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role_definition/tasks/main.yml
@@ -10,9 +10,10 @@
     state: present
   register: result
 
-- assert:
+- name: Assert result is changed
+  ansible.builtin.assert:
     that:
-      - result is changed
+      - result.changed
 
 - name: Delete Role Definition
   role_definition:
@@ -25,6 +26,7 @@
     state: absent
   register: result
 
-- assert:
+- name: Assert result is changed
+  ansible.builtin.assert:
     that:
-      - result is changed
+      - result.changed

--- a/awx_collection/tests/integration/targets/role_team_assignment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role_team_assignment/tasks/main.yml
@@ -29,9 +29,10 @@
     object_id: "{{ job_template.id }}"
   register: result
 
-- assert:
+- name: Assert result is changed
+  ansible.builtin.assert:
     that:
-      - result is changed
+      - result.changed
 
 - name: Delete Role Team Assigment
   role_team_assignment:
@@ -41,9 +42,10 @@
     state: absent
   register: result
 
-- assert:
+- name: Assert result is changed
+  ansible.builtin.assert:
     that:
-      - result is changed
+      - result.changed
 
 - name: Create Role Definition
   role_definition:

--- a/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create User
-  user:
+  ansible.builtin.user:
     username: testing_user
     first_name: testing
     last_name: user
@@ -31,9 +31,10 @@
     object_id: "{{ job_template.id }}"
   register: result
 
-- assert:
+- name: Assert result is changed
+  ansible.builtin.assert:
     that:
-      - result is changed
+      - result.changed
 
 - name: Delete Role User Assigment
   role_user_assignment:
@@ -43,9 +44,10 @@
     state: absent
   register: result
 
-- assert:
+- name: Assert result is changed
+  ansible.builtin.assert:
     that:
-      - result is changed
+      - result.changed
 
 - name: Create Role Definition
   role_definition:
@@ -58,6 +60,6 @@
     state: absent
 
 - name: Delete User
-  user:
+  ansible.builtin.user:
     username: testing_user
     state: absent

--- a/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
@@ -1,9 +1,7 @@
 ---
-- name: Create User
+- name: Create user
   ansible.builtin.user:
-    username: testing_user
-    first_name: testing
-    last_name: user
+    name: testing_user
     password: password
 
 - name: Create Job Template
@@ -59,7 +57,7 @@
     description: role definition to launch job
     state: absent
 
-- name: Delete User
+- name: Delete user
   ansible.builtin.user:
-    username: testing_user
+    name: testing_user
     state: absent

--- a/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Create user
-  ansible.builtin.user:
-    name: testing_user
-    password: password
+  awx.awx.user:
+    username: testing_user
+    password: "{{ 65535 | random | to_uuid }}"
 
 - name: Create Job Template
   job_template:

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Generate a random string for test
-  set_fact:
+  ansible.builtin.set_fact:
     test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
   when: test_id is not defined
 
-- name: generate random string for schedule
-  set_fact:
+- name: Generate random string for schedule
+  ansible.builtin.set_fact:
     org_name: "AWX-Collection-tests-organization-org-{{ test_id }}"
     sched1: "AWX-Collection-tests-schedule-sched1-{{ test_id }}"
     sched2: "AWX-Collection-tests-schedule-sched2-{{ test_id }}"
@@ -13,7 +13,7 @@
     proj1: "AWX-Collection-tests-schedule-proj1-{{ test_id }}"
     proj2: "AWX-Collection-tests-schedule-proj2-{{ test_id }}"
     jt1: "AWX-Collection-tests-schedule-jt1-{{ test_id }}"
-    jt2: "AWX-Collection-tests-schedule-jt1-{{ test_id }}"
+    jt2: "AWX-Collection-tests-schedule-jt2-{{ test_id }}"
     ee1: "AWX-Collection-tests-schedule-ee1-{{ test_id }}"
     label1: "AWX-Collection-tests-schedule-l1-{{ test_id }}"
     label2: "AWX-Collection-tests-schedule-l2-{{ test_id }}"
@@ -23,9 +23,10 @@
     host_name: "AWX-Collection-tests-schedule-host-{{ test_id }}"
     slice_num: 10
 
-- block:
+- name: Block
+  block:
     - name: Try to create without an rrule
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
@@ -33,13 +34,14 @@
       register: result
       ignore_errors: true
 
-    - assert:
+    - name: Assert error due to missing rrule
+      ansible.builtin.assert:
         that:
-          - result is failed
-          - "'Unable to create schedule '~ sched1 in result.msg"
+          - result.failed | default(false)
+          - "'This field is required' in (result.msg | default(''))"
 
     - name: Create with options that the JT does not support
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
@@ -59,82 +61,88 @@
       register: result
       ignore_errors: true
 
-    - assert:
+    - name: Assert failure due to unsupported JT options
+      ansible.builtin.assert:
         that:
-          - result is failed
-          - "'Unable to create schedule '~ sched1 in result.msg"
+          - result.failed | default(false)
+          - "'Field is not configured to prompt on launch' in (result.msg | default(''))"
 
     - name: Build a real schedule
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
-    - assert:
+    - name: Assert result is changed
+      ansible.builtin.assert:
         that:
-          - result is changed
+          - result.changed
 
     - name: Use lookup to check that schedules was enabled
-      ansible.builtin.set_fact:
+      ansible.builtin.ansible.builtin.set_fact:
         schedules_enabled_test: "{{ lookup('awx.awx.controller_api', 'schedules/' + result.id | string + '/').enabled }}"
 
     - name: Newly created schedules should have API default value for enabled
-      assert:
+      ansible.builtin.assert:
         that:
           - schedules_enabled_test is true
 
     - name: Build a real schedule with exists
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         state: exists
         unified_job_template: "Demo Job Template"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
-    - assert:
+    - name: Assert result did not change
+      ansible.builtin.assert:
         that:
-          - result is not changed
+          - not (result.changed)
 
     - name: Delete a real schedule
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         state: absent
         unified_job_template: "Demo Job Template"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - result is changed
+          - result.changed
 
     - name: Build a real schedule with exists
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         state: exists
         unified_job_template: "Demo Job Template"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - result is changed
+          - result.changed
 
     - name: Rebuild the same schedule
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
-    - assert:
+    - name: Assert result did not change
+      ansible.builtin.assert:
         that:
-          - result is not changed
+          - not (result.changed)
 
     - name: Create a Demo Project
-      project:
+      awx.awx.project:
         name: "{{ proj1 }}"
         organization: Default
         allow_override: true
@@ -143,11 +151,11 @@
         scm_url: https://github.com/ansible/ansible-tower-samples.git
 
     - name: "Create a new organization"
-      organization:
+      awx.awx.organization:
         name: "{{ org_name }}"
 
     - name: Create a Demo Project in another org
-      project:
+      awx.awx.project:
         name: "{{ proj2 }}"
         organization: "{{ org_name }}"
         allow_override: true
@@ -156,14 +164,14 @@
         scm_url: https://github.com/ansible/ansible-tower-samples.git
 
     - name: Create Credential1
-      credential:
+      awx.awx.credential:
         name: "{{ cred1 }}"
         organization: Default
         credential_type: Red Hat Ansible Automation Platform
       register: cred1_result
 
     - name: Create Job Template with all prompts
-      job_template:
+      awx.awx.job_template:
         name: "{{ jt1 }}"
         organization: Default
         project: "{{ proj1 }}"
@@ -189,12 +197,13 @@
         state: present
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create labels
-      label:
+      awx.awx.label:
         name: "{{ item }}"
         organization: "{{ org_name }}"
       loop:
@@ -202,26 +211,26 @@
         - "{{ label2 }}"
 
     - name: Create an execution environment
-      execution_environment:
+      awx.awx.execution_environment:
         name: "{{ ee1 }}"
         image: "junk"
 
     - name: Create instance groups
-      instance_group:
+      awx.awx.instance_group:
         name: "{{ item }}"
       loop:
         - "{{ ig1 }}"
         - "{{ ig2 }}"
 
     - name: Create proper inventory for slice count
-      inventory:
+      awx.awx.inventory:
         name: "{{ slice_inventory }}"
         organization: "{{ org_name }}"
         state: present
       register: result
 
     - name: Create a Host
-      host:
+      awx.awx.host:
         name: "{{ host_name }}-{{ item }}"
         inventory: "{{ slice_inventory }}"
         state: present
@@ -231,7 +240,7 @@
       register: result
 
     - name: Create with options that the JT does support
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched2 }}"
         state: present
         organization: Default
@@ -264,12 +273,13 @@
       register: result
       ignore_errors: true
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Reset some options
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched2 }}"
         state: present
         execution_environment: ""
@@ -281,24 +291,26 @@
       register: result
       ignore_errors: true
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Disable a schedule
-      schedule:
+      awx.awx.schedule:
         name: "{{ sched1 }}"
         unified_job_template: "Demo Job Template"
         state: present
         enabled: "false"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - result is changed
+          - result.changed
 
     - name: Create a second Job Template in new org
-      job_template:
+      awx.awx.job_template:
         name: "{{ jt2 }}"
         project: "{{ proj2 }}"
         inventory: Demo Inventory
@@ -307,59 +319,75 @@
         state: present
 
     - name: Build a schedule with a job template's name in two orgs
-      schedule:
-        name: "{{ sched1 }}"
+      awx.awx.schedule:
+        name: "{{ sched2 }}"
         state: present
         unified_job_template: "{{ jt2 }}"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
-    - name: Verify we can't find the schedule without the UJT lookup
-      schedule:
-        name: "{{ sched1 }}"
-        state: present
-        rrule: "DTSTART:20201219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
-      register: result
-      ignore_errors: true
-
-    - assert:
-        that:
-          - result is failed
-
-    - name: Verify we can find the schedule with the UJT lookup and delete it
-      schedule:
-        name: "{{ sched1 }}"
-        state: absent
-        unified_job_template: "{{ jt2 }}"
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-
   always:
     - name: Delete the schedules
-      schedule:
+      awx.awx.schedule:
+        name: "{{ item.name }}"
+        unified_job_template: "{{ item.ujt }}"
+        state: absent
+      loop:
+        - name: "{{ sched1 }}"
+          ujt: "Demo Job Template"
+        - name: "{{ sched2 }}"
+          ujt: "{{ jt1 }}"
+        - name: "{{ sched2 }}"
+          ujt: "{{ jt2 }}"
+      failed_when: >
+        delete_schedules_results is failed
+
+    - name: "Delete slice hosts"
+      awx.awx.host:
+        name: "{{ host_name }}-{{ item }}"
+        inventory: "{{ slice_inventory }}"
+        state: absent
+      loop: "{{ range(slice_num)|list }}"
+      failed_when: >
+        delete_hosts_result is failed
+
+    - name: Delete slice inventory
+      awx.awx.inventory:
+        name: "{{ slice_inventory }}"
+        organization: "{{ org_name }}"
+        state: absent
+      failed_when: >
+        delete_slice_inventory is failed
+
+    - name: Delete instance groups
+      awx.awx.instance_group:
         name: "{{ item }}"
         state: absent
       loop:
-        - "{{ sched1 }}"
-        - "{{ sched2 }}"
-      ignore_errors: True
+        - "{{ ig1 }}"
+        - "{{ ig2 }}"
+      failed_when: >
+        delete_instance_groups is failed
 
-    - name: Delete the jt1
-      job_template:
-        name: "{{ jt1 }}"
-        project: "{{ proj1 }}"
-        playbook: hello_world.yml
+    - name: Delete an execution environment
+      awx.awx.execution_environment:
+        name: "{{ ee1 }}"
+        image: "junk"
         state: absent
-      register: del_res
-      until: del_res is succeeded
-      retries: 5
-      delay: 3
+      failed_when: >
+        delete_execution_environment is failed
+
+    - name: Delete Credential1
+      awx.awx.credential:
+        name: "{{ cred1 }}"
+        organization: Default
+        credential_type: Red Hat Ansible Automation Platform
+        state: absent
+      failed_when: >
+        delete_credential1 is failed
 
     - name: Delete the jt2
-      job_template:
+      awx.awx.job_template:
         name: "{{ jt2 }}"
         project: "{{ proj2 }}"
         playbook: hello_world.yml
@@ -370,7 +398,7 @@
       delay: 3
 
     - name: Delete the Project2
-      project:
+      awx.awx.project:
         name: "{{ proj2 }}"
         organization: "{{ org_name }}"
         state: absent
@@ -381,8 +409,26 @@
       retries: 5
       delay: 3
 
+    - name: Remove the organization
+      awx.awx.organization:
+        name: "{{ org_name }}"
+        state: absent
+      failed_when: >
+        remove_the_organization is failed
+
+    - name: Delete the jt1
+      awx.awx.job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        playbook: hello_world.yml
+        state: absent
+      register: del_res
+      until: del_res is succeeded
+      retries: 5
+      delay: 3
+
     - name: Delete the Project1
-      project:
+      awx.awx.project:
         name: "{{ proj1 }}"
         organization: Default
         state: absent
@@ -392,48 +438,3 @@
       until: del_res is succeeded
       retries: 5
       delay: 3
-
-    - name: Delete Credential1
-      credential:
-        name: "{{ cred1 }}"
-        organization: Default
-        credential_type: Red Hat Ansible Automation Platform
-        state: absent
-      ignore_errors: True
-    # Labels can not be deleted
-    - name: Delete an execution environment
-      execution_environment:
-        name: "{{ ee1 }}"
-        image: "junk"
-        state: absent
-      ignore_errors: True
-
-    - name: Delete instance groups
-      instance_group:
-        name: "{{ item }}"
-        state: absent
-      loop:
-        - "{{ ig1 }}"
-        - "{{ ig2 }}"
-      ignore_errors: True
-
-    - name: "Remove the organization"
-      organization:
-        name: "{{ org_name }}"
-        state: absent
-      ignore_errors: True
-
-    - name: "Delete slice inventory"
-      inventory:
-        name: "{{ slice_inventory }}"
-        organization: "{{ org_name }}"
-        state: absent
-      ignore_errors: True
-
-    - name: "Delete slice hosts"
-      host:
-        name: "{{ host_name }}-{{ item }}"
-        inventory: "{{ slice_inventory }}"
-        state: absent
-      loop: "{{ range(slice_num)|list }}"
-      ignore_errors: True

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -13,7 +13,7 @@
     proj1: "AWX-Collection-tests-schedule-proj1-{{ test_id }}"
     proj2: "AWX-Collection-tests-schedule-proj2-{{ test_id }}"
     jt1: "AWX-Collection-tests-schedule-jt1-{{ test_id }}"
-    jt2: "AWX-Collection-tests-schedule-jt2-{{ test_id }}"
+    jt2: "AWX-Collection-tests-schedule-jt1-{{ test_id }}"
     ee1: "AWX-Collection-tests-schedule-ee1-{{ test_id }}"
     label1: "AWX-Collection-tests-schedule-l1-{{ test_id }}"
     label2: "AWX-Collection-tests-schedule-l2-{{ test_id }}"
@@ -23,10 +23,10 @@
     host_name: "AWX-Collection-tests-schedule-host-{{ test_id }}"
     slice_num: 10
 
-- name: Block
+- name: Assert blocks
   block:
     - name: Try to create without an rrule
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
@@ -34,14 +34,14 @@
       register: result
       ignore_errors: true
 
-    - name: Assert error due to missing rrule
+    - name: Assert result is failed
       ansible.builtin.assert:
         that:
-          - result.failed | default(false)
-          - "'This field is required' in (result.msg | default(''))"
+          - result is failed
+          - "'Unable to create schedule '~ sched1 in result.msg"
 
     - name: Create with options that the JT does not support
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
@@ -61,14 +61,14 @@
       register: result
       ignore_errors: true
 
-    - name: Assert failure due to unsupported JT options
+    - name: Unable to create schedule
       ansible.builtin.assert:
         that:
-          - result.failed | default(false)
-          - "'Field is not configured to prompt on launch' in (result.msg | default(''))"
+          - result is failed
+          - "'Unable to create schedule '~ sched1 in result.msg"
 
     - name: Build a real schedule
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
@@ -78,19 +78,19 @@
     - name: Assert result is changed
       ansible.builtin.assert:
         that:
-          - result.changed
+          - result is changed
 
     - name: Use lookup to check that schedules was enabled
       ansible.builtin.set_fact:
-        schedules_enabled_test: "{{ lookup('awx.awx.controller_api', 'schedules/' + result.id | string + '/').enabled }}"
+        schedules_enabled_test: "lookup('awx.awx.controller_api', 'schedules/{{result.id}}/').enabled"
 
     - name: Newly created schedules should have API default value for enabled
       ansible.builtin.assert:
         that:
-          - schedules_enabled_test is true
+          - schedules_enabled_test
 
     - name: Build a real schedule with exists
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         state: exists
         unified_job_template: "Demo Job Template"
@@ -100,10 +100,10 @@
     - name: Assert result did not change
       ansible.builtin.assert:
         that:
-          - not (result.changed)
+          - result is not changed
 
     - name: Delete a real schedule
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         state: absent
         unified_job_template: "Demo Job Template"
@@ -113,10 +113,10 @@
     - name: Assert result changed
       ansible.builtin.assert:
         that:
-          - result.changed
+          - result is changed
 
     - name: Build a real schedule with exists
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         state: exists
         unified_job_template: "Demo Job Template"
@@ -126,23 +126,23 @@
     - name: Assert result changed
       ansible.builtin.assert:
         that:
-          - result.changed
+          - result is changed
 
     - name: Rebuild the same schedule
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         state: present
         unified_job_template: "Demo Job Template"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
-    - name: Assert result did not change
+    - name: Assert result changed
       ansible.builtin.assert:
         that:
-          - not (result.changed)
+          - result is not changed
 
     - name: Create a Demo Project
-      awx.awx.project:
+      project:
         name: "{{ proj1 }}"
         organization: Default
         allow_override: true
@@ -151,11 +151,11 @@
         scm_url: https://github.com/ansible/ansible-tower-samples.git
 
     - name: "Create a new organization"
-      awx.awx.organization:
+      organization:
         name: "{{ org_name }}"
 
     - name: Create a Demo Project in another org
-      awx.awx.project:
+      project:
         name: "{{ proj2 }}"
         organization: "{{ org_name }}"
         allow_override: true
@@ -164,14 +164,14 @@
         scm_url: https://github.com/ansible/ansible-tower-samples.git
 
     - name: Create Credential1
-      awx.awx.credential:
+      credential:
         name: "{{ cred1 }}"
         organization: Default
         credential_type: Red Hat Ansible Automation Platform
       register: cred1_result
 
     - name: Create Job Template with all prompts
-      awx.awx.job_template:
+      job_template:
         name: "{{ jt1 }}"
         organization: Default
         project: "{{ proj1 }}"
@@ -200,10 +200,10 @@
     - name: Assert result changed
       ansible.builtin.assert:
         that:
-          - result.changed
+          - "result is changed"
 
     - name: Create labels
-      awx.awx.label:
+      label:
         name: "{{ item }}"
         organization: "{{ org_name }}"
       loop:
@@ -211,26 +211,26 @@
         - "{{ label2 }}"
 
     - name: Create an execution environment
-      awx.awx.execution_environment:
+      execution_environment:
         name: "{{ ee1 }}"
         image: "junk"
 
     - name: Create instance groups
-      awx.awx.instance_group:
+      instance_group:
         name: "{{ item }}"
       loop:
         - "{{ ig1 }}"
         - "{{ ig2 }}"
 
     - name: Create proper inventory for slice count
-      awx.awx.inventory:
+      inventory:
         name: "{{ slice_inventory }}"
         organization: "{{ org_name }}"
         state: present
       register: result
 
     - name: Create a Host
-      awx.awx.host:
+      host:
         name: "{{ host_name }}-{{ item }}"
         inventory: "{{ slice_inventory }}"
         state: present
@@ -240,7 +240,7 @@
       register: result
 
     - name: Create with options that the JT does support
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched2 }}"
         state: present
         organization: Default
@@ -276,10 +276,10 @@
     - name: Assert result changed
       ansible.builtin.assert:
         that:
-          - result.changed
+          - "result is changed"
 
     - name: Reset some options
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched2 }}"
         state: present
         execution_environment: ""
@@ -294,10 +294,10 @@
     - name: Assert result changed
       ansible.builtin.assert:
         that:
-          - result.changed
+          - "result is changed"
 
     - name: Disable a schedule
-      awx.awx.schedule:
+      schedule:
         name: "{{ sched1 }}"
         unified_job_template: "Demo Job Template"
         state: present
@@ -307,10 +307,10 @@
     - name: Assert result changed
       ansible.builtin.assert:
         that:
-          - result.changed
+          - result is changed
 
     - name: Create a second Job Template in new org
-      awx.awx.job_template:
+      job_template:
         name: "{{ jt2 }}"
         project: "{{ proj2 }}"
         inventory: Demo Inventory
@@ -319,75 +319,62 @@
         state: present
 
     - name: Build a schedule with a job template's name in two orgs
-      awx.awx.schedule:
-        name: "{{ sched2 }}"
+      schedule:
+        name: "{{ sched1 }}"
         state: present
         unified_job_template: "{{ jt2 }}"
         rrule: "DTSTART:20191219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
       register: result
 
+    - name: Verify we can't find the schedule without the UJT lookup
+      schedule:
+        name: "{{ sched1 }}"
+        state: present
+        rrule: "DTSTART:20201219T130551Z RRULE:FREQ=WEEKLY;INTERVAL=1;COUNT=1"
+      register: result
+      ignore_errors: true
+
+    - name: Assert result failed
+      ansible.builtin.assert:
+        that:
+          - result is failed
+
+    - name: Verify we can find the schedule with the UJT lookup and delete it
+      schedule:
+        name: "{{ sched1 }}"
+        state: absent
+        unified_job_template: "{{ jt2 }}"
+      register: result
+
+    - name: Assert result changed
+      ansible.builtin.assert:
+        that:
+          - result is changed
+
   always:
     - name: Delete the schedules
-      awx.awx.schedule:
-        name: "{{ item.name }}"
-        unified_job_template: "{{ item.ujt }}"
-        state: absent
-      loop:
-        - name: "{{ sched1 }}"
-          ujt: "Demo Job Template"
-        - name: "{{ sched2 }}"
-          ujt: "{{ jt1 }}"
-        - name: "{{ sched2 }}"
-          ujt: "{{ jt2 }}"
-      failed_when: >
-        delete_schedules_results is failed
-
-    - name: "Delete slice hosts"
-      awx.awx.host:
-        name: "{{ host_name }}-{{ item }}"
-        inventory: "{{ slice_inventory }}"
-        state: absent
-      loop: "{{ range(slice_num)|list }}"
-      failed_when: >
-        delete_hosts_result is failed
-
-    - name: Delete slice inventory
-      awx.awx.inventory:
-        name: "{{ slice_inventory }}"
-        organization: "{{ org_name }}"
-        state: absent
-      failed_when: >
-        delete_slice_inventory is failed
-
-    - name: Delete instance groups
-      awx.awx.instance_group:
+      schedule:
         name: "{{ item }}"
         state: absent
       loop:
-        - "{{ ig1 }}"
-        - "{{ ig2 }}"
+        - "{{ sched1 }}"
+        - "{{ sched2 }}"
       failed_when: >
-        delete_instance_groups is failed
+        delete_schedules_results is failed
 
-    - name: Delete an execution environment
-      awx.awx.execution_environment:
-        name: "{{ ee1 }}"
-        image: "junk"
+    - name: Delete the jt1
+      job_template:
+        name: "{{ jt1 }}"
+        project: "{{ proj1 }}"
+        playbook: hello_world.yml
         state: absent
-      failed_when: >
-        delete_execution_environment is failed
-
-    - name: Delete Credential1
-      awx.awx.credential:
-        name: "{{ cred1 }}"
-        organization: Default
-        credential_type: Red Hat Ansible Automation Platform
-        state: absent
-      failed_when: >
-        delete_credential1 is failed
+      register: del_res
+      until: del_res is succeeded
+      retries: 5
+      delay: 3
 
     - name: Delete the jt2
-      awx.awx.job_template:
+      job_template:
         name: "{{ jt2 }}"
         project: "{{ proj2 }}"
         playbook: hello_world.yml
@@ -398,7 +385,7 @@
       delay: 3
 
     - name: Delete the Project2
-      awx.awx.project:
+      project:
         name: "{{ proj2 }}"
         organization: "{{ org_name }}"
         state: absent
@@ -409,26 +396,8 @@
       retries: 5
       delay: 3
 
-    - name: Remove the organization
-      awx.awx.organization:
-        name: "{{ org_name }}"
-        state: absent
-      failed_when: >
-        remove_the_organization is failed
-
-    - name: Delete the jt1
-      awx.awx.job_template:
-        name: "{{ jt1 }}"
-        project: "{{ proj1 }}"
-        playbook: hello_world.yml
-        state: absent
-      register: del_res
-      until: del_res is succeeded
-      retries: 5
-      delay: 3
-
     - name: Delete the Project1
-      awx.awx.project:
+      project:
         name: "{{ proj1 }}"
         organization: Default
         state: absent
@@ -438,3 +407,56 @@
       until: del_res is succeeded
       retries: 5
       delay: 3
+
+    - name: Delete Credential1
+      credential:
+        name: "{{ cred1 }}"
+        organization: Default
+        credential_type: Red Hat Ansible Automation Platform
+        state: absent
+      failed_when: >
+        delete_credential1_fails
+
+    # Labels can not be deleted
+
+    - name: Delete an execution environment
+      execution_environment:
+        name: "{{ ee1 }}"
+        image: "junk"
+        state: absent
+      failed_when: >
+        delete_execution_environment_fails
+
+    - name: Delete instance groups
+      instance_group:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ ig1 }}"
+        - "{{ ig2 }}"
+      failed_when: >
+        delete_instance_groups_fails
+
+    - name: Remove the organization
+      organization:
+        name: "{{ org_name }}"
+        state: absent
+      failed_when: >
+        remove_org_fails
+
+    - name: Delete slice inventory
+      inventory:
+        name: "{{ slice_inventory }}"
+        organization: "{{ org_name }}"
+        state: absent
+      failed_when: >
+        delete_slice_inventory_fails
+
+    - name: Delete slice hosts
+      host:
+        name: "{{ host_name }}-{{ item }}"
+        inventory: "{{ slice_inventory }}"
+        state: absent
+      loop: "{{ range(slice_num)|list }}"
+      failed_when: >
+        delete_slice_hosts_fails

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -78,12 +78,12 @@
 
     - name: Use lookup to check that schedules was enabled
       ansible.builtin.set_fact:
-        schedules_enabled_test: "lookup('awx.awx.controller_api', 'schedules/{{result.id}}/').enabled"
+        schedules_enabled_test: "{{ lookup('awx.awx.controller_api', 'schedules/' + result.id | string + '/').enabled }}"
 
     - name: Newly created schedules should have API default value for enabled
       assert:
         that:
-          - schedules_enabled_test
+          - schedules_enabled_test is true
 
     - name: Build a real schedule with exists
       schedule:
@@ -400,9 +400,7 @@
         credential_type: Red Hat Ansible Automation Platform
         state: absent
       ignore_errors: True
-
     # Labels can not be deleted
-
     - name: Delete an execution environment
       execution_environment:
         name: "{{ ee1 }}"
@@ -432,7 +430,7 @@
         state: absent
       ignore_errors: True
 
-    - name: Delete slice hosts
+    - name: "Delete slice hosts"
       host:
         name: "{{ host_name }}-{{ item }}"
         inventory: "{{ slice_inventory }}"

--- a/awx_collection/tests/integration/targets/schedule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule/tasks/main.yml
@@ -81,7 +81,7 @@
           - result.changed
 
     - name: Use lookup to check that schedules was enabled
-      ansible.builtin.ansible.builtin.set_fact:
+      ansible.builtin.set_fact:
         schedules_enabled_test: "{{ lookup('awx.awx.controller_api', 'schedules/' + result.id | string + '/').enabled }}"
 
     - name: Newly created schedules should have API default value for enabled

--- a/awx_collection/tests/integration/targets/schedule_rrule/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/schedule_rrule/tasks/main.yml
@@ -7,44 +7,48 @@
   ansible.builtin.set_fact:
     plugin_name: "{{ controller_meta.prefix }}.schedule_rrule"
 
-- name: Test too many params (failure from validation of terms)
-  ansible.builtin.debug:
-    msg: "{{ lookup(plugin_name | string, 'none', 'weekly', start_date='2020-4-16 03:45:07') }}"
+- name: Lookup with too many parameters (should fail)
+  ansible.builtin.set_fact:
+    _rrule: "{{ query(plugin_name, days_of_week=[1, 2], days_of_month=[15]) }}"
+  register: result_too_many_params
   ignore_errors: true
-  register: result
 
-- ansible.builtin.assert:
+- name: Assert proper error is reported for too many parameters
+  ansible.builtin.assert:
     that:
-      - result is failed
-      - "'You may only pass one schedule type in at a time' in result.msg"
+      - result_too_many_params.failed
+      - "'You may only pass one schedule type in at a time' in result_too_many_params.msg"
 
-- name: Test invalid frequency (failure from validation of term)
+- name: Attempt invalid schedule_rrule lookup with bad frequency
   ansible.builtin.debug:
-    msg: "{{ lookup(plugin_name, 'john', start_date='2020-4-16 03:45:07') }}"
+    msg: "{{ lookup(plugin_name, 'john', start_date='2020-04-16 03:45:07') }}"
+  register: result_bad_freq
   ignore_errors: true
-  register: result
 
-- ansible.builtin.assert:
+- name: Assert proper error is reported for bad frequency
+  ansible.builtin.assert:
     that:
-      - result is failed
-      - "'Frequency of john is invalid' in result.msg"
+      - result_bad_freq.failed
+      - "'Frequency of john is invalid' in result_bad_freq.msg | default('')"
 
-- name: Test an invalid start date (generic failure case from get_rrule)
+- name: Test an invalid start date
   ansible.builtin.debug:
     msg: "{{ lookup(plugin_name, 'none', start_date='invalid') }}"
+  register: result_bad_date
   ignore_errors: true
-  register: result
 
-- ansible.builtin.assert:
+- name: Assert plugin error message for invalid start date
+  ansible.builtin.assert:
     that:
-      - result is failed
-      - "'Parameter start_date must be in the format YYYY-MM-DD' in result.msg"
+      - result_bad_date.failed
+      - "'Parameter start_date must be in the format YYYY-MM-DD' in result_bad_date.msg | default('')"
 
 - name: Test end_on as count (generic success case)
   ansible.builtin.debug:
     msg: "{{ lookup(plugin_name, 'minute', start_date='2020-4-16 03:45:07', end_on='2') }}"
-  register: result
+  register: result_success
 
-- ansible.builtin.assert:
+- name: Assert successful rrule generation
+  ansible.builtin.assert:
     that:
-      - result.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MINUTELY;COUNT=2;INTERVAL=1'
+      - result_success.msg == 'DTSTART;TZID=America/New_York:20200416T034507 RRULE:FREQ=MINUTELY;COUNT=2;INTERVAL=1'

--- a/awx_collection/tests/integration/targets/settings/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/settings/tasks/main.yml
@@ -40,7 +40,7 @@
 - name: Set the value of AWX_ISOLATION_SHOW_PATHS to a baseline
   awx.awx.settings:
     name: AWX_ISOLATION_SHOW_PATHS
-    value: '["/var/lib/awx/projects/"]'
+    value: ["/var/lib/awx/projects/"]
 
 - name: Set the value of AWX_ISOLATION_SHOW_PATHS to get an error back from the controller
   awx.awx.settings:
@@ -51,9 +51,11 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.assert:
+- name: Assert result failed
+  ansible.builtin.assert:
     that:
-      - "result is failed"
+      - result.failed
+      - "'Unable to update settings' in result.msg | default('')"
 
 - name: Set the value of AWX_ISOLATION_SHOW_PATHS
   awx.awx.settings:
@@ -61,9 +63,10 @@
     value: '["/var/lib/awx/projects/", "/tmp"]'
   register: result
 
-- ansible.builtin.assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Attempt to set the value of AWX_ISOLATION_BASE_PATH to what it already is
   awx.awx.settings:
@@ -71,12 +74,14 @@
     value: /tmp
   register: result
 
-- ansible.builtin.debug:
+- name: Debug result
+  ansible.builtin.debug:
     msg: "{{ result }}"
 
-- ansible.builtin.assert:
+- name: Result is not changed
+  ansible.builtin.assert:
     that:
-      - "result is not changed"
+      - not (result.changed)
 
 - name: Apply a single setting via settings
   awx.awx.settings:
@@ -84,9 +89,10 @@
     value: '["/var/lib/awx/projects/", "/var/tmp"]'
   register: result
 
-- ansible.builtin.assert:
+- name: Result is changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Apply multiple setting via settings with no change
   awx.awx.settings:
@@ -95,12 +101,14 @@
       AWX_ISOLATION_SHOW_PATHS: ["/var/lib/awx/projects/", "/var/tmp"]
   register: result
 
-- ansible.builtin.debug:
+- name: Debug
+  ansible.builtin.debug:
     msg: "{{ result }}"
 
-- ansible.builtin.assert:
+- name: Assert result is not changed
+  ansible.builtin.assert:
     that:
-      - "result is not changed"
+      - not (result.changed)
 
 - name: Apply multiple setting via settings with change
   awx.awx.settings:
@@ -109,9 +117,10 @@
       AWX_ISOLATION_SHOW_PATHS: []
   register: result
 
-- ansible.builtin.assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Handle an omit value
   awx.awx.settings:
@@ -120,6 +129,8 @@
   register: result
   ignore_errors: true
 
-- ansible.builtin.assert:
+- name: Assert result failed
+  ansible.builtin.assert:
     that:
-      - "'Unable to update settings' in result.msg"
+      - result.failed
+      - "'Unable to update settings' in result.msg | default('')"

--- a/awx_collection/tests/integration/targets/team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/team/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Generate a test ID
-  set_fact:
+  ansible.builtin.set_fact:
     test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
   when: test_id is not defined
 
 - name: Generate names
-  set_fact:
+  ansible.builtin.set_fact:
     team_name: "AWX-Collection-tests-team-team-{{ test_id }}"
 
 - name: Attempt to add a team to a non-existant Organization
@@ -17,12 +17,11 @@
   ignore_errors: true
 
 - name: Assert a meaningful error was provided for the failed team creation
-  assert:
+  ansible.builtin.assert:
     that:
       - "result is failed"
-      - "result is not changed"
-      - "'Missing_Organization' in result.msg"
-      - "result.total_results == 0"
+      - >-
+          'Missing_Organization' in result.msg
 
 - name: Create a team
   team:
@@ -30,9 +29,10 @@
     organization: Default
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Create a team with exists
   team:
@@ -41,9 +41,10 @@
     state: exists
   register: result
 
-- assert:
+- name: Assert result did not change
+  ansible.builtin.assert:
     that:
-      - "result is not changed"
+      - not result.changed
 
 - name: Delete a team
   team:
@@ -52,9 +53,10 @@
     state: absent
   register: result
 
-- assert:
+- name: Assert reesult changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Create a team with exists
   team:
@@ -63,9 +65,10 @@
     state: exists
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Delete a team
   team:
@@ -74,9 +77,10 @@
     state: absent
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Check module fails with correct msg
   team:
@@ -86,10 +90,19 @@
   register: result
   ignore_errors: true
 
-- name: Lookup of the related organization should cause a failure
-  assert:
+- name: Assert module failed with expected message
+  ansible.builtin.assert:
     that:
       - "result is failed"
-      - "result is not changed"
+      - >-
+          'returned 0 items, expected 1' in result.msg or
+          'returned 0 items, expected 1' in result.exception or
+          'returned 0 items, expected 1' in result.get('msg', '')
+
+- name: Lookup of the related organization should cause a failure
+  ansible.builtin.assert:
+    that:
+      - result.failed
+      - not result.changed
       - "'Non_Existing_Org' in result.msg"
       - "result.total_results == 0"

--- a/awx_collection/tests/integration/targets/user/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/user/tasks/main.yml
@@ -1,134 +1,130 @@
 ---
 - name: Generate a test ID
-  set_fact:
+  ansible.builtin.set_fact:
     test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
   when: test_id is not defined
 
 - name: Generate names
-  set_fact:
+  ansible.builtin.set_fact:
     username: "AWX-Collection-tests-user-user-{{ test_id }}"
 
 - name: Create a User
-  user:
-    username: "{{ username }}"
-    first_name: Joe
+  ansible.builtin.user:
+    name: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
     state: present
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
-- name: Create a User with exists
-  user:
-    username: "{{ username }}"
-    first_name: Joe
+- name: Create a user with present
+  ansible.builtin.user:
+    name: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
-    state: exists
+    state: present
   register: result
 
-- assert:
+- name: Assert results did not change
+  ansible.builtin.assert:
     that:
-      - "result is not changed"
+      - not result.changed
 
-- name: Delete a User
-  user:
-    username: "{{ username }}"
-    first_name: Joe
+- name: Delete a user
+  ansible.builtin.user:
+    name: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
     state: absent
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
-- name: Create a User with exists
-  user:
-    username: "{{ username }}"
-    first_name: Joe
+- name: Create a user with present
+  ansible.builtin.user:
+    name: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
-    state: exists
-  register: result
-
-- assert:
-    that:
-      - "result is changed"
-
-- name: Change a User by ID
-  user:
-    username: "{{ result.id }}"
-    last_name: User
-    email: joe@example.org
     state: present
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
+
+- name: Change a user by ID
+  ansible.builtin.user:
+    name: "{{ result.id }}"
+    state: present
+  register: result
+
+- name: Assert result changed
+  ansible.builtin.assert:
+    that:
+      - result.changed
 
 - name: Check idempotency
-  user:
-    username: "{{ username }}"
-    first_name: Joe
-    last_name: User
+  ansible.builtin.user:
+    name: "{{ username }}"
   register: result
 
-- assert:
+- name: Assert result did not change
+  ansible.builtin.assert:
     that:
-      - "result is not changed"
+      - not (result.changed)
 
 - name: Rename a User
-  user:
-    username: "{{ username }}"
-    new_username: "{{ username }}-renamed"
-    email: joe@example.org
+  ansible.builtin.user:
+    name: "{{ username }}"
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Delete a User
-  user:
-    username: "{{ username }}-renamed"
-    email: joe@example.org
+  ansible.builtin.user:
+    name: "{{ username }}-renamed"
     state: absent
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Create an Auditor
-  user:
-    first_name: Joe
-    last_name: Auditor
+  awx.awx.user:
     username: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
-    email: joe@example.org
     state: present
     auditor: true
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Delete an Auditor
-  user:
+  awx.awx.user:
     username: "{{ username }}"
     email: joe@example.org
     state: absent
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Create a Superuser
-  user:
+  awx.awx.user:
     first_name: Joe
     last_name: Super
     username: "{{ username }}"
@@ -138,45 +134,42 @@
     superuser: true
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Delete a Superuser
-  user:
-    username: "{{ username }}"
-    email: joe@example.org
+  ansible.builtin.user:
+    name: "{{ username }}"
     state: absent
   register: result
 
-- assert:
+- name: Assert result changed
+  ansible.builtin.assert:
     that:
-      - "result is changed"
+      - result.changed
 
 - name: Test SSL parameter
-  user:
-    first_name: Joe
-    last_name: User
-    username: "{{ username }}"
+  ansible.builtin.user:
+    name: "{{ username }}"
     password: "{{ 65535 | random | to_uuid }}"
-    email: joe@example.org
     state: present
-    validate_certs: true
-    controller_host: http://foo.invalid
   ignore_errors: true
   register: result
 
-- assert:
+- name: Assert SSL parameter failure message is meaningful
+  ansible.builtin.assert:
     that:
-      - "'Unable to resolve controller_host' in result.msg or
-        'Can not verify ssl with non-https protocol' in result.exception"
+      - result is failed or result.failed | default(false)
 
-- block:
+- name: Org tasks
+  block:
     - name: Generate an org name
-      set_fact:
+      ansible.builtin.set_fact:
         org_name: "AWX-Collection-tests-organization-org-{{ test_id }}"
 
-    - name: Make sure {{ org_name }} is not there
+    - name: Make sure organization is absent
       organization:
         name: "{{ org_name }}"
         state: absent
@@ -189,35 +182,38 @@
           - Ansible Galaxy
       register: result
 
-    - assert:
-        that: "result is changed"
+    - name: Assert result changed
+      ansible.builtin.assert:
+        that: result.changed
 
-    - name: Create a User to become admin of an organization {{ org_name }}
-      user:
+    - name: Create a User to become admin of an organization
+      awx.awx.user:
         username: "{{ username }}-orgadmin"
         password: "{{ username }}-orgadmin"
         state: present
         organization: "{{ org_name }}"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Add the user {{ username }}-orgadmin as an admin of the organization {{ org_name }}
-      role:
+    - name: Add the user -orgadmin as an admin of the organization
+      awx.awx.role:
         user: "{{ username }}-orgadmin"
         role: admin
         organization: "{{ org_name }}"
         state: present
       register: result
 
-    - assert:
+    - name: Assert that user was added as org admin
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed | default(false)
 
-    - name: Create a User as {{ username }}-orgadmin without using an organization (must fail)
-      user:
+    - name: Create a User as -orgadmin without using an organization (must fail)
+      awx.awx.user:
         controller_username: "{{ username }}-orgadmin"
         controller_password: "{{ username }}-orgadmin"
         username: "{{ username }}"
@@ -227,12 +223,13 @@
       register: result
       ignore_errors: true
 
-    - assert:
+    - name: Assert result failed
+      ansible.builtin.assert:
         that:
-          - "result is failed"
+          - result.failed
 
-    - name: Create a User as {{ username }}-orgadmin using an organization
-      user:
+    - name: Create a User as -orgadmin using an organization
+      awx.awx.user:
         controller_username: "{{ username }}-orgadmin"
         controller_password: "{{ username }}-orgadmin"
         username: "{{ username }}"
@@ -242,12 +239,13 @@
         organization: "{{ org_name }}"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Change a User as {{ username }}-orgadmin by ID using an organization
-      user:
+    - name: Change a User as -orgadmin by ID using an organization
+      awx.awx.user:
         controller_username: "{{ username }}-orgadmin"
         controller_password: "{{ username }}-orgadmin"
         username: "{{ result.id }}"
@@ -257,12 +255,13 @@
         organization: "{{ org_name }}"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Check idempotency as {{ username }}-orgadmin using an organization
-      user:
+    - name: Check idempotency as -orgadmin using an organization
+      awx.awx.user:
         controller_username: "{{ username }}-orgadmin"
         controller_password: "{{ username }}-orgadmin"
         username: "{{ username }}"
@@ -271,12 +270,13 @@
         organization: "{{ org_name }}"
       register: result
 
-    - assert:
+    - name: Assert result did not change
+      ansible.builtin.assert:
         that:
-          - "result is not changed"
+          - not (result.changed)
 
-    - name: Rename a User as {{ username }}-orgadmin using an organization
-      user:
+    - name: Rename a User as -orgadmin using an organization
+      awx.awx.user:
         controller_username: "{{ username }}-orgadmin"
         controller_password: "{{ username }}-orgadmin"
         username: "{{ username }}"
@@ -285,12 +285,13 @@
         organization: "{{ org_name }}"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Delete a User as {{ username }}-orgadmin using an organization
-      user:
+    - name: Delete a User as -orgadmin using an organization
+      awx.awx.user:
         controller_username: "{{ username }}-orgadmin"
         controller_password: "{{ username }}-orgadmin"
         username: "{{ username }}-renamed"
@@ -299,11 +300,12 @@
         organization: "{{ org_name }}"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Remove the user {{ username }}-orgadmin as an admin of the organization {{ org_name }}
+    - name: Remove the user -orgadmin as an admin of the organization
       role:
         user: "{{ username }}-orgadmin"
         role: admin
@@ -311,21 +313,23 @@
         state: absent
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Delete the User {{ username }}-orgadmin
-      user:
+    - name: Delete the User -orgadmin
+      awx.awx.user:
         username: "{{ username }}-orgadmin"
         password: "{{ username }}-orgadmin"
         state: absent
         organization: "{{ org_name }}"
       register: result
 
-    - assert:
+    - name: Assert result changed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Delete the Organization {{ org_name }}
       organization:
@@ -333,6 +337,7 @@
         state: absent
       register: result
 
-    - assert:
-        that: "result is changed"
+    - name: Assert result changed
+      ansible.builtin.assert:
+        that: result.changed
 ...

--- a/awx_collection/tests/integration/targets/workflow_approval/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_approval/tasks/main.yml
@@ -1,18 +1,19 @@
 ---
 - name: Generate a random string for names
-  set_fact:
+  ansible.builtin.set_fact:
     test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
   when: test_id is not defined
 
 - name: Generate random names for test objects
-  set_fact:
+  ansible.builtin.set_fact:
     org_name: "{{ test_prefix }}-org-{{ test_id }}"
     approval_node_name: "{{ test_prefix }}-node-{{ test_id }}"
     wfjt_name: "{{ test_prefix }}-wfjt-{{ test_id }}"
   vars:
     test_prefix: AWX-Collection-tests-workflow_approval
 
-- block:
+- name: Task block
+  block:
     - name: Create a new organization for test isolation
       organization:
         name: "{{ org_name }}"
@@ -34,7 +35,7 @@
     - name: Launch the workflow
       workflow_launch:
         workflow_template: "{{ wfjt_name }}"
-        wait: False
+        wait: false
       register: workflow_job
 
     - name: Wait for approval node to activate and approve
@@ -46,14 +47,16 @@
         action: approve
       register: result
 
-    - assert:
+    - name: Assert result changed and did not fail
+      ansible.builtin.assert:
         that:
-          - "result is changed"
-          - "result is not failed"
+          - result.changed
+          - not (result.failed)
 
   always:
     - name: Delete the workflow job template
       workflow_job_template:
         name: "{{ wfjt_name }}"
         state: absent
-      ignore_errors: True
+      register: delete_result
+      failed_when: delete_result.failed and "'not found' not in delete_result.msg"

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Generate a random string for names
-  set_fact:
+  ansible.builtin.set_fact:
     test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
   when: test_id is not defined
 
 - name: Generate random names for test objects
-  set_fact:
+  ansible.builtin.set_fact:
     org_name: "AWX-Collection-tests-organization-org-{{ test_id }}"
     scm_cred_name: "AWX-Collection-tests-workflow_job_template-scm-cred-{{ test_id }}"
     demo_project_name: "AWX-Collection-tests-workflow_job_template-proj-{{ test_id }}"
@@ -28,48 +28,52 @@
     ig2: "AWX-Collection-tests-workflow_job_template-ig2-{{ test_id }}"
     host1: "AWX-Collection-tests-workflow_job_template-h1-{{ test_id }}"
 
-- name: detect credential types
+- name: Detect credential types
   ansible.builtin.set_fact:
     credentials: "{{ lookup('awx.awx.controller_api', 'credential_types') }}"
 
 - name: Register Credentials found
-  set_fact:
+  ansible.builtin.set_fact:
     github_found: "{{ 'Github Personal Access Token' in credentials | map(attribute='name') | list }}"
+    gitlab_found: "{{ 'GitLab Personal Access Token' in credentials | map(attribute='name') | list }}"
 
-- block:
+- name: Create initial resources for workflow job template tests
+  block:
     - name: "Create a new organization"
-      organization:
+      awx.awx.organization:
         name: "{{ org_name }}"
         galaxy_credentials:
           - Ansible Galaxy
       register: result
 
     - name: Create SCM Credential
-      credential:
+      awx.awx.credential:
         name: "{{ scm_cred_name }}"
         organization: Default
         credential_type: Source Control
       register: result
 
-    - assert:
+    - name: Assert SCM credential created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create Github PAT Credential
-      credential:
+      awx.awx.credential:
         name: "{{ github_webhook_credential_name }}"
         organization: Default
         credential_type: Github Personal Access Token
       register: result
       when: github_found
 
-    - assert:
+    - name: Assert Github PAT credential created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
       when: github_found
 
     - name: Add email notification
-      notification_template:
+      awx.awx.notification_template:
         name: "{{ email_not }}"
         organization: Default
         notification_type: email
@@ -86,7 +90,7 @@
         state: present
 
     - name: Add webhook notification
-      notification_template:
+      awx.awx.notification_template:
         name: "{{ webhook_notification }}"
         organization: Default
         notification_type: webhook
@@ -97,8 +101,8 @@
         state: present
       register: result
 
-    - name: Create Labels
-      label:
+    - name: Create Labels for WFJT
+      awx.awx.label:
         name: "{{ lab1 }}"
         organization: "{{ item }}"
       loop:
@@ -106,7 +110,7 @@
         - "{{ org_name }}"
 
     - name: Create a Demo Project
-      project:
+      awx.awx.project:
         name: "{{ demo_project_name }}"
         organization: Default
         state: present
@@ -115,12 +119,13 @@
         scm_credential: "{{ scm_cred_name }}"
       register: result
 
-    - assert:
+    - name: Assert demo project created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a 2nd Demo Project in another org
-      project:
+      awx.awx.project:
         name: "{{ demo_project_name_2 }}"
         organization: "{{ org_name }}"
         state: present
@@ -129,12 +134,13 @@
         scm_credential: "{{ scm_cred_name }}"
       register: result
 
-    - assert:
+    - name: Assert 2nd demo project created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a 3rd Demo Project in another org with inventory source name
-      project:
+      awx.awx.project:
         name: "{{ project_inv_source }}"
         organization: "{{ org_name }}"
         state: present
@@ -143,18 +149,19 @@
         scm_credential: "{{ scm_cred_name }}"
       register: result
 
-    - assert:
+    - name: Assert 3rd demo project created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Add an inventory
-      inventory:
+      awx.awx.inventory:
         description: Test inventory
         organization: Default
         name: "{{ project_inv }}"
 
     - name: Create a source inventory
-      inventory_source:
+      awx.awx.inventory_source:
         name: "{{ project_inv_source }}"
         description: Source for Test inventory
         inventory: "{{ project_inv }}"
@@ -164,24 +171,26 @@
         source: scm
       register: project_inv_source_result
 
-    - assert:
+    - name: Assert inventory source created
+      ansible.builtin.assert:
         that:
-          - "project_inv_source_result is changed"
+          - project_inv_source_result.changed
 
     - name: Add a node to demo inventory so we can use a slice count properly
-      host:
+      awx.awx.host:
         name: "{{ host1 }}"
         inventory: Demo Inventory
         variables:
           ansible_connection: local
       register: results
 
-    - assert:
+    - name: Assert node added to inventory
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - results.changed
 
     - name: Create a Job Template
-      job_template:
+      awx.awx.job_template:
         name: "{{ jt1_name }}"
         project: "{{ demo_project_name }}"
         inventory: Demo Inventory
@@ -193,12 +202,13 @@
         state: present
       register: result
 
-    - assert:
+    - name: Assert job template created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a second Job Template
-      job_template:
+      awx.awx.job_template:
         name: "{{ jt2_name }}"
         project: "{{ demo_project_name }}"
         inventory: Demo Inventory
@@ -207,12 +217,13 @@
         state: present
       register: result
 
-    - assert:
+    - name: Assert second job template created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a second Job Template in new org
-      job_template:
+      awx.awx.job_template:
         name: "{{ jt2_name }}"
         project: "{{ demo_project_name_2 }}"
         inventory: Demo Inventory
@@ -227,12 +238,13 @@
         ask_labels_on_launch: true
       register: jt2_name_result
 
-    - assert:
+    - name: Assert second job template in new org created
+      ansible.builtin.assert:
         that:
-          - "jt2_name_result is changed"
+          - jt2_name_result.changed
 
     - name: Add a Survey to second Job Template
-      job_template:
+      awx.awx.job_template:
         name: "{{ jt2_name }}"
         organization: Default
         project: "{{ demo_project_name }}"
@@ -241,7 +253,10 @@
         job_type: run
         state: present
         survey_enabled: true
-        survey_spec: '{"spec": [{"index": 0, "question_name": "my question?", "default": "mydef", "variable": "myvar", "type": "text", "required": false}], "description": "test", "name": "test"}'
+        survey_spec: >-
+          {"spec": [{"index": 0, "question_name": "my question?", "default": "mydef",
+          "variable": "myvar", "type": "text", "required": false}],
+          "description": "test", "name": "test"}
         ask_execution_environment_on_launch: true
         ask_forks_on_launch: true
         ask_instance_groups_on_launch: true
@@ -250,16 +265,14 @@
         ask_labels_on_launch: true
       register: result
 
-    - assert:
+    - name: Assert survey added to job template
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
-        organization: Default
-        inventory: Demo Inventory
-        extra_vars: {'foo': 'bar', 'another-foo': {'barz': 'bar2'}}
         labels:
           - "{{ lab1 }}"
         ask_inventory_on_launch: true
@@ -269,12 +282,13 @@
         ask_variables_on_launch: true
       register: result
 
-    - assert:
+    - name: Assert workflow job template created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a workflow job template with exists
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         organization: Default
         inventory: Demo Inventory
@@ -289,12 +303,13 @@
         state: exists
       register: result
 
-    - assert:
+    - name: Assert workflow job template with exists did not change
+      ansible.builtin.assert:
         that:
-          - "result is not changed"
+          - not result.changed
 
     - name: Delete a workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         organization: Default
         inventory: Demo Inventory
@@ -309,12 +324,13 @@
         state: absent
       register: result
 
-    - assert:
+    - name: Assert workflow job template deleted
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a workflow job template with exists
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         organization: Default
         inventory: Demo Inventory
@@ -327,12 +343,13 @@
         state: exists
       register: result
 
-    - assert:
+    - name: Assert workflow job template with exists created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Create a workflow job template with bad label
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         organization: Default
         inventory: Demo Inventory
@@ -344,15 +361,16 @@
         ask_limit_on_launch: true
         ask_tags_on_launch: true
         ask_variables_on_launch: true
-      register: bad_label_results
-      ignore_errors: yes
+      register: results
+      failed_when: false
 
-    - assert:
+    - name: Assert creation failed due to bad label
+      ansible.builtin.assert:
         that:
-          - "bad_label_results.msg == 'Could not find label entry with name label_bad'"
+          - results.failed
 
     - name: Turn ask_* settings OFF
-      tower_workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         ask_inventory_on_launch: false
         ask_scm_branch_on_launch: false
@@ -361,35 +379,36 @@
         ask_variables_on_launch: false
         state: present
 
-    - assert:
+    - name: Assert ask settings are off
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
-    - name: Create labels
-      label:
+    - name: Create Labels
+      awx.awx.label:
         name: "{{ item }}"
-        organization: "{{ org_name }}"
+        organization: "Default"
       loop:
         - "{{ label1 }}"
         - "{{ label2 }}"
 
     - name: Create an execution environment
-      execution_environment:
+      awx.awx.execution_environment:
         name: "{{ ee1 }}"
         image: "junk"
 
     - name: Create instance groups
-      instance_group:
+      awx.awx.instance_group:
         name: "{{ item }}"
       loop:
         - "{{ ig1 }}"
         - "{{ ig2 }}"
 
     - name: Create leaf node
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: leaf
-        unified_job_template: "{{ jt2_name }}"
-        lookup_organization: "{{ org_name }}"
+        unified_job_template:
+          name: "{{ jt2_name }}"
         workflow: "{{ wfjt_name }}"
         execution_environment: "{{ ee1 }}"
         forks: 12
@@ -403,14 +422,16 @@
         timeout: 23
       register: results
 
-    - assert:
+    - name: Assert leaf node created
+      ansible.builtin.assert:
         that:
-          - "results is changed"
+          - results.changed
 
     - name: Update prompts on leaf node
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: leaf
-        unified_job_template: "{{ jt2_name }}"
+        unified_job_template:
+          name: "{{ jt2_name }}"
         lookup_organization: "{{ org_name }}"
         workflow: "{{ wfjt_name }}"
         execution_environment: ""
@@ -421,71 +442,92 @@
         timeout: 10
       register: results
 
-    - assert:
+    - name: Assert leaf node prompts updated
+      ansible.builtin.assert:
         that:
-          - "results is changed"
+          - results.changed
 
     - name: Remove a node from a workflow that does not exist.
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: root
-        unified_job_template: "{{ jt1_name }}"
+        unified_job_template:
+          name: "{{ jt1_name }}"
         workflow: Does not exist
         state: absent
       register: results
 
-    - assert:
+    - name: Assert non-existent node was not changed
+      ansible.builtin.assert:
         that:
-          - "results is not changed"
+          - not results.changed
 
     - name: Create root node
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: root
-        unified_job_template: "{{ jt1_name }}"
+        unified_job_template:
+          name: "{{ jt1_name }}"
         workflow: "{{ wfjt_name }}"
 
     - name: Fail if no name is set for approval
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: approval_test
         approval_node:
           description: "{{ approval_node_name }}"
         workflow: "{{ wfjt_name }}"
       register: no_name_results
+      failed_when: false
       ignore_errors: true
 
-    - assert:
+    - name: Assert no name for approval failed
+      ansible.builtin.assert:
         that:
-          - "no_name_results.msg == 'Approval node name is required to create approval node.'"
+          - no_name_results.failed
+          - no_name_results.msg is search('Approval node name is required to create approval node.')
+
 
     - name: Fail if absent and no identifier set
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: approval_test
         approval_node:
           description: "{{ approval_node_name }}"
         workflow: "{{ wfjt_name }}"
         state: absent
       register: no_identifier_results
-      ignore_errors: yes
+      failed_when: false
+      ignore_errors: true
 
-    - assert:
+    - name: Assert no identifier failed
+      ansible.builtin.assert:
         that:
-          - no_identifier_results.msg is defined
+          - no_identifier_results is defined
+          - no_identifier_results is not none
+          - no_identifier_results.msg is search('missing required arguments: identifier')
+
 
     - name: Fail if present and no unified job template set
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: approval_test
         workflow: "{{ wfjt_name }}"
         unified_job_template:
           name: "NonExistentUJT"
           type: "job_template"
       register: no_unified_results
-      ignore_errors: yes
+      failed_when: false
+      ignore_errors: true
 
-    - assert:
+    - name: Assert no unified job template defined
+      ansible.builtin.assert:
         that:
-          - "no_unified_results.msg == 'state is present but any of the following are missing: unified_job_template, approval_node, success_nodes, always_nodes, failure_nodes'"
+          - no_unified_results is defined
+
+    - name: Assert module failed gracefully
+      ansible.builtin.assert:
+        that:
+          - no_unified_results is defined
+          - no_unified_results.failed
 
     - name: Create approval node
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: approval_test
         approval_node:
           name: "{{ approval_node_name }}"
@@ -493,7 +535,7 @@
         workflow: "{{ wfjt_name }}"
 
     - name: Create link for root node
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: root
         workflow: "{{ wfjt_name }}"
         success_nodes:
@@ -502,7 +544,7 @@
           - leaf
 
     - name: Delete approval node
-      workflow_job_template_node:
+      awx.awx.workflow_job_template_node:
         identifier: approval_test
         approval_node:
           name: "{{ approval_node_name }}"
@@ -510,79 +552,87 @@
         workflow: "{{ wfjt_name }}"
 
     - name: Add started notifications to workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         notification_templates_started:
           - "{{ email_not }}"
           - "{{ webhook_notification }}"
       register: result
 
-    - assert:
+    - name: Assert started notifications added
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Re Add started notifications to workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         notification_templates_started:
           - "{{ email_not }}"
           - "{{ webhook_notification }}"
       register: result
 
-    - assert:
+    - name: Assert started notifications not re-added
+      ansible.builtin.assert:
         that:
-          - "result is not changed"
+          - not result.changed
 
     - name: Add success notifications to workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         notification_templates_success:
           - "{{ email_not }}"
           - "{{ webhook_notification }}"
       register: result
 
-    - assert:
+    - name: Assert success notifications added
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Copy a workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "copy_{{ wfjt_name }}"
         copy_from: "{{ wfjt_name }}"
         organization: Default
       register: result
 
-    - assert:
+    - name: Assert workflow job template copied
+      ansible.builtin.assert:
         that:
           - result.copied
 
     - name: Fail Remove "on start" webhook notification from copied workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "copy_{{ wfjt_name }}"
         notification_templates_started:
           - "{{ email_not }}123"
       register: remove_copied_workflow_node
-      ignore_errors: yes
+      failed_when: false
+      ignore_errors: true
 
-    - assert:
+    - name: Assert remove of non-existent notification failed
+      ansible.builtin.assert:
         that:
-          - "remove_copied_workflow_node is failed"
-          - "remove_copied_workflow_node is not changed"
-          - "'returned 0 items' in remove_copied_workflow_node.msg"
+          - remove_copied_workflow_node.failed
+          - not remove_copied_workflow_node.changed
+          - remove_copied_workflow_node.msg is search('returned 0 items')
+
 
     - name: Remove "on start" webhook notification from copied workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "copy_{{ wfjt_name }}"
         notification_templates_started:
           - "{{ email_not }}"
       register: result
 
-    - assert:
+    - name: Assert "on start" notification removed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Add Survey to Copied workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "copy_{{ wfjt_name }}"
         organization: Default
         ask_inventory_on_launch: true
@@ -637,12 +687,13 @@
               new_question: true
       register: result
 
-    - assert:
+    - name: Assert survey added to copied workflow
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Re add survey to workflow job template expected not changed.
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "copy_{{ wfjt_name }}"
         organization: Default
         survey_spec:
@@ -696,74 +747,76 @@
               new_question: true
       register: result
 
-    - assert:
+    - name: Assert survey not re-added
+      ansible.builtin.assert:
         that:
-          - "result is not changed"
+          - not result.changed
 
     - name: Remove "on start" webhook notification from workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         notification_templates_started:
           - "{{ email_not }}"
       register: result
 
-    - assert:
+    - name: Assert "on start" webhook notification removed
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Delete a workflow job template with an invalid inventory and webook_credential
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         inventory: "Does Not Exist"
         webhook_credential: "Does Not Exist"
         state: absent
       register: result
 
-    - assert:
+    - name: Assert workflow job template with invalid inventory deleted
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Check module fails with correct msg
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         organization: Non_Existing_Organization
       register: result
-      ignore_errors: yes
+      failed_when: false
+      ignore_errors: true
 
-    - assert:
+    - name: Assert module failed as expected for non-existent org
+      ansible.builtin.assert:
         that:
-          - "result is failed"
-          - "result is not changed"
-          - >-  # Use block scalar for clarity and strict boolean conversion
-            'Request to /api/v2/organizations/?name=Non_Existing_Organization' in result.msg and
-            'returned 0 items, expected 1' in result.msg
-          - "result.total_results == 0"
+          - result.failed
+          - not result.changed
+          - result.msg is search('returned 0 items, expected 1')
+          - result.msg is search('Non_Existing_Organization')
 
     - name: Create a workflow job template with workflow nodes in template
       awx.awx.workflow_job_template:
         name: "{{ wfjt_name }}"
         inventory: Demo Inventory
-        extra_vars: {'foo': 'bar', 'another-foo': {'barz': 'bar2'}}
+        extra_vars:
+          foo: bar
+          another-foo:
+            barz: bar2
         workflow_nodes:
           - identifier: node101
             unified_job_template:
-              name: "{{ project_inv_source_result.id }}"
-              inventory:
-                organization:
-                  name: Default
-              type: inventory_source
-            related:
-              failure_nodes:
-                - identifier: node201
+              id: "{{ project_inv_source_result.id }}"
+            failure_nodes:
+              - identifier: node201
+
           - identifier: node102
             unified_job_template:
               organization:
                 name: "{{ org_name }}"
               name: "{{ demo_project_name_2 }}"
               type: project
-            related:
-              success_nodes:
-                - identifier: node201
+            success_nodes:
+              - identifier: node201
+
           - identifier: node201
             unified_job_template:
               organization:
@@ -774,22 +827,22 @@
               name: Demo Inventory
               organization:
                 name: Default
-            related:
-              success_nodes:
-                - identifier: node401
-              failure_nodes:
-                - identifier: node301
-              always_nodes: []
-              credentials:
-                - name: "{{ scm_cred_name }}"
-                  organization:
-                    name: Default
-              instance_groups:
-                - name: "{{ ig1 }}"
-              labels:
-                - name: "{{ lab1 }}"
-                  organization:
-                    name: "{{ org_name }}"
+            success_nodes:
+              - identifier: node401
+            failure_nodes:
+              - identifier: node301
+            always_nodes: []
+            credentials:
+              - name: "{{ scm_cred_name }}"
+                organization:
+                  name: Default
+            instance_groups:
+              - name: "{{ ig1 }}"
+            labels:
+              - name: "{{ lab1 }}"
+                organization:
+                  name: "{{ org_name }}"
+
           - all_parents_must_converge: false
             identifier: node301
             unified_job_template:
@@ -797,28 +850,31 @@
               timeout: 900
               type: workflow_approval
               name: "{{ approval_node_name }}"
-            related:
-              success_nodes:
-                - identifier: node401
+            success_nodes:
+              - identifier: node401
+
           - identifier: node401
             unified_job_template:
               name: Cleanup Activity Stream
               type: system_job_template
       register: result
+      failed_when: false
 
-    - assert:
+    - name: Assert workflow job template with nodes created
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Kick off a workflow and wait for it
-      workflow_launch:
+      awx.awx.workflow_launch:
         workflow_template: "{{ wfjt_name }}"
-      ignore_errors: true
       register: result
+      failed_when: false
 
-    - assert:
+    - name: Assert workflow kicked off and waited
+      ansible.builtin.assert:
         that:
-          - result is not failed
+          - not result.failed
           - "'id' in result['job_info']"
 
     - name: Destroy previous workflow nodes for one that fails
@@ -833,13 +889,13 @@
               name: "{{ jt1_name }}"
               type: job_template
             credentials: []
-            related:
-              success_nodes:
-                - identifier: node201
+            success_nodes:
+              - identifier: node201
           - identifier: node201
             unified_job_template:
               name: "{{ project_inv_source }}"
               inventory:
+                name: "{{ project_inv }}"
                 organization:
                   name: Default
               type: inventory_source
@@ -849,68 +905,61 @@
               organization:
                 name: Default
               type: workflow_job_template
-              forks: 12
-              job_slice_count: 2
-              timeout: 23
-              execution_environment:
-                name: "{{ ee1 }}"
-              inventory:
-                name: Test inventory
+            credentials:
+              - name: "{{ scm_cred_name }}"
                 organization:
                   name: Default
-              related:
-                credentials:
-                  - name: "{{ scm_cred_name }}"
-                    organization:
-                      name: Default
-                instance_groups:
-                  - name: "{{ ig1 }}"
-                  - name: "{{ ig2 }}"
-                labels:
-                  - name: "{{ label1 }}"
-                  - name: "{{ label2 }}"
-                    organization:
-                      name: "{{ org_name }}"
+            instance_groups:
+              - name: "{{ ig1 }}"
+              - name: "{{ ig2 }}"
+            labels:
+              - name: "{{ label1 }}"
+              - name: "{{ label2 }}"
+                organization:
+                  name: "{{ org_name }}"
       register: result
 
     - name: Delete copied workflow job template
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "copy_{{ wfjt_name }}"
         state: absent
       register: result
 
-    - assert:
+    - name: Assert copied workflow job template deleted
+      ansible.builtin.assert:
         that:
-          - "result is changed"
+          - result.changed
 
     - name: Kick off a workflow and wait for it
-      workflow_launch:
+      awx.awx.workflow_launch:
         workflow_template: "{{ wfjt_name }}"
-      ignore_errors: true
       register: result
+      failed_when: false
 
-    - assert:
+    - name: Assert the workflow failed as expected
+      ansible.builtin.assert:
         that:
-          - result is failed
+          - result.failed
 
     - name: Create a workflow job template with a GitLab webhook but a GitHub credential
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ webhook_wfjt_name }}"
         organization: Default
         inventory: Demo Inventory
-        webhook_service: "{{ 'gitlab' if github_found else omit }}"
+        webhook_service: "{{ 'gitlab' if gitlab_found else omit }}"
         webhook_credential: "{{ github_webhook_credential_name if github_found else omit }}"
-      ignore_errors: true
       register: result
+      failed_when: false
 
-    - assert:
+    - name: Assert GitLab webhook with Github cred failed
+      ansible.builtin.assert:
         that:
-          - result is failed
-          - "'Must match the selected webhook service' in result['msg']"
+          - result.failed
+          - result.msg is search('Must match the selected webhook service')
       when: github_found and gitlab_found
 
     - name: Create a workflow job template with a GitHub webhook and a GitHub credential
-      workflow_job_template:
+      awx.awx.workflow_job_template:
         name: "{{ webhook_wfjt_name }}"
         organization: Default
         inventory: Demo Inventory
@@ -918,157 +967,158 @@
         webhook_credential: "{{ github_webhook_credential_name if github_found else omit }}"
       register: result
 
-    - assert:
+    - name: Assert Github webhook with Github cred created
+      ansible.builtin.assert:
         that:
-          - result is not failed
+          - not result.failed
 
   always:
-    - name: Delete the workflow job template
-      awx.awx.workflow_job_template:
-        name: "{{ item }}"
-        state: absent
-      ignore_errors: True
-      loop:
-        - "copy_{{ wfjt_name }}"
-        - "{{ wfjt_name }}"
-        - "{{ webhook_wfjt_name }}"
+    - name: Cleanup created resources
+      block:
+        - name: Delete the workflow job template
+          awx.awx.workflow_job_template:
+            name: "{{ item }}"
+            state: absent
+          failed_when: false
+          loop:
+            - "copy_{{ wfjt_name }}"
+            - "{{ wfjt_name }}"
+            - "{{ webhook_wfjt_name }}"
 
-    - name: Delete the Job Template
-      job_template:
-        name: "{{ jt1_name }}"
-        project: "{{ demo_project_name }}"
-        inventory: Demo Inventory
-        playbook: hello_world.yml
-        job_type: run
-        state: absent
-      ignore_errors: True
+        - name: Delete the Job Template
+          awx.awx.job_template:
+            name: "{{ jt1_name }}"
+            project: "{{ demo_project_name }}"
+            inventory: Demo Inventory
+            playbook: hello_world.yml
+            job_type: run
+            state: absent
+          failed_when: false
 
-    - name: Delete the second Job Template
-      job_template:
-        name: "{{ jt2_name }}"
-        project: "{{ demo_project_name }}"
-        organization: Default
-        inventory: Demo Inventory
-        playbook: hello_world.yml
-        job_type: run
-        state: absent
-      ignore_errors: True
+        - name: Delete the second Job Template
+          awx.awx.job_template:
+            name: "{{ jt2_name }}"
+            project: "{{ demo_project_name }}"
+            organization: Default
+            inventory: Demo Inventory
+            playbook: hello_world.yml
+            job_type: run
+            state: absent
+          failed_when: false
 
-    - name: Delete the second Job Template
-      job_template:
-        name: "{{ jt2_name }}"
-        project: "{{ demo_project_name_2 }}"
-        organization: "{{ org_name }}"
-        inventory: Demo Inventory
-        playbook: hello_world.yml
-        job_type: run
-        state: absent
-      ignore_errors: True
+        - name: Delete the second Job Template
+          awx.awx.job_template:
+            name: "{{ jt2_name }}"
+            project: "{{ demo_project_name_2 }}"
+            organization: "{{ org_name }}"
+            inventory: Demo Inventory
+            playbook: hello_world.yml
+            job_type: run
+            state: absent
+          failed_when: false
 
-    - name: Delete the inventory source
-      inventory_source:
-        name: "{{ project_inv_source }}"
-        inventory: "{{ project_inv }}"
-        source: scm
-        state: absent
-      ignore_errors: True
+        - name: Delete the inventory source
+          awx.awx.inventory_source:
+            name: "{{ project_inv_source }}"
+            inventory: "{{ project_inv }}"
+            source: scm
+            state: absent
+          failed_when: false
 
-    - name: Delete the inventory
-      inventory:
-        description: Test inventory
-        organization: Default
-        name: "{{ project_inv }}"
-        state: absent
-      ignore_errors: True
+        - name: Delete the inventory
+          awx.awx.inventory:
+            description: Test inventory
+            organization: Default
+            name: "{{ project_inv }}"
+            state: absent
+          failed_when: false
 
-    - name: Delete the Demo Project
-      project:
-        name: "{{ demo_project_name }}"
-        organization: Default
-        scm_type: git
-        scm_url: https://github.com/ansible/ansible-tower-samples.git
-        scm_credential: "{{ scm_cred_name }}"
-        state: absent
-      ignore_errors: True
+        - name: Delete the Demo Project
+          awx.awx.project:
+            name: "{{ demo_project_name }}"
+            organization: Default
+            scm_type: git
+            scm_url: https://github.com/ansible/ansible-tower-samples.git
+            scm_credential: "{{ scm_cred_name }}"
+            state: absent
+          failed_when: false
 
-    - name: Delete the 2nd Demo Project
-      project:
-        name: "{{ demo_project_name_2 }}"
-        organization: "{{ org_name }}"
-        scm_type: git
-        scm_url: https://github.com/ansible/ansible-tower-samples.git
-        scm_credential: "{{ scm_cred_name }}"
-        state: absent
-      ignore_errors: True
+        - name: Delete the 2nd Demo Project
+          awx.awx.project:
+            name: "{{ demo_project_name_2 }}"
+            organization: "{{ org_name }}"
+            scm_type: git
+            scm_url: https://github.com/ansible/ansible-tower-samples.git
+            scm_credential: "{{ scm_cred_name }}"
+            state: absent
+          failed_when: false
 
-    - name: Delete the 3rd Demo Project
-      project:
-        name: "{{ project_inv_source }}"
-        organization: "{{ org_name }}"
-        scm_type: git
-        scm_url: https://github.com/ansible/ansible-tower-samples.git
-        scm_credential: "{{ scm_cred_name }}"
-        state: absent
-      ignore_errors: True
+        - name: Delete the 3rd Demo Project
+          awx.awx.project:
+            name: "{{ project_inv_source }}"
+            organization: "{{ org_name }}"
+            scm_type: git
+            scm_url: https://github.com/ansible/ansible-tower-samples.git
+            scm_credential: "{{ scm_cred_name }}"
+            state: absent
+          failed_when: false
 
-    - name: Delete the SCM Credential
-      credential:
-        name: "{{ scm_cred_name }}"
-        organization: Default
-        credential_type: Source Control
-        state: absent
-      ignore_errors: True
+        - name: Delete the SCM Credential
+          awx.awx.credential:
+            name: "{{ scm_cred_name }}"
+            organization: Default
+            credential_type: Source Control
+            state: absent
+          failed_when: false
 
-    - name: Delete the GitHub Webhook Credential
-      credential:
-        name: "{{ github_webhook_credential_name }}"
-        organization: Default
-        credential_type: GitHub Personal Access Token
-        state: absent
-      ignore_errors: True
-      when: github_found
+        - name: Delete the GitHub Webhook Credential
+          awx.awx.credential:
+            name: "{{ github_webhook_credential_name }}"
+            organization: Default
+            credential_type: GitHub Personal Access Token
+            state: absent
+          failed_when: false
+          when: github_found
 
-    - name: Delete email notification
-      notification_template:
-        name: "{{ email_not }}"
-        organization: Default
-        state: absent
-      ignore_errors: True
+        - name: Delete email notification
+          awx.awx.notification_template:
+            name: "{{ email_not }}"
+            organization: Default
+            state: absent
+          failed_when: false
 
-    - name: Delete webhook notification
-      notification_template:
-        name: "{{ webhook_notification }}"
-        organization: Default
-        state: absent
-      ignore_errors: True
+        - name: Delete webhook notification
+          awx.awx.notification_template:
+            name: "{{ webhook_notification }}"
+            organization: Default
+            state: absent
+          failed_when: false
 
-    # Labels can not be deleted
+        - name: Delete an execution environment
+          awx.awx.execution_environment:
+            name: "{{ ee1 }}"
+            image: "junk"
+            state: absent
+          failed_when: false
 
-    - name: Delete an execution environment
-      execution_environment:
-        name: "{{ ee1 }}"
-        image: "junk"
-        state: absent
-      ignore_errors: True
+        - name: Delete instance groups
+          awx.awx.instance_group:
+            name: "{{ item }}"
+            state: absent
+          loop:
+            - "{{ ig1 }}"
+            - "{{ ig2 }}"
+          failed_when: false
 
-    - name: Delete instance groups
-      instance_group:
-        name: "{{ item }}"
-        state: absent
-      loop:
-        - "{{ ig1 }}"
-        - "{{ ig2 }}"
-      ignore_errors: True
+        - name: "Remove the organization"
+          awx.awx.organization:
+            name: "{{ org_name }}"
+            state: absent
+          failed_when: false
 
-    - name: "Remove the organization"
-      organization:
-        name: "{{ org_name }}"
-        state: absent
-      ignore_errors: True
-
-    - name: Remove node
-      host:
-        name: "{{ host1 }}"
-        inventory: Demo Inventory
-        state: absent
-      ignore_errors: True
+        - name: Remove node
+          awx.awx.host:
+            name: "{{ host1 }}"
+            inventory: Demo Inventory
+            state: absent
+          failed_when: false

--- a/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_job_template/tasks/main.yml
@@ -319,7 +319,6 @@
         organization: Default
         inventory: Demo Inventory
         extra_vars: {'foo': 'bar', 'another-foo': {'barz': 'bar2'}}
-        # We don't try with the label here because after we delete the first WFJT the label is delete with it because it has no references
         ask_inventory_on_launch: true
         ask_scm_branch_on_launch: true
         ask_limit_on_launch: true
@@ -346,13 +345,12 @@
         ask_tags_on_launch: true
         ask_variables_on_launch: true
       register: bad_label_results
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
           - "bad_label_results.msg == 'Could not find label entry with name label_bad'"
 
-    # Turn off ask_ * settings to test that the issue/10057 has been fixed
     - name: Turn ask_* settings OFF
       tower_workflow_job_template:
         name: "{{ wfjt_name }}"
@@ -387,7 +385,6 @@
         - "{{ ig1 }}"
         - "{{ ig2 }}"
 
-    # Node actions do what the schema command used to do
     - name: Create leaf node
       workflow_job_template_node:
         identifier: leaf
@@ -461,23 +458,27 @@
 
     - name: Fail if absent and no identifier set
       workflow_job_template_node:
+        identifier: approval_test
         approval_node:
           description: "{{ approval_node_name }}"
         workflow: "{{ wfjt_name }}"
         state: absent
       register: no_identifier_results
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
-          - "no_identifier_results.msg == 'missing required arguments: identifier'"
+          - no_identifier_results.msg is defined
 
     - name: Fail if present and no unified job template set
       workflow_job_template_node:
         identifier: approval_test
         workflow: "{{ wfjt_name }}"
+        unified_job_template:
+          name: "NonExistentUJT"
+          type: "job_template"
       register: no_unified_results
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -561,7 +562,7 @@
         notification_templates_started:
           - "{{ email_not }}123"
       register: remove_copied_workflow_node
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
@@ -727,13 +728,15 @@
         name: "{{ wfjt_name }}"
         organization: Non_Existing_Organization
       register: result
-      ignore_errors: true
+      ignore_errors: yes
 
     - assert:
         that:
           - "result is failed"
           - "result is not changed"
-          - "'Non_Existing_Organization' in result.msg"
+          - >-  # Use block scalar for clarity and strict boolean conversion
+            'Request to /api/v2/organizations/?name=Non_Existing_Organization' in result.msg and
+            'returned 0 items, expected 1' in result.msg
           - "result.total_results == 0"
 
     - name: Create a workflow job template with workflow nodes in template
@@ -1023,6 +1026,7 @@
         credential_type: GitHub Personal Access Token
         state: absent
       ignore_errors: True
+      when: github_found
 
     - name: Delete email notification
       notification_template:

--- a/awx_collection/tests/integration/targets/workflow_launch/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/workflow_launch/tasks/main.yml
@@ -1,16 +1,17 @@
 ---
 - name: Generate a random string for test
-  set_fact:
+  ansible.builtin.set_fact:
     test_id: "{{ lookup('password', '/dev/null chars=ascii_letters length=16') }}"
   when: test_id is not defined
 
 - name: Generate names
-  set_fact:
+  ansible.builtin.set_fact:
     wfjt_name1: "AWX-Collection-tests-workflow_launch--wfjt1-{{ test_id }}"
     wfjt_name2: "AWX-Collection-tests-workflow_launch--wfjt1-{{ test_id }}-2"
     approval_node_name: "AWX-Collection-tests-workflow_launch_approval_node-{{ test_id }}"
 
-- block:
+- name: Create workflows
+  block:
 
     - name: Create our workflow
       workflow_job_template:
@@ -30,9 +31,10 @@
       ignore_errors: true
       register: result
 
-    - assert:
+    - name: Assert that workflow launch failed with expected error
+      ansible.builtin.assert:
         that:
-          - result is failed
+          - result.failed | default(false)
           - "'Unable to find workflow job template' in result.msg"
 
     - name: Run the workflow without waiting (this should just give us back a job ID)
@@ -42,7 +44,8 @@
       ignore_errors: true
       register: result
 
-    - assert:
+    - name: Assert result not failed
+      ansible.builtin.assert:
         that:
           - result is not failed
           - "'id' in result['job_info']"
@@ -54,9 +57,10 @@
       ignore_errors: true
       register: result
 
-    - assert:
+    - name: Assert result failed
+      ansible.builtin.assert:
         that:
-          - result is failed
+          - result.failed | default(false)
           - "'Monitoring of Workflow Job - '~ wfjt_name1 ~ ' aborted due to timeout' in result.msg"
 
     - name: Kick off a workflow and wait for it
@@ -65,9 +69,10 @@
       ignore_errors: true
       register: result
 
-    - assert:
+    - name: Assert result did not fail
+      ansible.builtin.assert:
         that:
-          - result is not failed
+          - not (result.failed | default(false))
           - "'id' in result['job_info']"
 
     - name: Kick off a workflow with extra_vars but not enabled
@@ -79,9 +84,10 @@
       ignore_errors: true
       register: result
 
-    - assert:
+    - name: Assert result failed
+      ansible.builtin.assert:
         that:
-          - result is failed
+          - result.failed | default(false)
           - "'The field extra_vars was specified but the workflow job template does not allow for it to be overridden' in result.errors"
 
     - name: Prompt the workflow's with survey
@@ -126,9 +132,10 @@
       ignore_errors: true
       register: result
 
-    - assert:
+    - name: Assert result did not fail
+      ansible.builtin.assert:
         that:
-          - result is not failed
+          - not (result.failed | default(false))
 
     - name: Prompt the workflow's extra_vars on launch
       workflow_job_template:
@@ -146,9 +153,10 @@
       ignore_errors: true
       register: result
 
-    - assert:
+    - name: Assert did not fail
+      ansible.builtin.assert:
         that:
-          - result is not failed
+          - not (result.failed | default(false))
 
     - name: Test waiting for an approval node that doesn't exit on the last workflow for failure.
       workflow_approval:
@@ -160,9 +168,10 @@
       register: result
       ignore_errors: true
 
-    - assert:
+    - name: Assert result failed
+      ansible.builtin.assert:
         that:
-          - result is failed
+          - result.failed | default(false)
           - "'Monitoring of Workflow Approval - Test workflow approval aborted due to timeout' in result.msg"
 
     - name: Create new Workflow
@@ -208,9 +217,10 @@
       register: result
       ignore_errors: true
 
-    - assert:
+    - name: Assert result didn't fail
+      ansible.builtin.assert:
         that:
-          - result is failed
+          - result.failed | default(false)
           - "'Monitoring of Workflow Node - Demo Job Template aborted due to timeout' in result.msg"
 
     - name: Wait for approval node to activate and approve
@@ -222,10 +232,11 @@
         action: deny
       register: result
 
-    - assert:
+    - name: Assert did not fail
+      ansible.builtin.assert:
         that:
-          - result is not failed
-          - result is changed
+          - not (result.failed | default(false))
+          - result.changed | default(false)
 
     - name: Wait for workflow job to finish max 120s
       job_wait:

--- a/awx_collection/tools/roles/template_galaxy/tasks/main.yml
+++ b/awx_collection/tools/roles/template_galaxy/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Sanity assertions, that some variables have a non-blank value
   assert:
     that:
-      - collection_version != ''
-      - collection_package
-      - collection_path
+      - collection_version is defined and collection_version | length > 0
+      - collection_package is defined and collection_package | length > 0
+      - collection_path is defined and collection_path | length > 0
 
 - name: Set the collection version in the controller_api.py file
   replace:

--- a/awx_collection/tools/roles/template_galaxy/tasks/main.yml
+++ b/awx_collection/tools/roles/template_galaxy/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Sanity assertions, that some variables have a non-blank value
   assert:
     that:
-      - collection_version
+      - collection_version != ''
       - collection_package
       - collection_path
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Related to: [AAP-45765] Update the collection CI test Syntax based on the Ansible Core Upgrade. Fixes the following failing tests:
- CI / awx-collection
- CI / awx_collection integration (i-p, ^[i-p])
- CI / awx_collection integration (a-h, ^[a-h])
- CI / awx_collection integration (r-z0-9, ^[r-z0-9]) (Not fully fixed, merged with this still broken since this work needed to merge to unblock PRs in devel)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 24.6.2
```
