### PR TITLE
Add timeout and on duplicate to system tasks

### DIFF
--- a/awx/main/analytics/analytics_tasks.py
+++ b/awx/main/analytics/analytics_tasks.py
@@ -9,7 +9,7 @@ from awx.main.dispatch import get_task_queuename
 logger = logging.getLogger('awx.main.scheduler')
 
 
-@task_awx(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename, timeout=300, on_duplicate='discard')
 def send_subsystem_metrics():
     DispatcherMetrics().send_metrics()
     CallbackReceiverMetrics().send_metrics()

--- a/awx/main/tasks/host_indirect.py
+++ b/awx/main/tasks/host_indirect.py
@@ -159,7 +159,7 @@ def cleanup_old_indirect_host_entries() -> None:
     IndirectManagedNodeAudit.objects.filter(created__lt=limit).delete()
 
 
-@task(queue=get_task_queuename)
+@task(queue=get_task_queuename, timeout=3600 * 5)
 def save_indirect_host_entries(job_id: int, wait_for_events: bool = True) -> None:
     try:
         job = Job.objects.get(id=job_id)
@@ -201,7 +201,7 @@ def save_indirect_host_entries(job_id: int, wait_for_events: bool = True) -> Non
         logger.exception(f'Error processing indirect host data for job_id={job_id}')
 
 
-@task(queue=get_task_queuename)
+@task(queue=get_task_queuename, timeout=3600 * 5)
 def cleanup_and_save_indirect_host_entries_fallback() -> None:
     if not flag_enabled("FEATURE_INDIRECT_NODE_COUNTING_ENABLED"):
         return

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -852,7 +852,7 @@ def reload_receptor():
         raise RuntimeError("Receptor reload failed")
 
 
-@task_awx()
+@task_awx(on_duplicate='queue_one')
 def write_receptor_config():
     """
     This task runs async on each control node, K8S only.
@@ -875,7 +875,7 @@ def write_receptor_config():
             reload_receptor()
 
 
-@task_awx(queue=get_task_queuename)
+@task_awx(queue=get_task_queuename, on_duplicate='discard')
 def remove_deprovisioned_node(hostname):
     InstanceLink.objects.filter(source__hostname=hostname).update(link_state=InstanceLink.States.REMOVING)
     InstanceLink.objects.filter(target__instance__hostname=hostname).update(link_state=InstanceLink.States.REMOVING)

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -139,7 +139,7 @@ def construct_rsyslog_conf_template(settings=settings):
     return tmpl
 
 
-@task_awx(queue='rsyslog_configurer')
+@task_awx(queue='rsyslog_configurer', timeout=600, on_duplicate='queue_one')
 def reconfigure_rsyslog():
     tmpl = construct_rsyslog_conf_template()
     # Write config to a temp file then move it to preserve atomicity


### PR DESCRIPTION
Modify the invocation of @task_awx to accept `timeout` and `on_duplicate` keyword arguments. These arguments are only used in the new dispatcher implementation.

Added these decorator params to most tasks in system.py
- timeout
- on_duplicate

to ensure better recovery for stuck or long-running processes.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds timeout/on_duplicate to the task decorator and propagates timeouts/duplicate policies across system, receptor, analytics, and logging tasks; removes the obsolete cluster_node_health_check.
> 
> - **Dispatch Core**:
>   - Extend `awx.main.dispatch.publish.task` to accept `timeout` and `on_duplicate`; forward to `dispatcherd.submit_task` with `Blocker.Params` and `processor_options`.
> - **System/Worker Tasks**:
>   - Add timeouts and duplicate policies to many tasks in `awx/main/tasks/system.py` (e.g., `apply_cluster_membership_policies` `queue_one`, `awx_periodic_scheduler` `discard`, reapers, notifications, inventory updates/deletes, smart inventory membership updates `queue_one`, resource sync `discard`, stdout purge `queue_one`, images/files cleanup `queue_one`, handle_removed_image, migrate_jsonfield, deep_copy_model_obj, gather_analytics `discard`).
>   - Receptor-related: `write_receptor_config` `queue_one`; `remove_deprovisioned_node` `discard`.
>   - Indirect host processing: add 5h timeouts to `save_indirect_host_entries` and fallback task.
>   - Analytics: `send_subsystem_metrics` gets `timeout=300`, `on_duplicate='discard'`.
>   - External logging: `reconfigure_rsyslog` gets `timeout=600`, `on_duplicate='queue_one'`.
> - **Removal**:
>   - Delete `cluster_node_health_check` task from `system.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73e0ca815e1d1d08ccff881045271ea6464b329c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->