### PR TITLE
Unpin rsyslog in container

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -140,7 +140,7 @@ RUN dnf -y update && dnf install -y 'dnf-command(config-manager)' && \
     "python3.11-packaging" \
     "python3.11-psycopg2" \
     rsync \
-    rsyslog-8.2102.0-106.el9 \
+    rsyslog \
     subversion \
     sudo \
     vim-minimal \


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

docker buildx build fails with
"Error: Unable to find a match: rsyslog-8.2102.0-106.el9"

unpinning builds successfully for both arm64 and x86_64

we had pinned this a while back to fix some failling tests https://github.com/ansible/awx/pull/14117
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unpins `rsyslog` in `tools/ansible/roles/dockerfile/templates/Dockerfile.j2` by replacing `rsyslog-8.2102.0-106.el9` with `rsyslog` in the runtime package install list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f79bf2d85a42e207904001a1ad5f14dee6b413d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->