### PR TITLE
Fix devel awx, awx_devel, awx_kube_devel build

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1116,12 +1116,6 @@ ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = False  # System auditor has always been restricted to users
 ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API = False  # Do not allow creating user-defined system-wide roles
 
-# Registry for models tracked by the DAB RBAC system (AWX uses permission_registry.register() instead)
-ANSIBLE_BASE_RBAC_MODEL_REGISTRY = {}
-
-# Registry for managed role definitions (AWX manages roles via data migrations)
-ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {}
-
 # system username for django-ansible-base
 SYSTEM_USERNAME = None
 

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1116,6 +1116,12 @@ ANSIBLE_BASE_ALLOW_SINGLETON_USER_ROLES = True
 ANSIBLE_BASE_ALLOW_SINGLETON_TEAM_ROLES = False  # System auditor has always been restricted to users
 ANSIBLE_BASE_ALLOW_SINGLETON_ROLES_API = False  # Do not allow creating user-defined system-wide roles
 
+# Registry for models tracked by the DAB RBAC system (AWX uses permission_registry.register() instead)
+ANSIBLE_BASE_RBAC_MODEL_REGISTRY = {}
+
+# Registry for managed role definitions (AWX manages roles via data migrations)
+ANSIBLE_BASE_MANAGED_ROLE_REGISTRY = {}
+
 # system username for django-ansible-base
 SYSTEM_USERNAME = None
 

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -179,7 +179,7 @@ RUN dnf -y install \
     wget \
     diffutils \
     unzip && \
-    npm install -g n && n 16.13.1 && npm install -g npm@8.5.0 && dnf remove -y nodejs
+    npm install -g n && n 18 && dnf remove -y nodejs
 
 RUN pip3.12 install -vv git+https://github.com/coderanger/supervisor-stdout.git@973ba19967cdaf46d9c1634d1675fc65b9574f6e
 RUN pip3.12 install -vv black setuptools-scm build

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -102,7 +102,7 @@ COPY --from=ui-builder /tmp/src/awx/ui/build /tmp/src/awx/ui/build
 RUN make sdist && /var/lib/awx/venv/awx/bin/pip install dist/awx.tar.gz
 
 {% if not headless|bool %}
-RUN DJANGO_SETTINGS_MODULE=awx.settings.defaults SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear
+RUN AWX_MODE=development DJANGO_SETTINGS_MODULE=awx.settings.defaults SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear
 {% endif %}
 
 {% endif %}

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -102,7 +102,11 @@ COPY --from=ui-builder /tmp/src/awx/ui/build /tmp/src/awx/ui/build
 RUN make sdist && /var/lib/awx/venv/awx/bin/pip install dist/awx.tar.gz
 
 {% if not headless|bool %}
-RUN AWX_MODE=development DJANGO_SETTINGS_MODULE=awx.settings.defaults SKIP_SECRET_KEY_CHECK=yes SKIP_PG_VERSION_CHECK=yes /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear
+RUN AWX_MODE=defaults \
+    SKIP_SECRET_KEY_CHECK=yes \
+    SKIP_PG_VERSION_CHECK=yes \
+    AWX_SKIP_CREDENTIAL_TYPES_DISCOVER=yes \
+    /var/lib/awx/venv/awx/bin/awx-manage collectstatic --noinput --clear
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
Node.js 16.13.1 fails to extract on ARM64 in Docker BuildKit's overlay filesystem during multi-arch builds. Upgrade to Node 18 which is already used by the UI builder stage and has proper ARM64 support.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Upgrade dev image Node.js from `16.13.1` (and explicit npm pin) to `18` via `n`, removing the extra npm install step
> - Update `awx-manage collectstatic` env: replace `DJANGO_SETTINGS_MODULE=awx.settings.defaults` with `AWX_MODE=defaults` and add `AWX_SKIP_CREDENTIAL_TYPES_DISCOVER=yes` (keeps existing skip checks)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e0f4f11630f663ca9d315b08706914fce9b6012d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->