### PR TITLE
Bump requirement because version was yanked from PyPI

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -352,7 +352,7 @@ pkgconfig==1.5.5
     # via -r /awx_devel/requirements/requirements.in
 prometheus-client==0.23.1
     # via -r /awx_devel/requirements/requirements.in
-propcache==0.4.0
+propcache==0.4.1
     # via
     #   aiohttp
     #   yarl


### PR DESCRIPTION
##### SUMMARY
See https://github.com/aio-libs/propcache/issues/159, we have a listed requirement version that _was yanked from PyPI_. The reasons to avoid this are fairly obvious. Is there any build system this _won't_ break?

Confirmed that `./updater.sh run` completes and is satisfied with this code state.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps dependency pin to avoid a yanked release.
> 
> - Update `propcache` from `0.4.0` to `0.4.1` in `requirements/requirements.txt` (used by `aiohttp`/`yarl`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00449486ab650b82e76d07232696f8ef77a0f82e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->