### PR TITLE
Sanitize SSH key whitespace to prevent validation errors

### DIFF
--- a/awx/main/tests/unit/test_validators.py
+++ b/awx/main/tests/unit/test_validators.py
@@ -132,6 +132,25 @@ def test_cert_with_key():
     assert not pem_objects[1]['key_enc']
 
 
+def test_ssh_key_with_whitespace():
+    # Test that SSH keys with leading/trailing whitespace/newlines are properly sanitized
+    # This addresses issue #14219 where copy-paste can introduce hidden newlines
+    valid_key_with_whitespace = "\n\n" + TEST_SSH_KEY_DATA + "\n\n"
+    pem_objects = validate_ssh_private_key(valid_key_with_whitespace)
+    assert pem_objects[0]['key_type'] == 'rsa'
+    assert not pem_objects[0]['key_enc']
+
+    # Test with just leading whitespace
+    valid_key_leading = "\n\n\n" + TEST_SSH_KEY_DATA
+    pem_objects = validate_ssh_private_key(valid_key_leading)
+    assert pem_objects[0]['key_type'] == 'rsa'
+
+    # Test with just trailing whitespace
+    valid_key_trailing = TEST_SSH_KEY_DATA + "\n\n\n"
+    pem_objects = validate_ssh_private_key(valid_key_trailing)
+    assert pem_objects[0]['key_type'] == 'rsa'
+
+
 @pytest.mark.parametrize(
     "var_str",
     [

--- a/awx/main/validators.py
+++ b/awx/main/validators.py
@@ -181,6 +181,8 @@ def validate_ssh_private_key(data):
     certificates; should handle any valid options for ssh_private_key on a
     credential.
     """
+    # Strip leading and trailing whitespace/newlines to handle common copy-paste issues
+    data = data.strip()
     return validate_pem(data, min_keys=1)
 
 


### PR DESCRIPTION
Strip leading and trailing whitespace from SSH keys in `validate_ssh_private_key()` to handle common copy-paste scenarios where hidden newlines cause base64 decoding failures.

## Problem
Users encounter confusing HTTP 500 errors when creating credentials with SSH keys that contain hidden newline characters from copy-paste operations. The error manifests as `binascii.Error: Incorrect padding` in server logs, but users only see a generic 500 error.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

## Changes
- Added `data.strip()` in `validate_ssh_private_key()` before calling `validate_pem()` (awx/main/validators.py:185)
- Added `test_ssh_key_with_whitespace()` to verify keys with leading/trailing newlines are properly sanitized and validated (awx/main/tests/unit/test_validators.py:135-151)

## Testing
- All existing validator tests pass (48 tests)
- New test verifies SSH keys with leading/trailing whitespace are accepted
- Invalid keys are still properly rejected (validated with existing tests)

## Impact
This prevents the confusing "HTTP 500: Internal Server Error" when users paste SSH keys with accidental whitespace, improving the user experience without weakening validation.

Fixes #14219