### PR TITLE
Collect operator logs on timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Run test deployment with awx-operator
         working-directory: awx-operator
         id: awx_operator_test
-        timeout-minutes: 1
+        timeout-minutes: 55
         continue-on-error: true
         run: |
           python -m pip install -r molecule/requirements.txt
@@ -224,8 +224,9 @@ jobs:
           AWX_EE_TEST_IMAGE: quay.io/ansible/awx-ee:latest
           STORE_DEBUG_OUTPUT: true
 
-      - name: Collect awx-operator logs on failure/timeout
-        if: steps.awx_operator_test.outcome != 'success'
+      - name: Collect awx-operator logs on timeout
+        # Only run on timeout; normal failures should use molecule's built-in log collection.
+        if: steps.awx_operator_test.outcome == 'cancelled'
         run: |
           mkdir -p "$DEBUG_OUTPUT_DIR"
           if command -v kind >/dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          timeout 60s bash -lc '
+          timeout 54m bash -lc '
             python -m pip install -r molecule/requirements.txt
             python -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
             $(realpath ../awx/tools/scripts/rewrite-awx-operator-requirements.py) molecule/requirements.yml $(realpath ../awx)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,22 @@ jobs:
           AWX_EE_TEST_IMAGE: quay.io/ansible/awx-ee:latest
           STORE_DEBUG_OUTPUT: true
 
+      - name: Collect awx-operator logs on failure/timeout
+        if: steps.awx_operator_test.outcome != 'success'
+        run: |
+          mkdir -p "$DEBUG_OUTPUT_DIR"
+          if command -v kind >/dev/null 2>&1; then
+            for cluster in $(kind get clusters 2>/dev/null); do
+              kind export logs "$DEBUG_OUTPUT_DIR/$cluster" --name "$cluster" || true
+            done
+          fi
+          if command -v kubectl >/dev/null 2>&1; then
+            kubectl get all -A -o wide > "$DEBUG_OUTPUT_DIR/kubectl-get-all.txt" || true
+            kubectl get pods -A -o wide > "$DEBUG_OUTPUT_DIR/kubectl-get-pods.txt" || true
+            kubectl describe pods -A > "$DEBUG_OUTPUT_DIR/kubectl-describe-pods.txt" || true
+          fi
+          docker ps -a > "$DEBUG_OUTPUT_DIR/docker-ps.txt" || true
+
       - name: Upload debug output
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          timeout 54m bash -lc '
+          timeout 54m bash -elc '
             python -m pip install -r molecule/requirements.txt
             python -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
             $(realpath ../awx/tools/scripts/rewrite-awx-operator-requirements.py) molecule/requirements.yml $(realpath ../awx)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,16 +208,24 @@ jobs:
       - name: Run test deployment with awx-operator
         working-directory: awx-operator
         id: awx_operator_test
-        timeout-minutes: 55
+        timeout-minutes: 2
         continue-on-error: true
         run: |
-          python -m pip install -r molecule/requirements.txt
-          python -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
-          $(realpath ../awx/tools/scripts/rewrite-awx-operator-requirements.py) molecule/requirements.yml $(realpath ../awx)
-          ansible-galaxy collection install -r molecule/requirements.yml
-          sudo rm -f $(which kustomize)
-          make kustomize
-          KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule -v test -s kind -- --skip-tags=replicas
+          set +e
+          timeout 60s bash -lc '
+            python -m pip install -r molecule/requirements.txt
+            python -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
+            $(realpath ../awx/tools/scripts/rewrite-awx-operator-requirements.py) molecule/requirements.yml $(realpath ../awx)
+            ansible-galaxy collection install -r molecule/requirements.yml
+            sudo rm -f $(which kustomize)
+            make kustomize
+            KUSTOMIZE_PATH=$(readlink -f bin/kustomize) molecule -v test -s kind -- --skip-tags=replicas
+          '
+          rc=$?
+          if [ $rc -eq 124 ]; then
+            echo "timed_out=true" >> "$GITHUB_OUTPUT"
+          fi
+          exit $rc
         env:
           AWX_TEST_IMAGE: local/awx
           AWX_TEST_VERSION: ci
@@ -226,7 +234,7 @@ jobs:
 
       - name: Collect awx-operator logs on timeout
         # Only run on timeout; normal failures should use molecule's built-in log collection.
-        if: steps.awx_operator_test.outcome == 'cancelled'
+        if: steps.awx_operator_test.outputs.timed_out == 'true'
         run: |
           mkdir -p "$DEBUG_OUTPUT_DIR"
           if command -v kind >/dev/null 2>&1; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Run test deployment with awx-operator
         working-directory: awx-operator
         id: awx_operator_test
-        timeout-minutes: 2
+        timeout-minutes: 60
         continue-on-error: true
         run: |
           set +e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,9 @@ jobs:
 
       - name: Run test deployment with awx-operator
         working-directory: awx-operator
+        id: awx_operator_test
+        timeout-minutes: 1
+        continue-on-error: true
         run: |
           python -m pip install -r molecule/requirements.txt
           python -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
@@ -222,11 +225,15 @@ jobs:
           STORE_DEBUG_OUTPUT: true
 
       - name: Upload debug output
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: awx-operator-debug-output
           path: ${{ env.DEBUG_OUTPUT_DIR }}
+
+      - name: Fail awx-operator check if test deployment failed
+        if: steps.awx_operator_test.outcome != 'success'
+        run: exit 1
 
   collection-sanity:
     name: awx_collection sanity


### PR DESCRIPTION
##### SUMMARY
Opening as draft to see the timeout happen.

After output confirms we get the logs then we have to adjust the specific numbers so that we'll catch timeout logs in real cases.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves observability and robustness of the `awx-operator` CI job.
> 
> - Wraps molecule test in a 54m `timeout`, captures exit code, and flags `timed_out` via `GITHUB_OUTPUT`
> - On timeout, collects cluster logs (`kind export logs`), `kubectl get/describe`, and `docker ps` into `DEBUG_OUTPUT_DIR`
> - Always uploads debug artifacts (`actions/upload-artifact`), not just on failure
> - Adds explicit failure step if `awx_operator_test` did not succeed to preserve CI status
> - Introduces `DEBUG_OUTPUT_DIR` env and assigns step `id` for conditional handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9cdf1ad60cbf305f342719bb4a7182b4582eedeb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->