### PR TITLE
Improve logging for starting jobs and test cleanup

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -197,12 +197,24 @@ def with_path_cleanup(f):
 
 @task(on_duplicate='queue_one', bind=True, queue=get_task_queuename)
 def dispatch_waiting_jobs(binder):
-    for uj in UnifiedJob.objects.filter(status='waiting', controller_node=settings.CLUSTER_HOST_ID).only('id', 'status', 'polymorphic_ctype', 'celery_task_id'):
+    start_time = time.monotonic()
+    job_id_list = []
+    for uj in UnifiedJob.objects.filter(status='waiting', controller_node=settings.CLUSTER_HOST_ID).only('id', 'status', 'polymorphic_ctype', 'celery_task_id')[
+        :25
+    ]:
         kwargs = uj.get_start_kwargs()
         if not kwargs:
             kwargs = {}
+        job_id_list.append(uj.pk)
         binder.control('run', data={'task': serialize_task(uj._get_task_class()), 'args': [uj.id], 'kwargs': kwargs, 'uuid': uj.celery_task_id})
         UnifiedJob.objects.filter(pk=uj.pk, status='waiting').update(status='running', start_args='')
+    if job_id_list:
+        logger.info(f'Dispatching off waiting jobs {job_id_list}, in time {time.monotonic() - start_time}')
+        # If this is a burst, the task manager may still be producing more jobs so reschedule
+        if len(job_id_list) > 1:
+            binder.control('run', data={'task': serialize_task(dispatch_waiting_jobs), 'args': [], 'kwargs': {}})
+    else:
+        logger.debug('No more waiting jobs to dispatch on this node')
 
 
 class BaseTask(object):

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -10,8 +10,6 @@ from awx.main.models.jobs import JobTemplate
 from awx.main.models import Organization, Inventory, WorkflowJob, ExecutionEnvironment, Host
 from awx.main.scheduler import TaskManager
 
-from django.test import override_settings
-
 
 @pytest.mark.django_db
 @pytest.mark.parametrize('num_hosts, num_queries', [(1, 15), (10, 15)])

--- a/awx/main/tests/functional/test_bulk.py
+++ b/awx/main/tests/functional/test_bulk.py
@@ -2,6 +2,8 @@ import pytest
 
 from uuid import uuid4
 
+from django.test import override_settings
+
 from awx.api.versioning import reverse
 
 from awx.main.models.jobs import JobTemplate
@@ -100,10 +102,10 @@ def test_bulk_job_launch_queries(job_template, organization, inventory, project,
     inventory.save()
     jobs = [{'unified_job_template': jt.id, 'inventory': inventory.id} for _ in range(num_jobs)]
 
-    # This is not working, we need to figure that out if we want to include tests for more jobs
-    # with mock.patch('awx.api.serializers.settings.BULK_JOB_MAX_LAUNCH', num_jobs + 1):
-    with django_assert_max_num_queries(num_queries):
-        bulk_job_launch_response = post(reverse('api:bulk_job_launch'), {'name': 'Bulk Job Launch', 'jobs': jobs}, normal_user, expect=201).data
+    # Assure settings allow given number of jobs
+    with override_settings(BULK_JOB_MAX_LAUNCH=num_jobs + 1):
+        with django_assert_max_num_queries(num_queries):
+            bulk_job_launch_response = post(reverse('api:bulk_job_launch'), {'name': 'Bulk Job Launch', 'jobs': jobs}, normal_user, expect=201).data
 
     # Run task manager so the workflow job nodes actually spawn
     TaskManager().schedule()


### PR DESCRIPTION
##### SUMMARY
This is a mop-up of any remaining issues I saw while trying to do performance testing related to dispatcherd.

We had a case where scale-ups could result in missed messages, making these messages really important. Although the lost messages were recovered, it was still a pretty bad bug. It should be fixed now, but the logs are also valuable to keep.

This also adds some re-scheduling logic, which is going off of a gut intuition more than anything else. This did not ever cause a delay in job starting, and in practice it was always quite fast.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches job dispatching logic that controls transitioning jobs from `waiting` to `running` and adds self-rescheduling behavior, which could affect job start throughput/order under load. Test change is low risk but the runtime dispatch changes warrant extra attention in clustered/scale-up scenarios.
> 
> **Overview**
> **Improves dispatcher startup visibility and burst handling.** `dispatch_waiting_jobs` now measures dispatch duration, logs the list of dispatched job IDs, and logs when no jobs remain.
> 
> **Adds batching and optional re-queueing.** Dispatching is capped to 25 waiting jobs per invocation and will enqueue another `dispatch_waiting_jobs` run when multiple jobs were dispatched to help drain bursts.
> 
> **Fixes bulk launch functional test isolation.** `test_bulk_job_launch_queries` now uses `override_settings(BULK_JOB_MAX_LAUNCH=...)` so query-count assertions aren’t impacted by the global bulk-launch limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 332dbdeaa9ba92dde03e9432fd5390bdb77b3d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job dispatching to track dispatch timing, accumulate launched jobs, provide clearer logging, and reschedule extra work when multiple jobs start concurrently for smoother processing.

* **Tests**
  * Adjusted bulk-job tests to enforce configured launch limits during the test run and cleaned up duplicated imports to ensure reliable assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->