### PR TITLE
Add kubernetes python client from git at release-34.0

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -60,7 +60,7 @@ requests
 slack-sdk
 twilio
 twisted[tls]>=24.7.0  # CVE-2024-41810
-urllib3<2.4.0, >=1.26.19 # CVE-2024-37891. capped by kubernetes 34.1.0 reqs
+urllib3>=2.6.3 # CVE-2024-37891. capped by kubernetes 34.1.0 reqs
 uWSGI>=2.0.28
 uwsgitop
 wheel>=0.38.1  # CVE-2022-40898

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -253,8 +253,10 @@ jsonschema==4.25.1
     #   drf-spectacular
 jsonschema-specifications==2025.9.1
     # via jsonschema
-kubernetes==34.1.0
-    # via openshift
+# kubernetes @ git+https://github.com/kubernetes-client/python.git@df31d90d6c910d6b5c883b98011c93421cac067d  # git requirements installed separately
+    # via
+    #   -r /awx_devel/requirements/requirements_git.txt
+    #   openshift
 lockfile==0.12.2
     # via python-daemon
 markdown==3.9
@@ -524,7 +526,7 @@ typing-extensions==4.15.0
     #   twisted
 uritemplate==4.2.0
     # via drf-spectacular
-urllib3==2.3.0
+urllib3==2.6.3
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   botocore

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -22,3 +22,4 @@ ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel
 awx-plugins-core[credentials-github-app] @ git+https://github.com/ansible/awx-plugins.git@devel
 django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel
 awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
+kubernetes @ git+https://github.com/kubernetes-client/python.git@df31d90d6c910d6b5c883b98011c93421cac067d


### PR DESCRIPTION
##### SUMMARY
Switch to git-based installation of kubernetes python client from github.com/kubernetes-client/python at commit df31d90d6c910d6b5c883b98011c93421cac067d (release-34.0 branch). This also allows removing the urllib3<2.4.0 upper bound constraint that was previously required by kubernetes 34.1.0 from PyPI.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts dependency management to use the upstream `kubernetes` Python client from Git (commit `df31d90…` on `release-34.0`) and updates `urllib3` accordingly.
> 
> - Install `kubernetes` from Git via `requirements_git.txt`; remove PyPI pin from `requirements.txt` and add corresponding comment to avoid duplicate install
> - Remove `urllib3<2.4.0` cap and bump to `urllib3==2.6.3` in `requirements.in` and compiled `requirements.txt`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae2d83724aeab4390e142d4e40d1c261aa2a631c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->