### PR TITLE
Rewrite the s3 upload step to fix breakage with new Ansible version

### DIFF
--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -38,11 +38,11 @@ jobs:
             --workdir=/awx_devel `make print-DEVEL_IMAGE_NAME` /start_tests.sh genschema
 
       - name: Upload API Schema
-        env:
-          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
-          AWS_REGION: 'us-east-1'
-        run: |
-          ansible localhost -c local, -m command -a "{{ ansible_python_interpreter + ' -m pip install boto3'}}"
-          ansible localhost -c local -m aws_s3 \
-            -a "src=${{ github.workspace }}/schema.json bucket=awx-public-ci-files object=${GITHUB_REF##*/}/schema.json mode=put permission=public-read"
+        uses: keithweaver/aws-s3-github-action@v1.0.0
+        with:
+          command: cp
+          source: ${{ github.workspace }}/schema.json
+          destination: s3://awx-public-ci-files/${{ github.ref_name }}/schema.json
+          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY }}
+          aws_secret_access_key: ${{ secrets.AWS_SECRET_KEY }}
+          aws_region: us-east-1

--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -46,3 +46,4 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_KEY }}
           aws_region: us-east-1
+          flags: --acl public-read --only-show-errors

--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -38,7 +38,7 @@ jobs:
             --workdir=/awx_devel `make print-DEVEL_IMAGE_NAME` /start_tests.sh genschema
 
       - name: Upload API Schema
-        uses: keithweaver/aws-s3-github-action@v1.0.0
+        uses: keithweaver/aws-s3-github-action@4dd5a7b81d54abaa23bbac92b27e85d7f405ae53
         with:
           command: cp
           source: ${{ github.workspace }}/schema.json


### PR DESCRIPTION
##### SUMMARY

Schema upload (on push) is failing with:

```
Run ansible localhost -c local, -m command -a "{{ ansible_python_interpreter + ' -m pip install boto3'}}"
  ansible localhost -c local, -m command -a "{{ ansible_python_interpreter + ' -m pip install boto3'}}"
  ansible localhost -c local -m aws_s3 \
    -a "src=/home/runner/work/awx/awx/schema.json bucket=awx-public-ci-files object=${GITHUB_REF##*/}/schema.json mode=put permission=public-read"
  shell: /usr/bin/bash -e {0}
  env:
    LC_ALL: C.UTF-8
    py_version: 3
    pythonLocation: /opt/hostedtoolcache/Python/3.13.7/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.13.7/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.7/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.7/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.13.7/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.13.7/x64/lib
    OWNER_LC: ansible
    SSH_AUTH_SOCK: /tmp/ssh-94NjsaX6Yk2M/agent.2101
    SSH_AGENT_PID: 2102
    AWS_ACCESS_KEY: ***
    AWS_SECRET_KEY: ***
    AWS_REGION: us-east-1
Warning: : No inventory was parsed, only implicit localhost is available
Error: : Unexpected Exception, this is probably a bug: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)

Traceback (most recent call last):
  File "/opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible/cli/__init__.py", line 660, in cli_executor
    exit_code = cli.run()
                ^^^^^^^^^
  File "/opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible/cli/adhoc.py", line 158, in run
    play_ds = self._play_ds(pattern, context.CLIARGS['seconds'], context.CLIARGS['poll_interval'])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible/cli/adhoc.py", line 84, in _play_ds
    module_args = json.loads(module_args_raw, cls=_legacy.Decoder)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 359, in loads
    return cls(**kw).decode(s)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible/_internal/_json/_profiles/_legacy.py", line 189, in raw_decode
    return super().raw_decode(s, idx)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible/module_utils/_internal/_json/_profiles/__init__.py", line 352, in raw_decode
    obj, end = super().raw_decode(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
               ^^^^^^^^^^^^^^^^^^^^^^
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/pipx/venvs/ansible-core/lib/python3.12/site-packages/ansible/cli/__init__.py", line 669, in cli_executor
    raise AnsibleError("Unexpected Exception, this is probably a bug.") from ex
ansible.errors.AnsibleError: Unexpected Exception, this is probably a bug: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

The problematic syntax was introduced in https://github.com/ansible/awx/pull/10711 and is very brittle and hacky.

Uses, modeled after example at:

https://github.com/marketplace/actions/aws-s3-github-action


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches schema upload to use aws-s3-github-action to copy schema.json to S3 with public-read ACL.
> 
> - **CI/CD**:
>   - **Workflow `/.github/workflows/upload_schema.yml`**: Replace Ansible-based `aws_s3` upload with `keithweaver/aws-s3-github-action` using `cp`.
>     - Sets `source` to `${{ github.workspace }}/schema.json` and `destination` to `s3://awx-public-ci-files/${{ github.ref_name }}/schema.json`.
>     - Supplies `aws_access_key_id`, `aws_secret_access_key`, `aws_region`, and flags `--acl public-read --only-show-errors`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3efdac1f6ff81b6ecd76535fe56217418b98d7ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->