### PR TITLE
Add make targets for updating requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ else
 endif
 
 .PHONY: awx-link clean clean-tmp clean-venv requirements requirements_dev \
+	update_requirements upgrade_requirements update_requirements_dev \
+	docker_update_requirements docker_upgrade_requirements docker_update_requirements_dev \
 	develop refresh adduser migrate dbchange \
 	receiver test test_unit test_coverage coverage_html \
 	sdist \
@@ -195,6 +197,36 @@ requirements: requirements_awx
 requirements_dev: requirements_awx requirements_awx_dev
 
 requirements_test: requirements
+
+## Update requirements files using pip-compile (run inside container)
+update_requirements:
+	cd requirements && ./updater.sh run
+
+## Upgrade all requirements to latest versions (run inside container)
+upgrade_requirements:
+	cd requirements && ./updater.sh upgrade
+
+## Update development requirements (run inside container)
+update_requirements_dev:
+	cd requirements && ./updater.sh dev
+
+## Update requirements using docker-runner
+docker_update_requirements:
+	@echo "Running requirements updater..."
+	AWX_DOCKER_CMD='make update_requirements' $(MAKE) docker-runner
+	@echo "Requirements update complete!"
+
+## Upgrade requirements using docker-runner
+docker_upgrade_requirements:
+	@echo "Running requirements upgrader..."
+	AWX_DOCKER_CMD='make upgrade_requirements' $(MAKE) docker-runner
+	@echo "Requirements upgrade complete!"
+
+## Update dev requirements using docker-runner
+docker_update_requirements_dev:
+	@echo "Running dev requirements updater..."
+	AWX_DOCKER_CMD='make update_requirements_dev' $(MAKE) docker-runner
+	@echo "Dev requirements update complete!"
 
 ## "Install" awx package in development mode.
 develop:


### PR DESCRIPTION
##### SUMMARY
Introduces new Makefile targets to update and upgrade requirements files using pip-compile, both directly and via docker-runner. These additions streamline dependency management for development and CI workflows.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Makefile targets to update/upgrade requirements (including dev) and docker-runner wrappers for running them.
> 
> - **Makefile**:
>   - **New requirement management targets**:
>     - `update_requirements`, `upgrade_requirements`, `update_requirements_dev` to run `requirements/updater.sh` (run/upgrade/dev).
>     - Docker wrappers: `docker_update_requirements`, `docker_upgrade_requirements`, `docker_update_requirements_dev` executing the above via `docker-runner`.
>   - `.PHONY` updated to include new targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 348e22a178b3846bd8a8eb9ff6cbb2239c599fb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->