### PR TITLE
Standardize spelling of 'canceled' in wsrelay.py

### DIFF
--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -94,7 +94,7 @@ class WebsocketRelayConnection:
         except asyncio.CancelledError:
             # TODO: Check if connected and disconnect
             # Possibly use run_until_complete() if disconnect is async
-            logger.warning(f"Connection from {self.name} to {self.remote_host} cancelled.")
+            logger.warning(f"Connection from {self.name} to {self.remote_host} canceled.")
         except client_exceptions.ClientConnectorError as e:
             logger.warning(f"Connection from {self.name} to {self.remote_host} failed: '{e}'.", exc_info=True)
         except asyncio.TimeoutError:
@@ -291,7 +291,7 @@ class WebSocketRelayManager(object):
             except asyncio.TimeoutError:
                 logger.warning(f"Tried to cancel relay connection for {hostname} but it timed out during cleanup.")
             except asyncio.CancelledError:
-                # Handle the case where the task was already cancelled by the time we got here.
+                # Handle the case where the task was already canceled by the time we got here.
                 pass
 
             del self.relay_connections[hostname]


### PR DESCRIPTION
Changed two instances of 'cancelled' to 'canceled' in awx/main/wsrelay.py to match AWX's standardized American English spelling convention.

## Changes
- Updated log message in `WebsocketRelayConnection.connect()` (line 97)
- Updated comment in `WebSocketRelayManager.cleanup_offline_host()` (line 294)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

## Testing
- Ran `black --check` - passed
- Ran wsrelay tests via `pytest awx/main/tests/functional/test_routing.py` - all passed (4 passed, 1 expected failure)
- Syntax validation passed

Fixes #15177