### PR TITLE
Allow creating galaxy credential types without an organization

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3102,9 +3102,6 @@ class CredentialSerializerCreate(CredentialSerializer):
         if attrs.get('team'):
             attrs['organization'] = attrs['team'].organization
 
-        if 'credential_type' in attrs and attrs['credential_type'].kind == 'galaxy' and list(owner_fields) != ['organization']:
-            raise serializers.ValidationError({"organization": _("Galaxy credentials must be owned by an Organization.")})
-
         return super(CredentialSerializerCreate, self).validate(attrs)
 
     def create(self, validated_data):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -3027,11 +3027,6 @@ class CredentialSerializer(BaseSerializer):
                 ret.remove(field)
         return ret
 
-    def validate_organization(self, org):
-        if self.instance and (not self.instance.managed) and self.instance.credential_type.kind == 'galaxy' and org is None:
-            raise serializers.ValidationError(_("Galaxy credentials must be owned by an Organization."))
-        return org
-
     def validate_credential_type(self, credential_type):
         if self.instance and credential_type.pk != self.instance.credential_type.pk:
             for related_objects in (


### PR DESCRIPTION
##### SUMMARY

Remove the check for organizations from galaxy credential types too.

##### ISSUE TYPE

 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```
