### PR TITLE
AAP-58457 Update UT for removed IPv6 feature flag

### DIFF
--- a/awx/main/tests/functional/dab_feature_flags/test_feature_flags_api.py
+++ b/awx/main/tests/functional/dab_feature_flags/test_feature_flags_api.py
@@ -26,5 +26,5 @@ def test_feature_flags_list_endpoint_override(get, flag_val):
     seed_feature_flags()
     url = "/api/v2/feature_flags/states/"
     response = get(url, user=bob, expect=200)
-    assert len(response.data["results"]) == 6
+    assert len(response.data["results"]) == 5
     assert flag_state(flag_name) == flag_val


### PR DESCRIPTION
##### SUMMARY

Just updated a UT for removal of FEATURE_GATEWAY_IPV6_USAGE_ENABLED (expected count).  No other changes.

DAB: https://github.com/ansible/django-ansible-base/pull/908
GATEWAY: https://github.com/ansible-automation-platform/aap-gateway/pull/1183

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### ADDITIONAL INFORMATION
N/A
