### PR TITLE
[AAP-44277] License module now validates API responses for subscription IDs. (Moved from Tower)

### DIFF
--- a/awx_collection/plugins/modules/license.py
+++ b/awx_collection/plugins/modules/license.py
@@ -67,6 +67,7 @@ EXAMPLES = '''
 '''
 
 import base64
+
 from ..module_utils.controller_api import ControllerAPIModule
 
 
@@ -120,11 +121,17 @@ def main():
 
     # Do the actual install, if we need to
     if perform_install:
-        json_output['changed'] = True
         if module.params.get('manifest', None):
-            module.post_endpoint('config', data={'manifest': manifest.decode()})
+            response = module.post_endpoint('config', data={'manifest': manifest.decode()})
         else:
-            module.post_endpoint('config/attach', data={'subscription_id': module.params.get('subscription_id')})
+            response = module.post_endpoint('config/attach', data={'subscription_id': module.params.get('subscription_id')})
+
+        # Check API response for errors (AAP-44277 fix)
+        if response and response.get('status_code', 200) >= 400:
+            error_msg = response.get('json', {}).get('error', 'License operation failed')
+            module.fail_json(msg=error_msg)
+
+        json_output['changed'] = True
 
     module.exit_json(**json_output)
 

--- a/awx_collection/plugins/modules/license.py
+++ b/awx_collection/plugins/modules/license.py
@@ -127,7 +127,7 @@ def main():
             response = module.post_endpoint('config/attach', data={'subscription_id': module.params.get('subscription_id')})
 
         # Check API response for errors (AAP-44277 fix)
-        if response and response.get('status_code', 200) >= 400:
+        if response and response.get('status_code') and response.get('status_code') != 200:
             error_msg = response.get('json', {}).get('error', 'License operation failed')
             module.fail_json(msg=error_msg)
 

--- a/awx_collection/test/awx/test_license_subscription.py
+++ b/awx_collection/test/awx/test_license_subscription.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_license_invalid_subscription_id_should_fail(run_module, admin_user):
+    """Test invalid subscription ID returns failure."""
+    result = run_module('license', {'subscription_id': 'invalid-test-12345', 'state': 'present'}, admin_user)
+
+    assert result.get('failed', False)
+    assert 'msg' in result
+    assert 'subscription' in result['msg'].lower()
+
+
+@pytest.mark.django_db
+def test_license_invalid_manifest_should_fail(run_module, admin_user):
+    """Test invalid manifest returns failure."""
+    result = run_module('license', {'manifest': '/nonexistent/test.zip', 'state': 'present'}, admin_user)
+
+    assert result.get('failed', False)
+    assert 'msg' in result
+
+
+@pytest.mark.django_db
+def test_license_state_absent_works(run_module, admin_user):
+    """Test license removal works."""
+    result = run_module('license', {'state': 'absent'}, admin_user)
+
+    assert not result.get('failed', False)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

(Moved from [Tower](https://github.com/ansible/tower/pull/7106))

Fixes AAP-44277: License module now validates API responses for subscription IDs. Previously, the module ignored API error responses and returned `changed=True` even for invalid subscription IDs. Added response status checking to fail properly when the API returns errors.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

Related AAP-44277

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Controller

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

**Problem**: License module returns success for invalid subscription IDs and manifests
**Root Cause**: Module ignored API error responses (HTTP 400)
**Solution**: Added response.status_code validation before setting changed=True

### Before (incorrect behavior)
```bash
# Invalid subscription ID
ansible-playbook reproduce.yml -v
# Returns: {"changed": True}  # BUG: Should fail instead
```

### After (correct behavior)
```bash
# Invalid subscription ID
ansible-playbook reproduce.yml -v
# Returns: {"failed": True, "msg": "Missing subscription credentials"}
```
