### PR TITLE
Gracefully handle hostname change in metrics code

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -456,7 +456,10 @@ class CustomToPrometheusMetricsCollector(prometheus_client.registry.Collector):
             logger.debug(f"No metric data not found in redis for metric namespace '{self._metrics._namespace}'")
             return None
 
-        host_metrics = instance_data.get(my_hostname)
+        if not (host_metrics := instance_data.get(my_hostname)):
+            logger.debug(f"Metric data for this node '{my_hostname}' not found in redis for metric namespace '{self._metrics._namespace}'")
+            return None
+
         for _, metric in self._metrics.METRICS.items():
             entry = host_metrics.get(metric.field)
             if not entry:


### PR DESCRIPTION
##### SUMMARY
* Previously, we would error out because we assumed that when we got a metrics payload from redis, that there was data in it and it was for the current host.
* Now, we do not assume that since we got a metrics payload, that is well formed and for the current hostname because the hostname could have changed and we could have not yet collected metrics for the new host.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION

## Steps to test:

* Do these steps before this fix to ensure you get the traceback and after the fix to ensure you no longer get the traceback

```
awx-manage shell_plus

# Happy path

from awx.main.analytics.subsystem_metrics import *
m=CallbackReceiverMetricsServer()
list(m._registry.collect())

# [Metric(callback_receiver_batch_events_insert_db, Number of events batch inserted into database, histogram, , [Sample(name='callback_receiver_batch_events_insert_db_bucket', labels={'le': '10'}, value='0', timestamp=None, exemplar=None), Sample(name='callback_receiver_batch_events_insert_db_bucket', labels={'le': '50'}, value='0', timestamp=None, exemplar=None), Sample(name='callback_receiver_batch_events_insert_db_bucket', labels={'le': '150'}, value='0', timestamp=None, exemplar=None), Sample(name='callback_receiver_batch_events_insert_db_bucket', labels={'le': '350'}, value='0', timestamp=None, exemplar=None), Sample(name='callback_receiver_batch_events_insert_db_bucket', labels={'le': '650'}, value='0', timestamp=None, exemplar=None), Sample(name='callback_receiver_batch_events_insert_db_bucket', labels={'le': '2000'}, value='0', timestamp=None, exemplar=None), Sample(name='callback_receiver_batch_events_insert_db_count', labels={}, value='0', timestamp=None, exemplar=None), Sample(name='callback_receiver_batch_events_insert_db_sum', labels={}, value=0, timestamp=None, exemplar=None)])]

# Hostname change path

settings.CLUSTER_HOST_ID = 'foobar'
Instance.objects.update(hostname='foobar')

# Before this change, the below operation would cause a traceback
m=CallbackReceiverMetricsServer()
list(m._registry.collect())

# []
```

These changes fix this traceback:

```
Traceback (most recent call last):
  File "/usr/bin/awx-manage", line 8, in <module>
    sys.exit(manage())
             ^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/__init__.py", line 178, in manage
    execute_from_command_line(sys.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/management/commands/run_dispatcher.py", line 66, in handle
    DispatcherMetricsServer().start()
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/analytics/subsystem_metrics.py", line 462, in __init__
    registry.register(CustomToPrometheusMetricsCollector(CallbackReceiverMetrics(metrics_have_changed=False)))
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/prometheus_client/registry.py", line 40, in register
    names = self._get_names(collector)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/prometheus_client/registry.py", line 80, in _get_names
    for metric in desc_func():
  File "/var/lib/awx/venv/awx/lib64/python3.11/site-packages/awx/main/analytics/subsystem_metrics.py", line 440, in collect
    entry = host_metrics.get(metric.field)
            ^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoid AttributeError by returning early when redis payload lacks metrics for the current node, with added debug logging.
> 
> - **Metrics (subsystem)**:
>   - `CustomToPrometheusMetricsCollector.collect` now returns early if `instance_data` lacks current node `settings.CLUSTER_HOST_ID` metrics, adding a debug log.
>   - Prevents attempts to access fields on `None` (avoids AttributeError) before yielding `GaugeMetricFamily`/`HistogramMetricFamily`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 110736f98e3d4c327ba336ad89b8ca8cbff176bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->