### PR TITLE
AAP-63560 Assure that /service-index/ permission assignment respects permissions

### DIFF
--- a/awx/main/tests/functional/dab_rbac/test_service_index_role_user_assignments.py
+++ b/awx/main/tests/functional/dab_rbac/test_service_index_role_user_assignments.py
@@ -6,27 +6,31 @@ from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
 
 
 @pytest.mark.django_db
-def test_service_index_role_user_assignment_permissions(setup_managed_roles, organization, inventory, project, rando, user, post):
+def test_service_index_role_user_assignment_permissions(setup_managed_roles, organization, inventory, rando, user, post):
+    "Test permission checking under internal /service-index/ RBAC related views"
     user3 = user('user3', False)
     organization.member_role.members.add(user3)
     organization.member_role.members.add(rando)
+    # This is super technical, these are internal actions with internal mechanics
+    rando.resource_api_actions = "*"
 
-    rd = RoleDefinition.objects.get(name='Inventory Admin')
+    inv_admin_rd = RoleDefinition.objects.get(name='Inventory Admin')
     url = django_reverse('serviceuserassignment-assign')
     payload = {
-        'role_definition': rd.name,
+        'role_definition': inv_admin_rd.name,
         'user_ansible_id': str(user3.resource.ansible_id),
         'object_id': str(inventory.id),
         'from_service': 'test-service',
     }
 
+    # As just a member of the organization, rando can not give permissions
     assert rando.can_access(User, 'read', user3)
     post(url, data=payload, user=rando, expect=403)
+    assert not RoleUserAssignment.objects.filter(user=user3, role_definition=inv_admin_rd, object_id=inventory.id).exists()
 
-    project_admin_rd = RoleDefinition.objects.get(name='Project Admin')
-    project_admin_rd.give_permission(rando, project)
-    rando.resource_api_actions = ['assign']
+    inv_admin_rd.give_permission(rando, inventory)
+
+    # Now, having admin permission, rando can give permissions
     post(url, data=payload, user=rando, expect=201)
-
-    assert RoleUserAssignment.objects.filter(user=user3, role_definition=rd, object_id=inventory.id).exists()
+    assert RoleUserAssignment.objects.filter(user=user3, role_definition=inv_admin_rd, object_id=inventory.id).exists()
     assert user3.has_obj_perm(inventory, 'change') is True

--- a/awx/main/tests/functional/dab_rbac/test_service_index_role_user_assignments.py
+++ b/awx/main/tests/functional/dab_rbac/test_service_index_role_user_assignments.py
@@ -1,0 +1,32 @@
+import pytest
+from django.contrib.auth.models import User
+from django.urls import reverse as django_reverse
+
+from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
+
+
+@pytest.mark.django_db
+def test_service_index_role_user_assignment_permissions(setup_managed_roles, organization, inventory, project, rando, user, post):
+    user3 = user('user3', False)
+    organization.member_role.members.add(user3)
+    organization.member_role.members.add(rando)
+
+    rd = RoleDefinition.objects.get(name='Inventory Admin')
+    url = django_reverse('serviceuserassignment-assign')
+    payload = {
+        'role_definition': rd.name,
+        'user_ansible_id': str(user3.resource.ansible_id),
+        'object_id': str(inventory.id),
+        'from_service': 'test-service',
+    }
+
+    assert rando.can_access(User, 'read', user3)
+    post(url, data=payload, user=rando, expect=403)
+
+    project_admin_rd = RoleDefinition.objects.get(name='Project Admin')
+    project_admin_rd.give_permission(rando, project)
+    rando.resource_api_actions = ['assign']
+    post(url, data=payload, user=rando, expect=201)
+
+    assert RoleUserAssignment.objects.filter(user=user3, role_definition=rd, object_id=inventory.id).exists()
+    assert user3.has_obj_perm(inventory, 'change') is True


### PR DESCRIPTION
##### SUMMARY
This is a part of troubleshooting another issue - and it is meant to give confirmation that we do service-side permission checks when granting permissions via the `/service-index/` endpoint.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
