### PR TITLE
Bugfix: avoid receptor.conf.lock file conflicts in non-K8S deployments

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -540,18 +540,20 @@ def receptor_address_saved(sender, instance, **kwargs):
             with disable_activity_stream():
                 for control_instance in control_instances:
                     InstanceLink.objects.update_or_create(source=control_instance, target=address)
-                schedule_write_receptor_config()
+                if settings.IS_K8S:
+                    schedule_write_receptor_config()
     else:
         if address.peers_from.exists():
             with disable_activity_stream():
                 address.peers_from.remove(*control_instances)
-                schedule_write_receptor_config()
+                if settings.IS_K8S:
+                    schedule_write_receptor_config()
 
 
 @receiver(post_delete, sender=ReceptorAddress)
 def receptor_address_deleted(sender, instance, **kwargs):
     address = instance
-    if address.peers_from_control_nodes:
+    if address.peers_from_control_nodes and settings.IS_K8S:
         schedule_write_receptor_config()
 
 


### PR DESCRIPTION
##### SUMMARY
This PR fixes an error that occurs when AWX attempts to acquire a `receptor.conf` lock in non-K8S environments.

Since `receptor.conf` is not written to outside of Kubernetes, attempting to grab the lock is unnecessary and causes the error:
`OSError: [Errno 30] Read-only file system: '/etc/receptor/receptor.conf.lock'`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
To reproduce this error , run fresh migrations or create/update `ReceptorAddress` instance to trigger the `post_save` signal handler:
```bash
awx-manage shell
```
```py
from awx.main.models.ha import ReceptorAddress
addr = ReceptorAddress.objects.first()
addr.save()
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Receptor configuration writes for High Availability are now restricted to Kubernetes deployments.
  * This prevents unnecessary configuration updates in non-Kubernetes environments when HA receptor endpoints are added or removed, reducing unintended writebacks and improving stability during HA node changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->