### PR TITLE
Fix failing Collection CI Checks 

### DIFF
--- a/.github/actions/awx_devel_image/action.yml
+++ b/.github/actions/awx_devel_image/action.yml
@@ -11,8 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: ./.github/actions/setup-python
-
     - name: Set lower case owner name
       shell: bash
       run: echo "OWNER_LC=${OWNER,,}" >> $GITHUB_ENV

--- a/.github/actions/run_awx_devel/action.yml
+++ b/.github/actions/run_awx_devel/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Upgrade ansible-core
       shell: bash
-      run: python3 -m pip install --upgrade ansible-core
+      run: python -m pip install --upgrade ansible-core
 
     - name: Install system deps
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
 
       - uses: ./.github/actions/setup-python
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - uses: ./.github/actions/run_awx_devel
         id: awx
@@ -372,7 +372,7 @@ jobs:
 
       - uses: ./.github/actions/setup-python
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Upgrade ansible-core
         run: python3 -m pip install --upgrade ansible-core

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,11 +390,11 @@ jobs:
           mkdir -p ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage
           cp -rv coverage/* ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage/
           cd ~/.ansible/collections/ansible_collections/awx/awx
-          python3 -m ansible_test coverage combine --requirements
-          python3 -m ansible_test coverage html
+          python -m ansible.test coverage combine --requirements
+          python -m ansible.test coverage html
           echo '## AWX Collection Integration Coverage' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          python3 -m ansible_test coverage report >> $GITHUB_STEP_SUMMARY
+          python -m ansible.test coverage report >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
           echo '## AWX Collection Integration Coverage HTML' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
 
       - uses: ./.github/actions/setup-python
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - uses: ./.github/actions/run_awx_devel
         id: awx
@@ -188,7 +188,7 @@ jobs:
       - name: Setup python, referencing action at awx relative path
         uses: ./awx/.github/actions/setup-python
         with:
-          python-version: '3.x'
+          python-version: '3.13'
 
       - name: Install playbook dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,10 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Remove system ansible to avoid conflicts
+        run: |
+          python -m pip uninstall -y ansible ansible-core || true
+
       - uses: ./.github/actions/run_awx_devel
         id: awx
         with:
@@ -307,6 +311,7 @@ jobs:
         run: |
           python -m pip install -e ./awxkit/
           python -m pip install -r awx_collection/requirements.txt
+          hash -r  # Rehash to pick up newly installed scripts
 
       - name: Run integration tests
         id: make-run
@@ -374,6 +379,10 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Remove system ansible to avoid conflicts
+        run: |
+          python -m pip uninstall -y ansible ansible-core || true
+
       - name: Upgrade ansible-core
         run: python -m pip install --upgrade ansible-core
 
@@ -390,11 +399,12 @@ jobs:
           mkdir -p ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage
           cp -rv coverage/* ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage/
           cd ~/.ansible/collections/ansible_collections/awx/awx
-          ansible-test coverage combine --requirements
-          ansible-test coverage html
+          hash -r  # Rehash to pick up newly installed scripts
+          PATH="$(python -c 'import sys; import os; print(os.path.dirname(sys.executable))'):$PATH" ansible-test coverage combine --requirements
+          PATH="$(python -c 'import sys; import os; print(os.path.dirname(sys.executable))'):$PATH" ansible-test coverage html
           echo '## AWX Collection Integration Coverage' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          ansible-test coverage report >> $GITHUB_STEP_SUMMARY
+          PATH="$(python -c 'import sys; import os; print(os.path.dirname(sys.executable))'):$PATH" ansible-test coverage report >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
           echo '## AWX Collection Integration Coverage HTML' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,11 +390,11 @@ jobs:
           mkdir -p ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage
           cp -rv coverage/* ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage/
           cd ~/.ansible/collections/ansible_collections/awx/awx
-          ansible-test coverage combine --requirements
-          ansible-test coverage html
+          python3 -m ansible_test coverage combine --requirements
+          python3 -m ansible_test coverage html
           echo '## AWX Collection Integration Coverage' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          ansible-test coverage report >> $GITHUB_STEP_SUMMARY
+          python3 -m ansible_test coverage report >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
           echo '## AWX Collection Integration Coverage HTML' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,7 @@ jobs:
           echo 'password = password' >> ~/.tower_cli.cfg
           echo 'verify_ssl = false' >> ~/.tower_cli.cfg
           TARGETS="$(ls awx_collection/tests/integration/targets | grep '${{ matrix.target-regex.regex }}' | tr '\n' ' ')"
+          export PYTHONPATH="$(python -c 'import site; print(":".join(site.getsitepackages()))')${PYTHONPATH:+:$PYTHONPATH}"
           make COLLECTION_VERSION=100.100.100-git COLLECTION_TEST_TARGET="--requirements $TARGETS" test_collection_integration
         env:
           ANSIBLE_TEST_PREFER_PODMAN: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Install playbook dependencies
         run: |
-          python3 -m pip install docker
+          python -m pip install docker
 
       - name: Build AWX image
         working-directory: awx
@@ -206,8 +206,8 @@ jobs:
       - name: Run test deployment with awx-operator
         working-directory: awx-operator
         run: |
-          python3 -m pip install -r molecule/requirements.txt
-          python3 -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
+          python -m pip install -r molecule/requirements.txt
+          python -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
           $(realpath ../awx/tools/scripts/rewrite-awx-operator-requirements.py) molecule/requirements.yml $(realpath ../awx)
           ansible-galaxy collection install -r molecule/requirements.yml
           sudo rm -f $(which kustomize)
@@ -305,8 +305,8 @@ jobs:
 
       - name: Install dependencies for running tests
         run: |
-          python3 -m pip install -e ./awxkit/
-          python3 -m pip install -r awx_collection/requirements.txt
+          python -m pip install -e ./awxkit/
+          python -m pip install -r awx_collection/requirements.txt
 
       - name: Run integration tests
         id: make-run
@@ -375,7 +375,7 @@ jobs:
           python-version: '3.13'
 
       - name: Upgrade ansible-core
-        run: python3 -m pip install --upgrade ansible-core
+        run: python -m pip install --upgrade ansible-core
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
@@ -390,11 +390,11 @@ jobs:
           mkdir -p ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage
           cp -rv coverage/* ~/.ansible/collections/ansible_collections/awx/awx/tests/output/coverage/
           cd ~/.ansible/collections/ansible_collections/awx/awx
-          python -m ansible.test coverage combine --requirements
-          python -m ansible.test coverage html
+          ansible-test coverage combine --requirements
+          ansible-test coverage html
           echo '## AWX Collection Integration Coverage' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          python -m ansible.test coverage report >> $GITHUB_STEP_SUMMARY
+          ansible-test coverage report >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo >> $GITHUB_STEP_SUMMARY
           echo '## AWX Collection Integration Coverage HTML' >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -433,8 +433,8 @@ test_collection_sanity:
 
 test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
-		python3 -m ansible_test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
-		python3 -m ansible_test coverage xml --requirements --group-by command --group-by version
+		python -m ansible.test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
+		python -m ansible.test coverage xml --requirements --group-by command --group-by version
 	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
 	then \
 	  echo cov-report-files="$$(find "$(COLLECTION_INSTALL)/tests/output/reports/" -type f -name 'coverage=integration*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \

--- a/Makefile
+++ b/Makefile
@@ -433,8 +433,8 @@ test_collection_sanity:
 
 test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
-		python -m ansible.test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
-		python -m ansible.test coverage xml --requirements --group-by command --group-by version
+		ansible-test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
+		ansible-test coverage xml --requirements --group-by command --group-by version
 	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
 	then \
 	  echo cov-report-files="$$(find "$(COLLECTION_INSTALL)/tests/output/reports/" -type f -name 'coverage=integration*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \

--- a/Makefile
+++ b/Makefile
@@ -433,8 +433,8 @@ test_collection_sanity:
 
 test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
-		python$(ANSIBLE_TEST_PYTHON_VERSION) -m ansible_test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
-		python$(ANSIBLE_TEST_PYTHON_VERSION) -m ansible_test coverage xml --requirements --group-by command --group-by version
+		python3 -m ansible_test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
+		python3 -m ansible_test coverage xml --requirements --group-by command --group-by version
 	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
 	then \
 	  echo cov-report-files="$$(find "$(COLLECTION_INSTALL)/tests/output/reports/" -type f -name 'coverage=integration*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ TEST_DIRS ?= awx/main/tests/unit awx/main/tests/functional awx/conf/tests
 PARALLEL_TESTS ?= -n auto
 # collection integration test directories (defaults to all)
 COLLECTION_TEST_TARGET ?=
+# Python version for ansible-test (must be 3.11, 3.12, or 3.13)
+ANSIBLE_TEST_PYTHON_VERSION ?= 3.13
 # args for collection install
 COLLECTION_PACKAGE ?= awx
 COLLECTION_NAMESPACE ?= awx
@@ -431,7 +433,7 @@ test_collection_sanity:
 
 test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
-		ansible-test integration --coverage -vvv $(COLLECTION_TEST_TARGET) && \
+		ansible-test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
 		ansible-test coverage xml --requirements --group-by command --group-by version
 	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
 	then \

--- a/Makefile
+++ b/Makefile
@@ -433,8 +433,9 @@ test_collection_sanity:
 
 test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
-		ansible-test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
-		ansible-test coverage xml --requirements --group-by command --group-by version
+		$(PYTHON) -m pip show ansible-core > /dev/null 2>&1 && \
+		PATH="$$($(PYTHON) -c 'import sys; import os; print(os.path.dirname(sys.executable))'):$$PATH" ansible-test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
+		PATH="$$($(PYTHON) -c 'import sys; import os; print(os.path.dirname(sys.executable))'):$$PATH" ansible-test coverage xml --requirements --group-by command --group-by version
 	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
 	then \
 	  echo cov-report-files="$$(find "$(COLLECTION_INSTALL)/tests/output/reports/" -type f -name 'coverage=integration*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \

--- a/Makefile
+++ b/Makefile
@@ -433,7 +433,6 @@ test_collection_sanity:
 
 test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
-		$(PYTHON) -m pip show ansible-core > /dev/null 2>&1 && \
 		PATH="$$($(PYTHON) -c 'import sys; import os; print(os.path.dirname(sys.executable))'):$$PATH" ansible-test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
 		PATH="$$($(PYTHON) -c 'import sys; import os; print(os.path.dirname(sys.executable))'):$$PATH" ansible-test coverage xml --requirements --group-by command --group-by version
 	@if [ "${GITHUB_ACTIONS}" = "true" ]; \

--- a/Makefile
+++ b/Makefile
@@ -433,8 +433,8 @@ test_collection_sanity:
 
 test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
-		ansible-test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
-		ansible-test coverage xml --requirements --group-by command --group-by version
+		python$(ANSIBLE_TEST_PYTHON_VERSION) -m ansible_test integration --python $(ANSIBLE_TEST_PYTHON_VERSION) --coverage -vvv $(COLLECTION_TEST_TARGET) && \
+		python$(ANSIBLE_TEST_PYTHON_VERSION) -m ansible_test coverage xml --requirements --group-by command --group-by version
 	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
 	then \
 	  echo cov-report-files="$$(find "$(COLLECTION_INSTALL)/tests/output/reports/" -type f -name 'coverage=integration*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \

--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ Get Involved
 We welcome your feedback and ideas via the [Ansible Forum](https://forum.ansible.com/tag/awx).
 
 For a full list of all the ways to talk with the Ansible Community, see the [AWX Communication guide](https://ansible.readthedocs.io/projects/awx/en/latest/contributor/communication.html).
+
+#Dummy Check

--- a/README.md
+++ b/README.md
@@ -49,5 +49,3 @@ Get Involved
 We welcome your feedback and ideas via the [Ansible Forum](https://forum.ansible.com/tag/awx).
 
 For a full list of all the ways to talk with the Ansible Community, see the [AWX Communication guide](https://ansible.readthedocs.io/projects/awx/en/latest/contributor/communication.html).
-
-#Dummy Check


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix the following failing collection CI checks:
  - CI / awx_collection integration (a-h, ^[a-h])
  - CI / awx_collection integration (i-p, ^[i-p])
  - CI / awx_collection integration (r-z0-9, ^[r-z0-9])

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 4.6.20
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes CI on Python 3.13 and hardens collection integration/coverage by fixing Python/ansible-test resolution and environment setup.
> 
> - **CI/Workflows**:
>   - Standardize Python to `3.13` across `dev-env`, `awx-operator`, and `collection-integration` jobs.
>   - Replace `python3 -m pip` with `python -m pip`; add `hash -r` and adjust `PATH` to ensure `ansible-test` resolution.
>   - Uninstall system `ansible`/`ansible-core` before installs to avoid conflicts; explicitly upgrade `ansible-core`.
>   - For collection integration: export `PYTHONPATH` to include site-packages; upload and combine coverage with explicit Python bin `PATH`.
> - **GitHub Actions**:
>   - `run_awx_devel`: use `python -m pip` for upgrading `ansible-core`.
>   - `awx_devel_image`: remove redundant `setup-python` step.
> - **Makefile**:
>   - Add `ANSIBLE_TEST_PYTHON_VERSION` (default `3.13`) and pass `--python` to `ansible-test integration`.
>   - Prefix `ansible-test` invocations with Python bin in `PATH` for integration coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d914625a1514e78874538b7e80a0a455aff17a72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->