### PR TITLE
Add note about setting correct env variable in cli usage

### DIFF
--- a/awxkit/awxkit/cli/docs/source/conf.py
+++ b/awxkit/awxkit/cli/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'AWX CLI'
-copyright = '2024, Ansible by Red Hat'
+copyright = '2025, Ansible by Red Hat'
 author = 'Ansible by Red Hat'
 
 
@@ -54,5 +54,5 @@ rst_epilog = '''
 .. |prog| replace:: awx
 .. |at| replace:: automation controller
 .. |At| replace:: Automation controller
-.. |RHAT| replace:: Red Hat Ansible Automation Platform controller
+.. |RHAT| replace:: Red Hat Ansible Automation Platform
 '''

--- a/awxkit/awxkit/cli/docs/source/usage.rst
+++ b/awxkit/awxkit/cli/docs/source/usage.rst
@@ -34,6 +34,13 @@ Using |prog| requires some initial configuration.  Here is a simple example for 
         --conf.insecure \
         users list
 
+.. note:: To execute AWX CLI on |rhaap| 2.5 and later, you must set your environment variable to:
+    
+    .. code:: 
+        
+        AWXKIT_API_BASE_PATH=/api/controller/
+
+
 There are multiple ways to configure and authenticate with an AWX or |RHAT| server.  For more details, see :ref:`authentication`.
 
 By default, |prog| prints valid JSON for successful commands.  Certain commands (such as those for printing job stdout) print raw text and do not allow for custom formatting.  For details on customizing |prog|'s output format, see :ref:`formatting`.


### PR DESCRIPTION
##### SUMMARY
Added a note in the Usage section of the CLI Guide to resolve [AAP-37812](https://issues.redhat.com/browse/AAP-37812). The note instructs users to set their env variable so the CLI will work with AAP 2.5.

Other misc fixes include updating the copyright year and fixing variable to drop 'controller" from AAP.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI
 - Docs

##### ADDITIONAL INFORMATION
Needs Jenkins build to generate new docs: https://jenkins-csb-aap-main.dno.corp.redhat.com/job/Docs/job/Build_AWX_Cli_Docs/
