### PR TITLE
Do not eat errors building images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -578,7 +578,7 @@ docker-compose-build: Dockerfile.dev
 docker-compose-buildx: Dockerfile.dev
 	- docker buildx create --name docker-compose-buildx
 	docker buildx use docker-compose-buildx
-	- docker buildx build \
+	docker buildx build \
 		--ssh default=$(SSH_AUTH_SOCK) \
 		--push \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \
@@ -638,7 +638,7 @@ awx-kube-build: Dockerfile
 awx-kube-buildx: Dockerfile
 	- docker buildx create --name awx-kube-buildx
 	docker buildx use awx-kube-buildx
-	- docker buildx build \
+	docker buildx build \
 		--ssh default=$(SSH_AUTH_SOCK) \
 		--push \
 		--build-arg VERSION=$(VERSION) \
@@ -672,7 +672,7 @@ awx-kube-dev-build: Dockerfile.kube-dev
 awx-kube-dev-buildx: Dockerfile.kube-dev
 	- docker buildx create --name awx-kube-dev-buildx
 	docker buildx use awx-kube-dev-buildx
-	- docker buildx build \
+	docker buildx build \
 		--ssh default=$(SSH_AUTH_SOCK) \
 		--push \
 		--build-arg BUILDKIT_INLINE_CACHE=1 \


### PR DESCRIPTION
##### SUMMARY
I tried to pull awx_devel image and I couldn't. Still have image from December. The recent merges had passing checks, but actually were error. I got angry and made this.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures build failures surface during multi-arch image builds instead of being ignored.
> 
> - Remove the error-ignoring prefix from `docker buildx build` in `docker-compose-buildx`, `awx-kube-buildx`, and `awx-kube-dev-buildx` targets in the `Makefile`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b665b0481d4ded14aba59bc934de24f839d9eed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->