### PR TITLE
Update ENV pattern in Dockerfile

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -19,10 +19,10 @@ RUN make ui
 # Build container
 FROM quay.io/centos/centos:stream9 AS builder
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV AWX_LOGGING_MODE stdout
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV AWX_LOGGING_MODE=stdout
 
 
 USER root
@@ -111,10 +111,10 @@ RUN DJANGO_SETTINGS_MODULE=awx.settings.defaults SKIP_SECRET_KEY_CHECK=yes SKIP_
 # Final container(s)
 FROM quay.io/centos/centos:stream9
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
-ENV AWX_LOGGING_MODE stdout
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+ENV AWX_LOGGING_MODE=stdout
 
 USER root
 


### PR DESCRIPTION
##### SUMMARY
Try to reduce number of warnings in output

```
2025-12-09T02:33:49.7952640Z  [33m8 warnings found (use docker --debug to expand):
2025-12-09T02:33:49.7953629Z [0m - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 14)
2025-12-09T02:33:49.7954700Z  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 85)
2025-12-09T02:33:49.7955768Z  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 86)
2025-12-09T02:33:49.7957167Z  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 87)
2025-12-09T02:33:49.7958346Z  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 88)
2025-12-09T02:33:49.7959273Z  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 11)
2025-12-09T02:33:49.7960308Z  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 12)
2025-12-09T02:33:49.7962242Z  - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 13)
```

from image build, because it distracts from other troubleshooting

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Dockerfile ENV declarations to key=value format in builder and final stages to reduce linter warnings.
> 
> - **Dockerfile Template (`tools/ansible/roles/dockerfile/templates/Dockerfile.j2`)**
>   - Update `ENV` instructions to `key=value` format in both the **builder** and **final** stages for `LANG`, `LANGUAGE`, `LC_ALL`, and `AWX_LOGGING_MODE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42140edd827e89058cac355fac8a8a0cf5153590. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->