### PR TITLE
AAP-29938 add force flag to refspec

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1346,7 +1346,7 @@ class RunProjectUpdate(BaseTask):
             extra_vars['scm_refspec'] = project_update.scm_refspec
         elif project_update.project.allow_override:
             # If branch is override-able, do extra fetch for all branches
-            extra_vars['scm_refspec'] = 'refs/heads/*:refs/remotes/origin/*'
+            extra_vars['scm_refspec'] = '+refs/heads/*:refs/remotes/origin/*'
 
         if project_update.scm_type == 'archive':
             # for raw archive, prevent error moving files between volumes

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -26,6 +26,9 @@ logger = logging.getLogger(__name__)
 PROJ_DATA = os.path.join(os.path.dirname(data.__file__), 'projects')
 
 
+del load_all_credentials
+
+
 def _copy_folders(source_path, dest_path, clear=False):
     "folder-by-folder, copy dirs in the source root dir to the destination root dir"
     for dirname in os.listdir(source_path):
@@ -139,7 +142,7 @@ def podman_image_generator():
 
 @pytest.fixture
 def project_factory(post, default_org, admin):
-    def _rf(scm_url=None, local_path=None):
+    def _rf(scm_url=None, local_path=None, **extra_kwargs):
         proj_kwargs = {}
         if local_path:
             # manual path
@@ -152,6 +155,9 @@ def project_factory(post, default_org, admin):
             proj_kwargs['scm_url'] = scm_url
         else:
             raise RuntimeError('Need to provide scm_url or local_path')
+
+        if extra_kwargs:
+            proj_kwargs.update(extra_kwargs)
 
         proj_kwargs['name'] = project_name
         proj_kwargs['organization'] = default_org.id

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -26,9 +26,6 @@ logger = logging.getLogger(__name__)
 PROJ_DATA = os.path.join(os.path.dirname(data.__file__), 'projects')
 
 
-del load_all_credentials
-
-
 def _copy_folders(source_path, dest_path, clear=False):
     "folder-by-folder, copy dirs in the source root dir to the destination root dir"
     for dirname in os.listdir(source_path):

--- a/awx/main/tests/live/tests/projects/test_file_projects.py
+++ b/awx/main/tests/live/tests/projects/test_file_projects.py
@@ -1,2 +1,25 @@
+import os
+import subprocess
+
+import pytest
+
+from awx.main.tests.live.tests.conftest import wait_for_job
+
+
 def test_git_file_project(live_tmp_folder, run_job_from_playbook):
     run_job_from_playbook('test_git_file_project', 'debug.yml', scm_url=f'file://{live_tmp_folder}/debug')
+
+
+@pytest.mark.parametrize('allow_override', [True, False])
+def test_amend_commit(live_tmp_folder, project_factory, allow_override):
+    proj = project_factory(scm_url=f'file://{live_tmp_folder}/debug', allow_override=allow_override)
+    assert proj.current_job
+    wait_for_job(proj.current_job)
+    assert proj.allow_override is allow_override
+
+    source_dir = os.path.join(live_tmp_folder, 'debug')
+    subprocess.run('git commit --amend --no-edit', cwd=source_dir, shell=True)
+
+    update = proj.update()
+    update.signal_start()
+    wait_for_job(update)


### PR DESCRIPTION
##### SUMMARY

When creating a project with `allow branch override` and then trying to sync it after a rebase & force push, the project update fails with:

```
fatal: [localhost]: FAILED! => {"changed": false, "cmd": ["/usr/bin/git", "fetch", "--tags", "origin", "refs/heads/*:refs/remotes/origin/*"], "msg": "Failed to download remote objects and refs:  From https://github.com/pb82/ansible-tower-samples\\n ! [rejected]        master     -> origin/master  (non-fast-forward)\\n"}
```

Adding the force flag `+` fixes that.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
