### PR TITLE
Remove custom docs endpoint in DAB now

### DIFF
--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -148,9 +148,6 @@ v2_urls = [
 
 app_name = 'api'
 
-# Import schema views (needed for both development and testing)
-from awx.api.schema import schema_view, swagger_ui_view, redoc_view
-
 urlpatterns = [
     re_path(r'^$', ApiRootView.as_view(), name='api_root_view'),
     re_path(r'^(?P<version>(v2))/', include(v2_urls)),

--- a/awx/api/urls/urls.py
+++ b/awx/api/urls/urls.py
@@ -156,10 +156,7 @@ urlpatterns = [
     re_path(r'^(?P<version>(v2))/', include(v2_urls)),
     re_path(r'^login/$', LoggedLoginView.as_view(template_name='rest_framework/login.html', extra_context={'inside_login_context': True}), name='login'),
     re_path(r'^logout/$', LoggedLogoutView.as_view(next_page='/api/', redirect_field_name='next'), name='logout'),
-    # Schema endpoints (available in all modes for API documentation and testing)
-    re_path(r'^schema/$', schema_view, name='schema-json'),
-    re_path(r'^docs/$', swagger_ui_view, name='schema-swagger-ui'),
-    re_path(r'^redoc/$', redoc_view, name='schema-redoc'),
+    # the docs/, schema-related endpoints used to be listed here but now exposed by DAB api_documentation app
 ]
 
 from awx.api.urls.debug import urls as debug_urls


### PR DESCRIPTION
##### SUMMARY
Formally, it looks like this should have been done with https://github.com/ansible/awx/pull/16186, but at the time we didn't actually understand the feature set of DAB api_documentation. So just doing cleanup from that now.

This will help to directly expose us to changes from https://github.com/ansible/django-ansible-base/pull/902, because without this change there's a lot of confusion and unintended behavior.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `schema/`, `docs/`, and `redoc/` routes and related imports from `awx/api/urls/urls.py`; documentation now provided by DAB `api_documentation`.
> 
> - **API routing**:
>   - Remove `schema/`, `docs/`, and `redoc/` endpoints from `awx/api/urls/urls.py` and drop imports `schema_view`, `swagger_ui_view`, `redoc_view`.
>   - Note via comment that docs/schema are now exposed by DAB `api_documentation`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8ccf439a7a4a496e65bd69708512f2a0c4cd020. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->