### PR TITLE
docs: migrate RTD URLs to docs.ansible.com

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Community Code of Conduct
 
-Please see the official [Ansible Community Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+Please see the official [Ansible Community Code of Conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html).

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Please confirm the following
       options:
-        - label: I agree to follow this project's [code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+        - label: I agree to follow this project's [code of conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html).
           required: true
         - label: I have checked the [current issues](https://github.com/ansible/awx/issues) for duplicates.
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://github.com/ansible/awx#get-involved
     about: For general debugging or technical support please see the Get Involved section of our readme.
   - name: 📝 Ansible Code of Conduct
-    url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser
+    url: https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser
     about: AWX uses the Ansible Code of Conduct; ❤ Be nice to other members of the community. ☮ Behave.
   - name: 💼 For Enterprise
     url: https://www.ansible.com/products/engine?utm_medium=github&utm_source=issue_template_chooser

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Please confirm the following
       options:
-        - label: I agree to follow this project's [code of conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html).
+        - label: I agree to follow this project's [code of conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html).
           required: true
         - label: I have checked the [current issues](https://github.com/ansible/awx/issues) for duplicates.
           required: true

--- a/.github/triage_replies.md
+++ b/.github/triage_replies.md
@@ -70,10 +70,10 @@ Thank you for your submission and for supporting AWX!
 - Hello, we'd love to help, but we need a little more information about the problem you're having. Screenshots, log outputs, or any reproducers would be very helpful.
 
 ### Code of Conduct
-- Hello. Please keep in mind that Ansible adheres to a Code of Conduct in its community spaces. The spirit of the code of conduct is to be kind, and this is your friendly reminder to be so. Please see the full code of conduct here if you have questions: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html
+- Hello. Please keep in mind that Ansible adheres to a Code of Conduct in its community spaces. The spirit of the code of conduct is to be kind, and this is your friendly reminder to be so. Please see the full code of conduct here if you have questions: https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html
 
 ### EE Contents / Community General
-- Hello. The awx-ee contains the collections and dependencies needed for supported AWX features to function. Anything beyond that (like the community.general package) will require you to build your own EE. For information on how to do that, see https://ansible-builder.readthedocs.io/en/stable/ \
+- Hello. The awx-ee contains the collections and dependencies needed for supported AWX features to function. Anything beyond that (like the community.general package) will require you to build your own EE. For information on how to do that, see https://docs.ansible.com/projects/builder/en/stable/ \
 \
 The Ansible Community is looking at building an EE that corresponds to all of the collections inside the ansible package. That may help you if and when it happens; see https://github.com/ansible-community/community-topics/issues/31 for details.
 
@@ -88,7 +88,7 @@ The Ansible Community is looking at building an EE that corresponds to all of th
 - Hello, we think your idea is good! Please consider contributing a PR for this following our contributing guidelines: https://github.com/ansible/awx/blob/devel/CONTRIBUTING.md
 
 ### Receptor
-- You can find the receptor docs here: https://receptor.readthedocs.io/en/latest/
+- You can find the receptor docs here: https://docs.ansible.com/projects/receptor/en/latest/
 - Hello, your issue seems related to receptor. Could you please open an issue in the receptor repository? https://github.com/ansible/receptor. Thanks!
 
 ### Ansible Engine not AWX

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Have questions about this document or anything not covered here? Create a topic 
 - Take care to make sure no merge commits are in the submission, and use `git rebase` vs `git merge` for this reason.
   - If collaborating with someone else on the same branch, consider using `--force-with-lease` instead of `--force`. This will prevent you from accidentally overwriting commits pushed by someone else. For more information, see [git push docs](https://git-scm.com/docs/git-push#git-push---force-with-leaseltrefnamegt).
 - If submitting a large code change, it's a good idea to create a [forum topic tagged with 'awx'](https://forum.ansible.com/tag/awx), and talk about what you would like to do or add first. This not only helps everyone know what's going on, it also helps save time and effort, if the community decides some changes are needed.
-- We ask all of our community members and contributors to adhere to the [Ansible code of conduct](http://docs.ansible.com/ansible/latest/community/code_of_conduct.html). If you have questions, or need assistance, please reach out to our community team at [codeofconduct@ansible.com](mailto:codeofconduct@ansible.com)
+- We ask all of our community members and contributors to adhere to the [Ansible code of conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html). If you have questions, or need assistance, please reach out to our community team at [codeofconduct@ansible.com](mailto:codeofconduct@ansible.com)
 
 ## Setting up your development environment
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/ansible/awx/actions/workflows/ci.yml/badge.svg?branch=devel)](https://github.com/ansible/awx/actions/workflows/ci.yml) [![codecov](https://codecov.io/github/ansible/awx/graph/badge.svg?token=4L4GSP9IAR)](https://codecov.io/github/ansible/awx) [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-yellow.svg)](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html) [![Apache v2 License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](https://github.com/ansible/awx/blob/devel/LICENSE.md) [![AWX on the Ansible Forum](https://img.shields.io/badge/mailing%20list-AWX-orange.svg)](https://forum.ansible.com/tag/awx)
+[![CI](https://github.com/ansible/awx/actions/workflows/ci.yml/badge.svg?branch=devel)](https://github.com/ansible/awx/actions/workflows/ci.yml) [![codecov](https://codecov.io/github/ansible/awx/graph/badge.svg?token=4L4GSP9IAR)](https://codecov.io/github/ansible/awx) [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-Ansible-yellow.svg)](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html) [![Apache v2 License](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](https://github.com/ansible/awx/blob/devel/LICENSE.md) [![AWX on the Ansible Forum](https://img.shields.io/badge/mailing%20list-AWX-orange.svg)](https://forum.ansible.com/tag/awx)
 [![Ansible Matrix](https://img.shields.io/badge/matrix-Ansible%20Community-blueviolet.svg?logo=matrix)](https://chat.ansible.im/#/welcome) [![Ansible Discourse](https://img.shields.io/badge/discourse-Ansible%20Community-yellowgreen.svg?logo=discourse)](https://forum.ansible.com)
 
 <img src="https://raw.githubusercontent.com/ansible/awx-logos/master/awx/ui/client/assets/logo-login.svg?sanitize=true" width=200 alt="AWX" />
@@ -18,7 +18,7 @@ AWX provides a web-based user interface, REST API, and task engine built on top 
 
 To install AWX, please view the [Install guide](./INSTALL.md).
 
-To learn more about using AWX, view the [AWX docs site](https://ansible.readthedocs.io/projects/awx/en/latest/).
+To learn more about using AWX, view the [AWX docs site](https://docs.ansible.com/projects/awx/en/latest/).
 
 The AWX Project Frequently Asked Questions can be found [here](https://www.ansible.com/awx-project-faq).
 
@@ -41,11 +41,11 @@ If you're experiencing a problem that you feel is a bug in AWX or have ideas for
 Code of Conduct
 ---------------
 
-We require all of our community members and contributors to adhere to the [Ansible code of conduct](http://docs.ansible.com/ansible/latest/community/code_of_conduct.html). If you have questions or need assistance, please reach out to our community team at [codeofconduct@ansible.com](mailto:codeofconduct@ansible.com)
+We require all of our community members and contributors to adhere to the [Ansible code of conduct](https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html). If you have questions or need assistance, please reach out to our community team at [codeofconduct@ansible.com](mailto:codeofconduct@ansible.com)
 
 Get Involved
 ------------
 
 We welcome your feedback and ideas via the [Ansible Forum](https://forum.ansible.com/tag/awx).
 
-For a full list of all the ways to talk with the Ansible Community, see the [AWX Communication guide](https://ansible.readthedocs.io/projects/awx/en/latest/contributor/communication.html).
+For a full list of all the ways to talk with the Ansible Community, see the [AWX Communication guide](https://docs.ansible.com/projects/awx/en/latest/contributor/communication.html).

--- a/awx_collection/TESTING.md
+++ b/awx_collection/TESTING.md
@@ -32,7 +32,7 @@ Inside the `/tests` directory, there are two folders:
 - `/integration`
 - `/sanity`
 
-In the `/sanity` folder are file directives for specific Ansible versions which contain information about which tests to skip for specific files. There are a number of reasons you may need to skip a sanity test. See the [`ansible-test` documentation](https://docs.ansible.com/ansible/latest/dev_guide/testing_running_locally.html) for more details about how and why you might want to skip a test.
+In the `/sanity` folder are file directives for specific Ansible versions which contain information about which tests to skip for specific files. There are a number of reasons you may need to skip a sanity test. See the [`ansible-test` documentation](https://docs.ansible.com/projects/ansible/latest/dev_guide/testing_running_locally.html) for more details about how and why you might want to skip a test.
 
 In the `integration/targets` folder you will see directories (which act as roles) for all of the different modules and plugins. When the collection is tested, an instance of Automation Platform Controller (or AWX) will be spun up and these roles will be applied to the target server to validate the functionality of the modules. Since these are really roles, each directory will contain a tasks folder under it with a `main.yml` file as an entry point.
 

--- a/docs/capacity.md
+++ b/docs/capacity.md
@@ -68,7 +68,7 @@ The value `fork_per_cpu` can be controlled by setting the AWX settings value (or
 
 When selecting the capacity, it's important to understand how each job type affects it.
 
-It's helpful to understand what `forks` mean to Ansible: http://docs.ansible.com/ansible/latest/intro_configuration.html#forks
+It's helpful to understand what `forks` mean to Ansible: https://docs.ansible.com/projects/ansible/latest/intro_configuration.html#forks
 
 The default forks value for ansible is `5`. However, if AWX knows that you're running against fewer systems than that, then the actual concurrency value
 will be lower.

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -82,7 +82,7 @@ job runs. It will populate the cache id set by the last "check" type update.
 
 For details on how Galaxy servers are configured in Ansible in general see:
 
-https://docs.ansible.com/ansible/devel/user_guide/collections_using.html
+https://docs.ansible.com/projects/ansible/devel/user_guide/collections_using.html
 (if "devel" link goes stale in the future, it is for Ansible 2.9)
 
 You can specify a list of zero or more servers to download roles and

--- a/docs/credentials/multi_credential_assignment.md
+++ b/docs/credentials/multi_credential_assignment.md
@@ -162,7 +162,7 @@ is the ability to assign multiple Vault credentials to a Job Template run.
 
 This specific use case covers Ansible's support for multiple Vault passwords for
 a playbook run (since Ansible 2.4):
-http://docs.ansible.com/ansible/latest/vault.html#vault-ids-and-multiple-vault-passwords
+https://docs.ansible.com/projects/ansible/latest/vault.html#vault-ids-and-multiple-vault-passwords
 
 Vault credentials in AWX now have an optional field, `vault_id`, which is
 analogous to the `--vault-id` argument to `ansible-playbook`.  To run

--- a/docs/docsite/rst/404.rst
+++ b/docs/docsite/rst/404.rst
@@ -12,8 +12,8 @@ The page you are looking for is not in the current AWX documentation.
 You can find different versions of the AWX documentation by opening the Read the Docs fly out menu at the bottom right.
 For your convenience, here are some links:
 
-* `AWX latest <https://ansible.readthedocs.io/projects/awx/en/latest/>`_ documentation, includes release notes and known issues, contributor's guide, and API reference.
-* `AWX 24.6.1 <https://ansible.readthedocs.io/projects/awx/en/24.6.1/>`_ documentation, includes release notes, contributor's guide, AWX quickstart, user guide, API reference, and administrator guide.
+* `AWX latest <https://docs.ansible.com/projects/awx/en/latest/>`_ documentation, includes release notes and known issues, contributor's guide, and API reference.
+* `AWX 24.6.1 <https://docs.ansible.com/projects/awx/en/24.6.1/>`_ documentation, includes release notes, contributor's guide, AWX quickstart, user guide, API reference, and administrator guide.
 
 If you have more questions or still can't find the docs you're looking for, join the `Ansible Forum <https://forum.ansible.com>`_.
 Here are some useful links for AWX users:

--- a/docs/docsite/rst/contributor/communication.rst
+++ b/docs/docsite/rst/contributor/communication.rst
@@ -22,7 +22,7 @@ Join the `Ansible Forum <https://forum.ansible.com>`_ as a single starting point
 
 * `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example `awx`, `ee`, and  `documentation`.
 * `Posts tagged with 'awx' <https://forum.ansible.com/tag/awx>`_: subscribe to participate in project/technology-related conversations. There are other related tags in the forum you can use.
-* `Bullhorn newsletter <https://docs.ansible.com/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
+* `Bullhorn newsletter <https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
 * `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
 * `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
 

--- a/docs/docsite/rst/contributor/communication.rst
+++ b/docs/docsite/rst/contributor/communication.rst
@@ -22,7 +22,7 @@ Join the `Ansible Forum <https://forum.ansible.com>`_ as a single starting point
 
 * `Get Help <https://forum.ansible.com/c/help/6>`_: get help or help others. Please add appropriate tags if you start new discussions, for example `awx`, `ee`, and  `documentation`.
 * `Posts tagged with 'awx' <https://forum.ansible.com/tag/awx>`_: subscribe to participate in project/technology-related conversations. There are other related tags in the forum you can use.
-* `Bullhorn newsletter <https://docs.ansible.com/projects/ansible/devel/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
+* `Bullhorn newsletter <https://docs.ansible.com/projects/ansible/latest/community/communication.html#the-bullhorn>`_: used to announce releases and important changes.
 * `Social Spaces <https://forum.ansible.com/c/chat/4>`_: gather and interact with fellow enthusiasts.
 * `News & Announcements <https://forum.ansible.com/c/news/5>`_: track project-wide announcements including social events.
 

--- a/docs/docsite/rst/contributor/work_items.rst
+++ b/docs/docsite/rst/contributor/work_items.rst
@@ -18,7 +18,7 @@ Fixing and updating the documentation are always appreciated, so reviewing the b
 Things to know prior to submitting revisions
 ----------------------------------------------
 
-- Please follow the `Ansible code of conduct <http://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_ in all your interactions with the community.
+- Please follow the `Ansible code of conduct <https://docs.ansible.com/projects/ansible/latest/community/code_of_conduct.html>`_ in all your interactions with the community.
 - All doc revisions or additions are done through pull requests against the ``devel`` branch.
 - You must use ``git commit --signoff`` for any commit to be merged, and agree that usage of ``--signoff`` constitutes agreement with the terms of `DCO 1.1 <https://github.com/ansible/awx/blob/devel/DCO_1_1.md>`_.
 - Take care to make sure no merge commits are in the submission, and use ``git rebase`` vs ``git merge`` for this reason.

--- a/docs/execution_environments.md
+++ b/docs/execution_environments.md
@@ -4,8 +4,8 @@ All jobs use container isolation for environment consistency and security.
 Compliant images are referred to as Execution Environments (EE)s.
 
 For more information about the EE technology as well as how to build and test EEs, see:
-- [Getting started with Execution Environments guide](https://ansible.readthedocs.io/en/latest/getting_started_ee/index.html)
-- [Ansible Builder documentation](https://ansible.readthedocs.io/projects/builder/en/latest/)
+- [Getting started with Execution Environments guide](https://docs.ansible.com/en/latest/getting_started_ee/index.html)
+- [Ansible Builder documentation](https://docs.ansible.com/projects/builder/en/latest/)
 
 The Execution Environment model has an `image` field for the image identifier which will be used by jobs.
 The job details view will link to the execution environment that the job uses.

--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -34,7 +34,7 @@ Notable files:
 
 - [Docker](https://docs.docker.com/engine/installation/) on the host where AWX will be deployed. After installing Docker, the Docker service must be started (depending on your OS, you may have to add the local user that uses Docker to the `docker` group, refer to the documentation for details)
 - [Docker Compose](https://docs.docker.com/compose/install/).
-- [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) will need to be installed as we use it to template files needed for the docker-compose.
+- [Ansible](https://docs.ansible.com/projects/ansible/latest/installation_guide/intro_installation.html) will need to be installed as we use it to template files needed for the docker-compose.
 - OpenSSL.
 
 ### Tested Operating Systems


### PR DESCRIPTION

##### SUMMARY
This PR updates `readthedocs.io` URLs to their `docs.ansible.com` equivalents with proper anchor preservation.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Docs




##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

