### PR TITLE
Use dnf module for Node.js 18 instead of n version manager - damn it aarch64

### DIFF
--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -8,8 +8,7 @@
 # UI_next build contaienr
 FROM quay.io/centos/centos:stream9 AS ui-builder
 USER root
-RUN dnf -y update && dnf install -y nodejs make git
-RUN npm install -g n && n 18
+RUN dnf -y update && dnf module -y enable nodejs:18 && dnf module -y install nodejs:18/common && dnf install -y make git
 
 COPY . /tmp/src/
 WORKDIR /tmp/src/
@@ -159,7 +158,8 @@ RUN rm -rf /root/.cache && rm -rf /tmp/*
 
 {% if (build_dev|bool) or (kube_dev|bool) %}
 # Install development/test requirements
-RUN dnf -y install \
+RUN dnf module -y enable nodejs:18 && dnf module -y install nodejs:18/common && \
+    dnf -y install \
     crun \
     gdb \
     gtk3 \
@@ -174,7 +174,6 @@ RUN dnf -y install \
     vim \
     nmap-ncat \
     libpq-devel \
-    nodejs \
     nss \
     make \
     patch \
@@ -182,8 +181,7 @@ RUN dnf -y install \
     tmux \
     wget \
     diffutils \
-    unzip && \
-    npm install -g n && n 18 && dnf remove -y nodejs
+    unzip
 
 RUN pip3.12 install -vv git+https://github.com/coderanger/supervisor-stdout.git@973ba19967cdaf46d9c1634d1675fc65b9574f6e
 RUN pip3.12 install -vv black setuptools-scm build


### PR DESCRIPTION
##### SUMMARY
The n version manager fails to extract Node.js archives due to very long file paths in include/node/openssl/archs/ directories when running in Docker BuildKit's overlay filesystem. This causes CI build failures with tar "Cannot open: Invalid argument" errors.

Switch to installing Node.js 18 directly from CentOS Stream 9's module stream which avoids the archive extraction issue entirely.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches Node.js installation to CentOS Stream 9’s `nodejs:18/common` module to avoid overlayfs tar extraction issues and simplify builds.
> 
> - In `Dockerfile.j2`, `ui-builder` and dev/kube dev stages now `dnf module enable/install nodejs:18` instead of using `npm n` to fetch Node.js
> - Removes prior `npm n` install/cleanup steps and the transient `nodejs` package juggling; keeps remaining build/dev packages unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1a32447b0b9c5128086fc52f8ea8da1b661e318. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->