### PR TITLE
Fix issue with some modules not honoring Controller API prefix

### DIFF
--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -44,7 +44,11 @@ class ControllerAWXKitModule(ControllerModule):
             if not self.authenticated:
                 self.authenticate()
             prefix = getenv('CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX', '/api/')
-            v2_path = path.join('/', prefix, 'v2/')
+            if not prefix.startswith('/'):
+                prefix = f"/{prefix}"
+            if not prefix.endswith('/'):
+                prefix = f"{prefix}/"
+            v2_path = f"{prefix}v2/"
             v2_index = get_registered_page(v2_path)(self.connection).get()
             self.api_ref = ApiV2(connection=self.connection, **{'json': v2_index})
         return self.api_ref

--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -4,6 +4,7 @@ __metaclass__ = type
 
 from .controller_api import ControllerModule
 from ansible.module_utils.basic import missing_required_lib
+from os import getenv
 
 try:
     from awxkit.api.client import Connection
@@ -42,7 +43,8 @@ class ControllerAWXKitModule(ControllerModule):
         if not self.apiV2Ref:
             if not self.authenticated:
                 self.authenticate()
-            v2_index = get_registered_page('/api/v2/')(self.connection).get()
+            prefix = getenv('CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX', '/api/')
+            v2_index = get_registered_page(f"{prefix}v2/")(self.connection).get()
             self.api_ref = ApiV2(connection=self.connection, **{'json': v2_index})
         return self.api_ref
 

--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 from .controller_api import ControllerModule
 from ansible.module_utils.basic import missing_required_lib
-from os import getenv, path
+from os import getenv
 
 try:
     from awxkit.api.client import Connection

--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 from .controller_api import ControllerModule
 from ansible.module_utils.basic import missing_required_lib
-from os import getenv
+from os import getenv, path
 
 try:
     from awxkit.api.client import Connection
@@ -44,7 +44,8 @@ class ControllerAWXKitModule(ControllerModule):
             if not self.authenticated:
                 self.authenticate()
             prefix = getenv('CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX', '/api/')
-            v2_index = get_registered_page(f"{prefix}v2/")(self.connection).get()
+            v2_path = path.join('/', prefix, 'v2/')
+            v2_index = get_registered_page(v2_path)(self.connection).get()
             self.api_ref = ApiV2(connection=self.connection, **{'json': v2_index})
         return self.api_ref
 

--- a/awx_collection/test/awx/test_controller_api_urlpattern_prefix.py
+++ b/awx_collection/test/awx/test_controller_api_urlpattern_prefix.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+from unittest import mock
+
+__metaclass__ = type
+
+import pytest
+
+def mock_get_registered_page(prefix):
+  return mock.Mock(
+    return_value=mock.Mock(
+      get=mock.Mock(return_value={'prefix': prefix })
+    )
+  )
+
+@pytest.mark.parametrize(
+    "env_prefix, controller_host, expected",
+    [
+        # without CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX env variable
+        [None, "https://localhost", "/api/v2/" ],
+        # with CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX env variable
+        ["/api/controller/", "https://localhost", "/api/controller/v2/"],
+        ["/api/controller", "https://localhost", "/api/controller/v2/"],
+        ["api/controller", "https://localhost", "/api/controller/v2/"],
+        ["/custom/path/", "https://localhost", "/custom/path/v2/"]
+    ]
+)
+def test_controller_awxkit_get_api_v2_object(collection_import, env_prefix, controller_host, expected):
+    controller_awxkit_class = collection_import('plugins.module_utils.awxkit').ControllerAWXKitModule
+    controller_awxkit = controller_awxkit_class(argument_spec={}, direct_params=dict(controller_host=controller_host))
+    with mock.patch('plugins.module_utils.awxkit.get_registered_page', mock_get_registered_page):
+      if env_prefix:
+          with mock.patch.dict(os.environ, {"CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX": env_prefix}):
+              api_v2_object = controller_awxkit.get_api_v2_object()
+      else:
+          api_v2_object = controller_awxkit.get_api_v2_object()
+      assert getattr(api_v2_object, 'prefix') == expected

--- a/awx_collection/test/awx/test_controller_api_urlpattern_prefix.py
+++ b/awx_collection/test/awx/test_controller_api_urlpattern_prefix.py
@@ -7,32 +7,30 @@ __metaclass__ = type
 
 import pytest
 
+
 def mock_get_registered_page(prefix):
-  return mock.Mock(
-    return_value=mock.Mock(
-      get=mock.Mock(return_value={'prefix': prefix })
-    )
-  )
+    return mock.Mock(return_value=mock.Mock(get=mock.Mock(return_value={'prefix': prefix})))
+
 
 @pytest.mark.parametrize(
     "env_prefix, controller_host, expected",
     [
         # without CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX env variable
-        [None, "https://localhost", "/api/v2/" ],
+        [None, "https://localhost", "/api/v2/"],
         # with CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX env variable
         ["/api/controller/", "https://localhost", "/api/controller/v2/"],
         ["/api/controller", "https://localhost", "/api/controller/v2/"],
         ["api/controller", "https://localhost", "/api/controller/v2/"],
-        ["/custom/path/", "https://localhost", "/custom/path/v2/"]
-    ]
+        ["/custom/path/", "https://localhost", "/custom/path/v2/"],
+    ],
 )
 def test_controller_awxkit_get_api_v2_object(collection_import, env_prefix, controller_host, expected):
     controller_awxkit_class = collection_import('plugins.module_utils.awxkit').ControllerAWXKitModule
     controller_awxkit = controller_awxkit_class(argument_spec={}, direct_params=dict(controller_host=controller_host))
     with mock.patch('plugins.module_utils.awxkit.get_registered_page', mock_get_registered_page):
-      if env_prefix:
-          with mock.patch.dict(os.environ, {"CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX": env_prefix}):
-              api_v2_object = controller_awxkit.get_api_v2_object()
-      else:
-          api_v2_object = controller_awxkit.get_api_v2_object()
-      assert getattr(api_v2_object, 'prefix') == expected
+        if env_prefix:
+            with mock.patch.dict(os.environ, {"CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX": env_prefix}):
+                api_v2_object = controller_awxkit.get_api_v2_object()
+        else:
+            api_v2_object = controller_awxkit.get_api_v2_object()
+        assert getattr(api_v2_object, 'prefix') == expected


### PR DESCRIPTION
##### SUMMARY

Fixes a bug in the `awx_collection`'s `export` module that caused failures when the API endpoint was not at `/api/v2` and was not honoring an environment variable that should override it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

##### ADDITIONAL INFORMATION

Given a deployment with AWX at `/api/controller/v2/`, the following playbook now succeeds:

```yaml
- name: Export Demo Project
  hosts: localhost
  environment:
    CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX: '/api/controller/'
    AWXKIT_API_BASE_PATH: '/api/controller/'
  tasks:
    - name: Export projects
      awx.awx.export:
        projects: ['Demo Project']
        controller_host: <gateway host>
        controller_username: ...
        controller_password: ...
```

Added tests in `awx_collection/test/awx/test_controller_api_urlpattern_prefix.py` to confirm `CONTROLLER_OPTIONAL_API_URLPATTERN_PREFIX` is honored in `ControllerAWXKitModule` (used by export/import)
