### PR TITLE
Fix migration failure for 0200

### DIFF
--- a/awx/main/migrations/0200_template_name_constraint.py
+++ b/awx/main/migrations/0200_template_name_constraint.py
@@ -38,13 +38,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(rename_jts, migrations.RunPython.noop),
-        migrations.RunPython(rename_projects, migrations.RunPython.noop),
         migrations.AddField(
             model_name='unifiedjobtemplate',
             name='org_unique',
             field=models.BooleanField(blank=True, default=True, editable=False, help_text='Used internally to selectively enforce database constraint on name'),
         ),
+        migrations.RunPython(rename_jts, migrations.RunPython.noop),
+        migrations.RunPython(rename_projects, migrations.RunPython.noop),
         migrations.RunPython(rename_wfjt, migrations.RunPython.noop),
         migrations.RunPython(change_inventory_source_org_unique, migrations.RunPython.noop),
         migrations.AddConstraint(


### PR DESCRIPTION
##### SUMMARY
Moved the AddField operation before the RunPython operations for 'rename_jts' and 'rename_projects' in migration 0200_template_name_constraint.py. This ensures the new 'org_unique' field exists before related data migrations are executed.

Fix
```
django.db.utils.ProgrammingError: column main_unifiedjobtemplate.org_unique does not exist
```

while applying migration 0200_template_name_constraint.py

when there's a job template or poject with duplicate name in the same org


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
