### PR TITLE
Cache juggling to help address test flake

### DIFF
--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -59,9 +59,14 @@ def live_tmp_folder():
     for dirname in os.listdir(path):
         source_dir = os.path.join(path, dirname)
         subprocess.run(GIT_COMMANDS, cwd=source_dir, shell=True)
+    # force invalidation of key before checking it in case it is stale
+    cache.delete_many(['AWX_ISOLATION_SHOW_PATHS'])
     if path not in settings.AWX_ISOLATION_SHOW_PATHS:
+        logger.info(f'Modifying settings.AWX_ISOLATION_SHOW_PATHS for live test: {settings.AWX_ISOLATION_SHOW_PATHS + [path]}')
         settings.AWX_ISOLATION_SHOW_PATHS = settings.AWX_ISOLATION_SHOW_PATHS + [path]
         cache.delete_many(['AWX_ISOLATION_SHOW_PATHS'])
+    else:
+        logger.info(f'Believed that {path} is already in settings.AWX_ISOLATION_SHOW_PATHS: {settings.AWX_ISOLATION_SHOW_PATHS}')
     return path
 
 


### PR DESCRIPTION
##### SUMMARY
Seen a frequent failure:

```
____________________________ test_git_file_project _____________________________

live_tmp_folder = '/tmp/live_tests'
run_job_from_playbook = <function run_job_from_playbook.<locals>._rf at 0x7f2bee3637e0>

    def test_git_file_project(live_tmp_folder, run_job_from_playbook):
>       run_job_from_playbook('test_git_file_project', 'debug.yml', scm_url=f'file://{live_tmp_folder}/debug')

tests/projects/test_file_projects.py:10: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/conftest.py:195: in _rf
    wait_for_job(proj.current_job)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

job = <ProjectUpdate: 2026-01-08 16:44:18.068146+00:00-4-failed>
final_status = 'successful', running_timeout = 800

    def wait_for_job(job, final_status='successful', running_timeout=800):
        wait_to_leave_status(job, 'pending')
        wait_to_leave_status(job, 'waiting')
        wait_to_leave_status(job, 'running', timeout=running_timeout)
    
>       assert job.status == final_status, f'Job was not successful id={job.id} status={job.status} tb={job.result_traceback} output=\n{unified_job_stdout(job)}'
E       AssertionError: Job was not successful id=4 status=failed tb= output=
E         
E         
E         PLAY [Update source tree if necessary] *****************************************
E         
E         TASK [Update project using git] ************************************************
E         
E         fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/git ls-remote file:///tmp/live_tests/debug -h refs/heads/HEAD", "msg": "fatal: '/tmp/live_tests/debug' does not appear to be a git repository\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.", "rc": 128, "stderr": "fatal: '/tmp/live_tests/debug' does not appear to be a git repository\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.\n", "stderr_lines": ["fatal: '/tmp/live_tests/debug' does not appear to be a git repository", "fatal: Could not read from remote repository.", "", "Please make sure you have the correct access rights", "and the repository exists."], "stdout": "", "stdout_lines": []}
E         
E         PLAY RECAP *********************************************************************
E         localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
E       assert 'failed' == 'successful'
E         
E         - successful
E         + failed

tests/conftest.py:102: AssertionError
```

@TheRealHaoLiu suggested it's a cache issue, and this seems pretty definite. Hopefully this gets it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `live_tmp_folder` fixture setup robustness and observability.
> 
> - Preemptively invalidates the `AWX_ISOLATION_SHOW_PATHS` cache key before checking membership; still clears it after mutation
> - Adds info logs when modifying or confirming `settings.AWX_ISOLATION_SHOW_PATHS`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c11cebc6c3dd630e37beabc1f279bf30ecaf0a04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->