### PR TITLE
Avoid errors installing with python 3.11 because I am sure it is fine

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -92,7 +92,7 @@ setup(
         'requests',
         'setuptools',
     ],
-    python_requires=">=3.12",
+    python_requires=">=3.11",
     extras_require={'formatting': ['jq'], 'websockets': ['websocket-client==0.57.0'], 'crypto': ['cryptography']},
     license='Apache 2.0',
     classifiers=[
@@ -104,6 +104,7 @@ setup(
         'Operating System :: MacOS :: MacOS X',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Topic :: System :: Software Distribution',
         'Topic :: System :: Systems Administration',


### PR DESCRIPTION
##### SUMMARY
It is crazy inconvenient that our _client library_ does not support at least a little window of python versions, and this is going to be an issue with RHEL distributions in an obvious way. So just let people install awxkit with python3.11. It's not used for much externally anyway.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands awxkit packaging metadata to include Python 3.11.
> 
> - Relaxes `python_requires` from `>=3.12` to `>=3.11`
> - Adds classifier for `Programming Language :: Python :: 3.11`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbfcedc4e3c421aa53dadec5924f28d4b8a66aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->