### PR TITLE
fixed description for option notification_templates_approvals in module organizations

### DIFF
--- a/awx_collection/plugins/modules/organization.py
+++ b/awx_collection/plugins/modules/organization.py
@@ -76,7 +76,7 @@ options:
       elements: str
     notification_templates_approvals:
       description:
-        - list of notifications to send on start
+        - list of notifications to send on approval
       type: list
       elements: str
     galaxy_credentials:


### PR DESCRIPTION
##### SUMMARY
Fixed a wrong word in the description of the option notification_templates_approvals in module organization.

Used to be:
```
notification_templates_approvals:
  description:
    - list of notifications to send on start
```

Now fixed to:
```
notification_templates_approvals:
  description:
    - list of notifications to send on approval
```
Using the same word (approval) that is already used in: awx_collection/plugins/modules/workflow_job_template.py

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Docs

##### ADDITIONAL INFORMATION
None