### PR TITLE
Never ever put a task in a retired workers queue

### DIFF
--- a/awx/main/dispatch/pool.py
+++ b/awx/main/dispatch/pool.py
@@ -304,11 +304,24 @@ class WorkerPool(object):
         now = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
         return tmpl.render(pool=self, workers=self.workers, meta=self.debug_meta, dt=now)
 
+    def queue_attempt_order(self, preferred_queue):
+        """
+        Return the order in which write() will attempt to assign work.
+        """
+        return sorted(range(len(self.workers)), key=lambda x: -1 if x == preferred_queue else x)
+
     def write(self, preferred_queue, body):
-        queue_order = sorted(range(len(self.workers)), key=lambda x: -1 if x == preferred_queue else x)
+        queue_order = self.queue_attempt_order(preferred_queue)
         write_attempt_order = []
+        skipped_retired = []
+        task_uuid = body.get('uuid') if isinstance(body, dict) else None
         for queue_actual in queue_order:
+            worker = self.workers[queue_actual]
+            if getattr(worker, 'retiring', False):
+                skipped_retired.append(queue_actual)
+                continue
             try:
+                write_attempt_order.append(queue_actual)
                 self.workers[queue_actual].put(body)
                 return queue_actual
             except QueueFull:
@@ -317,7 +330,11 @@ class WorkerPool(object):
                 tb = traceback.format_exc()
                 logger.warning("could not write to queue %s" % preferred_queue)
                 logger.warning("detail: {}".format(tb))
-            write_attempt_order.append(preferred_queue)
+        if skipped_retired and not write_attempt_order:
+            logger.error("All workers are retiring; abandoning task {} after skipping queues: {}".format(task_uuid or 'unknown', skipped_retired))
+            return None
+        if skipped_retired:
+            logger.warning("Skipped retired workers while dispatching task {}: {}".format(task_uuid or 'unknown', skipped_retired))
         logger.error("could not write payload to any queue, attempted order: {}".format(write_attempt_order))
         return None
 
@@ -557,7 +574,7 @@ class AutoscalePool(WorkerPool):
             workers = self.workers[:]
             random.shuffle(workers)
             for w in workers:
-                if not w.busy:
+                if not w.busy and not getattr(w, 'retiring', False):
                     w.put(body)
                     break
             else:

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -10,6 +10,7 @@ from unittest import mock
 from flags.state import disable_flag, enable_flag
 from django.utils.timezone import now as tz_now
 import pytest
+from queue import Full as QueueFull
 
 from awx.main.models import Job, WorkflowJob, Instance
 from awx.main.dispatch import reaper

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -1,3 +1,5 @@
+import logging
+import ast
 import datetime
 import multiprocessing
 import random
@@ -11,7 +13,7 @@ import pytest
 
 from awx.main.models import Job, WorkflowJob, Instance
 from awx.main.dispatch import reaper
-from awx.main.dispatch.pool import StatefulPoolWorker, WorkerPool, AutoscalePool
+from awx.main.dispatch.pool import PoolWorker, StatefulPoolWorker, WorkerPool, AutoscalePool
 from awx.main.dispatch.publish import task
 from awx.main.dispatch.worker import BaseWorker, TaskWorker
 from awx.main.dispatch.periodic import Scheduler
@@ -162,6 +164,28 @@ class TestWorkerPool:
 
         total_handled = sum([worker.messages_sent for worker in self.pool.workers])
         assert total_handled == 10
+
+    def test_queue_attempt_log_contains_actual_workers(self, caplog, monkeypatch):
+        self.pool.init_workers(SimpleWorker().work_loop)
+
+        def always_full(self, body):
+            raise QueueFull("full")
+
+        monkeypatch.setattr(PoolWorker, "put", always_full)
+
+        with caplog.at_level(logging.ERROR, logger='awx.main.dispatch'):
+            self.pool.write(2, {'task': 'noop'})
+
+        log = [record for record in caplog.records if 'could not write payload to any queue' in record.message][0]
+        attempted = ast.literal_eval(log.message.split('attempted order: ')[1])
+        assert attempted == [2, 0, 1]
+
+    def test_retired_worker_not_preferred(self):
+        self.pool.init_workers(SimpleWorker().work_loop)
+        retired_idx = 1
+        self.pool.workers[retired_idx].retiring = True
+        order = self.pool.queue_attempt_order(retired_idx)
+        assert order[0] != retired_idx
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY
We had a few problems with the accuracy of logs related to retired workers that this intends to address, but it really came from a stuck task.

Also, the path for retiring a worker is complicated if it gets additional items in its queue, so this just gives up on placing a task if all workers are retired.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

