### PR TITLE
AAP-60452 Remove the dynamic log level filter for the dispatcherd main process

### DIFF
--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -2,11 +2,14 @@
 # All Rights Reserved.
 import logging
 import yaml
+import copy
 
 import redis
 
 from django.conf import settings
+from django.db import connection
 from django.core.management.base import BaseCommand, CommandError
+from django.core.cache import cache as django_cache
 
 from flags.state import flag_enabled
 
@@ -104,6 +107,22 @@ class Command(BaseCommand):
                 return
 
         if flag_enabled('FEATURE_DISPATCHERD_ENABLED'):
+            # Apply special log rule for the parent process
+            special_logging = copy.deepcopy(settings.LOGGING)
+            for handler_name, handler_config in special_logging['handlers'].items():
+                if 'dynamic_level_filter' in handler_config.get('filters', []):
+                    handler_config['filters'].remove('dynamic_level_filter')
+                    logger.info(f'Dispatcherd main process replaced log level filter for {handler_name} handler')
+
+            # Apply the custom logging level here, before the asyncio code starts
+            special_logging['loggers']['dispatcherd']['level'] = settings.LOG_AGGREGATOR_LEVEL
+
+            logging.config.dictConfig(special_logging)
+
+            # Close the connection, because the pg_notify broker will create new async connection
+            connection.close()
+            django_cache.close()
+
             dispatcher_setup(get_dispatcherd_config(for_service=True))
             run_service()
         else:

--- a/awx/main/management/commands/run_dispatcher.py
+++ b/awx/main/management/commands/run_dispatcher.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2015 Ansible, Inc.
 # All Rights Reserved.
 import logging
+import logging.config
 import yaml
 import copy
 
@@ -107,17 +108,7 @@ class Command(BaseCommand):
                 return
 
         if flag_enabled('FEATURE_DISPATCHERD_ENABLED'):
-            # Apply special log rule for the parent process
-            special_logging = copy.deepcopy(settings.LOGGING)
-            for handler_name, handler_config in special_logging['handlers'].items():
-                if 'dynamic_level_filter' in handler_config.get('filters', []):
-                    handler_config['filters'].remove('dynamic_level_filter')
-                    logger.info(f'Dispatcherd main process replaced log level filter for {handler_name} handler')
-
-            # Apply the custom logging level here, before the asyncio code starts
-            special_logging['loggers']['dispatcherd']['level'] = settings.LOG_AGGREGATOR_LEVEL
-
-            logging.config.dictConfig(special_logging)
+            self.configure_dispatcher_logging()
 
             # Close the connection, because the pg_notify broker will create new async connection
             connection.close()
@@ -141,3 +132,18 @@ class Command(BaseCommand):
                 logger.debug('Terminating Task Dispatcher')
                 if consumer:
                     consumer.stop()
+
+    def configure_dispatcher_logging(self):
+        # Apply special log rule for the parent process
+        special_logging = copy.deepcopy(settings.LOGGING)
+        for handler_name, handler_config in special_logging.get('handlers', {}).items():
+            filters = handler_config.get('filters', [])
+            if 'dynamic_level_filter' in filters:
+                handler_config['filters'] = [flt for flt in filters if flt != 'dynamic_level_filter']
+                logger.info(f'Dispatcherd main process replaced log level filter for {handler_name} handler')
+
+        # Apply the custom logging level here, before the asyncio code starts
+        special_logging.setdefault('loggers', {}).setdefault('dispatcherd', {})
+        special_logging['loggers']['dispatcherd']['level'] = settings.LOG_AGGREGATOR_LEVEL
+
+        logging.config.dictConfig(special_logging)

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -13,6 +13,9 @@ from datetime import datetime
 from distutils.version import LooseVersion as Version
 from io import StringIO
 
+# dispatcherd
+from dispatcherd.factories import get_control_from_settings
+
 # Runner
 import ansible_runner.cleanup
 import psycopg
@@ -353,6 +356,11 @@ def clear_setting_cache(setting_keys):
     cache_keys = set(setting_keys)
     logger.debug('cache delete_many(%r)', cache_keys)
     cache.delete_many(cache_keys)
+
+    if 'LOG_AGGREGATOR_LEVEL' in setting_keys:
+        ctl = get_control_from_settings()
+        ctl.queuename = get_task_queuename()
+        ctl.control('set_log_level', data={'level': settings.LOG_AGGREGATOR_LEVEL})
 
 
 @task_awx(queue='tower_broadcast_all', timeout=600)

--- a/awx/main/tests/functional/tasks/test_tasks_system.py
+++ b/awx/main/tests/functional/tasks/test_tasks_system.py
@@ -132,6 +132,7 @@ def test_clear_setting_cache_log_level_branch(settings):
     assert body['control_data'] == {'level': 'DEBUG'}
 
 
+@pytest.mark.django_db
 def test_configure_dispatcher_logging_updates_level(settings):
     original_logging_settings = copy.deepcopy(settings.LOGGING)
     settings.LOGGING = {

--- a/awx/main/tests/functional/tasks/test_tasks_system.py
+++ b/awx/main/tests/functional/tasks/test_tasks_system.py
@@ -1,10 +1,12 @@
+import json
 import os
 import tempfile
 import shutil
+from unittest import mock
 
 import pytest
 
-from awx.main.tasks.system import CleanupImagesAndFiles, execution_node_health_check, inspect_established_receptor_connections
+from awx.main.tasks.system import CleanupImagesAndFiles, execution_node_health_check, inspect_established_receptor_connections, clear_setting_cache
 from awx.main.models import Instance, Job, ReceptorAddress, InstanceLink
 
 
@@ -98,3 +100,30 @@ def test_folder_cleanup_multiple_running_jobs(job_folder_factory, me_inst):
     CleanupImagesAndFiles.run(grace_period=0)
 
     assert [os.path.exists(d) for d in dirs] == [True for i in range(num_jobs)]
+
+
+@pytest.mark.django_db
+def test_clear_setting_cache_log_level_branch(settings):
+    settings.LOG_AGGREGATOR_LEVEL = 'DEBUG'
+    settings.CLUSTER_HOST_ID = 'control-node'
+    published_messages = []
+
+    class DummyBroker:
+        def publish_message(self, channel, message):
+            published_messages.append((channel, message))
+
+        def close(self):
+            pass
+
+    dummy_broker = DummyBroker()
+
+    with mock.patch('dispatcherd.control.get_broker', return_value=dummy_broker) as mock_get_broker:
+        clear_setting_cache(['LOG_AGGREGATOR_LEVEL'])
+
+    mock_get_broker.assert_called_once()
+    assert published_messages, 'control command was not sent through the broker'
+    queue, payload = published_messages[-1]
+    assert queue == 'control-node'
+    body = json.loads(payload)
+    assert body['control'] == 'set_log_level'
+    assert body['control_data'] == {'level': 'DEBUG'}

--- a/awx/main/tests/functional/tasks/test_tasks_system.py
+++ b/awx/main/tests/functional/tasks/test_tasks_system.py
@@ -1,4 +1,6 @@
+import copy
 import json
+import logging
 import os
 import tempfile
 import shutil
@@ -7,6 +9,7 @@ from unittest import mock
 import pytest
 
 from awx.main.tasks.system import CleanupImagesAndFiles, execution_node_health_check, inspect_established_receptor_connections, clear_setting_cache
+from awx.main.management.commands.run_dispatcher import Command
 from awx.main.models import Instance, Job, ReceptorAddress, InstanceLink
 
 
@@ -127,3 +130,36 @@ def test_clear_setting_cache_log_level_branch(settings):
     body = json.loads(payload)
     assert body['control'] == 'set_log_level'
     assert body['control_data'] == {'level': 'DEBUG'}
+
+
+def test_configure_dispatcher_logging_updates_level(settings):
+    original_logging_settings = copy.deepcopy(settings.LOGGING)
+    settings.LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'filters': {
+            'dynamic_level_filter': {
+                '()': 'logging.Filter',
+            }
+        },
+        'handlers': {
+            'console': {
+                'class': 'logging.StreamHandler',
+                'filters': ['dynamic_level_filter'],
+                'stream': 'ext://sys.stdout',
+            }
+        },
+        'loggers': {
+            'dispatcherd': {
+                'handlers': ['console'],
+                'level': 'INFO',
+                'propagate': False,
+            }
+        },
+    }
+    settings.LOG_AGGREGATOR_LEVEL = 'WARNING'
+
+    Command().configure_dispatcher_logging()
+
+    assert logging.getLogger('dispatcherd').level == logging.WARNING
+    settings.LOGGING = original_logging_settings

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 
 from django.conf import settings
+from django.core.cache import cache
 
 from awx.api.versioning import reverse
 
@@ -60,6 +61,7 @@ def live_tmp_folder():
         subprocess.run(GIT_COMMANDS, cwd=source_dir, shell=True)
     if path not in settings.AWX_ISOLATION_SHOW_PATHS:
         settings.AWX_ISOLATION_SHOW_PATHS = settings.AWX_ISOLATION_SHOW_PATHS + [path]
+        cache.delete_many(['AWX_ISOLATION_SHOW_PATHS'])
     return path
 
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -120,7 +120,7 @@ cython==3.1.3
     # via -r /awx_devel/requirements/requirements.in
 daphne==4.2.1
     # via -r /awx_devel/requirements/requirements.in
-dispatcherd[pg_notify]==2025.12.10
+dispatcherd[pg_notify]==2025.12.12
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
Right now, it looks like logs will respect the dynamic_level_filter, and this is a bad thing, and was never intended. Because doing this means talking to postgres, and that has no async version, which means that it will likely create a new synchronous connection in asyncio code, which is very bad, although it might be kind of working for now.

This sets the dynamic log level only on startup, and then just to be sure, closes the connection.

I will put up a separate proposal for on-the-fly adjustments of the log level which I argue should be done by memory modification via a task (formally a control task), which the dispatcherd process, specifically, has facilities to allow.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies a static logging configuration for `dispatcherd` and wires settings changes to propagate via control messages.
> 
> - Add `configure_dispatcher_logging()` in `run_dispatcher.py` to strip `dynamic_level_filter` from handlers and set `loggers['dispatcherd'].level` from `settings.LOG_AGGREGATOR_LEVEL`; invoke it when `FEATURE_DISPATCHERD_ENABLED` is on
> - Before starting `dispatcherd`, close `django.db` connection and `django_cache` to avoid sync connections with the async broker
> - In `clear_setting_cache`, when `LOG_AGGREGATOR_LEVEL` changes, publish `control`=`set_log_level` with `{'level': settings.LOG_AGGREGATOR_LEVEL}` to `get_task_queuename()`
> - Tests: assert log-level publish in `test_tasks_system.py` and that `configure_dispatcher_logging()` updates `logging.getLogger('dispatcherd').level`; clear `AWX_ISOLATION_SHOW_PATHS` cache in live tests
> - Bump `dispatcherd[pg_notify]` to `2025.12.12`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6176e0a79bc73b35226c87e9a0e092d75736b67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->