### PR TITLE
AAP-37812 Added mention about setting correct env variable in cli usage

### DIFF
--- a/awxkit/awxkit/cli/docs/source/conf.py
+++ b/awxkit/awxkit/cli/docs/source/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'AWX CLI'
-copyright = '2024, Ansible by Red Hat'
+copyright = '2025, Ansible by Red Hat'
 author = 'Ansible by Red Hat'
 
 
@@ -54,5 +54,5 @@ rst_epilog = '''
 .. |prog| replace:: awx
 .. |at| replace:: automation controller
 .. |At| replace:: Automation controller
-.. |RHAT| replace:: Red Hat Ansible Automation Platform controller
+.. |RHAT| replace:: Red Hat Ansible Automation Platform
 '''

--- a/awxkit/awxkit/cli/docs/source/usage.rst
+++ b/awxkit/awxkit/cli/docs/source/usage.rst
@@ -10,7 +10,7 @@ Installation
 Synopsis
 --------
 
-|prog| commands follow a simple format:
+CLI commands follow a simple format:
 
 .. code:: bash
 
@@ -25,7 +25,14 @@ The ``action`` is the thing you want to do (a verb). Resources generally have a 
 Getting Started
 ---------------
 
-Using |prog| requires some initial configuration.  Here is a simple example for interacting with an AWX or |RHAT| server:
+Using |prog| requires some initial configuration. To execute AWX CLI on |RHAT| 2.5 and later, you must set your environment variable to:
+    
+    .. code:: 
+        
+        AWXKIT_API_BASE_PATH=/api/controller/
+
+
+Here is a simple example for interacting with an AWX or |RHAT| server:
 
 .. code:: bash
 


### PR DESCRIPTION
##### SUMMARY
Added mention in the Usage section of the CLI Guide to resolve issue. The note instructs users to set their env variable so the CLI will work with AAP 2.5.

Other misc fixes include updating the copyright year and fixing variable to drop 'controller" from AAP.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI
 - Docs

##### ADDITIONAL INFORMATION
