### PR TITLE
Make project and private data directories 0o700

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -237,7 +237,7 @@ class BaseTask(object):
         for subfolder in ('inventory', 'env'):
             runner_subfolder = os.path.join(path, subfolder)
             if not os.path.exists(runner_subfolder):
-                os.mkdir(runner_subfolder)
+                os.mkdir(runner_subfolder, 0o700)
         return path
 
     def build_project_dir(self, instance, private_data_dir):
@@ -247,7 +247,7 @@ class BaseTask(object):
         """
         project_dir = os.path.join(private_data_dir, 'project')
         if not os.path.exists(project_dir):
-            os.mkdir(project_dir)
+            os.mkdir(project_dir, 0o700)
 
     def build_private_data_files(self, instance, private_data_dir):
         """


### PR DESCRIPTION
##### SUMMARY
Python's `os.mkdir` creates directories with 0o777 by default. When the project directory is created on the fly by AWX this results in the following warning:

```
[WARNING] Ansible is being run in a world writable directory (/...),
ignoring it as an ansible.cfg source. For more information see ...
```

This makes the project and private data directories only readable by the user that AWX is running as.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other
