### PR TITLE
Update api.js to fix resize button

### DIFF
--- a/awx/static/api/api.js
+++ b/awx/static/api/api.js
@@ -71,7 +71,7 @@ $(function() {
 
   $('a.resize').click(function() {
     $(this).tooltip('hide');
-    if ($(this).find('span.glyphicon-resize-full').size()) {
+    if ($(this).find('span.glyphicon-resize-full').length) {
       $(this).find('span.glyphicon').addClass('glyphicon-resize-small').removeClass('glyphicon-resize-full');
       $('.container').addClass('container-fluid').removeClass('container');
       document.cookie = 'api_width=wide; path=/api/';


### PR DESCRIPTION
##### SUMMARY
In the API Web UI, the Resize button in the top right corner doesn't work.  When clicking it you get a javascript error.

```
Uncaught TypeError: $(...).find(...).size is not a function
```

the .size() function was deprecated back in jquery 1.8 and completely removed in 3.0.  

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### ADDITIONAL INFORMATION
Also tested downstream in AAP 2.4 and error seems to persist there too.