### PR TITLE
Install galaxy deps from github

### DIFF
--- a/tools/docker-compose/ansible/requirements.yml
+++ b/tools/docker-compose/ansible/requirements.yml
@@ -2,5 +2,11 @@
 collections:
   - source: ./awx_collection
     type: dir
-  - flowerysong.hvault
-  - community.docker
+  - name: flowerysong.hvault
+    source: https://github.com/flowerysong/ansible-flowerysong.hvault.git
+    type: git
+    version: "v0.3.0"
+  - name: community.docker
+    source: https://github.com/ansible-collections/community.docker.git
+    type: git
+    version: "5.0.5"


### PR DESCRIPTION
##### SUMMARY
Proposal:

Elsewhere, https://github.com/ansible/awx/pull/16243, we can not run checks.

<img width="582" height="459" alt="Screenshot From 2026-01-26 08-55-13" src="https://github.com/user-attachments/assets/0ec475f9-b23e-4ab0-9784-46ddf3995a60" />

I tested locally and this command works:

```
ansible-galaxy install --ignore-certs -r tools/docker-compose/ansible/requirements.yml --force
```

We're already doing a hacky local install for the AWX collection. What's a few more hacks between friends?

This should temporarily get us past that blocker for checks. But for the longer term... I think this is okay? This will take load off the galaxy server, and it's github running the checks, so if github isn't responding it likely isn't running them in the first place.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

