### PR TITLE
Update kubernetes python client to 35.0.0 from PyPI

### DIFF
--- a/requirements/README.md
+++ b/requirements/README.md
@@ -57,9 +57,8 @@ they are functionally working. Versions need to match the versions used in the p
 
 Verify ansible-runner's build dependency doesn't conflict with the changes made.
 
-### urllib3 and OPA-python-client
-There are incompatible version dependancies for urllib3 between OPA-python-client and kubernetes.
-OPA-python-client v2.0.3+ requires urllib3 v2.5.0+ and kubernetes v34.1.0 caps it at v.2.4.0.
+### OPA-python-client
+OPA-python-client v2.0.3+ requires urllib3 v2.5.0+ but has other compatibility issues that need investigation.
 
 ## djangorestframework
 Upgrading to 3.16.1 introduced errors on the tests around CredentialInputSource. We have several

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -35,6 +35,7 @@ maturin  # pydantic-core build dep
 msgpack
 msrestazure
 OPA-python-client==2.0.2 # upgrading requires urllib3 2.5.0+ which is blocked by other deps
+kubernetes>=35.0.0
 openshift
 opentelemetry-api~=1.37     # new y streams can be drastically different, in a good way
 opentelemetry-sdk~=1.37
@@ -60,7 +61,7 @@ requests
 slack-sdk
 twilio
 twisted[tls]>=24.7.0  # CVE-2024-41810
-urllib3>=2.6.3 # CVE-2024-37891. capped by kubernetes 34.1.0 reqs
+urllib3>=2.6.3 # CVE-2024-37891
 uWSGI>=2.0.28
 uwsgitop
 wheel>=0.38.1  # CVE-2022-40898

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -253,9 +253,9 @@ jsonschema==4.25.1
     #   drf-spectacular
 jsonschema-specifications==2025.9.1
     # via jsonschema
-# kubernetes @ git+https://github.com/kubernetes-client/python.git@df31d90d6c910d6b5c883b98011c93421cac067d  # git requirements installed separately
+kubernetes==35.0.0
     # via
-    #   -r /awx_devel/requirements/requirements_git.txt
+    #   -r /awx_devel/requirements/requirements.in
     #   openshift
 lockfile==0.12.2
     # via python-daemon

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -22,4 +22,3 @@ ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel
 awx-plugins-core[credentials-github-app] @ git+https://github.com/ansible/awx-plugins.git@devel
 django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel
 awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git
-kubernetes @ git+https://github.com/kubernetes-client/python.git@df31d90d6c910d6b5c883b98011c93421cac067d


### PR DESCRIPTION
##### SUMMARY

Update kubernetes python client from git-based install to PyPI v35.0.0.

- kubernetes 35.0.0 is now available on PyPI, removing the need for git-based installation
- kubernetes 35.0.0 no longer caps urllib3, so removed related comments from requirements.in and README.md

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### ADDITIONAL INFORMATION

Files changed:
- `requirements/requirements_git.txt` - Removed kubernetes git reference
- `requirements/requirements.in` - Added `kubernetes>=35.0.0`
- `requirements/requirements.txt` - Updated via `updater.sh run`
- `requirements/README.md` - Updated upgrade blocker documentation

```
$ pip index versions kubernetes
kubernetes (35.0.0)
Available versions: 35.0.0, 34.1.0, 34.0.0, ...
```