### PR TITLE
Adopt new DAB schema processors

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -352,6 +352,7 @@ INSTALLED_APPS = [
     'ansible_base.resource_registry',
     'ansible_base.rbac',
     'ansible_base.feature_flags',
+    'ansible_base.api_documentation',
     'flags',
 ]
 

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ansible/system-certifi.git@devel#egg=certifi
 git+https://github.com/ansible/ansible-runner.git@devel#egg=ansible-runner
 awx-plugins-core @ git+https://github.com/ansible/awx-plugins.git@devel#egg=awx-plugins-core[credentials-github-app]
-django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac,feature-flags]
+django-ansible-base @ git+https://github.com/huffmanca/django-ansible-base@AAP-56282#egg=django-ansible-base[rest-filters,jwt_consumer,resource-registry,rbac,feature-flags]
 awx_plugins.interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git


### PR DESCRIPTION
##### SUMMARY
~Likely won't work on first try~ worked on first try

instructions at:

https://github.com/huffmanca/django-ansible-base/blob/ff8c7d263357469caaa05c1bf6d6adb91b549919/docs/apps/ai_documentation/x_ai_description_guide.md

This is expected to enable a pre & post processor.

That is then expected to add a lot of lines to the schema, which should be obvious in the schema differ check from Github actions here.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

