### PR TITLE
Make subscriptions credentials mutually exclusive

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -155,6 +155,7 @@ register(
     help_text=_('Username used to retrieve subscription and content information'),  # noqa
     category=_('System'),
     category_slug='system',
+    hidden=True,
 )
 
 register(
@@ -168,6 +169,7 @@ register(
     help_text=_('Password used to retrieve subscription and content information'),  # noqa
     category=_('System'),
     category_slug='system',
+    hidden=True,
 )
 
 
@@ -182,6 +184,7 @@ register(
     help_text=_('Client ID used to retrieve subscription and content information'),  # noqa
     category=_('System'),
     category_slug='system',
+    hidden=True,
 )
 
 register(
@@ -195,6 +198,7 @@ register(
     help_text=_('Client secret used to retrieve subscription and content information'),  # noqa
     category=_('System'),
     category_slug='system',
+    hidden=True,
 )
 
 register(


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`settings.SUBSCRIPTIONS_USERNAME` and
`settings.SUBSCRIPTIONS_CLIENT_ID`

should be mutually exclusive. This is because the POST to api/v2/config/attach/ accepts only a subscription_id, and infers which credentials to use based on settings. If both are set, it is ambiguous and can lead to unexpected 400s when attempting to attach a license.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces mutual exclusivity between basic auth and service account subscription credentials, hides these settings, and updates tests accordingly.
> 
> - **API**:
>   - `ApiV2SubscriptionView.post`: Enforces mutual exclusion between basic auth (`SUBSCRIPTIONS_USERNAME/PASSWORD`) and service account (`SUBSCRIPTIONS_CLIENT_ID/SECRET`) by clearing the alternate pair when one is set.
>   - Removes plumbing of service account credentials into `REDHAT_USERNAME/PASSWORD`.
> - **Settings**:
>   - Hide subscription credential settings: `SUBSCRIPTIONS_USERNAME`, `SUBSCRIPTIONS_PASSWORD`, `SUBSCRIPTIONS_CLIENT_ID`, `SUBSCRIPTIONS_CLIENT_SECRET` (`hidden=True`).
> - **Tests** (`awx/main/tests/functional/api/test_licensing.py`):
>   - Add tests for exception handling, mixed credentials prioritizing `client_id`, and that setting one credential type clears the other.
>   - Remove tests asserting analytics (`REDHAT_*`) plumbing behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 647d0a5ab69e7ffd25791d3b96f4f07da9b22ae8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->