### PR TITLE
Add hcp_terraform to list of expected cred types to fix failing api test CI Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ We require all of our community members and contributors to adhere to the [Ansib
 
 Get Involved
 ------------
-#DummyChange
 
 We welcome your feedback and ideas via the [Ansible Forum](https://forum.ansible.com/tag/awx).
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ We require all of our community members and contributors to adhere to the [Ansib
 
 Get Involved
 ------------
+#DummyChange
 
 We welcome your feedback and ideas via the [Ansible Forum](https://forum.ansible.com/tag/awx).
 

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -93,6 +93,7 @@ def test_default_cred_types():
             'gpg_public_key',
             'hashivault_kv',
             'hashivault_ssh',
+            'hcp_terraform',
             'insights',
             'kubernetes_bearer_token',
             'net',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
PR to fix failing API-Test CI Check in devel, add hcp_terraform to list of expected cred types to fix failing api test ci check.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 4.6.20
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `hcp_terraform` to the expected default credential types in `test_default_cred_types`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c42da265c91128473a7138b1163b8f957e7271d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->