### PR TITLE
Clear in-memory cache, suggested by bugbot

### DIFF
--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -69,7 +69,7 @@ def live_tmp_folder():
         cache.delete_many(['AWX_ISOLATION_SHOW_PATHS'])
         settings._awx_conf_memoizedcache.clear()
         # cache is cleared in test environment, but need to clear in test environment
-        clear_setting_cache.delay()
+        clear_setting_cache.delay(['AWX_ISOLATION_SHOW_PATHS'])
         time.sleep(0.2)  # allow task to finish, we have no real metric to know
     else:
         logger.info(f'Believed that {path} is already in settings.AWX_ISOLATION_SHOW_PATHS: {settings.AWX_ISOLATION_SHOW_PATHS}')

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -19,6 +19,7 @@ from awx.main.tests.conftest import load_all_credentials  # noqa: F401; pylint: 
 from awx.main.tests import data
 
 from awx.main.models import Project, JobTemplate, Organization, Inventory
+from awx.main.tasks.system import clear_setting_cache
 
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,9 @@ def live_tmp_folder():
         settings.AWX_ISOLATION_SHOW_PATHS = settings.AWX_ISOLATION_SHOW_PATHS + [path]
         cache.delete_many(['AWX_ISOLATION_SHOW_PATHS'])
         settings._awx_conf_memoizedcache.clear()
+        # cache is cleared in test environment, but need to clear in test environment
+        clear_setting_cache.delay()
+        time.sleep(0.2)  # allow task to finish, we have no real metric to know
     else:
         logger.info(f'Believed that {path} is already in settings.AWX_ISOLATION_SHOW_PATHS: {settings.AWX_ISOLATION_SHOW_PATHS}')
     return path

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -61,10 +61,12 @@ def live_tmp_folder():
         subprocess.run(GIT_COMMANDS, cwd=source_dir, shell=True)
     # force invalidation of key before checking it in case it is stale
     cache.delete_many(['AWX_ISOLATION_SHOW_PATHS'])
+    settings._awx_conf_memoizedcache.clear()
     if path not in settings.AWX_ISOLATION_SHOW_PATHS:
         logger.info(f'Modifying settings.AWX_ISOLATION_SHOW_PATHS for live test: {settings.AWX_ISOLATION_SHOW_PATHS + [path]}')
         settings.AWX_ISOLATION_SHOW_PATHS = settings.AWX_ISOLATION_SHOW_PATHS + [path]
         cache.delete_many(['AWX_ISOLATION_SHOW_PATHS'])
+        settings._awx_conf_memoizedcache.clear()
     else:
         logger.info(f'Believed that {path} is already in settings.AWX_ISOLATION_SHOW_PATHS: {settings.AWX_ISOLATION_SHOW_PATHS}')
     return path


### PR DESCRIPTION
##### SUMMARY
from

https://github.com/ansible/awx/pull/16217

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures live test setup properly propagates `AWX_ISOLATION_SHOW_PATHS` changes across processes.
> 
> - Clears in-memory settings cache via `settings._awx_conf_memoizedcache.clear()` before and after mutating `AWX_ISOLATION_SHOW_PATHS`
> - Schedules `clear_setting_cache.delay(['AWX_ISOLATION_SHOW_PATHS'])` and adds a brief sleep to allow the task to complete
> - Minor import addition for `clear_setting_cache` in `conftest.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a962c81bd0051432396c43ab7211356f08207f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->