### PR TITLE
Enhance OpenAPI schema with AI descriptions and fix method names

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -547,11 +547,11 @@ class InstanceGroupList(ListCreateAPIView):
     serializer_class = serializers.InstanceGroupSerializer
     resource_purpose = 'instance groups'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of instance groups."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of instance groups."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Create a new instance group."})
+    @extend_schema_if_available(extensions={"x-ai-description": "Create an instance group. Instances in this group determine where a job will be executed"})
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
@@ -884,11 +884,11 @@ class ExecutionEnvironmentList(ListCreateAPIView):
     swagger_topic = "Execution Environments"
     resource_purpose = 'execution environments'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of execution environments."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of execution environments."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Create a new execution environment."})
+    @extend_schema_if_available(extensions={"x-ai-description": "Create a new execution environment. Once associated with JT/org/etc"})
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
@@ -915,11 +915,15 @@ class ExecutionEnvironmentDetail(RetrieveUpdateDestroyAPIView):
                     raise PermissionDenied(_("Only the 'pull' field can be edited for managed execution environments."))
         return super().update(request, *args, **kwargs)
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Update all fields of an execution environment. All fields must be provided in the request body."})
+    @extend_schema_if_available(
+        extensions={"x-ai-description": "Update all fields of an execution environment. All fields must be provided in the request body."}
+    )
     def put(self, request, *args, **kwargs):
         return super().put(request, *args, **kwargs)
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Update specific fields of an execution environment. Only the fields you provide will be updated."})
+    @extend_schema_if_available(
+        extensions={"x-ai-description": "Update specific fields of an execution environment. Only the fields you provide will be updated."}
+    )
     def patch(self, request, *args, **kwargs):
         return super().patch(request, *args, **kwargs)
 
@@ -957,7 +961,7 @@ class ProjectList(ListCreateAPIView):
     serializer_class = serializers.ProjectSerializer
     resource_purpose = 'projects'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of projects."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of projects."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -1386,7 +1390,7 @@ class CredentialTypeList(ListCreateAPIView):
     serializer_class = serializers.CredentialTypeSerializer
     resource_purpose = 'credential types'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of credential types"})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of credential types"})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -1444,7 +1448,7 @@ class CredentialList(ListCreateAPIView):
     serializer_class = serializers.CredentialSerializerCreate
     resource_purpose = 'credentials'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of credentials"})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of credentials"})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -1737,7 +1741,7 @@ class HostList(HostRelatedSearchMixin, ListCreateAPIView):
     serializer_class = serializers.HostSerializer
     resource_purpose = 'hosts'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of hosts."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of hosts."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -1884,7 +1888,7 @@ class GroupList(ListCreateAPIView):
     serializer_class = serializers.GroupSerializer
     resource_purpose = 'groups'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of groups."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of groups."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -2442,7 +2446,7 @@ class JobTemplateList(ListCreateAPIView):
     always_allow_superuser = False
     resource_purpose = 'job templates'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of job templates."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of job templates."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -3222,7 +3226,7 @@ class WorkflowJobTemplateList(ListCreateAPIView):
     always_allow_superuser = False
     resource_purpose = 'workflow job templates'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of workflow job templates."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of workflow job templates."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -3498,7 +3502,7 @@ class WorkflowJobList(ListAPIView):
     serializer_class = serializers.WorkflowJobListSerializer
     resource_purpose = 'workflow jobs'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of workflow jobs."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of workflow jobs."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -3527,7 +3531,7 @@ class WorkflowJobCancel(GenericCancelView):
     serializer_class = serializers.WorkflowJobCancelSerializer
     resource_purpose = 'cancel for a workflow job'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Cancel a running workflow job"})
+    @extend_schema_if_available(extensions={"x-ai-description": "Cancel a running or pending workflow job"})
     def post(self, request, *args, **kwargs):
         r = super().post(request, *args, **kwargs)
         ScheduleWorkflowManager().schedule()
@@ -3648,7 +3652,7 @@ class JobList(ListAPIView):
     serializer_class = serializers.JobListSerializer
     resource_purpose = 'jobs'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of jobs."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of jobs."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -3701,7 +3705,7 @@ class JobCancel(GenericCancelView):
     serializer_class = serializers.JobCancelSerializer
     resource_purpose = 'cancel for a job'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Cancel a running job."})
+    @extend_schema_if_available(extensions={"x-ai-description": "Cancel a running or pending job"})
     def post(self, request, *args, **kwargs):
         return super().post(request, *args, **kwargs)
 
@@ -4504,7 +4508,7 @@ class NotificationTemplateList(ListCreateAPIView):
     serializer_class = serializers.NotificationTemplateSerializer
     resource_purpose = 'notification templates'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of notification templates."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of notification templates."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 
@@ -4607,7 +4611,7 @@ class ActivityStreamList(SimpleListAPIView):
 
     @extend_schema_if_available(
         extensions={
-            "x-ai-description": "A paginated list of activity stream entries. An activity stream entry tracks actions or changes that were previously made to the system."
+            "x-ai-description": "A list of activity stream entries. An activity stream entry tracks actions or changes that were previously made to the system."
         }
     )
     def get(self, request, *args, **kwargs):

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -385,6 +385,14 @@ class InstanceList(ListCreateAPIView):
     ordering = ('id',)
     resource_purpose = 'instances'
 
+    @extend_schema_if_available(
+        extensions={
+            "x-ai-description": "Register an execution or hop node instance. Only available on openshift based AAP deployments. Use the install bundle playbook to further provision the instance"
+        }
+    )
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
     def get_queryset(self):
         qs = super().get_queryset().prefetch_related('receptor_addresses')
         return qs
@@ -538,6 +546,14 @@ class InstanceGroupList(ListCreateAPIView):
     model = models.InstanceGroup
     serializer_class = serializers.InstanceGroupSerializer
     resource_purpose = 'instance groups'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of instance groups."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Create a new instance group."})
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
 
 
 class InstanceGroupDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAPIView):
@@ -868,6 +884,14 @@ class ExecutionEnvironmentList(ListCreateAPIView):
     swagger_topic = "Execution Environments"
     resource_purpose = 'execution environments'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of execution environments."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Create a new execution environment."})
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
 
 class ExecutionEnvironmentDetail(RetrieveUpdateDestroyAPIView):
     always_allow_superuser = False
@@ -890,6 +914,18 @@ class ExecutionEnvironmentDetail(RetrieveUpdateDestroyAPIView):
                 if left != right:
                     raise PermissionDenied(_("Only the 'pull' field can be edited for managed execution environments."))
         return super().update(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Update all fields of an execution environment. All fields must be provided in the request body."})
+    def put(self, request, *args, **kwargs):
+        return super().put(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Update specific fields of an execution environment. Only the fields you provide will be updated."})
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Delete an execution environment."})
+    def delete(self, request, *args, **kwargs):
+        return super().delete(request, *args, **kwargs)
 
 
 class ExecutionEnvironmentJobTemplateList(SubListAPIView):
@@ -920,6 +956,10 @@ class ProjectList(ListCreateAPIView):
     model = models.Project
     serializer_class = serializers.ProjectSerializer
     resource_purpose = 'projects'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of projects."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
 
 
 class ProjectDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAPIView):
@@ -1346,11 +1386,27 @@ class CredentialTypeList(ListCreateAPIView):
     serializer_class = serializers.CredentialTypeSerializer
     resource_purpose = 'credential types'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of credential types"})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Create a new custom credential type"})
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
 
 class CredentialTypeDetail(RetrieveUpdateDestroyAPIView):
     model = models.CredentialType
     serializer_class = serializers.CredentialTypeSerializer
     resource_purpose = 'credential type detail'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Update a custom credential type."})
+    def put(self, request, *args, **kwargs):
+        return super().put(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Update a custom credential type."})
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
@@ -1359,6 +1415,10 @@ class CredentialTypeDetail(RetrieveUpdateDestroyAPIView):
         if instance.credentials.exists():
             raise PermissionDenied(detail=_("Credential types that are in use cannot be deleted"))
         return super(CredentialTypeDetail, self).destroy(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Delete a custom credential type. Cannot delete managed types or types currently in use."})
+    def delete(self, request, *args, **kwargs):
+        return super().delete(request, *args, **kwargs)
 
 
 class CredentialTypeCredentialList(SubListCreateAPIView):
@@ -1383,6 +1443,10 @@ class CredentialList(ListCreateAPIView):
     model = models.Credential
     serializer_class = serializers.CredentialSerializerCreate
     resource_purpose = 'credentials'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of credentials"})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
 
     @extend_schema_if_available(
         extensions={
@@ -1673,6 +1737,10 @@ class HostList(HostRelatedSearchMixin, ListCreateAPIView):
     serializer_class = serializers.HostSerializer
     resource_purpose = 'hosts'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of hosts."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def get_queryset(self):
         qs = super(HostList, self).get_queryset()
         filter_string = self.request.query_params.get('host_filter', None)
@@ -1815,6 +1883,14 @@ class GroupList(ListCreateAPIView):
     model = models.Group
     serializer_class = serializers.GroupSerializer
     resource_purpose = 'groups'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of groups."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Create a new group."})
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
 
 
 class EnforceParentRelationshipMixin(object):
@@ -2014,6 +2090,10 @@ class HostVariableData(BaseVariableData):
     model = models.Host
     serializer_class = serializers.HostVariableDataSerializer
     resource_purpose = 'variable data for a host'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "The extra variable configuration for this host."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
 
 
 class GroupVariableData(BaseVariableData):
@@ -2302,7 +2382,7 @@ class InventorySourceUpdateView(RetrieveAPIView):
     serializer_class = serializers.InventorySourceUpdateSerializer
     resource_purpose = 'update an inventory source'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Update inventory source"})
+    @extend_schema_if_available(extensions={"x-ai-description": "Sync the inventory source"})
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
         serializer = self.get_serializer(instance=obj, data=request.data)
@@ -2361,6 +2441,10 @@ class JobTemplateList(ListCreateAPIView):
     serializer_class = serializers.JobTemplateSerializer
     always_allow_superuser = False
     resource_purpose = 'job templates'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of job templates."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
 
     def check_permissions(self, request):
         if request.method == 'POST':
@@ -2439,9 +2523,7 @@ class JobTemplateLaunch(RetrieveAPIView):
 
         return modern_data
 
-    @extend_schema_if_available(
-        extensions={'x-ai-description': 'Launch a job'},
-    )
+    @extend_schema_if_available(extensions={"x-ai-description": "Launch the job template"})
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
 
@@ -3140,6 +3222,10 @@ class WorkflowJobTemplateList(ListCreateAPIView):
     always_allow_superuser = False
     resource_purpose = 'workflow job templates'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of workflow job templates."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
     def check_permissions(self, request):
         if request.method == 'POST':
             if request.user.is_anonymous:
@@ -3253,9 +3339,7 @@ class WorkflowJobTemplateLaunch(RetrieveAPIView):
 
         return data
 
-    @extend_schema_if_available(
-        extensions={'x-ai-description': 'Launch a workflow job'},
-    )
+    @extend_schema_if_available(extensions={"x-ai-description": "Launch the workflow job template."})
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
 
@@ -3297,9 +3381,7 @@ class WorkflowJobRelaunch(GenericAPIView):
     def get(self, request, *args, **kwargs):
         return Response({})
 
-    @extend_schema_if_available(
-        extensions={'x-ai-description': 'Relaunch a workflow job'},
-    )
+    @extend_schema_if_available(extensions={"x-ai-description": "Relaunch a workflow job"})
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
         if obj.is_sliced_job:
@@ -3416,6 +3498,10 @@ class WorkflowJobList(ListAPIView):
     serializer_class = serializers.WorkflowJobListSerializer
     resource_purpose = 'workflow jobs'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of workflow jobs."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
 
 class WorkflowJobDetail(UnifiedJobDeletionMixin, RetrieveDestroyAPIView):
     model = models.WorkflowJob
@@ -3441,7 +3527,7 @@ class WorkflowJobCancel(GenericCancelView):
     serializer_class = serializers.WorkflowJobCancelSerializer
     resource_purpose = 'cancel for a workflow job'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Cancel a workflow job"})
+    @extend_schema_if_available(extensions={"x-ai-description": "Cancel a running workflow job"})
     def post(self, request, *args, **kwargs):
         r = super().post(request, *args, **kwargs)
         ScheduleWorkflowManager().schedule()
@@ -3562,6 +3648,10 @@ class JobList(ListAPIView):
     serializer_class = serializers.JobListSerializer
     resource_purpose = 'jobs'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of jobs."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
 
 class JobDetail(UnifiedJobDeletionMixin, RetrieveDestroyAPIView):
     model = models.Job
@@ -3611,6 +3701,10 @@ class JobCancel(GenericCancelView):
     serializer_class = serializers.JobCancelSerializer
     resource_purpose = 'cancel for a job'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "Cancel a running job."})
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
 
 class JobRelaunch(RetrieveAPIView):
     model = models.Job
@@ -3645,9 +3739,7 @@ class JobRelaunch(RetrieveAPIView):
                 self.permission_denied(request, message=messages['detail'])
         return super(JobRelaunch, self).check_object_permissions(request, obj)
 
-    @extend_schema_if_available(
-        extensions={'x-ai-description': 'Relaunch a job'},
-    )
+    @extend_schema_if_available(extensions={"x-ai-description": "Relaunch a job"})
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
         context = self.get_serializer_context()
@@ -4397,6 +4489,10 @@ class JobStdout(UnifiedJobStdout):
     model = models.Job
     resource_purpose = 'stdout output of a job'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "Get the standard output for the selected job."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
 
 class AdHocCommandStdout(UnifiedJobStdout):
     model = models.AdHocCommand
@@ -4408,11 +4504,27 @@ class NotificationTemplateList(ListCreateAPIView):
     serializer_class = serializers.NotificationTemplateSerializer
     resource_purpose = 'notification templates'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of notification templates."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Create a new notification template."})
+    def post(self, request, *args, **kwargs):
+        return super().post(request, *args, **kwargs)
+
 
 class NotificationTemplateDetail(RetrieveUpdateDestroyAPIView):
     model = models.NotificationTemplate
     serializer_class = serializers.NotificationTemplateSerializer
     resource_purpose = 'notification template detail'
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Update a notification template."})
+    def put(self, request, *args, **kwargs):
+        return super().put(request, *args, **kwargs)
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Update a notification template."})
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
 
     @extend_schema_if_available(extensions={"x-ai-description": "Delete a notification template"})
     def delete(self, request, *args, **kwargs):
@@ -4492,6 +4604,14 @@ class ActivityStreamList(SimpleListAPIView):
     serializer_class = serializers.ActivityStreamSerializer
     search_fields = ('changes',)
     resource_purpose = 'audit trail entries for tracking system changes'
+
+    @extend_schema_if_available(
+        extensions={
+            "x-ai-description": "A paginated list of activity stream entries. An activity stream entry tracks actions or changes that were previously made to the system."
+        }
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
 
 
 class ActivityStreamDetail(RetrieveAPIView):

--- a/awx/api/views/analytics.py
+++ b/awx/api/views/analytics.py
@@ -52,9 +52,7 @@ class AnalyticsRootView(APIView):
     swagger_topic = 'Automation Analytics'
     resource_purpose = 'automation analytics endpoints'
 
-    @extend_schema_if_available(
-        extensions={'x-ai-description': 'Retrieve list of available analytics endpoints'},
-    )
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of additional API endpoints related to analytics"})
     def get(self, request, format=None):
         data = OrderedDict()
         data['authorized'] = reverse('api:analytics_authorized', request=request)

--- a/awx/api/views/inventory.py
+++ b/awx/api/views/inventory.py
@@ -74,6 +74,10 @@ class InventoryList(ListCreateAPIView):
     serializer_class = InventorySerializer
     resource_purpose = 'inventories'
 
+    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of inventories."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
 
 class InventoryDetail(RelatedJobsPreventDeleteMixin, RetrieveUpdateDestroyAPIView):
     model = Inventory

--- a/awx/api/views/inventory.py
+++ b/awx/api/views/inventory.py
@@ -74,7 +74,7 @@ class InventoryList(ListCreateAPIView):
     serializer_class = InventorySerializer
     resource_purpose = 'inventories'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "A paginated list of inventories."})
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of inventories."})
     def get(self, request, *args, **kwargs):
         return super().get(request, *args, **kwargs)
 

--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -366,9 +366,7 @@ class ApiV2ConfigView(APIView):
 
         return Response(data)
 
-    @extend_schema_if_available(
-        extensions={'x-ai-description': 'Upload a subscription manifest'},
-    )
+    @extend_schema_if_available(extensions={"x-ai-description": "Add or update a subscription manifest license"})
     def post(self, request):
         if not isinstance(request.data, dict):
             return Response({"error": _("Invalid subscription data")}, status=status.HTTP_400_BAD_REQUEST)

--- a/awx/conf/views.py
+++ b/awx/conf/views.py
@@ -31,6 +31,7 @@ from awx.conf.models import Setting
 from awx.conf.serializers import SettingCategorySerializer, SettingSingletonSerializer
 from awx.conf import settings_registry
 from awx.main.utils.external_logging import reconfigure_rsyslog
+from ansible_base.lib.utils.schema import extend_schema_if_available
 
 
 SettingCategory = collections.namedtuple('SettingCategory', ('url', 'slug', 'name'))
@@ -41,6 +42,10 @@ class SettingCategoryList(ListAPIView):
     serializer_class = SettingCategorySerializer
     filter_backends = []
     name = _('Setting Categories')
+
+    @extend_schema_if_available(extensions={"x-ai-description": "A list of additional API endpoints related to settings."})
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
 
     def get_queryset(self):
         setting_categories = []
@@ -62,6 +67,10 @@ class SettingSingletonDetail(RetrieveUpdateDestroyAPIView):
     serializer_class = SettingSingletonSerializer
     filter_backends = []
     name = _('Setting Detail')
+
+    @extend_schema_if_available(extensions={"x-ai-description": "Update system settings."})
+    def patch(self, request, *args, **kwargs):
+        return super().patch(request, *args, **kwargs)
 
     def get_queryset(self):
         self.category_slug = self.kwargs.get('category_slug', 'all')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add x-ai-description extensions to API endpoints for better AI agent comprehension. Fix view method names to
ensure proper drf-spectacular schema generation.

https://issues.redhat.com/browse/AAP-57670
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves DRF Spectacular/OpenAPI output by annotating endpoints with `x-ai-description` and exposing explicit HTTP method handlers used solely for schema generation.
> 
> - Adds `extend_schema_if_available` annotations to numerous list/detail endpoints (instances, instance groups, execution environments, projects, credentials, hosts/groups, inventory, job/workflow templates, jobs, notifications, activity stream, analytics, settings) and wraps `get/post/put/patch/delete` where needed
> - Imports `extend_schema_if_available` in `conf/views.py` and adds missing method stubs to attach schema metadata
> - Tweaks several descriptions for clarity (e.g., inventory source "Sync the inventory source", cancel endpoints clarified as "running or pending", launch/relaunch wording)
> - No functional behavior changes; changes are documentation/schema-focused
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b50973c4acc31b45c6771db6a42bf8527fea25e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->