### PR TITLE
remove requirement for galaxy credentials to belong to an organization

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3027,11 +3027,6 @@ class CredentialSerializer(BaseSerializer):
                 ret.remove(field)
         return ret
 
-    def validate_organization(self, org):
-        if self.instance and (not self.instance.managed) and self.instance.credential_type.kind == 'galaxy' and org is None:
-            raise serializers.ValidationError(_("Galaxy credentials must be owned by an Organization."))
-        return org
-
     def validate_credential_type(self, credential_type):
         if self.instance and credential_type.pk != self.instance.credential_type.pk:
             for related_objects in (


### PR DESCRIPTION
##### SUMMARY

Removes the requirement for galaxy credentials to belong to an organization.
This method was called automatically by DRF, removing it will lift the restriction.

A further UI change is required to make to field not-required in the UI as well.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```
