### PR TITLE
Build devel image and push to quay.io

### DIFF
--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -3,6 +3,7 @@ name: Build/Push Development Images
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
   DOCKER_CACHE: "--no-cache" # using the cache will not rebuild git requirements and other things
+  DOWNSTREAM_REPO: "ansible-automation-platform/tower"
 on:
   workflow_dispatch:
   push:
@@ -59,6 +60,11 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
+      - name: Log in to Quay
+        run: |
+          echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u ${{ secrets.QUAY_USER }} --password-stdin
+        if: github.repository == env.DOWNSTREAM_REPO
+
       - name: Setup node and npm for the new UI build
         uses: actions/setup-node@v2
         with:
@@ -77,3 +83,8 @@ jobs:
       - name: Build and push AWX devel images
         run: |
           make ${{ matrix.build-targets.make-target }}
+
+      - name: Build and push AWX devel image to Quay
+        run: |
+          make docker-compose-buildx-quay
+        if: github.repository == env.DOWNSTREAM_REPO && matrix.build-targets.image-name == 'awx_devel'

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -3,7 +3,8 @@ name: Build/Push Development Images
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
   DOCKER_CACHE: "--no-cache" # using the cache will not rebuild git requirements and other things
-  DOWNSTREAM_REPO: "ansible-automation-platform/tower"
+  DOWNSTREAM_REPO: "ansible/tower"
+  QUAY_OWNER: "aap"
 on:
   workflow_dispatch:
   push:
@@ -24,6 +25,8 @@ jobs:
       matrix:
         build-targets:
           - image-name: awx_devel
+            make-target: docker-compose-buildx
+          - image-name: tower_devel
             make-target: docker-compose-buildx
           - image-name: awx_kube_devel
             make-target: awx-kube-dev-buildx
@@ -54,6 +57,11 @@ jobs:
         env:
           OWNER: '${{ github.repository_owner }}'
 
+      - name: Overwrite DEV_DOCKER_TAG_BASE for tower_devel
+        run: |
+          echo "DEV_DOCKER_TAG_BASE=quay.io/${{ env.QUAY_OWNER }}" >> $GITHUB_ENV
+        if: matrix.build-targets.image-name == 'tower_devel'
+
       - uses: ./.github/actions/setup-python
 
       - name: Log in to registry
@@ -83,8 +91,3 @@ jobs:
       - name: Build and push AWX devel images
         run: |
           make ${{ matrix.build-targets.make-target }}
-
-      - name: Build and push AWX devel image to Quay
-        run: |
-          make docker-compose-buildx-quay
-        if: github.repository == env.DOWNSTREAM_REPO && matrix.build-targets.image-name == 'awx_devel'

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -3,7 +3,6 @@ name: Build/Push Development Images
 env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
   DOCKER_CACHE: "--no-cache" # using the cache will not rebuild git requirements and other things
-  DOWNSTREAM_REPO: "ansible/tower"
   QUAY_OWNER: "aap"
 on:
   workflow_dispatch:

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Log in to Quay
         run: |
-          echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u ${{ secrets.QUAY_USER }} --password-stdin
+          echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u ${{ vars.QUAY_USER }} --password-stdin
         if: matrix.build-targets.image-name == 'tower_devel'
 
       - name: Setup node and npm for the new UI build

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           OWNER: '${{ github.repository_owner }}'
 
-      - name: Overwrite DEV_DOCKER_TAG_BASE for tower_devel
+      - name: Overwrite DEV_DOCKER_TAG_BASE to Quay registry
         run: |
           echo "DEV_DOCKER_TAG_BASE=quay.io/${{ env.QUAY_OWNER }}" >> $GITHUB_ENV
         if: matrix.build-targets.image-name == 'tower_devel'
@@ -71,7 +71,7 @@ jobs:
       - name: Log in to Quay
         run: |
           echo "${{ secrets.QUAY_TOKEN }}" | docker login quay.io -u ${{ secrets.QUAY_USER }} --password-stdin
-        if: github.repository == env.DOWNSTREAM_REPO
+        if: matrix.build-targets.image-name == 'tower_devel'
 
       - name: Setup node and npm for the new UI build
         uses: actions/setup-node@v2

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ DEVEL_IMAGE_NAME ?= $(DEV_DOCKER_TAG_BASE)/$(GIT_REPO_NAME)_devel:$(COMPOSE_TAG)
 IMAGE_KUBE_DEV=$(DEV_DOCKER_TAG_BASE)/$(GIT_REPO_NAME)_kube_devel:$(COMPOSE_TAG)
 IMAGE_KUBE=$(DEV_DOCKER_TAG_BASE)/$(GIT_REPO_NAME):$(COMPOSE_TAG)
 
+# quay.io
+QUAY_OWNER ?= aap
+QUAY_TAG_BASE ?= quay.io/$(QUAY_OWNER)
+QUAY_DEVEL_IMAGE_NAME ?= $(QUAY_TAG_BASE)/$(GIT_REPO_NAME)_devel:$(COMPOSE_TAG)
+
 # Common command to use for running ansible-playbook
 ANSIBLE_PLAYBOOK ?= ansible-playbook -e ansible_python_interpreter=$(PYTHON)
 
@@ -619,6 +624,21 @@ docker-compose-buildx: Dockerfile.dev
 		--tag $(DEVEL_IMAGE_NAME) \
 		-f Dockerfile.dev .
 	- docker buildx rm docker-compose-buildx
+
+.PHONY: docker-compose-buildx-quay
+## Build image and push to quay.io only (reuse ghcr.io image)
+docker-compose-buildx-quay: Dockerfile.dev
+	- docker buildx create --name docker-compose-buildx-quay
+	docker buildx use docker-compose-buildx-quay
+	docker buildx build \
+		--ssh default=$(SSH_AUTH_SOCK) \
+		--push \
+		--build-arg BUILDKIT_INLINE_CACHE=1 \
+		--cache-from=$(DEVEL_IMAGE_NAME) \
+		--platform=$(PLATFORMS) \
+		--tag $(QUAY_DEVEL_IMAGE_NAME) \
+		-f Dockerfile.dev .
+	- docker buildx rm docker-compose-buildx-quay
 
 docker-clean:
 	-$(foreach container_id,$(shell docker ps -f name=tools_awx -aq && docker ps -f name=tools_receptor -aq),docker stop $(container_id); docker rm -f $(container_id);)

--- a/Makefile
+++ b/Makefile
@@ -69,11 +69,6 @@ DEVEL_IMAGE_NAME ?= $(DEV_DOCKER_TAG_BASE)/$(GIT_REPO_NAME)_devel:$(COMPOSE_TAG)
 IMAGE_KUBE_DEV=$(DEV_DOCKER_TAG_BASE)/$(GIT_REPO_NAME)_kube_devel:$(COMPOSE_TAG)
 IMAGE_KUBE=$(DEV_DOCKER_TAG_BASE)/$(GIT_REPO_NAME):$(COMPOSE_TAG)
 
-# quay.io
-QUAY_OWNER ?= aap
-QUAY_TAG_BASE ?= quay.io/$(QUAY_OWNER)
-QUAY_DEVEL_IMAGE_NAME ?= $(QUAY_TAG_BASE)/$(GIT_REPO_NAME)_devel:$(COMPOSE_TAG)
-
 # Common command to use for running ansible-playbook
 ANSIBLE_PLAYBOOK ?= ansible-playbook -e ansible_python_interpreter=$(PYTHON)
 
@@ -624,21 +619,6 @@ docker-compose-buildx: Dockerfile.dev
 		--tag $(DEVEL_IMAGE_NAME) \
 		-f Dockerfile.dev .
 	- docker buildx rm docker-compose-buildx
-
-.PHONY: docker-compose-buildx-quay
-## Build image and push to quay.io only (reuse ghcr.io image)
-docker-compose-buildx-quay: Dockerfile.dev
-	- docker buildx create --name docker-compose-buildx-quay
-	docker buildx use docker-compose-buildx-quay
-	docker buildx build \
-		--ssh default=$(SSH_AUTH_SOCK) \
-		--push \
-		--build-arg BUILDKIT_INLINE_CACHE=1 \
-		--cache-from=$(DEVEL_IMAGE_NAME) \
-		--platform=$(PLATFORMS) \
-		--tag $(QUAY_DEVEL_IMAGE_NAME) \
-		-f Dockerfile.dev .
-	- docker buildx rm docker-compose-buildx-quay
 
 docker-clean:
 	-$(foreach container_id,$(shell docker ps -f name=tools_awx -aq && docker ps -f name=tools_receptor -aq),docker stop $(container_id); docker rm -f $(container_id);)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes: https://issues.redhat.com/browse/AAP-61962

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### ADDITIONAL INFORMATION
- Requires setting `secrets.QUAY_TOKEN` and `secrets.QUAY_USER` (though `QUAY_USER` may not need to be a secret)
- My idea is to run this in the AAP repository only, which should have all branches (`devel` and `stable-*` branches)