### PR TITLE
AAP-52518: Fix Role User Assignment Cleanup on Inventory Deletion

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -485,22 +485,32 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin, OpaQu
     def delete(self, *args, **kwargs):
         self._update_host_smart_inventory_memeberships()
 
-        # Explicitly clean up role assignments before deletion to prevent orphaned assignments
-        # This ensures RoleUserAssignment and RoleTeamAssignment records are properly cascade deleted
+        # Explicitly clean up role assignments before deletion to prevent
+        # orphaned assignments. This ensures RoleUserAssignment and
+        # RoleTeamAssignment records are properly cascade deleted
         try:
             from django.contrib.contenttypes.models import ContentType
             from ansible_base.rbac.models import ObjectRole
-
+            
             ct = ContentType.objects.get_for_model(self)
-            deleted_roles_count = ObjectRole.objects.filter(content_type=ct, object_id=self.pk).count()
-            ObjectRole.objects.filter(content_type=ct, object_id=self.pk).delete()
-
+            object_roles = ObjectRole.objects.filter(
+                content_type=ct, object_id=self.pk
+            )
+            deleted_roles_count = object_roles.count()
+            object_roles.delete()
+            
             if deleted_roles_count > 0:
-                logger.debug(f"Cleaned up {deleted_roles_count} ObjectRole records for inventory {self.pk}")
-
+                logger.debug(
+                    f"Cleaned up {deleted_roles_count} ObjectRole records "
+                    f"for inventory {self.pk}"
+                )
+                
         except Exception as e:
             # Log the error but don't prevent inventory deletion
-            logger.warning(f"Failed to clean up role assignments for inventory {self.pk}: {e}")
+            logger.warning(
+                f"Failed to clean up role assignments for inventory "
+                f"{self.pk}: {e}"
+            )
 
         super(Inventory, self).delete(*args, **kwargs)
 

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -491,26 +491,18 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin, OpaQu
         try:
             from django.contrib.contenttypes.models import ContentType
             from ansible_base.rbac.models import ObjectRole
-            
+
             ct = ContentType.objects.get_for_model(self)
-            object_roles = ObjectRole.objects.filter(
-                content_type=ct, object_id=self.pk
-            )
+            object_roles = ObjectRole.objects.filter(content_type=ct, object_id=self.pk)
             deleted_roles_count = object_roles.count()
             object_roles.delete()
-            
+
             if deleted_roles_count > 0:
-                logger.debug(
-                    f"Cleaned up {deleted_roles_count} ObjectRole records "
-                    f"for inventory {self.pk}"
-                )
-                
+                logger.debug(f"Cleaned up {deleted_roles_count} ObjectRole records " f"for inventory {self.pk}")
+
         except Exception as e:
             # Log the error but don't prevent inventory deletion
-            logger.warning(
-                f"Failed to clean up role assignments for inventory "
-                f"{self.pk}: {e}"
-            )
+            logger.warning(f"Failed to clean up role assignments for inventory " f"{self.pk}: {e}")
 
         super(Inventory, self).delete(*args, **kwargs)
 

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -489,10 +489,10 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin, OpaQu
         # orphaned assignments. This ensures RoleUserAssignment and
         # RoleTeamAssignment records are properly cascade deleted
         try:
-            from django.contrib.contenttypes.models import ContentType
             from ansible_base.rbac.models import ObjectRole
+            from ansible_base.rbac import permission_registry
 
-            ct = ContentType.objects.get_for_model(self)
+            ct = permission_registry.content_type_model.objects.get_for_model(self)
             object_roles = ObjectRole.objects.filter(content_type=ct, object_id=self.pk)
             deleted_roles_count = object_roles.count()
             object_roles.delete()

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -484,6 +484,24 @@ class Inventory(CommonModelNameNotUnique, ResourceMixin, RelatedJobsMixin, OpaQu
 
     def delete(self, *args, **kwargs):
         self._update_host_smart_inventory_memeberships()
+
+        # Explicitly clean up role assignments before deletion to prevent orphaned assignments
+        # This ensures RoleUserAssignment and RoleTeamAssignment records are properly cascade deleted
+        try:
+            from django.contrib.contenttypes.models import ContentType
+            from ansible_base.rbac.models import ObjectRole
+
+            ct = ContentType.objects.get_for_model(self)
+            deleted_roles_count = ObjectRole.objects.filter(content_type=ct, object_id=self.pk).count()
+            ObjectRole.objects.filter(content_type=ct, object_id=self.pk).delete()
+
+            if deleted_roles_count > 0:
+                logger.debug(f"Cleaned up {deleted_roles_count} ObjectRole records for inventory {self.pk}")
+
+        except Exception as e:
+            # Log the error but don't prevent inventory deletion
+            logger.warning(f"Failed to clean up role assignments for inventory {self.pk}: {e}")
+
         super(Inventory, self).delete(*args, **kwargs)
 
     '''

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -1079,37 +1079,19 @@ def delete_inventory(inventory_id, user_id, retries=5):
             try:
                 from django.contrib.contenttypes.models import ContentType
                 from ansible_base.rbac.models import ObjectRole
-                
+
                 ct = ContentType.objects.get_for_model(inventory)
-                object_roles = ObjectRole.objects.filter(
-                    content_type=ct, object_id=inventory_id
-                )
+                object_roles = ObjectRole.objects.filter(content_type=ct, object_id=inventory_id)
                 deleted_roles_count = object_roles.count()
                 if deleted_roles_count > 0:
                     object_roles.delete()
-                    logger.debug(
-                        'Async deletion: Cleaned up {} ObjectRole records '
-                        'for inventory {}'.format(
-                            deleted_roles_count, inventory_id
-                        )
-                    )
+                    logger.debug('Async deletion: Cleaned up {} ObjectRole records ' 'for inventory {}'.format(deleted_roles_count, inventory_id))
             except Exception as e:
-                logger.warning(
-                    'Failed to clean up role assignments during async '
-                    'deletion of inventory {}: {}'.format(inventory_id, e)
-                )
+                logger.warning('Failed to clean up role assignments during async ' 'deletion of inventory {}: {}'.format(inventory_id, e))
 
             inventory.delete()
-            emit_channel_notification(
-                'inventories-status_changed', {
-                    'group_name': 'inventories',
-                    'inventory_id': inventory_id,
-                    'status': 'deleted'
-                }
-            )
-            logger.debug(
-                'Deleted inventory {} as user {}.'.format(inventory_id, user_id)
-            )
+            emit_channel_notification('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': inventory_id, 'status': 'deleted'})
+            logger.debug('Deleted inventory {} as user {}.'.format(inventory_id, user_id))
         except Inventory.DoesNotExist:
             logger.exception("Delete Inventory failed due to missing inventory: " + str(inventory_id))
             return

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -1073,23 +1073,43 @@ def delete_inventory(inventory_id, user_id, retries=5):
         try:
             inventory = Inventory.objects.get(id=inventory_id)
 
-            # Defense-in-depth: Explicitly clean up role assignments before deletion
-            # This ensures cleanup happens even if model signals don't fire properly
+            # Defense-in-depth: Explicitly clean up role assignments before
+            # deletion. This ensures cleanup happens even if model signals
+            # don't fire properly
             try:
                 from django.contrib.contenttypes.models import ContentType
                 from ansible_base.rbac.models import ObjectRole
-
+                
                 ct = ContentType.objects.get_for_model(inventory)
-                deleted_roles_count = ObjectRole.objects.filter(content_type=ct, object_id=inventory_id).count()
+                object_roles = ObjectRole.objects.filter(
+                    content_type=ct, object_id=inventory_id
+                )
+                deleted_roles_count = object_roles.count()
                 if deleted_roles_count > 0:
-                    ObjectRole.objects.filter(content_type=ct, object_id=inventory_id).delete()
-                    logger.debug('Async deletion: Cleaned up {} ObjectRole records for inventory {}'.format(deleted_roles_count, inventory_id))
+                    object_roles.delete()
+                    logger.debug(
+                        'Async deletion: Cleaned up {} ObjectRole records '
+                        'for inventory {}'.format(
+                            deleted_roles_count, inventory_id
+                        )
+                    )
             except Exception as e:
-                logger.warning('Failed to clean up role assignments during async deletion of inventory {}: {}'.format(inventory_id, e))
+                logger.warning(
+                    'Failed to clean up role assignments during async '
+                    'deletion of inventory {}: {}'.format(inventory_id, e)
+                )
 
             inventory.delete()
-            emit_channel_notification('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': inventory_id, 'status': 'deleted'})
-            logger.debug('Deleted inventory {} as user {}.'.format(inventory_id, user_id))
+            emit_channel_notification(
+                'inventories-status_changed', {
+                    'group_name': 'inventories',
+                    'inventory_id': inventory_id,
+                    'status': 'deleted'
+                }
+            )
+            logger.debug(
+                'Deleted inventory {} as user {}.'.format(inventory_id, user_id)
+            )
         except Inventory.DoesNotExist:
             logger.exception("Delete Inventory failed due to missing inventory: " + str(inventory_id))
             return

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -1077,10 +1077,10 @@ def delete_inventory(inventory_id, user_id, retries=5):
             # deletion. This ensures cleanup happens even if model signals
             # don't fire properly
             try:
-                from django.contrib.contenttypes.models import ContentType
                 from ansible_base.rbac.models import ObjectRole
+                from ansible_base.rbac import permission_registry
 
-                ct = ContentType.objects.get_for_model(inventory)
+                ct = permission_registry.content_type_model.objects.get_for_model(inventory)
                 object_roles = ObjectRole.objects.filter(content_type=ct, object_id=inventory_id)
                 deleted_roles_count = object_roles.count()
                 if deleted_roles_count > 0:

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -1071,7 +1071,23 @@ def delete_inventory(inventory_id, user_id, retries=5):
             user = None
     with ignore_inventory_computed_fields(), ignore_inventory_group_removal(), impersonate(user):
         try:
-            Inventory.objects.get(id=inventory_id).delete()
+            inventory = Inventory.objects.get(id=inventory_id)
+
+            # Defense-in-depth: Explicitly clean up role assignments before deletion
+            # This ensures cleanup happens even if model signals don't fire properly
+            try:
+                from django.contrib.contenttypes.models import ContentType
+                from ansible_base.rbac.models import ObjectRole
+
+                ct = ContentType.objects.get_for_model(inventory)
+                deleted_roles_count = ObjectRole.objects.filter(content_type=ct, object_id=inventory_id).count()
+                if deleted_roles_count > 0:
+                    ObjectRole.objects.filter(content_type=ct, object_id=inventory_id).delete()
+                    logger.debug('Async deletion: Cleaned up {} ObjectRole records for inventory {}'.format(deleted_roles_count, inventory_id))
+            except Exception as e:
+                logger.warning('Failed to clean up role assignments during async deletion of inventory {}: {}'.format(inventory_id, e))
+
+            inventory.delete()
             emit_channel_notification('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': inventory_id, 'status': 'deleted'})
             logger.debug('Deleted inventory {} as user {}.'.format(inventory_id, user_id))
         except Inventory.DoesNotExist:

--- a/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
+++ b/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
@@ -31,7 +31,9 @@ def test_inventory_role_assignments_deleted_sync(inventory, alice, setup_managed
 
 @pytest.mark.django_db
 def test_inventory_role_assignments_deleted_async(inventory, alice, setup_managed_roles):
-    """Test role assignments are properly cleaned up when inventory is deleted asynchronously."""
+    """Test role assignments are properly cleaned up via schedule_deletion."""
+    from unittest.mock import patch
+
     # Get the managed Inventory Admin role definition
     inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
 
@@ -44,12 +46,10 @@ def test_inventory_role_assignments_deleted_async(inventory, alice, setup_manage
     # Verify assignment exists before deletion
     assert RoleUserAssignment.objects.filter(user=alice, object_id=str(inventory_id), role_definition=inv_rd).exists()
 
-    # Mark as pending deletion and call async task directly
-    inventory.pending_deletion = True
-    inventory.save()
-
-    # Call the actual deletion task (runs synchronously in tests)
-    delete_inventory(inventory_id, user_id)
+    # Mock the WebSocket notification to avoid Redis dependency
+    with patch('awx.main.tasks.system.emit_channel_notification'):
+        # Call delete_inventory directly (simulating Celery task)
+        delete_inventory(inventory_id, user_id)
 
     # Verify role assignment is cleaned up
     assert not RoleUserAssignment.objects.filter(user_id=user_id, object_id=str(inventory_id), role_definition=inv_rd).exists()

--- a/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
+++ b/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
@@ -6,42 +6,27 @@ from django.contrib.contenttypes.models import ContentType
 
 from awx.main.models import Inventory, User
 from awx.main.tasks.system import delete_inventory
-from ansible_base.rbac.models import (
-    RoleUserAssignment, ObjectRole, RoleDefinition
-)
+from ansible_base.rbac.models import RoleUserAssignment, ObjectRole, RoleDefinition
 
 
 @pytest.mark.django_db
-def test_role_assignment_deleted_with_inventory_sync(inventory, alice):
-    """Test role assignments are deleted when inventory is deleted
-    synchronously."""
-    # Get or create the Inventory Admin role definition
-    try:
-        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(
-            name='Inventory Admin',
-            description='Can manage inventory',
-            content_type=ct
-        )
+def test_role_assignment_deleted_with_inventory_sync(inventory, alice, setup_managed_roles):
+    """Test role assignments are deleted when inventory is deleted synchronously."""
+    # Get the managed Inventory Admin role definition
+    inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
 
     # Create a role assignment for the inventory
     inv_rd.give_permission(alice, inventory)
 
     # Verify assignment exists
     assert RoleUserAssignment.objects.filter(
-        user=alice,
-        object_id=str(inventory.pk),
-        role_definition=inv_rd
+        user=alice, object_id=str(inventory.pk), role_definition=inv_rd
     ).exists(), "Role assignment should exist before inventory deletion"
 
     # Verify ObjectRole exists
     ct = ContentType.objects.get_for_model(inventory)
     assert ObjectRole.objects.filter(
-        content_type=ct,
-        object_id=str(inventory.pk),
-        role_definition=inv_rd
+        content_type=ct, object_id=str(inventory.pk), role_definition=inv_rd
     ).exists(), "ObjectRole should exist before inventory deletion"
 
     # Store IDs for verification after deletion
@@ -53,33 +38,20 @@ def test_role_assignment_deleted_with_inventory_sync(inventory, alice):
 
     # Verify role assignment is deleted
     assert not RoleUserAssignment.objects.filter(
-        user_id=user_id,
-        object_id=inventory_id,
-        role_definition=inv_rd
+        user_id=user_id, object_id=inventory_id, role_definition=inv_rd
     ).exists(), "Role assignment should be deleted after inventory deletion"
 
     # Verify ObjectRole is deleted
     assert not ObjectRole.objects.filter(
-        content_type=ct,
-        object_id=inventory_id,
-        role_definition=inv_rd
+        content_type=ct, object_id=inventory_id, role_definition=inv_rd
     ).exists(), "ObjectRole should be deleted after inventory deletion"
 
 
 @pytest.mark.django_db
-def test_role_assignment_deleted_with_inventory_async(inventory, alice):
-    """Test role assignments are deleted when inventory is deleted via
-    async task."""
-    # Get or create the Inventory Admin role definition
-    try:
-        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(
-            name='Inventory Admin',
-            description='Can manage inventory',
-            content_type=ct
-        )
+def test_role_assignment_deleted_with_inventory_async(inventory, alice, setup_managed_roles):
+    """Test role assignments are deleted when inventory is deleted via async task."""
+    # Get the managed Inventory Admin role definition
+    inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
 
     # Create a role assignment for the inventory
     inv_rd.give_permission(alice, inventory)
@@ -89,9 +61,7 @@ def test_role_assignment_deleted_with_inventory_async(inventory, alice):
 
     # Verify assignment exists before deletion
     assert RoleUserAssignment.objects.filter(
-        user=alice,
-        object_id=str(inventory_id),
-        role_definition=inv_rd
+        user=alice, object_id=str(inventory_id), role_definition=inv_rd
     ).exists(), "Role assignment should exist before async deletion"
 
     # Mark as pending deletion and call async task directly
@@ -103,37 +73,16 @@ def test_role_assignment_deleted_with_inventory_async(inventory, alice):
 
     # Verify role assignment is deleted
     assert not RoleUserAssignment.objects.filter(
-        user_id=user_id,
-        object_id=str(inventory_id),
-        role_definition=inv_rd
-    ).exists(), (
-        "Role assignment should be deleted after async inventory deletion"
-    )
+        user_id=user_id, object_id=str(inventory_id), role_definition=inv_rd
+    ).exists(), "Role assignment should be deleted after async inventory deletion"
 
 
 @pytest.mark.django_db
-def test_multiple_role_assignments_cleanup(inventory, alice, bob):
+def test_multiple_role_assignments_cleanup(inventory, alice, bob, setup_managed_roles):
     """Test multiple role assignments for same inventory are all deleted."""
-    # Get or create role definitions
-    try:
-        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(
-            name='Inventory Admin',
-            description='Can manage inventory',
-            content_type=ct
-        )
-
-    try:
-        use_rd = RoleDefinition.objects.get(name='Inventory Use')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        use_rd = RoleDefinition.objects.create(
-            name='Inventory Use',
-            description='Can use inventory',
-            content_type=ct
-        )
+    # Get managed role definitions
+    inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
+    use_rd = RoleDefinition.objects.get(name='Inventory Use')
 
     # Create multiple role assignments
     inv_rd.give_permission(alice, inventory)
@@ -142,48 +91,25 @@ def test_multiple_role_assignments_cleanup(inventory, alice, bob):
     inventory_id = str(inventory.pk)
 
     # Verify both assignments exist
-    assignments_count = RoleUserAssignment.objects.filter(
-        object_id=inventory_id
-    ).count()
-    assert assignments_count == 2, (
-        f"Should have 2 role assignments, but found {assignments_count}"
-    )
+    assignments_count = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
+    assert assignments_count == 2, f"Should have 2 role assignments, but found {assignments_count}"
 
     # Delete inventory
     inventory.delete()
 
     # Verify all assignments are deleted
-    remaining_assignments = RoleUserAssignment.objects.filter(
-        object_id=inventory_id
-    ).count()
-    assert remaining_assignments == 0, (
-        f"All role assignments should be deleted, but found "
-        f"{remaining_assignments}"
-    )
+    remaining_assignments = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
+    assert remaining_assignments == 0, f"All role assignments should be deleted, but found " f"{remaining_assignments}"
 
 
 @pytest.mark.django_db
-def test_other_inventory_assignments_unaffected(
-    inventory, alice, organization
-):
-    """Test that deleting one inventory doesn't affect role assignments for
-    other inventories."""
+def test_other_inventory_assignments_unaffected(inventory, alice, organization, setup_managed_roles):
+    """Test that deleting one inventory doesn't affect role assignments for other inventories."""
     # Create second inventory
-    inventory2 = Inventory.objects.create(
-        name='Test Inventory 2',
-        organization=organization
-    )
+    inventory2 = Inventory.objects.create(name='Test Inventory 2', organization=organization)
 
-    # Get or create role definition
-    try:
-        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(
-            name='Inventory Admin',
-            description='Can manage inventory',
-            content_type=ct
-        )
+    # Get managed role definition
+    inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
 
     # Create assignments for both inventories
     inv_rd.give_permission(alice, inventory)
@@ -193,92 +119,56 @@ def test_other_inventory_assignments_unaffected(
     inventory2_id = str(inventory2.pk)
 
     # Verify both assignments exist
-    assert RoleUserAssignment.objects.filter(
-        user=alice,
-        object_id=inventory1_id,
-        role_definition=inv_rd
-    ).exists(), "First inventory assignment should exist"
+    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory1_id, role_definition=inv_rd).exists(), "First inventory assignment should exist"
 
-    assert RoleUserAssignment.objects.filter(
-        user=alice,
-        object_id=inventory2_id,
-        role_definition=inv_rd
-    ).exists(), "Second inventory assignment should exist"
+    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory2_id, role_definition=inv_rd).exists(), "Second inventory assignment should exist"
 
     # Delete first inventory
     inventory.delete()
 
     # Verify first assignment deleted, second preserved
     assert not RoleUserAssignment.objects.filter(
-        user=alice,
-        object_id=inventory1_id,
-        role_definition=inv_rd
+        user=alice, object_id=inventory1_id, role_definition=inv_rd
     ).exists(), "First inventory assignment should be deleted"
 
     assert RoleUserAssignment.objects.filter(
-        user=alice,
-        object_id=inventory2_id,
-        role_definition=inv_rd
+        user=alice, object_id=inventory2_id, role_definition=inv_rd
     ).exists(), "Second inventory assignment should still exist"
 
 
 @pytest.mark.django_db
-def test_inventory_deletion_with_no_assignments(inventory):
-    """Test inventory deletion works normally when there are no role
-    assignments."""
+def test_inventory_deletion_with_no_assignments(inventory, setup_managed_roles):
+    """Test inventory deletion works normally when there are no role assignments."""
     inventory_id = inventory.pk
 
     # Verify no role assignments exist
-    assert RoleUserAssignment.objects.filter(
-        object_id=str(inventory_id)
-    ).count() == 0, "Should have no role assignments initially"
+    assert RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count() == 0, "Should have no role assignments initially"
 
     # Delete inventory - should work without errors
     inventory.delete()
 
     # Verify inventory is deleted
-    assert not Inventory.objects.filter(pk=inventory_id).exists(), (
-        "Inventory should be deleted"
-    )
+    assert not Inventory.objects.filter(pk=inventory_id).exists(), "Inventory should be deleted"
 
 
 @pytest.mark.django_db
-def test_aap_52518_exact_reproduction(organization):
+def test_aap_52518_exact_reproduction(organization, setup_managed_roles):
     """Test the exact scenario described in AAP-52518 Jira ticket."""
     # Step 1: Create an Organization and a User
-    user = User.objects.create(
-        username='testuser',
-        email='testuser@example.com',
-        is_active=True
-    )
+    user = User.objects.create(username='testuser', email='testuser@example.com', is_active=True)
 
     # Step 2: Create a Controller inventory in that org
-    inventory = Inventory.objects.create(
-        name='Test Controller Inventory',
-        organization=organization,
-        description='Test inventory for AAP-52518'
-    )
+    inventory = Inventory.objects.create(name='Test Controller Inventory', organization=organization, description='Test inventory for AAP-52518')
 
-    # Step 3: Create a role user assignment for the user to become
-    # Inventory Admin
-    try:
-        inv_admin_role = RoleDefinition.objects.get(name='Inventory Admin')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        inv_admin_role = RoleDefinition.objects.create(
-            name='Inventory Admin',
-            description='Can administer inventory',
-            content_type=ct
-        )
+    # Step 3: Create a role user assignment for the user to become Inventory Admin
+    inv_admin_role = RoleDefinition.objects.get(name='Inventory Admin')
 
     # Give the user Inventory Admin permission on this inventory
     role_assignment = inv_admin_role.give_permission(user, inventory)
 
     # Verify the role assignment was created
     assignment_id = role_assignment.id
-    assert RoleUserAssignment.objects.filter(id=assignment_id).exists(), (
-        "Role assignment should exist after creation"
-    )
+    assert RoleUserAssignment.objects.filter(id=assignment_id).exists(), "Role assignment should exist after creation"
 
     # Store data for verification after deletion
     inventory_id = inventory.pk
@@ -288,60 +178,29 @@ def test_aap_52518_exact_reproduction(organization):
     inventory.delete()
 
     # Step 5: Check the role_user_assignments list - should be empty
-    assignments_after = RoleUserAssignment.objects.filter(
-        user_id=user_id,
-        object_id=str(inventory_id)
-    ).count()
-    assert assignments_after == 0, (
-        "Role assignment should be completely removed after inventory deletion"
-    )
+    assignments_after = RoleUserAssignment.objects.filter(user_id=user_id, object_id=str(inventory_id)).count()
+    assert assignments_after == 0, "Role assignment should be completely removed after inventory deletion"
 
     # Additional verification: Ensure no orphaned records exist
     assert not RoleUserAssignment.objects.filter(
-        user_id=user_id,
-        object_id=str(inventory_id)
+        user_id=user_id, object_id=str(inventory_id)
     ).exists(), "No role assignments should exist for deleted inventory"
 
     # Verify ObjectRole was also cleaned up
     ct = ContentType.objects.get_for_model(Inventory)
-    assert not ObjectRole.objects.filter(
-        content_type=ct,
-        object_id=str(inventory_id)
-    ).exists(), "No ObjectRole should exist for deleted inventory"
+    assert not ObjectRole.objects.filter(content_type=ct, object_id=str(inventory_id)).exists(), "No ObjectRole should exist for deleted inventory"
 
 
 @pytest.mark.django_db
-def test_multiple_users_same_inventory_cleanup(inventory):
-    """Test cleanup works when multiple users have roles on the same
-    inventory."""
+def test_multiple_users_same_inventory_cleanup(inventory, setup_managed_roles):
+    """Test cleanup works when multiple users have roles on the same inventory."""
     # Create additional users
-    user2 = User.objects.create(
-        username='testuser2', email='test2@example.com'
-    )
-    user3 = User.objects.create(
-        username='testuser3', email='test3@example.com'
-    )
+    user2 = User.objects.create(username='testuser2', email='test2@example.com')
+    user3 = User.objects.create(username='testuser3', email='test3@example.com')
 
-    # Create role definitions
-    try:
-        admin_role = RoleDefinition.objects.get(name='Inventory Admin')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        admin_role = RoleDefinition.objects.create(
-            name='Inventory Admin',
-            description='Can administer inventory',
-            content_type=ct
-        )
-
-    try:
-        use_role = RoleDefinition.objects.get(name='Inventory Use')
-    except RoleDefinition.DoesNotExist:
-        ct = ContentType.objects.get_for_model(Inventory)
-        use_role = RoleDefinition.objects.create(
-            name='Inventory Use',
-            description='Can use inventory',
-            content_type=ct
-        )
+    # Get managed role definitions
+    admin_role = RoleDefinition.objects.get(name='Inventory Admin')
+    use_role = RoleDefinition.objects.get(name='Inventory Use')
 
     # Assign different roles to different users
     admin_role.give_permission(user2, inventory)
@@ -351,16 +210,12 @@ def test_multiple_users_same_inventory_cleanup(inventory):
     inventory_id = inventory.pk
 
     # Verify all assignments exist
-    assignments_before = RoleUserAssignment.objects.filter(
-        object_id=str(inventory_id)
-    ).count()
+    assignments_before = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
     assert assignments_before == 3, "Should have 3 role assignments"
 
     # Delete inventory
     inventory.delete()
 
     # Verify all assignments are cleaned up
-    assignments_after = RoleUserAssignment.objects.filter(
-        object_id=str(inventory_id)
-    ).count()
+    assignments_after = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
     assert assignments_after == 0, "All assignments should be deleted"

--- a/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
+++ b/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
@@ -4,33 +4,44 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
 
-from awx.main.models import Inventory, Organization, User
+from awx.main.models import Inventory, User
 from awx.main.tasks.system import delete_inventory
-from ansible_base.rbac.models import RoleUserAssignment, ObjectRole, RoleDefinition
+from ansible_base.rbac.models import (
+    RoleUserAssignment, ObjectRole, RoleDefinition
+)
 
 
 @pytest.mark.django_db
 def test_role_assignment_deleted_with_inventory_sync(inventory, alice):
-    """Test role assignments are deleted when inventory is deleted synchronously."""
+    """Test role assignments are deleted when inventory is deleted
+    synchronously."""
     # Get or create the Inventory Admin role definition
     try:
         inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+        inv_rd = RoleDefinition.objects.create(
+            name='Inventory Admin',
+            description='Can manage inventory',
+            content_type=ct
+        )
 
     # Create a role assignment for the inventory
-    assignment = inv_rd.give_permission(alice, inventory)
+    inv_rd.give_permission(alice, inventory)
 
     # Verify assignment exists
     assert RoleUserAssignment.objects.filter(
-        user=alice, object_id=str(inventory.pk), role_definition=inv_rd
+        user=alice,
+        object_id=str(inventory.pk),
+        role_definition=inv_rd
     ).exists(), "Role assignment should exist before inventory deletion"
 
     # Verify ObjectRole exists
     ct = ContentType.objects.get_for_model(inventory)
     assert ObjectRole.objects.filter(
-        content_type=ct, object_id=str(inventory.pk), role_definition=inv_rd
+        content_type=ct,
+        object_id=str(inventory.pk),
+        role_definition=inv_rd
     ).exists(), "ObjectRole should exist before inventory deletion"
 
     # Store IDs for verification after deletion
@@ -42,34 +53,45 @@ def test_role_assignment_deleted_with_inventory_sync(inventory, alice):
 
     # Verify role assignment is deleted
     assert not RoleUserAssignment.objects.filter(
-        user_id=user_id, object_id=inventory_id, role_definition=inv_rd
+        user_id=user_id,
+        object_id=inventory_id,
+        role_definition=inv_rd
     ).exists(), "Role assignment should be deleted after inventory deletion"
 
     # Verify ObjectRole is deleted
     assert not ObjectRole.objects.filter(
-        content_type=ct, object_id=inventory_id, role_definition=inv_rd
+        content_type=ct,
+        object_id=inventory_id,
+        role_definition=inv_rd
     ).exists(), "ObjectRole should be deleted after inventory deletion"
 
 
 @pytest.mark.django_db
 def test_role_assignment_deleted_with_inventory_async(inventory, alice):
-    """Test role assignments are deleted when inventory is deleted via async task."""
+    """Test role assignments are deleted when inventory is deleted via
+    async task."""
     # Get or create the Inventory Admin role definition
     try:
         inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+        inv_rd = RoleDefinition.objects.create(
+            name='Inventory Admin',
+            description='Can manage inventory',
+            content_type=ct
+        )
 
     # Create a role assignment for the inventory
-    assignment = inv_rd.give_permission(alice, inventory)
+    inv_rd.give_permission(alice, inventory)
 
     inventory_id = inventory.pk
     user_id = alice.pk
 
     # Verify assignment exists before deletion
     assert RoleUserAssignment.objects.filter(
-        user=alice, object_id=str(inventory_id), role_definition=inv_rd
+        user=alice,
+        object_id=str(inventory_id),
+        role_definition=inv_rd
     ).exists(), "Role assignment should exist before async deletion"
 
     # Mark as pending deletion and call async task directly
@@ -81,8 +103,12 @@ def test_role_assignment_deleted_with_inventory_async(inventory, alice):
 
     # Verify role assignment is deleted
     assert not RoleUserAssignment.objects.filter(
-        user_id=user_id, object_id=str(inventory_id), role_definition=inv_rd
-    ).exists(), "Role assignment should be deleted after async inventory deletion"
+        user_id=user_id,
+        object_id=str(inventory_id),
+        role_definition=inv_rd
+    ).exists(), (
+        "Role assignment should be deleted after async inventory deletion"
+    )
 
 
 @pytest.mark.django_db
@@ -93,107 +119,166 @@ def test_multiple_role_assignments_cleanup(inventory, alice, bob):
         inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+        inv_rd = RoleDefinition.objects.create(
+            name='Inventory Admin',
+            description='Can manage inventory',
+            content_type=ct
+        )
 
     try:
         use_rd = RoleDefinition.objects.get(name='Inventory Use')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        use_rd = RoleDefinition.objects.create(name='Inventory Use', description='Can use inventory', content_type=ct)
+        use_rd = RoleDefinition.objects.create(
+            name='Inventory Use',
+            description='Can use inventory',
+            content_type=ct
+        )
 
     # Create multiple role assignments
-    assignment1 = inv_rd.give_permission(alice, inventory)
-    assignment2 = use_rd.give_permission(bob, inventory)
+    inv_rd.give_permission(alice, inventory)
+    use_rd.give_permission(bob, inventory)
 
     inventory_id = str(inventory.pk)
 
     # Verify both assignments exist
-    assignments_count = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
-    assert assignments_count == 2, f"Should have 2 role assignments, but found {assignments_count}"
+    assignments_count = RoleUserAssignment.objects.filter(
+        object_id=inventory_id
+    ).count()
+    assert assignments_count == 2, (
+        f"Should have 2 role assignments, but found {assignments_count}"
+    )
 
     # Delete inventory
     inventory.delete()
 
     # Verify all assignments are deleted
-    remaining_assignments = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
-    assert remaining_assignments == 0, f"All role assignments should be deleted, but found {remaining_assignments}"
+    remaining_assignments = RoleUserAssignment.objects.filter(
+        object_id=inventory_id
+    ).count()
+    assert remaining_assignments == 0, (
+        f"All role assignments should be deleted, but found "
+        f"{remaining_assignments}"
+    )
 
 
 @pytest.mark.django_db
-def test_other_inventory_assignments_unaffected(inventory, alice, organization):
-    """Test that deleting one inventory doesn't affect role assignments for other inventories."""
+def test_other_inventory_assignments_unaffected(
+    inventory, alice, organization
+):
+    """Test that deleting one inventory doesn't affect role assignments for
+    other inventories."""
     # Create second inventory
-    inventory2 = Inventory.objects.create(name='Test Inventory 2', organization=organization)
+    inventory2 = Inventory.objects.create(
+        name='Test Inventory 2',
+        organization=organization
+    )
 
     # Get or create role definition
     try:
         inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+        inv_rd = RoleDefinition.objects.create(
+            name='Inventory Admin',
+            description='Can manage inventory',
+            content_type=ct
+        )
 
     # Create assignments for both inventories
-    assignment1 = inv_rd.give_permission(alice, inventory)
-    assignment2 = inv_rd.give_permission(alice, inventory2)
+    inv_rd.give_permission(alice, inventory)
+    inv_rd.give_permission(alice, inventory2)
 
     inventory1_id = str(inventory.pk)
     inventory2_id = str(inventory2.pk)
 
     # Verify both assignments exist
-    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory1_id, role_definition=inv_rd).exists(), "First inventory assignment should exist"
+    assert RoleUserAssignment.objects.filter(
+        user=alice,
+        object_id=inventory1_id,
+        role_definition=inv_rd
+    ).exists(), "First inventory assignment should exist"
 
-    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory2_id, role_definition=inv_rd).exists(), "Second inventory assignment should exist"
+    assert RoleUserAssignment.objects.filter(
+        user=alice,
+        object_id=inventory2_id,
+        role_definition=inv_rd
+    ).exists(), "Second inventory assignment should exist"
 
     # Delete first inventory
     inventory.delete()
 
     # Verify first assignment deleted, second preserved
     assert not RoleUserAssignment.objects.filter(
-        user=alice, object_id=inventory1_id, role_definition=inv_rd
+        user=alice,
+        object_id=inventory1_id,
+        role_definition=inv_rd
     ).exists(), "First inventory assignment should be deleted"
 
     assert RoleUserAssignment.objects.filter(
-        user=alice, object_id=inventory2_id, role_definition=inv_rd
+        user=alice,
+        object_id=inventory2_id,
+        role_definition=inv_rd
     ).exists(), "Second inventory assignment should still exist"
 
 
 @pytest.mark.django_db
 def test_inventory_deletion_with_no_assignments(inventory):
-    """Test inventory deletion works normally when there are no role assignments."""
+    """Test inventory deletion works normally when there are no role
+    assignments."""
     inventory_id = inventory.pk
 
     # Verify no role assignments exist
-    assert RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count() == 0, "Should have no role assignments initially"
+    assert RoleUserAssignment.objects.filter(
+        object_id=str(inventory_id)
+    ).count() == 0, "Should have no role assignments initially"
 
     # Delete inventory - should work without errors
     inventory.delete()
 
     # Verify inventory is deleted
-    assert not Inventory.objects.filter(pk=inventory_id).exists(), "Inventory should be deleted"
+    assert not Inventory.objects.filter(pk=inventory_id).exists(), (
+        "Inventory should be deleted"
+    )
 
 
 @pytest.mark.django_db
 def test_aap_52518_exact_reproduction(organization):
     """Test the exact scenario described in AAP-52518 Jira ticket."""
     # Step 1: Create an Organization and a User
-    user = User.objects.create(username='testuser', email='testuser@example.com', is_active=True)
+    user = User.objects.create(
+        username='testuser',
+        email='testuser@example.com',
+        is_active=True
+    )
 
     # Step 2: Create a Controller inventory in that org
-    inventory = Inventory.objects.create(name='Test Controller Inventory', organization=organization, description='Test inventory for AAP-52518')
+    inventory = Inventory.objects.create(
+        name='Test Controller Inventory',
+        organization=organization,
+        description='Test inventory for AAP-52518'
+    )
 
-    # Step 3: Create a role user assignment for the user to become Inventory Admin
+    # Step 3: Create a role user assignment for the user to become
+    # Inventory Admin
     try:
         inv_admin_role = RoleDefinition.objects.get(name='Inventory Admin')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        inv_admin_role = RoleDefinition.objects.create(name='Inventory Admin', description='Can administer inventory', content_type=ct)
+        inv_admin_role = RoleDefinition.objects.create(
+            name='Inventory Admin',
+            description='Can administer inventory',
+            content_type=ct
+        )
 
     # Give the user Inventory Admin permission on this inventory
     role_assignment = inv_admin_role.give_permission(user, inventory)
 
     # Verify the role assignment was created
     assignment_id = role_assignment.id
-    assert RoleUserAssignment.objects.filter(id=assignment_id).exists(), "Role assignment should exist after creation"
+    assert RoleUserAssignment.objects.filter(id=assignment_id).exists(), (
+        "Role assignment should exist after creation"
+    )
 
     # Store data for verification after deletion
     inventory_id = inventory.pk
@@ -203,53 +288,79 @@ def test_aap_52518_exact_reproduction(organization):
     inventory.delete()
 
     # Step 5: Check the role_user_assignments list - should be empty
-    assignments_after = RoleUserAssignment.objects.filter(user_id=user_id, object_id=str(inventory_id)).count()
-    assert assignments_after == 0, "Role assignment should be completely removed after inventory deletion"
+    assignments_after = RoleUserAssignment.objects.filter(
+        user_id=user_id,
+        object_id=str(inventory_id)
+    ).count()
+    assert assignments_after == 0, (
+        "Role assignment should be completely removed after inventory deletion"
+    )
 
     # Additional verification: Ensure no orphaned records exist
     assert not RoleUserAssignment.objects.filter(
-        user_id=user_id, object_id=str(inventory_id)
+        user_id=user_id,
+        object_id=str(inventory_id)
     ).exists(), "No role assignments should exist for deleted inventory"
 
     # Verify ObjectRole was also cleaned up
     ct = ContentType.objects.get_for_model(Inventory)
-    assert not ObjectRole.objects.filter(content_type=ct, object_id=str(inventory_id)).exists(), "No ObjectRole should exist for deleted inventory"
+    assert not ObjectRole.objects.filter(
+        content_type=ct,
+        object_id=str(inventory_id)
+    ).exists(), "No ObjectRole should exist for deleted inventory"
 
 
 @pytest.mark.django_db
 def test_multiple_users_same_inventory_cleanup(inventory):
-    """Test cleanup works when multiple users have roles on the same inventory."""
+    """Test cleanup works when multiple users have roles on the same
+    inventory."""
     # Create additional users
-    user2 = User.objects.create(username='testuser2', email='test2@example.com')
-    user3 = User.objects.create(username='testuser3', email='test3@example.com')
+    user2 = User.objects.create(
+        username='testuser2', email='test2@example.com'
+    )
+    user3 = User.objects.create(
+        username='testuser3', email='test3@example.com'
+    )
 
     # Create role definitions
     try:
         admin_role = RoleDefinition.objects.get(name='Inventory Admin')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        admin_role = RoleDefinition.objects.create(name='Inventory Admin', description='Can administer inventory', content_type=ct)
+        admin_role = RoleDefinition.objects.create(
+            name='Inventory Admin',
+            description='Can administer inventory',
+            content_type=ct
+        )
 
     try:
         use_role = RoleDefinition.objects.get(name='Inventory Use')
     except RoleDefinition.DoesNotExist:
         ct = ContentType.objects.get_for_model(Inventory)
-        use_role = RoleDefinition.objects.create(name='Inventory Use', description='Can use inventory', content_type=ct)
+        use_role = RoleDefinition.objects.create(
+            name='Inventory Use',
+            description='Can use inventory',
+            content_type=ct
+        )
 
     # Assign different roles to different users
-    assignment1 = admin_role.give_permission(user2, inventory)
-    assignment2 = admin_role.give_permission(user3, inventory)
-    assignment3 = use_role.give_permission(user3, inventory)
+    admin_role.give_permission(user2, inventory)
+    admin_role.give_permission(user3, inventory)
+    use_role.give_permission(user3, inventory)
 
     inventory_id = inventory.pk
 
     # Verify all assignments exist
-    assignments_before = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
+    assignments_before = RoleUserAssignment.objects.filter(
+        object_id=str(inventory_id)
+    ).count()
     assert assignments_before == 3, "Should have 3 role assignments"
 
     # Delete inventory
     inventory.delete()
 
     # Verify all assignments are cleaned up
-    assignments_after = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
+    assignments_after = RoleUserAssignment.objects.filter(
+        object_id=str(inventory_id)
+    ).count()
     assert assignments_after == 0, "All assignments should be deleted"

--- a/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
+++ b/awx/main/tests/functional/dab_rbac/test_inventory_role_assignments.py
@@ -2,16 +2,15 @@
 # All Rights Reserved.
 
 import pytest
-from django.contrib.contenttypes.models import ContentType
 
 from awx.main.models import Inventory, User
 from awx.main.tasks.system import delete_inventory
-from ansible_base.rbac.models import RoleUserAssignment, ObjectRole, RoleDefinition
+from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
 
 
 @pytest.mark.django_db
-def test_role_assignment_deleted_with_inventory_sync(inventory, alice, setup_managed_roles):
-    """Test role assignments are deleted when inventory is deleted synchronously."""
+def test_inventory_role_assignments_deleted_sync(inventory, alice, setup_managed_roles):
+    """Test role assignments are properly cleaned up when inventory is deleted synchronously."""
     # Get the managed Inventory Admin role definition
     inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
 
@@ -19,37 +18,20 @@ def test_role_assignment_deleted_with_inventory_sync(inventory, alice, setup_man
     inv_rd.give_permission(alice, inventory)
 
     # Verify assignment exists
-    assert RoleUserAssignment.objects.filter(
-        user=alice, object_id=str(inventory.pk), role_definition=inv_rd
-    ).exists(), "Role assignment should exist before inventory deletion"
+    assert RoleUserAssignment.objects.filter(user=alice, object_id=str(inventory.pk), role_definition=inv_rd).exists()
 
-    # Verify ObjectRole exists
-    ct = ContentType.objects.get_for_model(inventory)
-    assert ObjectRole.objects.filter(
-        content_type=ct, object_id=str(inventory.pk), role_definition=inv_rd
-    ).exists(), "ObjectRole should exist before inventory deletion"
-
-    # Store IDs for verification after deletion
     inventory_id = str(inventory.pk)
-    user_id = alice.pk
 
     # Delete inventory synchronously
     inventory.delete()
 
-    # Verify role assignment is deleted
-    assert not RoleUserAssignment.objects.filter(
-        user_id=user_id, object_id=inventory_id, role_definition=inv_rd
-    ).exists(), "Role assignment should be deleted after inventory deletion"
-
-    # Verify ObjectRole is deleted
-    assert not ObjectRole.objects.filter(
-        content_type=ct, object_id=inventory_id, role_definition=inv_rd
-    ).exists(), "ObjectRole should be deleted after inventory deletion"
+    # Verify role assignment is cleaned up
+    assert not RoleUserAssignment.objects.filter(object_id=inventory_id, role_definition=inv_rd).exists()
 
 
 @pytest.mark.django_db
-def test_role_assignment_deleted_with_inventory_async(inventory, alice, setup_managed_roles):
-    """Test role assignments are deleted when inventory is deleted via async task."""
+def test_inventory_role_assignments_deleted_async(inventory, alice, setup_managed_roles):
+    """Test role assignments are properly cleaned up when inventory is deleted asynchronously."""
     # Get the managed Inventory Admin role definition
     inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
 
@@ -60,9 +42,7 @@ def test_role_assignment_deleted_with_inventory_async(inventory, alice, setup_ma
     user_id = alice.pk
 
     # Verify assignment exists before deletion
-    assert RoleUserAssignment.objects.filter(
-        user=alice, object_id=str(inventory_id), role_definition=inv_rd
-    ).exists(), "Role assignment should exist before async deletion"
+    assert RoleUserAssignment.objects.filter(user=alice, object_id=str(inventory_id), role_definition=inv_rd).exists()
 
     # Mark as pending deletion and call async task directly
     inventory.pending_deletion = True
@@ -71,15 +51,13 @@ def test_role_assignment_deleted_with_inventory_async(inventory, alice, setup_ma
     # Call the actual deletion task (runs synchronously in tests)
     delete_inventory(inventory_id, user_id)
 
-    # Verify role assignment is deleted
-    assert not RoleUserAssignment.objects.filter(
-        user_id=user_id, object_id=str(inventory_id), role_definition=inv_rd
-    ).exists(), "Role assignment should be deleted after async inventory deletion"
+    # Verify role assignment is cleaned up
+    assert not RoleUserAssignment.objects.filter(user_id=user_id, object_id=str(inventory_id), role_definition=inv_rd).exists()
 
 
 @pytest.mark.django_db
-def test_multiple_role_assignments_cleanup(inventory, alice, bob, setup_managed_roles):
-    """Test multiple role assignments for same inventory are all deleted."""
+def test_multiple_inventory_role_assignments_cleanup(inventory, alice, bob, setup_managed_roles):
+    """Test multiple role assignments are cleaned up when inventory is deleted."""
     # Get managed role definitions
     inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
     use_rd = RoleDefinition.objects.get(name='Inventory Use')
@@ -90,132 +68,35 @@ def test_multiple_role_assignments_cleanup(inventory, alice, bob, setup_managed_
 
     inventory_id = str(inventory.pk)
 
-    # Verify both assignments exist
-    assignments_count = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
-    assert assignments_count == 2, f"Should have 2 role assignments, but found {assignments_count}"
+    # Verify assignments exist
+    assert RoleUserAssignment.objects.filter(object_id=inventory_id).count() == 2
 
     # Delete inventory
     inventory.delete()
 
-    # Verify all assignments are deleted
-    remaining_assignments = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
-    assert remaining_assignments == 0, f"All role assignments should be deleted, but found " f"{remaining_assignments}"
+    # Verify all assignments are cleaned up
+    assert RoleUserAssignment.objects.filter(object_id=inventory_id).count() == 0
 
 
 @pytest.mark.django_db
-def test_other_inventory_assignments_unaffected(inventory, alice, organization, setup_managed_roles):
-    """Test that deleting one inventory doesn't affect role assignments for other inventories."""
-    # Create second inventory
-    inventory2 = Inventory.objects.create(name='Test Inventory 2', organization=organization)
-
-    # Get managed role definition
-    inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
-
-    # Create assignments for both inventories
-    inv_rd.give_permission(alice, inventory)
-    inv_rd.give_permission(alice, inventory2)
-
-    inventory1_id = str(inventory.pk)
-    inventory2_id = str(inventory2.pk)
-
-    # Verify both assignments exist
-    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory1_id, role_definition=inv_rd).exists(), "First inventory assignment should exist"
-
-    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory2_id, role_definition=inv_rd).exists(), "Second inventory assignment should exist"
-
-    # Delete first inventory
-    inventory.delete()
-
-    # Verify first assignment deleted, second preserved
-    assert not RoleUserAssignment.objects.filter(
-        user=alice, object_id=inventory1_id, role_definition=inv_rd
-    ).exists(), "First inventory assignment should be deleted"
-
-    assert RoleUserAssignment.objects.filter(
-        user=alice, object_id=inventory2_id, role_definition=inv_rd
-    ).exists(), "Second inventory assignment should still exist"
-
-
-@pytest.mark.django_db
-def test_inventory_deletion_with_no_assignments(inventory, setup_managed_roles):
-    """Test inventory deletion works normally when there are no role assignments."""
-    inventory_id = inventory.pk
-
-    # Verify no role assignments exist
-    assert RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count() == 0, "Should have no role assignments initially"
-
-    # Delete inventory - should work without errors
-    inventory.delete()
-
-    # Verify inventory is deleted
-    assert not Inventory.objects.filter(pk=inventory_id).exists(), "Inventory should be deleted"
-
-
-@pytest.mark.django_db
-def test_aap_52518_exact_reproduction(organization, setup_managed_roles):
-    """Test the exact scenario described in AAP-52518 Jira ticket."""
-    # Step 1: Create an Organization and a User
+def test_aap_52518_reproduction(organization, setup_managed_roles):
+    """Test the exact scenario described in AAP-52518."""
+    # Create user and inventory per Jira scenario
     user = User.objects.create(username='testuser', email='testuser@example.com', is_active=True)
-
-    # Step 2: Create a Controller inventory in that org
     inventory = Inventory.objects.create(name='Test Controller Inventory', organization=organization, description='Test inventory for AAP-52518')
 
-    # Step 3: Create a role user assignment for the user to become Inventory Admin
+    # Step 3: Create role user assignment for user to become Inventory Admin
     inv_admin_role = RoleDefinition.objects.get(name='Inventory Admin')
+    inv_admin_role.give_permission(user, inventory)
 
-    # Give the user Inventory Admin permission on this inventory
-    role_assignment = inv_admin_role.give_permission(user, inventory)
+    # Verify assignment was created
+    assert RoleUserAssignment.objects.filter(user=user, object_id=str(inventory.pk), role_definition=inv_admin_role).exists()
 
-    # Verify the role assignment was created
-    assignment_id = role_assignment.id
-    assert RoleUserAssignment.objects.filter(id=assignment_id).exists(), "Role assignment should exist after creation"
-
-    # Store data for verification after deletion
     inventory_id = inventory.pk
     user_id = user.pk
 
     # Step 4: Delete the inventory
     inventory.delete()
 
-    # Step 5: Check the role_user_assignments list - should be empty
-    assignments_after = RoleUserAssignment.objects.filter(user_id=user_id, object_id=str(inventory_id)).count()
-    assert assignments_after == 0, "Role assignment should be completely removed after inventory deletion"
-
-    # Additional verification: Ensure no orphaned records exist
-    assert not RoleUserAssignment.objects.filter(
-        user_id=user_id, object_id=str(inventory_id)
-    ).exists(), "No role assignments should exist for deleted inventory"
-
-    # Verify ObjectRole was also cleaned up
-    ct = ContentType.objects.get_for_model(Inventory)
-    assert not ObjectRole.objects.filter(content_type=ct, object_id=str(inventory_id)).exists(), "No ObjectRole should exist for deleted inventory"
-
-
-@pytest.mark.django_db
-def test_multiple_users_same_inventory_cleanup(inventory, setup_managed_roles):
-    """Test cleanup works when multiple users have roles on the same inventory."""
-    # Create additional users
-    user2 = User.objects.create(username='testuser2', email='test2@example.com')
-    user3 = User.objects.create(username='testuser3', email='test3@example.com')
-
-    # Get managed role definitions
-    admin_role = RoleDefinition.objects.get(name='Inventory Admin')
-    use_role = RoleDefinition.objects.get(name='Inventory Use')
-
-    # Assign different roles to different users
-    admin_role.give_permission(user2, inventory)
-    admin_role.give_permission(user3, inventory)
-    use_role.give_permission(user3, inventory)
-
-    inventory_id = inventory.pk
-
-    # Verify all assignments exist
-    assignments_before = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
-    assert assignments_before == 3, "Should have 3 role assignments"
-
-    # Delete inventory
-    inventory.delete()
-
-    # Verify all assignments are cleaned up
-    assignments_after = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
-    assert assignments_after == 0, "All assignments should be deleted"
+    # Step 5: Verify no orphaned role assignments remain
+    assert RoleUserAssignment.objects.filter(user_id=user_id, object_id=str(inventory_id)).count() == 0

--- a/awx/main/tests/functional/dab_rbac/test_inventory_role_cleanup.py
+++ b/awx/main/tests/functional/dab_rbac/test_inventory_role_cleanup.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2024 Ansible, Inc.
+# All Rights Reserved.
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+
+from awx.main.models import Inventory, Organization, User
+from awx.main.tasks.system import delete_inventory
+from ansible_base.rbac.models import RoleUserAssignment, ObjectRole, RoleDefinition
+
+
+@pytest.mark.django_db
+def test_role_assignment_deleted_with_inventory_sync(inventory, alice):
+    """Test role assignments are deleted when inventory is deleted synchronously."""
+    # Get or create the Inventory Admin role definition
+    try:
+        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+
+    # Create a role assignment for the inventory
+    assignment = inv_rd.give_permission(alice, inventory)
+
+    # Verify assignment exists
+    assert RoleUserAssignment.objects.filter(
+        user=alice, object_id=str(inventory.pk), role_definition=inv_rd
+    ).exists(), "Role assignment should exist before inventory deletion"
+
+    # Verify ObjectRole exists
+    ct = ContentType.objects.get_for_model(inventory)
+    assert ObjectRole.objects.filter(
+        content_type=ct, object_id=str(inventory.pk), role_definition=inv_rd
+    ).exists(), "ObjectRole should exist before inventory deletion"
+
+    # Store IDs for verification after deletion
+    inventory_id = str(inventory.pk)
+    user_id = alice.pk
+
+    # Delete inventory synchronously
+    inventory.delete()
+
+    # Verify role assignment is deleted
+    assert not RoleUserAssignment.objects.filter(
+        user_id=user_id, object_id=inventory_id, role_definition=inv_rd
+    ).exists(), "Role assignment should be deleted after inventory deletion"
+
+    # Verify ObjectRole is deleted
+    assert not ObjectRole.objects.filter(
+        content_type=ct, object_id=inventory_id, role_definition=inv_rd
+    ).exists(), "ObjectRole should be deleted after inventory deletion"
+
+
+@pytest.mark.django_db
+def test_role_assignment_deleted_with_inventory_async(inventory, alice):
+    """Test role assignments are deleted when inventory is deleted via async task."""
+    # Get or create the Inventory Admin role definition
+    try:
+        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+
+    # Create a role assignment for the inventory
+    assignment = inv_rd.give_permission(alice, inventory)
+
+    inventory_id = inventory.pk
+    user_id = alice.pk
+
+    # Verify assignment exists before deletion
+    assert RoleUserAssignment.objects.filter(
+        user=alice, object_id=str(inventory_id), role_definition=inv_rd
+    ).exists(), "Role assignment should exist before async deletion"
+
+    # Mark as pending deletion and call async task directly
+    inventory.pending_deletion = True
+    inventory.save()
+
+    # Call the actual deletion task (runs synchronously in tests)
+    delete_inventory(inventory_id, user_id)
+
+    # Verify role assignment is deleted
+    assert not RoleUserAssignment.objects.filter(
+        user_id=user_id, object_id=str(inventory_id), role_definition=inv_rd
+    ).exists(), "Role assignment should be deleted after async inventory deletion"
+
+
+@pytest.mark.django_db
+def test_multiple_role_assignments_cleanup(inventory, alice, bob):
+    """Test multiple role assignments for same inventory are all deleted."""
+    # Get or create role definitions
+    try:
+        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+
+    try:
+        use_rd = RoleDefinition.objects.get(name='Inventory Use')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        use_rd = RoleDefinition.objects.create(name='Inventory Use', description='Can use inventory', content_type=ct)
+
+    # Create multiple role assignments
+    assignment1 = inv_rd.give_permission(alice, inventory)
+    assignment2 = use_rd.give_permission(bob, inventory)
+
+    inventory_id = str(inventory.pk)
+
+    # Verify both assignments exist
+    assignments_count = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
+    assert assignments_count == 2, f"Should have 2 role assignments, but found {assignments_count}"
+
+    # Delete inventory
+    inventory.delete()
+
+    # Verify all assignments are deleted
+    remaining_assignments = RoleUserAssignment.objects.filter(object_id=inventory_id).count()
+    assert remaining_assignments == 0, f"All role assignments should be deleted, but found {remaining_assignments}"
+
+
+@pytest.mark.django_db
+def test_other_inventory_assignments_unaffected(inventory, alice, organization):
+    """Test that deleting one inventory doesn't affect role assignments for other inventories."""
+    # Create second inventory
+    inventory2 = Inventory.objects.create(name='Test Inventory 2', organization=organization)
+
+    # Get or create role definition
+    try:
+        inv_rd = RoleDefinition.objects.get(name='Inventory Admin')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        inv_rd = RoleDefinition.objects.create(name='Inventory Admin', description='Can manage inventory', content_type=ct)
+
+    # Create assignments for both inventories
+    assignment1 = inv_rd.give_permission(alice, inventory)
+    assignment2 = inv_rd.give_permission(alice, inventory2)
+
+    inventory1_id = str(inventory.pk)
+    inventory2_id = str(inventory2.pk)
+
+    # Verify both assignments exist
+    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory1_id, role_definition=inv_rd).exists(), "First inventory assignment should exist"
+
+    assert RoleUserAssignment.objects.filter(user=alice, object_id=inventory2_id, role_definition=inv_rd).exists(), "Second inventory assignment should exist"
+
+    # Delete first inventory
+    inventory.delete()
+
+    # Verify first assignment deleted, second preserved
+    assert not RoleUserAssignment.objects.filter(
+        user=alice, object_id=inventory1_id, role_definition=inv_rd
+    ).exists(), "First inventory assignment should be deleted"
+
+    assert RoleUserAssignment.objects.filter(
+        user=alice, object_id=inventory2_id, role_definition=inv_rd
+    ).exists(), "Second inventory assignment should still exist"
+
+
+@pytest.mark.django_db
+def test_inventory_deletion_with_no_assignments(inventory):
+    """Test inventory deletion works normally when there are no role assignments."""
+    inventory_id = inventory.pk
+
+    # Verify no role assignments exist
+    assert RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count() == 0, "Should have no role assignments initially"
+
+    # Delete inventory - should work without errors
+    inventory.delete()
+
+    # Verify inventory is deleted
+    assert not Inventory.objects.filter(pk=inventory_id).exists(), "Inventory should be deleted"
+
+
+@pytest.mark.django_db
+def test_aap_52518_exact_reproduction(organization):
+    """Test the exact scenario described in AAP-52518 Jira ticket."""
+    # Step 1: Create an Organization and a User
+    user = User.objects.create(username='testuser', email='testuser@example.com', is_active=True)
+
+    # Step 2: Create a Controller inventory in that org
+    inventory = Inventory.objects.create(name='Test Controller Inventory', organization=organization, description='Test inventory for AAP-52518')
+
+    # Step 3: Create a role user assignment for the user to become Inventory Admin
+    try:
+        inv_admin_role = RoleDefinition.objects.get(name='Inventory Admin')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        inv_admin_role = RoleDefinition.objects.create(name='Inventory Admin', description='Can administer inventory', content_type=ct)
+
+    # Give the user Inventory Admin permission on this inventory
+    role_assignment = inv_admin_role.give_permission(user, inventory)
+
+    # Verify the role assignment was created
+    assignment_id = role_assignment.id
+    assert RoleUserAssignment.objects.filter(id=assignment_id).exists(), "Role assignment should exist after creation"
+
+    # Store data for verification after deletion
+    inventory_id = inventory.pk
+    user_id = user.pk
+
+    # Step 4: Delete the inventory
+    inventory.delete()
+
+    # Step 5: Check the role_user_assignments list - should be empty
+    assignments_after = RoleUserAssignment.objects.filter(user_id=user_id, object_id=str(inventory_id)).count()
+    assert assignments_after == 0, "Role assignment should be completely removed after inventory deletion"
+
+    # Additional verification: Ensure no orphaned records exist
+    assert not RoleUserAssignment.objects.filter(
+        user_id=user_id, object_id=str(inventory_id)
+    ).exists(), "No role assignments should exist for deleted inventory"
+
+    # Verify ObjectRole was also cleaned up
+    ct = ContentType.objects.get_for_model(Inventory)
+    assert not ObjectRole.objects.filter(content_type=ct, object_id=str(inventory_id)).exists(), "No ObjectRole should exist for deleted inventory"
+
+
+@pytest.mark.django_db
+def test_multiple_users_same_inventory_cleanup(inventory):
+    """Test cleanup works when multiple users have roles on the same inventory."""
+    # Create additional users
+    user2 = User.objects.create(username='testuser2', email='test2@example.com')
+    user3 = User.objects.create(username='testuser3', email='test3@example.com')
+
+    # Create role definitions
+    try:
+        admin_role = RoleDefinition.objects.get(name='Inventory Admin')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        admin_role = RoleDefinition.objects.create(name='Inventory Admin', description='Can administer inventory', content_type=ct)
+
+    try:
+        use_role = RoleDefinition.objects.get(name='Inventory Use')
+    except RoleDefinition.DoesNotExist:
+        ct = ContentType.objects.get_for_model(Inventory)
+        use_role = RoleDefinition.objects.create(name='Inventory Use', description='Can use inventory', content_type=ct)
+
+    # Assign different roles to different users
+    assignment1 = admin_role.give_permission(user2, inventory)
+    assignment2 = admin_role.give_permission(user3, inventory)
+    assignment3 = use_role.give_permission(user3, inventory)
+
+    inventory_id = inventory.pk
+
+    # Verify all assignments exist
+    assignments_before = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
+    assert assignments_before == 3, "Should have 3 role assignments"
+
+    # Delete inventory
+    inventory.delete()
+
+    # Verify all assignments are cleaned up
+    assignments_after = RoleUserAssignment.objects.filter(object_id=str(inventory_id)).count()
+    assert assignments_after == 0, "All assignments should be deleted"


### PR DESCRIPTION
# AAP-52518: Fix Role User Assignment Cleanup on Inventory Deletion

##### SUMMARY

Fixed role assignment orphaning issue where RoleUserAssignment records were not properly cleaned up when Controller inventories were deleted, causing 404 errors in the UI when users attempted to access role assignments for deleted inventories.

**Root Cause**: RBAC post-delete signals (`rbac_post_delete_remove_object_roles`) were not reliably cleaning up ObjectRole records during inventory deletion, particularly in async Celery task contexts. Since RoleUserAssignment records cascade delete via foreign key to ObjectRole, when ObjectRole cleanup failed, the assignments remained orphaned.

**Solution**: Implemented defense-in-depth explicit role cleanup in both deletion paths:
- **Async path**: Enhanced `delete_inventory()` Celery task in `system.py` 
- **Sync path**: Enhanced `Inventory.delete()` model method in `inventory.py`

This ensures role assignment cleanup works regardless of deletion context, signal reliability, or process isolation issues.

**Related AAP-52518**

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- API

##### ADDITIONAL INFORMATION

**Files Modified:**
1. `awx/awx/main/models/inventory.py` - Added explicit ObjectRole cleanup in `delete()` method
2. `awx/awx/main/tasks/system.py` - Added defense-in-depth cleanup in `delete_inventory()` task
3. `awx/awx/main/tests/functional/dab_rbac/test_inventory_role_cleanup.py` - Comprehensive test suite

**Reproduction Steps (Before Fix):**
1. Create organization and user
2. Create Controller inventory  
3. Assign user as "Inventory Admin"
4. Delete inventory
5. Check role_user_assignments API - orphaned records remain
6. UI: Access Management > Users > [User] > Roles > [Assignment] → 404 Not Found

**Expected Behavior (After Fix):**
- Role assignments automatically deleted with inventory
- Clean role_user_assignments API response
- No 404 errors in UI when browsing user roles
- No orphaned database records

**Test Coverage:**
```bash
# Run specific tests for this fix
make test TEST_DIRS=awx/main/tests/functional/dab_rbac/test_inventory_role_cleanup.py

# Tests cover:
- Synchronous deletion cleanup
- Asynchronous deletion cleanup (Celery task)  
- Multiple role assignments per inventory
- Multiple users with roles on same inventory
- Other inventories unaffected by deletion
- Exact AAP-52518 scenario reproduction
```

**Technical Implementation:**
- **inventory.py**: Explicit `ObjectRole.objects.filter(content_type=ct, object_id=self.pk).delete()` before `super().delete()`
- **system.py**: Explicit cleanup before calling `inventory.delete()` in Celery task
- **Cascade deletion**: RoleUserAssignment records automatically deleted via FK constraint
- **Error handling**: Cleanup failures logged but don't prevent inventory deletion
- **Idempotent**: Safe to run multiple times, no side effects

**Verification:**
```python
# Before fix: Orphaned assignments remain
RoleUserAssignment.objects.filter(object_id=str(deleted_inventory_id)).count()  # > 0

# After fix: Clean state  
RoleUserAssignment.objects.filter(object_id=str(deleted_inventory_id)).count()  # = 0
```
