### PR TITLE
Sharing Credentials Across Organizations

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -721,8 +721,11 @@ class TeamRolesList(SubListAttachDetachAPIView):
         credential_content_type = ContentType.objects.get_for_model(models.Credential)
         if role.content_type == credential_content_type:
             if not role.content_object.organization or role.content_object.organization.id != team.organization.id:
-                data = dict(msg=_("You cannot grant credential access to a team when the Organization field isn't set, or belongs to a different organization"))
-                return Response(data, status=status.HTTP_400_BAD_REQUEST)
+                if not request.user.is_superuser:
+                    data = dict(msg=_("You cannot grant credential access to a team because you do not have permission to do so"))
+                    return Response(data, status=status.HTTP_400_BAD_REQUEST)
+                else:
+                    return super(TeamRolesList, self).post(request, *args, **kwargs)
 
         return super(TeamRolesList, self).post(request, *args, **kwargs)
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4207,9 +4207,15 @@ class RoleTeamsList(SubListAttachDetachAPIView):
 
         credential_content_type = ContentType.objects.get_for_model(models.Credential)
         if role.content_type == credential_content_type:
-            if not role.content_object.organization or role.content_object.organization.id != team.organization.id:
-                data = dict(msg=_("You cannot grant credential access to a team when the Organization field isn't set, or belongs to a different organization"))
+            # Private credentials (no organization) are never allowed for teams
+            if not role.content_object.organization:
+                data = dict(msg=_("You cannot grant private credential access to a team"))
                 return Response(data, status=status.HTTP_400_BAD_REQUEST)
+            # Cross-organization credentials are only allowed for superusers
+            elif role.content_object.organization.id != team.organization.id:
+                if not request.user.is_superuser:
+                    data = dict(msg=_("You cannot grant credential access to a team because you do not have permission to do so"))
+                    return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
         action = 'attach'
         if request.data.get('disassociate', None):

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -721,11 +721,17 @@ class TeamRolesList(SubListAttachDetachAPIView):
         credential_content_type = ContentType.objects.get_for_model(models.Credential)
         if role.content_type == credential_content_type:
             if not role.content_object.organization:
-                data = dict(msg=_("You cannot grant private credential access to a team"))
+                data = dict(
+                    msg=_("You cannot grant access to a credential that is not assigned to an organization (private credentials cannot be assigned to teams)")
+                )
                 return Response(data, status=status.HTTP_400_BAD_REQUEST)
             elif role.content_object.organization.id != team.organization.id:
                 if not request.user.is_superuser:
-                    data = dict(msg=_("You cannot grant credential access to a team because you do not have permission to do so"))
+                    data = dict(
+                        msg=_(
+                            "You cannot grant a team access to a credential in a different organization. Only superusers can grant cross-organization credential access to teams"
+                        )
+                    )
                     return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
         return super(TeamRolesList, self).post(request, *args, **kwargs)
@@ -4209,12 +4215,18 @@ class RoleTeamsList(SubListAttachDetachAPIView):
         if role.content_type == credential_content_type:
             # Private credentials (no organization) are never allowed for teams
             if not role.content_object.organization:
-                data = dict(msg=_("You cannot grant private credential access to a team"))
+                data = dict(
+                    msg=_("You cannot grant access to a credential that is not assigned to an organization (private credentials cannot be assigned to teams)")
+                )
                 return Response(data, status=status.HTTP_400_BAD_REQUEST)
             # Cross-organization credentials are only allowed for superusers
             elif role.content_object.organization.id != team.organization.id:
                 if not request.user.is_superuser:
-                    data = dict(msg=_("You cannot grant credential access to a team because you do not have permission to do so"))
+                    data = dict(
+                        msg=_(
+                            "You cannot grant a team access to a credential in a different organization. Only superusers can grant cross-organization credential access to teams"
+                        )
+                    )
                     return Response(data, status=status.HTTP_400_BAD_REQUEST)
 
         action = 'attach'

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -720,12 +720,13 @@ class TeamRolesList(SubListAttachDetachAPIView):
         team = get_object_or_404(models.Team, pk=self.kwargs['pk'])
         credential_content_type = ContentType.objects.get_for_model(models.Credential)
         if role.content_type == credential_content_type:
-            if not role.content_object.organization or role.content_object.organization.id != team.organization.id:
+            if not role.content_object.organization:
+                data = dict(msg=_("You cannot grant private credential access to a team"))
+                return Response(data, status=status.HTTP_400_BAD_REQUEST)
+            elif role.content_object.organization.id != team.organization.id:
                 if not request.user.is_superuser:
                     data = dict(msg=_("You cannot grant credential access to a team because you do not have permission to do so"))
                     return Response(data, status=status.HTTP_400_BAD_REQUEST)
-                else:
-                    return super(TeamRolesList, self).post(request, *args, **kwargs)
 
         return super(TeamRolesList, self).post(request, *args, **kwargs)
 

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -296,9 +296,15 @@ def test_grant_credential_to_team_different_organization(post, get, credential, 
     team.organization = orgs[1]
     team.save()
 
+    # Non-superuser (org_admin) trying cross-org assignment should get 400
     response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
     assert response.status_code == 400
+    assert (
+        "You do not have permission to grant credential access to a team when the Organization field isn't set, or belongs to a different organization"
+        in response.data['msg']
+    )
 
+    # Superuser (admin) can do cross-org assignment
     response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, admin)
     assert response.status_code == 204
 
@@ -308,16 +314,33 @@ def test_grant_credential_to_team_different_organization(post, get, credential, 
     assert team_member in credential.use_role
     assert team_member not in credential.admin_role
 
-    # Assert: Team member can see the credential in API (functional check)
+    # Team member can see the credential in API (functional check)
     response = get(reverse('api:team_credentials_list', kwargs={'pk': team.id}), team_member)
     assert response.status_code == 200
     assert response.data['count'] == 1
     assert response.data['results'][0]['id'] == credential.id
 
-    # Assert: Team member can see the credential in general credentials API
+    # Team member can see the credential in general credentials API
     response = get(reverse('api:credential_list'), team_member)
     assert response.status_code == 200
     assert any(cred['id'] == credential.id for cred in response.data['results'])
+
+
+@pytest.mark.django_db
+def test_grant_credential_with_no_organization_to_team(post, credential, admin, org_admin, team):
+    """Test granting credential with no organization to a team"""
+    credential.organization = None
+    credential.save()
+
+    # Non-superuser (org_admin) trying to assign private credential should get 400
+    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
+    assert response.status_code == 400
+    assert "You cannot grant private credential access to a team" in response.data['msg']
+
+    # Even superuser cannot assign private credential to team
+    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, admin)
+    assert response.status_code == 400
+    assert "You cannot grant private credential access to a team" in response.data['msg']
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -288,20 +288,61 @@ def test_sa_grant_private_credential_to_team_through_role_teams(post, credential
 
 
 @pytest.mark.django_db
-def test_grant_credential_to_team_different_organization(post, get, credential, organizations, admin, org_admin, team, team_member):
-    """Test that credential from different org can be assigned to team"""
+def test_grant_credential_to_team_different_organization_via_role_teams(post, get, credential, organizations, admin, org_admin, team, team_member):
+    # Test cross-org credential assignment via role_teams_list endpoint
     orgs = organizations(2)
     credential.organization = orgs[0]
     credential.save()
     team.organization = orgs[1]
     team.save()
 
-    # Non-superuser (org_admin) trying cross-org assignment should get 400
-    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
+    # Non-superuser (org_admin) trying cross-org assignment
+    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, org_admin)
     assert response.status_code == 400
     assert "You cannot grant credential access to a team because you do not have permission to do so" in response.data['msg']
 
     # Superuser (admin) can do cross-org assignment
+    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, admin)
+    assert response.status_code == 204
+
+    assert credential.use_role in team.member_role.children.all()
+    assert team_member in credential.read_role
+    assert team_member in credential.use_role
+    assert team_member not in credential.admin_role
+
+
+@pytest.mark.django_db
+def test_grant_credential_with_no_organization_to_team_via_role_teams(post, credential, admin, org_admin, team):
+    # Test private credential access control via role_teams_list endpoint
+    credential.organization = None
+    credential.save()
+
+    # Non-superuser (org_admin) trying to assign private credential should get 400
+    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, org_admin)
+    assert response.status_code == 400
+    assert "You cannot grant private credential access to a team" in response.data['msg']
+
+    # Even superuser cannot assign private credential to team
+    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, admin)
+    assert response.status_code == 400
+    assert "You cannot grant private credential access to a team" in response.data['msg']
+
+
+@pytest.mark.django_db
+def test_grant_credential_to_team_different_organization(post, get, credential, organizations, admin, org_admin, team, team_member):
+    # Test that credential from different org can be assigned to team
+    orgs = organizations(2)
+    credential.organization = orgs[0]
+    credential.save()
+    team.organization = orgs[1]
+    team.save()
+
+    # Non-superuser (org_admin, ...) trying cross-org assignment
+    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
+    assert response.status_code == 400
+    assert "You cannot grant credential access to a team because you do not have permission to do so" in response.data['msg']
+
+    # Superuser (system admin) can do cross-org assignment
     response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, admin)
     assert response.status_code == 204
 
@@ -311,7 +352,7 @@ def test_grant_credential_to_team_different_organization(post, get, credential, 
     assert team_member in credential.use_role
     assert team_member not in credential.admin_role
 
-    # Team member can see the credential in API (functional check)
+    # Team member can see the credential in API
     response = get(reverse('api:team_credentials_list', kwargs={'pk': team.id}), team_member)
     assert response.status_code == 200
     assert response.data['count'] == 1
@@ -325,11 +366,11 @@ def test_grant_credential_to_team_different_organization(post, get, credential, 
 
 @pytest.mark.django_db
 def test_grant_credential_with_no_organization_to_team(post, credential, admin, org_admin, team):
-    """Test granting credential with no organization to a team"""
+    # Test granting credential with no organization to a team
     credential.organization = None
     credential.save()
 
-    # Non-superuser (org_admin) trying to assign private credential should get 400
+    # Non-superuser (org_admin) trying to assign private credential
     response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
     assert response.status_code == 400
     assert "You cannot grant private credential access to a team" in response.data['msg']

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -288,6 +288,39 @@ def test_sa_grant_private_credential_to_team_through_role_teams(post, credential
 
 
 @pytest.mark.django_db
+def test_grant_credential_to_team_different_organization(post, get, credential, organizations, admin, org_admin, team, team_member):
+    """Test that credential from different org can be assigned to team"""
+    orgs = organizations(2)
+    credential.organization = orgs[0]
+    credential.save()
+    team.organization = orgs[1]
+    team.save()
+
+    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
+    assert response.status_code == 400
+
+    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, admin)
+    assert response.status_code == 204
+
+    assert credential.use_role in team.member_role.children.all()
+
+    assert team_member in credential.read_role
+    assert team_member in credential.use_role
+    assert team_member not in credential.admin_role
+
+    # Assert: Team member can see the credential in API (functional check)
+    response = get(reverse('api:team_credentials_list', kwargs={'pk': team.id}), team_member)
+    assert response.status_code == 200
+    assert response.data['count'] == 1
+    assert response.data['results'][0]['id'] == credential.id
+
+    # Assert: Team member can see the credential in general credentials API
+    response = get(reverse('api:credential_list'), team_member)
+    assert response.status_code == 200
+    assert any(cred['id'] == credential.id for cred in response.data['results'])
+
+
+@pytest.mark.django_db
 def test_sa_grant_private_credential_to_team_through_team_roles(post, credential, admin, team):
     # not even a system admin can grant a private cred to a team though
     response = post(reverse('api:role_teams_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, admin)

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -288,8 +288,8 @@ def test_sa_grant_private_credential_to_team_through_role_teams(post, credential
 
 
 @pytest.mark.django_db
-def test_grant_credential_to_team_different_organization_via_role_teams(post, get, credential, organizations, admin, org_admin, team, team_member):
-    # Test cross-org credential assignment via role_teams_list endpoint
+def test_grant_credential_to_team_different_organization_through_role_teams(post, get, credential, organizations, admin, org_admin, team, team_member):
+    # # Test that credential from different org can be assigned to team by a superuser through role_teams_list endpoint
     orgs = organizations(2)
     credential.organization = orgs[0]
     credential.save()
@@ -312,25 +312,8 @@ def test_grant_credential_to_team_different_organization_via_role_teams(post, ge
 
 
 @pytest.mark.django_db
-def test_grant_credential_with_no_organization_to_team_via_role_teams(post, credential, admin, org_admin, team):
-    # Test private credential access control via role_teams_list endpoint
-    credential.organization = None
-    credential.save()
-
-    # Non-superuser (org_admin) trying to assign private credential should get 400
-    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, org_admin)
-    assert response.status_code == 400
-    assert "You cannot grant private credential access to a team" in response.data['msg']
-
-    # Even superuser cannot assign private credential to team
-    response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, admin)
-    assert response.status_code == 400
-    assert "You cannot grant private credential access to a team" in response.data['msg']
-
-
-@pytest.mark.django_db
 def test_grant_credential_to_team_different_organization(post, get, credential, organizations, admin, org_admin, team, team_member):
-    # Test that credential from different org can be assigned to team
+    # Test that credential from different org can be assigned to team by a superuser
     orgs = organizations(2)
     credential.organization = orgs[0]
     credential.save()
@@ -362,23 +345,6 @@ def test_grant_credential_to_team_different_organization(post, get, credential, 
     response = get(reverse('api:credential_list'), team_member)
     assert response.status_code == 200
     assert any(cred['id'] == credential.id for cred in response.data['results'])
-
-
-@pytest.mark.django_db
-def test_grant_credential_with_no_organization_to_team(post, credential, admin, org_admin, team):
-    # Test granting credential with no organization to a team
-    credential.organization = None
-    credential.save()
-
-    # Non-superuser (org_admin) trying to assign private credential
-    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
-    assert response.status_code == 400
-    assert "You cannot grant private credential access to a team" in response.data['msg']
-
-    # Even superuser cannot assign private credential to team
-    response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, admin)
-    assert response.status_code == 400
-    assert "You cannot grant private credential access to a team" in response.data['msg']
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -296,10 +296,13 @@ def test_grant_credential_to_team_different_organization_through_role_teams(post
     team.organization = orgs[1]
     team.save()
 
-    # Non-superuser (org_admin) trying cross-org assignment
+    # Non-superuser (org_admin) trying cross-org assignment should be denied
     response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, org_admin)
     assert response.status_code == 400
-    assert "You cannot grant credential access to a team because you do not have permission to do so" in response.data['msg']
+    assert (
+        "You cannot grant a team access to a credential in a different organization. Only superusers can grant cross-organization credential access to teams"
+        in response.data['msg']
+    )
 
     # Superuser (admin) can do cross-org assignment
     response = post(reverse('api:role_teams_list', kwargs={'pk': credential.use_role.id}), {'id': team.id}, admin)
@@ -320,10 +323,13 @@ def test_grant_credential_to_team_different_organization(post, get, credential, 
     team.organization = orgs[1]
     team.save()
 
-    # Non-superuser (org_admin, ...) trying cross-org assignment
+    # Non-superuser (org_admin, ...) trying cross-org assignment should be denied
     response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, org_admin)
     assert response.status_code == 400
-    assert "You cannot grant credential access to a team because you do not have permission to do so" in response.data['msg']
+    assert (
+        "You cannot grant a team access to a credential in a different organization. Only superusers can grant cross-organization credential access to teams"
+        in response.data['msg']
+    )
 
     # Superuser (system admin) can do cross-org assignment
     response = post(reverse('api:team_roles_list', kwargs={'pk': team.id}), {'id': credential.use_role.id}, admin)

--- a/tools/docker-compose/inventory
+++ b/tools/docker-compose/inventory
@@ -15,5 +15,6 @@ localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env pyth
 # pg_username=""
 # pg_hostname=""
 
-# awx_image="ghcr.io/ansible/awx_devel"
+awx_image="ghcr.io/ansible/awx_devel"
+awx_image_tag="devel"
 # migrate_local_docker=false

--- a/tools/docker-compose/inventory
+++ b/tools/docker-compose/inventory
@@ -15,6 +15,5 @@ localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env pyth
 # pg_username=""
 # pg_hostname=""
 
-awx_image="ghcr.io/ansible/awx_devel"
-awx_image_tag="devel"
+# awx_image="ghcr.io/ansible/awx_devel"
 # migrate_local_docker=false


### PR DESCRIPTION
##### SUMMARY
At the current state of AWX/Controller, a Credential from an Organization cannot be shared with a Team belong to another Organization. This PR ensured that such an action is possible, given the one taking action is a system administrator.

Jira Issue Link: [AAP-50775](https://issues.redhat.com/browse/AAP-50775)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
These changes:
- Ensured that only system administrator can perform the action of sharing a Credential to Teams in different Organizations (as they are the only ones with read/write access across organizations)
- Added extensive tests to ensure roles are properly transferred


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable superusers to grant a team access to credentials from a different organization (private credentials still disallowed); add functional tests for both endpoints and visibility.
> 
> - **API (Credentials ↔ Teams)**:
>   - `TeamRolesList.post` and `RoleTeamsList.post` now:
>     - Reject credentials without an `organization` (private) for teams.
>     - Permit cross-organization credential assignment only for `superuser`; otherwise return 400 with explicit message.
> - **Tests**:
>   - Add functional tests verifying:
>     - Non-superusers are denied cross-org assignment via `team_roles_list` and `role_teams_list`.
>     - Superusers can assign cross-org credentials; role propagation and team-member visibility in `team_credentials_list` and general `credential_list`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 333ebecdd10521214a4fb429fe515d5c22e0fe0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->