### PR TITLE
Fix extremely flaky failure

### DIFF
--- a/awxkit/test/test_utils.py
+++ b/awxkit/test/test_utils.py
@@ -93,7 +93,12 @@ def test_random_titles_generates_correct_characters(non_ascii):
     title = utils.random_title(non_ascii=non_ascii)
     if non_ascii:
         with pytest.raises(UnicodeEncodeError):
-            title.encode('ascii')
+            # There is a tiny (flaky) chance that random_title will just happen
+            # to generate unicode that is also valid ascii
+            # so we repeat a few times, just to be sure we get non-ascii
+            for i in range(4):
+                title = utils.random_title(non_ascii=non_ascii)
+                title.encode('ascii')
         title.encode('utf-8')
     else:
         title.encode('ascii')


### PR DESCRIPTION
##### SUMMARY
From my data, 4 out of 10,000 test runs will fail with a "DID NOT RAISE" assertion, which is an unintended flaky fail.

While 0.04% is pretty low, we actually have several documented instances of this. So this should take care of it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes the unicode/ascii validation in `test_random_titles_generates_correct_characters` to avoid rare false negatives.
> 
> - In `awxkit/test/test_utils.py`, when `non_ascii=True`, the test now retries `utils.random_title` a few times and encodes to `ascii` inside the `pytest.raises(UnicodeEncodeError)` block to reduce flakiness from occasionally ASCII-safe random output
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31f01452dd3b9ed273b1d16c983ba086cfbc0c73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->