### PR TITLE
Remove unused INSIGHTS_OIDC_ENDPOINT

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1329,7 +1329,6 @@ class RunProjectUpdate(BaseTask):
                 'local_path': os.path.basename(project_update.project.local_path),
                 'project_path': project_update.get_project_path(check_if_exists=False),  # deprecated
                 'insights_url': settings.INSIGHTS_URL_BASE,
-                'oidc_endpoint': settings.INSIGHTS_OIDC_ENDPOINT,
                 'awx_license_type': get_license().get('license_type', 'UNLICENSED'),
                 'awx_version': get_awx_version(),
                 'scm_url': scm_url,

--- a/awx/playbooks/action_plugins/insights.py
+++ b/awx/playbooks/action_plugins/insights.py
@@ -83,7 +83,6 @@ class ActionModule(ActionBase):
         password = self._task.args.get('password', None)
         client_id = self._task.args.get('client_id', None)
         client_secret = self._task.args.get('client_secret', None)
-        oidc_endpoint = self._task.args.get('oidc_endpoint', DEFAULT_OIDC_ENDPOINT)
 
         session.headers.update(
             {
@@ -93,7 +92,7 @@ class ActionModule(ActionBase):
         )
 
         if authentication == 'service_account' or (client_id and client_secret):
-            data = self._obtain_auth_token(oidc_endpoint, client_id, client_secret)
+            data = self._obtain_auth_token(DEFAULT_OIDC_ENDPOINT, client_id, client_secret)
             if 'token' not in data:
                 result['failed'] = data['failed']
                 result['msg'] = data['msg']

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -716,7 +716,6 @@ DISABLE_LOCAL_AUTH = False
 TOWER_URL_BASE = "https://platformhost"
 
 INSIGHTS_URL_BASE = "https://example.org"
-INSIGHTS_OIDC_ENDPOINT = "https://sso.example.org/"
 INSIGHTS_AGENT_MIME = 'application/example'
 # See https://github.com/ansible/awx-facts-playbooks
 INSIGHTS_SYSTEM_ID_FILE = '/etc/redhat-access-insights/machine-id'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This setting is set in defaults.py, but currently not being used. More technically, project_update.yml is not passing this value to the insights.py action plugin.
https://github.com/fosterseth/awx/blob/e782945232fde4a097f4d53759c3efbc6db52784/awx/playbooks/project_update.yml#L101

Therefore, we can safely remove references to it.

insights.py already has a default oidc endpoint defined for authentication.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes dead configuration and simplifies Insights authentication.
> 
> - Delete `INSIGHTS_OIDC_ENDPOINT` from `defaults.py` and stop passing/reading `oidc_endpoint` (removed from `jobs.py` extravars and `insights.py` task args)
> - In `awx/playbooks/action_plugins/insights.py`, always call `_obtain_auth_token` with `DEFAULT_OIDC_ENDPOINT`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8c168f21b207efca0b4e37900115289d7371fc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->