### PR TITLE
AAP-47956 Use pg_notify for cancel and debugging, abandon socket approach

### DIFF
--- a/awx/main/dispatch/config.py
+++ b/awx/main/dispatch/config.py
@@ -32,10 +32,8 @@ def get_dispatcherd_config(for_service: bool = False, mock_publish: bool = False
             "process_manager_cls": "ForkServerManager",
             "process_manager_kwargs": {"preload_modules": ['awx.main.dispatch.hazmat']},
         },
-        "brokers": {
-            "socket": {"socket_path": settings.DISPATCHERD_DEBUGGING_SOCKFILE},
-        },
-        "publish": {"default_control_broker": "socket"},
+        "brokers": {},
+        "publish": {},
         "worker": {"worker_cls": "awx.main.dispatch.worker.dispatcherd.AWXTaskWorker"},
     }
 

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -2,7 +2,6 @@
 # All Rights Reserved.
 import logging
 import yaml
-import os
 
 import redis
 

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -48,10 +48,6 @@ class Command(BaseCommand):
             ),
         )
 
-    def verify_dispatcherd_socket(self):
-        if not os.path.exists(settings.DISPATCHERD_DEBUGGING_SOCKFILE):
-            raise CommandError('Dispatcher is not running locally')
-
     def handle(self, *arg, **options):
         if options.get('status'):
             if flag_enabled('FEATURE_DISPATCHERD_ENABLED'):

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -421,9 +421,6 @@ DISPATCHER_DB_DOWNTIME_TOLERANCE = 40
 # sqlite3 based tests will use this
 DISPATCHER_MOCK_PUBLISH = False
 
-# Debugging sockfile for the --status command
-DISPATCHERD_DEBUGGING_SOCKFILE = os.path.join(BASE_DIR, 'dispatcherd.sock')
-
 BROKER_URL = 'unix:///var/run/redis/redis.sock'
 REDIS_RETRY_COUNT = 3  # Number of retries for Redis connection errors
 REDIS_BACKOFF_CAP = 1.0  # Maximum backoff delay in seconds for Redis retries

--- a/awx/settings/production_defaults.py
+++ b/awx/settings/production_defaults.py
@@ -23,9 +23,6 @@ ALLOWED_HOSTS = []
 # only used for deprecated fields and management commands for them
 BASE_VENV_PATH = os.path.realpath("/var/lib/awx/venv")
 
-# Switch to a writable location for the dispatcher sockfile location
-DISPATCHERD_DEBUGGING_SOCKFILE = os.path.realpath('/var/run/tower/dispatcherd.sock')
-
 # Very important that this is editable (not read_only) in the API
 AWX_ISOLATION_SHOW_PATHS = [
     '/etc/pki/ca-trust:/etc/pki/ca-trust:O',

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -71,7 +71,7 @@ setuptools_scm[toml]
 setuptools-rust>=0.11.4  # cryptography build dep
 pkgconfig>=1.5.1  # xmlsec build dep - needed for offline build
 django-flags>=5.0.13
-dispatcherd  # tasking system, previously part of AWX code base
+dispatcherd[pg_notify]  # tasking system, previously part of AWX code base
 protobuf>=4.25.8 # CVE-2025-4565
 idna>=3.10 # CVE-2024-3651
 # Temporarily added to use ansible-runner from git branch, to be removed

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -120,7 +120,7 @@ cython==3.1.3
     # via -r /awx_devel/requirements/requirements.in
 daphne==4.2.1
     # via -r /awx_devel/requirements/requirements.in
-dispatcherd==2025.5.21
+dispatcherd[pg_notify]==2025.12.10
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in
@@ -138,7 +138,7 @@ django==5.2.8
     #   django-solo
     #   djangorestframework
     #   drf-spectacular
-# django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel  # git requirements installed separately
+# django-ansible-base @ git+https://github.com/ansible/django-ansible-base@devel  # git requirements installed separately
     # via -r /awx_devel/requirements/requirements_git.txt
 django-cors-headers==4.9.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
The _main_ reason we didn't do this before was that we didn't have a means of splitting messages into multi-part messages to get under the 8,000 character limit of pg_notify. This is addressed with https://github.com/ansible/dispatcherd/pull/191 which I think is fairly final & durable.

Additionally, eda-server is making fast progress, and I want to push for us both to have the same solution, and the sockfile just takes too much debugging for it to be worth it.

We might add back in the socket broker later, or we might just have some sort of custom task on shutdown where we force it to dump the status output to logs or a file. If the self-check messages are, at all, working, this will probably cover us.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move dispatcher control/status/cancel to PostgreSQL NOTIFY, remove socket-based broker/debugging, and update dispatcherd dependency.
> 
> - **Dispatcher config (`awx/main/dispatch/config.py`)**:
>   - Replace socket broker config with `pg_notify` broker; set `publish.default_broker` to `pg_notify`.
>   - Add `default_publish_channel` (uses `settings.CLUSTER_HOST_ID`) and service `channels` (`tower_broadcast_all`, `tower_settings_change`, `get_task_queuename()`).
>   - Preserve mock mode via `noop` broker.
> - **Management command (`awx/main/management/commands/run_dispatcher.py`)**:
>   - Remove local socket checks/usage; `--status`/`--running`/`--cancel` now use `dispatcherd` control over `pg_notify`.
>   - Initialize dispatcher service via `dispatcherd.config.setup(get_dispatcherd_config(...))` before `run_service()`.
> - **Settings**:
>   - Remove `DISPATCHERD_DEBUGGING_SOCKFILE` from defaults and production defaults.
> - **Dependencies**:
>   - Change requirement to `dispatcherd[pg_notify]` and bump version in both `requirements.in` and `requirements.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a2ec6333588d6f8fa7515b0b64be95f445da3458. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->