### PR TITLE
Change Swagger UI endpoint from /api/swagger/ to /api/docs/

### DIFF
--- a/awx/api/schema.py
+++ b/awx/api/schema.py
@@ -1,5 +1,6 @@
 import warnings
 
+from rest_framework.permissions import IsAuthenticated
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.views import (
     SpectacularAPIView,
@@ -46,11 +47,29 @@ class CustomAutoSchema(AutoSchema):
         return getattr(self.view, 'deprecated', False)
 
 
+class AuthenticatedSpectacularAPIView(SpectacularAPIView):
+    """SpectacularAPIView that requires authentication."""
+
+    permission_classes = [IsAuthenticated]
+
+
+class AuthenticatedSpectacularSwaggerView(SpectacularSwaggerView):
+    """SpectacularSwaggerView that requires authentication."""
+
+    permission_classes = [IsAuthenticated]
+
+
+class AuthenticatedSpectacularRedocView(SpectacularRedocView):
+    """SpectacularRedocView that requires authentication."""
+
+    permission_classes = [IsAuthenticated]
+
+
 # Schema view (returns OpenAPI schema JSON/YAML)
-schema_view = SpectacularAPIView.as_view()
+schema_view = AuthenticatedSpectacularAPIView.as_view()
 
 # Swagger UI view
-swagger_ui_view = SpectacularSwaggerView.as_view(url_name='api:schema-json')
+swagger_ui_view = AuthenticatedSpectacularSwaggerView.as_view(url_name='api:schema-json')
 
 # ReDoc UI view
-redoc_view = SpectacularRedocView.as_view(url_name='api:schema-json')
+redoc_view = AuthenticatedSpectacularRedocView.as_view(url_name='api:schema-json')

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -158,7 +158,7 @@ urlpatterns = [
     re_path(r'^logout/$', LoggedLogoutView.as_view(next_page='/api/', redirect_field_name='next'), name='logout'),
     # Schema endpoints (available in all modes for API documentation and testing)
     re_path(r'^schema/$', schema_view, name='schema-json'),
-    re_path(r'^swagger/$', swagger_ui_view, name='schema-swagger-ui'),
+    re_path(r'^docs/$', swagger_ui_view, name='schema-swagger-ui'),
     re_path(r'^redoc/$', redoc_view, name='schema-redoc'),
 ]
 

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -59,7 +59,7 @@ class ApiRootView(APIView):
         data['custom_login_info'] = settings.CUSTOM_LOGIN_INFO
         data['login_redirect_override'] = settings.LOGIN_REDIRECT_OVERRIDE
         if MODE == 'development':
-            data['swagger'] = drf_reverse('api:schema-swagger-ui')
+            data['docs'] = drf_reverse('api:schema-swagger-ui')
         return Response(data)
 
 

--- a/awx/main/tests/unit/api/test_schema.py
+++ b/awx/main/tests/unit/api/test_schema.py
@@ -1,7 +1,14 @@
 import warnings
 from unittest.mock import Mock, patch
 
-from awx.api.schema import CustomAutoSchema
+from rest_framework.permissions import IsAuthenticated
+
+from awx.api.schema import (
+    CustomAutoSchema,
+    AuthenticatedSpectacularAPIView,
+    AuthenticatedSpectacularSwaggerView,
+    AuthenticatedSpectacularRedocView,
+)
 
 
 class TestCustomAutoSchema:
@@ -248,3 +255,19 @@ class TestCustomAutoSchema:
         tags = schema.get_tags()
         # swagger_topic should take priority
         assert tags == ['Priority_Topic']
+
+
+class TestAuthenticatedSchemaViews:
+    """Unit tests for authenticated schema view classes."""
+
+    def test_authenticated_spectacular_api_view_requires_authentication(self):
+        """Test that AuthenticatedSpectacularAPIView requires authentication."""
+        assert IsAuthenticated in AuthenticatedSpectacularAPIView.permission_classes
+
+    def test_authenticated_spectacular_swagger_view_requires_authentication(self):
+        """Test that AuthenticatedSpectacularSwaggerView requires authentication."""
+        assert IsAuthenticated in AuthenticatedSpectacularSwaggerView.permission_classes
+
+    def test_authenticated_spectacular_redoc_view_requires_authentication(self):
+        """Test that AuthenticatedSpectacularRedocView requires authentication."""
+        assert IsAuthenticated in AuthenticatedSpectacularRedocView.permission_classes

--- a/awx/main/tests/unit/api/test_views.py
+++ b/awx/main/tests/unit/api/test_views.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from collections import namedtuple
 
-from awx.api.views.root import ApiVersionRootView
+from awx.api.views.root import ApiVersionRootView, ApiRootView
 from awx.api.views import JobTemplateLabelList, InventoryInventorySourcesUpdate, JobTemplateSurveySpec
 
 from awx.main.views import handle_error

--- a/awx/main/tests/unit/api/test_views.py
+++ b/awx/main/tests/unit/api/test_views.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from collections import namedtuple
 
-from awx.api.views.root import ApiVersionRootView, ApiRootView
+from awx.api.views.root import ApiVersionRootView
 from awx.api.views import JobTemplateLabelList, InventoryInventorySourcesUpdate, JobTemplateSurveySpec
 
 from awx.main.views import handle_error

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1043,7 +1043,7 @@ SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX': r'/api/v[0-9]',
     'DEFAULT_GENERATOR_CLASS': 'drf_spectacular.generators.SchemaGenerator',
     'SCHEMA_COERCE_PATH_PK_SUFFIX': True,
-    'CONTACT': {'email': 'contact@snippets.local'},
+    'CONTACT': {'email': 'controller-eng@redhat.com'},
     'LICENSE': {'name': 'Apache License'},
     'TERMS_OF_SERVICE': 'https://www.google.com/policies/terms/',
     # Use our custom schema class that handles swagger_topic and deprecated views
@@ -1054,6 +1054,7 @@ SPECTACULAR_SETTINGS = {
         'persistAuthorization': True,
         'displayOperationId': True,
     },
+    'SERVE_PERMISSIONS': ['rest_framework.permissions.IsAuthenticated'],
     # Resolve enum naming collisions with meaningful names
     'ENUM_NAME_OVERRIDES': {
         # Status field collisions

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1054,7 +1054,6 @@ SPECTACULAR_SETTINGS = {
         'persistAuthorization': True,
         'displayOperationId': True,
     },
-    'SERVE_PERMISSIONS': ['rest_framework.permissions.IsAuthenticated'],
     # Resolve enum naming collisions with meaningful names
     'ENUM_NAME_OVERRIDES': {
         # Status field collisions


### PR DESCRIPTION
- Update URL pattern to use /docs/ instead of /swagger/
- Update API root response to show 'docs' key instead of 'swagger'
- Add authentication requirement for schema documentation endpoints
- Update contact email to controller-eng@redhat.com

The schema endpoints (/api/docs/, /api/schema/, /api/redoc/) now require authentication to prevent unauthorized access to API documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Protect OpenAPI/Swagger/ReDoc endpoints with authentication and move Swagger UI from /api/swagger/ to /api/docs/, with minor settings and tests updates.
> 
> - **API schema/views**:
>   - Add `AuthenticatedSpectacularAPIView`, `AuthenticatedSpectacularSwaggerView`, `AuthenticatedSpectacularRedocView` enforcing `IsAuthenticated`.
>   - Switch `schema_view`, `swagger_ui_view`, `redoc_view` to authenticated variants in `awx/api/schema.py`.
> - **URLs and API root**:
>   - Change Swagger UI route to `^docs/$` (was `^swagger/$`) in `awx/api/urls/urls.py`.
>   - In development, API root returns `docs` link instead of `swagger` in `awx/api/views/root.py`.
> - **Tests**:
>   - Add unit tests verifying authenticated schema views in `awx/main/tests/unit/api/test_schema.py`.
> - **Settings**:
>   - Update `SPECTACULAR_SETTINGS.CONTACT.email` to `controller-eng@redhat.com` in `awx/settings/defaults.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a875673a61bba97b03ce99d2c765e2aaf163dfb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->