### PR TITLE
AAP-41776 Enable new fancy asyncio metrics for dispatcherd

### DIFF
--- a/awx/main/analytics/dispatcherd_metrics.py
+++ b/awx/main/analytics/dispatcherd_metrics.py
@@ -1,0 +1,41 @@
+import http.client
+import socket
+import urllib.error
+import urllib.request
+import logging
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+def get_dispatcherd_metrics(request):
+    metrics_cfg = settings.METRICS_SUBSYSTEM_CONFIG.get('server', {}).get(settings.METRICS_SERVICE_DISPATCHER, {})
+    host = metrics_cfg.get('host', 'localhost')
+    port = metrics_cfg.get('port', 8015)
+    metrics_filter = []
+    if request is not None and hasattr(request, "query_params"):
+        try:
+            nodes_filter = request.query_params.getlist("node")
+        except Exception:
+            nodes_filter = []
+        if nodes_filter and settings.CLUSTER_HOST_ID not in nodes_filter:
+            return ''
+        try:
+            metrics_filter = request.query_params.getlist("metric")
+        except Exception:
+            metrics_filter = []
+    if metrics_filter:
+        # Right now we have no way of filtering the dispatcherd metrics
+        # so just avoid getting in the way if another metric is filtered for
+        return ''
+    url = f"http://{host}:{port}/metrics"
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as response:
+            payload = response.read()
+            if not payload:
+                return ''
+            return payload.decode('utf-8')
+    except (urllib.error.URLError, UnicodeError, socket.timeout, TimeoutError, http.client.HTTPException) as exc:
+        logger.debug(f"Failed to collect dispatcherd metrics from {url}: {exc}")
+        return ''

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -5,6 +5,7 @@ import time
 import logging
 
 import prometheus_client
+import socket
 import urllib.error
 import urllib.request
 from prometheus_client.core import GaugeMetricFamily, HistogramMetricFamily
@@ -438,7 +439,7 @@ def _get_dispatcherd_metrics():
             if not payload:
                 return ''
             return payload.decode('utf-8')
-    except (urllib.error.URLError, UnicodeError) as exc:
+    except (urllib.error.URLError, UnicodeError, socket.timeout, TimeoutError) as exc:
         logger.debug(f"Failed to collect dispatcherd metrics from {url}: {exc}")
         return ''
 

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -3,12 +3,8 @@ import redis
 import json
 import time
 import logging
-import http.client
 
 import prometheus_client
-import socket
-import urllib.error
-import urllib.request
 from prometheus_client.core import GaugeMetricFamily, HistogramMetricFamily
 from prometheus_client.registry import CollectorRegistry
 from django.conf import settings
@@ -19,6 +15,7 @@ from rest_framework.request import Request
 from awx.main.consumers import emit_channel_notification
 from awx.main.utils import is_testing
 from awx.main.utils.redis import get_redis_client
+from .dispatcherd_metrics import get_dispatcherd_metrics
 
 root_key = settings.SUBSYSTEM_METRICS_REDIS_KEY_PREFIX
 logger = logging.getLogger('awx.main.analytics')
@@ -427,44 +424,12 @@ class CallbackReceiverMetrics(Metrics):
         super().__init__(settings.METRICS_SERVICE_CALLBACK_RECEIVER, *args, **kwargs)
 
 
-def _get_dispatcherd_metrics(request):
-    metrics_cfg = settings.METRICS_SUBSYSTEM_CONFIG.get('server', {}).get(settings.METRICS_SERVICE_DISPATCHER, {})
-    host = metrics_cfg.get('host', 'localhost')
-    port = metrics_cfg.get('port', 8015)
-    metrics_filter = []
-    if request is not None and hasattr(request, "query_params"):
-        try:
-            nodes_filter = request.query_params.getlist("node")
-        except Exception:
-            nodes_filter = []
-        if nodes_filter and settings.CLUSTER_HOST_ID not in nodes_filter:
-            return ''
-        try:
-            metrics_filter = request.query_params.getlist("metric")
-        except Exception:
-            metrics_filter = []
-    if metrics_filter:
-        dispatcher_metrics = {metric.field for metric in DispatcherMetrics.METRICSLIST}
-        if not dispatcher_metrics.intersection(metrics_filter):
-            return ''
-    url = f"http://{host}:{port}/metrics"
-    try:
-        with urllib.request.urlopen(url, timeout=1.0) as response:
-            payload = response.read()
-            if not payload:
-                return ''
-            return payload.decode('utf-8')
-    except (urllib.error.URLError, UnicodeError, socket.timeout, TimeoutError, http.client.HTTPException) as exc:
-        logger.debug(f"Failed to collect dispatcherd metrics from {url}: {exc}")
-        return ''
-
-
 def metrics(request):
     output_text = ''
     output_text += DispatcherMetrics().generate_metrics(request)
     output_text += CallbackReceiverMetrics().generate_metrics(request)
 
-    dispatcherd_metrics = _get_dispatcherd_metrics(request)
+    dispatcherd_metrics = get_dispatcherd_metrics(request)
     if dispatcherd_metrics:
         output_text += dispatcherd_metrics
     return output_text
@@ -514,13 +479,6 @@ class CallbackReceiverMetricsServer(MetricsServer):
         registry = CollectorRegistry(auto_describe=True)
         registry.register(CustomToPrometheusMetricsCollector(CallbackReceiverMetrics(metrics_have_changed=False)))
         super().__init__(settings.METRICS_SERVICE_CALLBACK_RECEIVER, registry)
-
-
-class DispatcherMetricsServer(MetricsServer):
-    def __init__(self):
-        registry = CollectorRegistry(auto_describe=True)
-        registry.register(CustomToPrometheusMetricsCollector(DispatcherMetrics(metrics_have_changed=False)))
-        super().__init__(settings.METRICS_SERVICE_DISPATCHER, registry)
 
 
 class WebsocketsMetricsServer(MetricsServer):

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -3,6 +3,7 @@ import redis
 import json
 import time
 import logging
+import http.client
 
 import prometheus_client
 import socket
@@ -426,12 +427,17 @@ class CallbackReceiverMetrics(Metrics):
         super().__init__(settings.METRICS_SERVICE_CALLBACK_RECEIVER, *args, **kwargs)
 
 
-def _get_dispatcherd_metrics():
+def _get_dispatcherd_metrics(request):
     metrics_cfg = settings.METRICS_SUBSYSTEM_CONFIG.get('server', {}).get(settings.METRICS_SERVICE_DISPATCHER, {})
     host = metrics_cfg.get('host', 'localhost')
-    port = metrics_cfg.get('port')
-    if not port:
-        return ''
+    port = metrics_cfg.get('port', 8015)
+    if request is not None and hasattr(request, "query_params"):
+        try:
+            nodes_filter = request.query_params.getlist("node")
+        except Exception:
+            nodes_filter = []
+        if nodes_filter and settings.CLUSTER_HOST_ID not in nodes_filter:
+            return ''
     url = f"http://{host}:{port}/metrics"
     try:
         with urllib.request.urlopen(url, timeout=1.0) as response:
@@ -439,7 +445,7 @@ def _get_dispatcherd_metrics():
             if not payload:
                 return ''
             return payload.decode('utf-8')
-    except (urllib.error.URLError, UnicodeError, socket.timeout, TimeoutError) as exc:
+    except (urllib.error.URLError, UnicodeError, socket.timeout, TimeoutError, http.client.HTTPException) as exc:
         logger.debug(f"Failed to collect dispatcherd metrics from {url}: {exc}")
         return ''
 
@@ -449,7 +455,7 @@ def metrics(request):
     output_text += DispatcherMetrics().generate_metrics(request)
     output_text += CallbackReceiverMetrics().generate_metrics(request)
 
-    dispatcherd_metrics = _get_dispatcherd_metrics()
+    dispatcherd_metrics = _get_dispatcherd_metrics(request)
     if dispatcherd_metrics:
         output_text += dispatcherd_metrics
     return output_text

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -431,12 +431,21 @@ def _get_dispatcherd_metrics(request):
     metrics_cfg = settings.METRICS_SUBSYSTEM_CONFIG.get('server', {}).get(settings.METRICS_SERVICE_DISPATCHER, {})
     host = metrics_cfg.get('host', 'localhost')
     port = metrics_cfg.get('port', 8015)
+    metrics_filter = []
     if request is not None and hasattr(request, "query_params"):
         try:
             nodes_filter = request.query_params.getlist("node")
         except Exception:
             nodes_filter = []
         if nodes_filter and settings.CLUSTER_HOST_ID not in nodes_filter:
+            return ''
+        try:
+            metrics_filter = request.query_params.getlist("metric")
+        except Exception:
+            metrics_filter = []
+    if metrics_filter:
+        dispatcher_metrics = {metric.field for metric in DispatcherMetrics.METRICSLIST}
+        if not dispatcher_metrics.intersection(metrics_filter):
             return ''
     url = f"http://{host}:{port}/metrics"
     try:

--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -5,6 +5,8 @@ import time
 import logging
 
 import prometheus_client
+import urllib.error
+import urllib.request
 from prometheus_client.core import GaugeMetricFamily, HistogramMetricFamily
 from prometheus_client.registry import CollectorRegistry
 from django.conf import settings
@@ -398,11 +400,6 @@ class DispatcherMetrics(Metrics):
         SetFloatM('workflow_manager_recorded_timestamp', 'Unix timestamp when metrics were last recorded'),
         SetFloatM('workflow_manager_spawn_workflow_graph_jobs_seconds', 'Time spent spawning workflow tasks'),
         SetFloatM('workflow_manager_get_tasks_seconds', 'Time spent loading workflow tasks from db'),
-        # dispatcher subsystem metrics
-        SetIntM('dispatcher_pool_scale_up_events', 'Number of times local dispatcher scaled up a worker since startup'),
-        SetIntM('dispatcher_pool_active_task_count', 'Number of active tasks in the worker pool when last task was submitted'),
-        SetIntM('dispatcher_pool_max_worker_count', 'Highest number of workers in worker pool in last collection interval, about 20s'),
-        SetFloatM('dispatcher_availability', 'Fraction of time (in last collection interval) dispatcher was able to receive messages'),
     ]
 
     def __init__(self, *args, **kwargs):
@@ -428,10 +425,32 @@ class CallbackReceiverMetrics(Metrics):
         super().__init__(settings.METRICS_SERVICE_CALLBACK_RECEIVER, *args, **kwargs)
 
 
+def _get_dispatcherd_metrics():
+    metrics_cfg = settings.METRICS_SUBSYSTEM_CONFIG.get('server', {}).get(settings.METRICS_SERVICE_DISPATCHER, {})
+    host = metrics_cfg.get('host', 'localhost')
+    port = metrics_cfg.get('port')
+    if not port:
+        return ''
+    url = f"http://{host}:{port}/metrics"
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as response:
+            payload = response.read()
+            if not payload:
+                return ''
+            return payload.decode('utf-8')
+    except (urllib.error.URLError, UnicodeError) as exc:
+        logger.debug(f"Failed to collect dispatcherd metrics from {url}: {exc}")
+        return ''
+
+
 def metrics(request):
     output_text = ''
-    for m in [DispatcherMetrics(), CallbackReceiverMetrics()]:
-        output_text += m.generate_metrics(request)
+    output_text += DispatcherMetrics().generate_metrics(request)
+    output_text += CallbackReceiverMetrics().generate_metrics(request)
+
+    dispatcherd_metrics = _get_dispatcherd_metrics()
+    if dispatcherd_metrics:
+        output_text += dispatcherd_metrics
     return output_text
 
 

--- a/awx/main/dispatch/config.py
+++ b/awx/main/dispatch/config.py
@@ -60,7 +60,7 @@ def get_dispatcherd_config(for_service: bool = False, mock_publish: bool = False
         if metrics_cfg:
             config["service"]["metrics_kwargs"] = {
                 "host": metrics_cfg.get("host", "localhost"),
-                "port": metrics_cfg["port"],
+                "port": metrics_cfg.get("port", 8015),
             }
 
     return config

--- a/awx/main/dispatch/config.py
+++ b/awx/main/dispatch/config.py
@@ -38,8 +38,8 @@ def get_dispatcherd_config(for_service: bool = False, mock_publish: bool = False
     }
 
     if mock_publish:
-        config["brokers"]["noop"] = {}
-        config["publish"]["default_broker"] = "noop"
+        config["brokers"]["dispatcherd.testing.brokers.noop"] = {}
+        config["publish"]["default_broker"] = "dispatcherd.testing.brokers.noop"
     else:
         config["brokers"]["pg_notify"] = {
             "config": get_pg_notify_params(),
@@ -56,5 +56,11 @@ def get_dispatcherd_config(for_service: bool = False, mock_publish: bool = False
         }
 
         config["brokers"]["pg_notify"]["channels"] = ['tower_broadcast_all', 'tower_settings_change', get_task_queuename()]
+        metrics_cfg = settings.METRICS_SUBSYSTEM_CONFIG.get('server', {}).get(settings.METRICS_SERVICE_DISPATCHER)
+        if metrics_cfg:
+            config["service"]["metrics_kwargs"] = {
+                "host": metrics_cfg.get("host", "localhost"),
+                "port": metrics_cfg["port"],
+            }
 
     return config

--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -97,36 +97,39 @@ class DummyMetricsResponse:
         return False
 
 
-def test_dispatcherd_metrics_node_filter_match(monkeypatch, settings):
+def test_dispatcherd_metrics_node_filter_match(mocker, settings):
     settings.CLUSTER_HOST_ID = "awx-1"
     payload = b'# HELP test_metric A test metric\n# TYPE test_metric gauge\ntest_metric 1\n'
 
     def fake_urlopen(url, timeout=1.0):
         return DummyMetricsResponse(payload)
 
-    monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
+    mocker.patch('urllib.request.urlopen', fake_urlopen)
+
     request = Request(RequestFactory().get('/api/v2/metrics/', {'node': 'awx-1'}))
 
     assert get_dispatcherd_metrics(request) == payload.decode('utf-8')
 
 
-def test_dispatcherd_metrics_node_filter_excludes_local(monkeypatch, settings):
+def test_dispatcherd_metrics_node_filter_excludes_local(mocker, settings):
     settings.CLUSTER_HOST_ID = "awx-1"
 
     def fake_urlopen(*args, **kwargs):
         raise AssertionError("urlopen should not be called when node filter excludes local node")
 
-    monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
+    mocker.patch('urllib.request.urlopen', fake_urlopen)
+
     request = Request(RequestFactory().get('/api/v2/metrics/', {'node': 'awx-2'}))
 
     assert get_dispatcherd_metrics(request) == ''
 
 
-def test_dispatcherd_metrics_metric_filter_excludes_unrelated(monkeypatch):
+def test_dispatcherd_metrics_metric_filter_excludes_unrelated(mocker):
     def fake_urlopen(*args, **kwargs):
         raise AssertionError("urlopen should not be called when metric filter excludes dispatcherd metrics")
 
-    monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
+    mocker.patch('urllib.request.urlopen', fake_urlopen)
+
     request = Request(RequestFactory().get('/api/v2/metrics/', {'metric': 'awx_system_info'}))
 
     assert get_dispatcherd_metrics(request) == ''

--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from awx.main import models
 from awx.main.analytics.metrics import metrics
 import awx.main.analytics.subsystem_metrics as s_metrics
+from awx.main.analytics.dispatcherd_metrics import get_dispatcherd_metrics
 from awx.api.versioning import reverse
 
 EXPECTED_VALUES = {
@@ -106,7 +107,7 @@ def test_dispatcherd_metrics_node_filter_match(monkeypatch, settings):
     monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
     request = Request(RequestFactory().get('/api/v2/metrics/', {'node': 'awx-1'}))
 
-    assert s_metrics._get_dispatcherd_metrics(request) == payload.decode('utf-8')
+    assert get_dispatcherd_metrics(request) == payload.decode('utf-8')
 
 
 def test_dispatcherd_metrics_node_filter_excludes_local(monkeypatch, settings):
@@ -118,7 +119,7 @@ def test_dispatcherd_metrics_node_filter_excludes_local(monkeypatch, settings):
     monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
     request = Request(RequestFactory().get('/api/v2/metrics/', {'node': 'awx-2'}))
 
-    assert s_metrics._get_dispatcherd_metrics(request) == ''
+    assert get_dispatcherd_metrics(request) == ''
 
 
 def test_dispatcherd_metrics_metric_filter_excludes_unrelated(monkeypatch):
@@ -128,4 +129,4 @@ def test_dispatcherd_metrics_metric_filter_excludes_unrelated(monkeypatch):
     monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
     request = Request(RequestFactory().get('/api/v2/metrics/', {'metric': 'awx_system_info'}))
 
-    assert s_metrics._get_dispatcherd_metrics(request) == ''
+    assert get_dispatcherd_metrics(request) == ''

--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -1,8 +1,11 @@
 import pytest
 
+from django.test import RequestFactory
 from prometheus_client.parser import text_string_to_metric_families
+from rest_framework.request import Request
 from awx.main import models
 from awx.main.analytics.metrics import metrics
+import awx.main.analytics.subsystem_metrics as s_metrics
 from awx.api.versioning import reverse
 
 EXPECTED_VALUES = {
@@ -77,3 +80,42 @@ def test_metrics_http_methods(get, post, patch, put, options, admin):
     assert patch(get_metrics_view_db_only(), user=admin).status_code == 405
     assert post(get_metrics_view_db_only(), user=admin).status_code == 405
     assert options(get_metrics_view_db_only(), user=admin).status_code == 200
+
+
+class DummyMetricsResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_dispatcherd_metrics_node_filter_match(monkeypatch, settings):
+    settings.CLUSTER_HOST_ID = "awx-1"
+    payload = b'# HELP test_metric A test metric\n# TYPE test_metric gauge\ntest_metric 1\n'
+
+    def fake_urlopen(url, timeout=1.0):
+        return DummyMetricsResponse(payload)
+
+    monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
+    request = Request(RequestFactory().get('/api/v2/metrics/', {'node': 'awx-1'}))
+
+    assert s_metrics._get_dispatcherd_metrics(request) == payload.decode('utf-8')
+
+
+def test_dispatcherd_metrics_node_filter_excludes_local(monkeypatch, settings):
+    settings.CLUSTER_HOST_ID = "awx-1"
+
+    def fake_urlopen(*args, **kwargs):
+        raise AssertionError("urlopen should not be called when node filter excludes local node")
+
+    monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
+    request = Request(RequestFactory().get('/api/v2/metrics/', {'node': 'awx-2'}))
+
+    assert s_metrics._get_dispatcherd_metrics(request) == ''

--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -119,3 +119,13 @@ def test_dispatcherd_metrics_node_filter_excludes_local(monkeypatch, settings):
     request = Request(RequestFactory().get('/api/v2/metrics/', {'node': 'awx-2'}))
 
     assert s_metrics._get_dispatcherd_metrics(request) == ''
+
+
+def test_dispatcherd_metrics_metric_filter_excludes_unrelated(monkeypatch):
+    def fake_urlopen(*args, **kwargs):
+        raise AssertionError("urlopen should not be called when metric filter excludes dispatcherd metrics")
+
+    monkeypatch.setattr(s_metrics.urllib.request, 'urlopen', fake_urlopen)
+    request = Request(RequestFactory().get('/api/v2/metrics/', {'metric': 'awx_system_info'}))
+
+    assert s_metrics._get_dispatcherd_metrics(request) == ''

--- a/awx/main/tests/functional/analytics/test_metrics.py
+++ b/awx/main/tests/functional/analytics/test_metrics.py
@@ -5,7 +5,6 @@ from prometheus_client.parser import text_string_to_metric_families
 from rest_framework.request import Request
 from awx.main import models
 from awx.main.analytics.metrics import metrics
-import awx.main.analytics.subsystem_metrics as s_metrics
 from awx.main.analytics.dispatcherd_metrics import get_dispatcherd_metrics
 from awx.api.versioning import reverse
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -116,7 +116,7 @@ cython==3.1.3
     # via -r /awx_devel/requirements/requirements.in
 daphne==4.2.1
     # via -r /awx_devel/requirements/requirements.in
-dispatcherd[pg-notify]==2026.01.14
+dispatcherd[pg-notify]==2026.01.27
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -116,7 +116,7 @@ cython==3.1.3
     # via -r /awx_devel/requirements/requirements.in
 daphne==4.2.1
     # via -r /awx_devel/requirements/requirements.in
-dispatcherd[pg-notify]==2025.12.12
+dispatcherd[pg-notify]==2026.01.14
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
Still WIP but this has the basics.

Next up: validate that `/api/v2/metrics/` can return the new keys, for what those are see:

https://github.com/ansible/dispatcherd/blob/main/dispatcherd/service/metrics.py

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the metrics surface area and runtime behavior by proxying an internal HTTP endpoint and shifting dispatcher metrics sourcing to dispatcherd’s own server. Potential risks are missing/duplicated metrics or failures/timeouts when dispatcherd metrics are unavailable.
> 
> **Overview**
> `/api/v2/metrics/` now appends raw Prometheus output fetched from the local dispatcherd service (`http://host:port/metrics`) via a new `get_dispatcherd_metrics` helper, while honoring the existing `node` filter (skip when requesting other nodes) and skipping dispatcherd entirely when a `metric` filter is present.
> 
> Dispatcher subsystem “pool” metrics are removed from the Redis-backed `DispatcherMetrics` list, the standalone `DispatcherMetricsServer` is dropped, and dispatcherd is configured to start its own metrics server via new `metrics_kwargs` passed from `METRICS_SUBSYSTEM_CONFIG`. Tests were added for the new filtering behavior, and the `dispatcherd[pg-notify]` dependency is bumped to `2026.01.27`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9b9263a28b68cd5c7b2af1cf31b78744e013134. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->