### PR TITLE
Fix f-string in log that is broken

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1321,7 +1321,7 @@ class RunProjectUpdate(BaseTask):
 
         galaxy_creds_are_defined = project_update.project.organization and project_update.project.organization.galaxy_credentials.exists()
         if not galaxy_creds_are_defined and (settings.AWX_ROLES_ENABLED or settings.AWX_COLLECTIONS_ENABLED):
-            logger.warning('Galaxy role/collection syncing is enabled, but no credentials are configured for {project_update.project.organization}.')
+            logger.warning(f'Galaxy role/collection syncing is enabled, but no credentials are configured for {project_update.project.organization}.')
 
         extra_vars.update(
             {


### PR DESCRIPTION
##### SUMMARY
It seems that this was my bug introduced in https://github.com/ansible/awx/pull/14112

Saw in logs:

```
2025-10-14 15:18:06,947 WARNING  [ce74e7edbf084373a52cfc42c57cac7e] awx.main.tasks.jobs Galaxy role/collection syncing is enabled, but no credentials are configured for {project_update.project.organization}.
```

That's an obvious goof. At some point, this log was working, and this changes it to the original behavior.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes the Galaxy role/collection syncing warning to interpolate the organization name in `awx/main/tasks/jobs.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fca1aca6e7ef6b6b569ad9982eb0015d8172d436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->