### PR TITLE
Only document JSON for the API spec

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1054,6 +1054,10 @@ SPECTACULAR_SETTINGS = {
         'persistAuthorization': True,
         'displayOperationId': True,
     },
+    # Only document the JSON API, not the browseable forms
+    'PARSER_WHITELIST': [
+        'rest_framework.parsers.JSONParser',
+    ],
     # Resolve enum naming collisions with meaningful names
     'ENUM_NAME_OVERRIDES': {
         # Status field collisions


### PR DESCRIPTION
##### SUMMARY
Looking to see if this changes the spec, but not expecting it to.

This makes it explicit what media types we are considering for documenting.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limits OpenAPI schema generation to JSON by whitelisting `rest_framework.parsers.JSONParser` in `SPECTACULAR_SETTINGS.PARSER_WHITELIST`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a4a88adeff5d1b1d3de678c45c1e342fcb79867. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->