### PR TITLE
Add npm cache path to fix UI building (push images job)

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -85,9 +85,11 @@ jobs:
           cp ../awx-logos/awx/ui/client/assets/* awx/ui/public/static/media/
 
       - name: Setup node and npm for new UI build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: awx/awx/ui/**/package-lock.json
 
       - name: Prebuild new UI for awx image (to speed up build process)
         working-directory: awx

--- a/awx/ui/Makefile
+++ b/awx/ui/Makefile
@@ -87,7 +87,14 @@ ui/src/webpack: $(UI_DIR)/src/node_modules/webpack
 ## True target for ui/src/webpack.
 $(UI_DIR)/src/node_modules/webpack:
 	@echo "=== Installing webpack ==="
-	@cd $(UI_DIR)/src && n 18 && npm install webpack
+	@cd $(UI_DIR)/src && \
+	  maj=$$(node -p "process.versions.node.split('.')[0]"); \
+	  if [ "$$maj" != "18" ]; then \
+	    echo "Error: Need Node 18.x; found $$(node -v)" >&2; \
+	    exit 1; \
+	  fi; \
+	  npm install webpack
+
 
 .PHONY: clean/ui
 ## Clean ui


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/awx/actions/runs/17924583251/job/50967458822

In

 - [push-development-images (awx, awx-kube-buildx)](https://github.com/ansible/awx/actions/runs/17924583251/job/50967458822#logs)
   - Prebuild new UI for awx image (to speed up build process)

we get error

```
Run make ui
  make ui
  shell: /usr/bin/bash -e {0}
  env:
    LC_ALL: C.UTF-8
    DOCKER_CACHE: --no-cache
    DEV_DOCKER_TAG_BASE: ghcr.io/ansible
    COMPOSE_TAG: devel
    py_version: 3
    pythonLocation: /opt/hostedtoolcache/Python/3.13.7/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.13.7/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.7/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.7/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.7/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.13.7/x64/lib
make[1]: Entering directory '/home/runner/work/awx/awx'
=== Setting up awx/ui/src ===
=== Cloning awx/ui/src from main of https://github.com/ansible/ansible-ui.git ===
Cloning into 'awx/ui/src'...
=== Installing webpack ===
  installing : node-v18.20.8
       mkdir : /usr/local/n/versions/node/18.20.8
mkdir: cannot create directory ‘/usr/local/n/versions/node/18.20.8’: Permission denied

  Error: sudo required (or change ownership, or define N_PREFIX)

make[1]: *** [awx/ui/Makefile:90: awx/ui/src/node_modules/webpack] Error 1
make[1]: Leaving directory '/home/runner/work/awx/awx'
make: *** [awx/ui/Makefile:25: awx/ui/build] Error 2
Error: Process completed with exit code 2.
```

this seeks to fix that

started a job to confirm here:

https://github.com/ansible/awx/actions/runs/17934251762

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 - UI
