### PR TITLE
Try to fix schema collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ swagger: reports
 		. $(VENV_BASE)/awx/bin/activate; \
 	fi; \
 	(set -o pipefail && py.test $(COVERAGE_ARGS) $(PARALLEL_TESTS) awx/conf/tests/functional awx/main/tests/functional/api awx/main/tests/docs | tee reports/$@.report)
-	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
+	@if [ "${GITHUB_ACTIONS}" = "true" ] && [ -n "${GITHUB_OUTPUT}" ]; \
 	then \
 	  echo 'cov-report-files=reports/coverage.xml' >> "${GITHUB_OUTPUT}"; \
 	  echo 'test-result-files=reports/junit.xml' >> "${GITHUB_OUTPUT}"; \
@@ -355,7 +355,7 @@ live_test:
 ## Run all API unit tests with coverage enabled.
 test_coverage:
 	$(MAKE) test PYTEST_ADDOPTS="--create-db $(COVERAGE_ARGS)"
-	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
+	@if [ "${GITHUB_ACTIONS}" = "true" ] && [ -n "${GITHUB_OUTPUT}" ]; \
 	then \
 	  echo 'cov-report-files=awxkit/coverage.xml,reports/coverage.xml' >> "${GITHUB_OUTPUT}"; \
 	  echo 'test-result-files=awxkit/report.xml,reports/junit.xml' >> "${GITHUB_OUTPUT}"; \
@@ -363,7 +363,7 @@ test_coverage:
 
 test_migrations:
 	PYTHONDONTWRITEBYTECODE=1 py.test -p no:cacheprovider --migrations -m migration_test --create-db $(PARALLEL_TESTS) $(COVERAGE_ARGS) $(TEST_DIRS)
-	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
+	@if [ "${GITHUB_ACTIONS}" = "true" ] && [ -n "${GITHUB_OUTPUT}" ]; \
 	then \
 	  echo 'cov-report-files=reports/coverage.xml' >> "${GITHUB_OUTPUT}"; \
 	  echo 'test-result-files=reports/junit.xml' >> "${GITHUB_OUTPUT}"; \
@@ -381,7 +381,7 @@ test_collection:
 	if ! [ -x "$(shell command -v ansible-playbook)" ]; then pip install ansible-core; fi
 	ansible --version
 	py.test $(COLLECTION_TEST_DIRS) $(COVERAGE_ARGS) -v
-	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
+	@if [ "${GITHUB_ACTIONS}" = "true" ] && [ -n "${GITHUB_OUTPUT}" ]; \
 	then \
 	  echo 'cov-report-files=reports/coverage.xml' >> "${GITHUB_OUTPUT}"; \
 	  echo 'test-result-files=reports/junit.xml' >> "${GITHUB_OUTPUT}"; \
@@ -423,7 +423,7 @@ test_collection_sanity:
 	cd $(COLLECTION_INSTALL) && \
 		ansible-test sanity $(COLLECTION_SANITY_ARGS) --coverage --junit && \
 		ansible-test coverage xml --requirements --group-by command --group-by version
-	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
+	@if [ "${GITHUB_ACTIONS}" = "true" ] && [ -n "${GITHUB_OUTPUT}" ]; \
 	then \
 	  echo cov-report-files="$$(find "$(COLLECTION_INSTALL)/tests/output/reports/" -type f -name 'coverage=sanity*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \
 	  echo test-result-files="$$(find "$(COLLECTION_INSTALL)/tests/output/junit/" -type f -name '*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \
@@ -433,7 +433,7 @@ test_collection_integration: install_collection
 	cd $(COLLECTION_INSTALL) && \
 		ansible-test integration --coverage -vvv $(COLLECTION_TEST_TARGET) && \
 		ansible-test coverage xml --requirements --group-by command --group-by version
-	@if [ "${GITHUB_ACTIONS}" = "true" ]; \
+	@if [ "${GITHUB_ACTIONS}" = "true" ] && [ -n "${GITHUB_OUTPUT}" ]; \
 	then \
 	  echo cov-report-files="$$(find "$(COLLECTION_INSTALL)/tests/output/reports/" -type f -name 'coverage=integration*.xml' -print0 | tr '\0' ',' | sed 's#,$$##')" >> "${GITHUB_OUTPUT}"; \
 	fi


### PR DESCRIPTION
##### SUMMARY
I believe that the schema differ job isn't working. This is an attempted fix. Prior error text:

```
docker run -u 1001 --rm -v /home/runner/work/awx/awx:/awx_devel/:Z -e GITHUB_ACTIONS --workdir=/awx_devel ghcr.io/ansible/awx_devel:devel make detect-schema-change SCHEMA_DIFF_BASE_BRANCH=devel
time="2025-10-28T17:35:42Z" level=warning msg="\"/\" is not a shared mount, this could cause issues or missing mounts with rootless containers"
cannot clone: Operation not permitted
Error: cannot re-exec process
mkdir -p reports
make swagger PYTEST_ADDOPTS="--genschema --create-db "
make[1]: Entering directory '/awx_devel'
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-8.4.2, pluggy-1.6.0
django: version: 4.2.21, settings: awx.main.tests.settings_for_test (from ini)
rootdir: /awx_devel
configfile: pytest.ini
plugins: anyio-4.11.0, django-test-migrations-1.5.0, timeout-2.4.0, asyncio-1.2.0, django-4.11.1, cov-7.0.0, xdist-3.8.0, mock-3.15.1
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
created: 2/2 workers
2 workers [1010 items]

........................................................................ [  7%]
........................................................................ [ 14%]
........................................................................ [ 21%]
........................................................................ [ 28%]
........................................................................ [ 35%]
..........s............................................................. [ 42%]
........................................................................ [ 49%]
........................................................................ [ 57%]
........................................................................ [ 64%]
........................................................................ [ 71%]
........................................................................ [ 78%]
........................................................................ [ 85%]
........................................................................ [ 92%]
.............................................................s.......... [ 99%]
..                                                                       [100%]2025-10-28 17:36:00,483 ERROR    [-] awx.conf.settings Error reading something related to database settings: no such table: conf_setting.

=============================== warnings summary ===============================
../var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py:186
../var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py:186
../var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py:186
  /var/lib/awx/venv/awx/lib64/python3.11/site-packages/_pytest/assertion/rewrite.py:186: DeprecationWarning: module 'sre_constants' is deprecated
    exec(co, module.__dict__)

awx/main/tests/functional/api/test_user.py::test_user_verify_attribute_created
  /var/lib/awx/venv/awx/lib64/python3.11/site-packages/django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField User.date_joined received a naive datetime (2020-01-01 00:00:00) while time zone support is active.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
--------------- generated xml file: /awx_devel/reports/junit.xml ---------------
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.11.13-final-0 _______________

Coverage XML written to file ./reports/coverage.xml
=========== 1008 passed, 2 skipped, 4 warnings in 159.54s (0:02:39) ============
bash: line 3: : No such file or directory
bash: line 4: : No such file or directory
make[1]: *** [Makefile:323: swagger] Error 1
make[1]: Leaving directory '/awx_devel'
make: *** [Makefile:318: genschema] Error 2
make: *** [Makefile:374: docker-runner] Error 2
Error: Process completed with exit code 2.
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
