### PR TITLE
[awx collection] - Enabling selecting a source project from other organization for inventory sources

### DIFF
--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -284,9 +284,9 @@ def main():
     if ee is not None:
         inventory_source_fields['execution_environment'] = module.resolve_name_to_id('execution_environments', ee)
     if source_project is not None:
-        source_project_object = module.get_one('projects', name_or_id=source_project, data=lookup_data)
+        source_project_object = module.get_one('projects', name_or_id=source_project)
         if not source_project_object:
-            module.fail_json(msg='The specified source project, {0}, was not found.'.format(lookup_data))
+            module.fail_json(msg='The specified source project, {0}, was not found.'.format(source_project))
         inventory_source_fields['source_project'] = source_project_object['id']
 
     OPTIONAL_VARS = (


### PR DESCRIPTION
##### SUMMARY

Enable Selecting Source Project from Other Organizations for Inventory Sources


This change updates the inventory_source module to allow specifying a source project that belongs to a different organization. Previously, the module only supported selecting source projects within the same organization.

**Changes:**

- Updated the retrieval of the source_project object to remove unnecessary lookup_data filtering.
- Ensures the module checks for the existence of the specified project across organizations.
- Provides a clear error message if the project cannot be found.

**Impact:**

- Users can now create inventory sources using projects from other organizations, enabling cross-organization automation and resource sharing.
- Backwards-compatible with existing workflows that use projects within the same organization.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
