### PR TITLE
change contact email address

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1027,7 +1027,7 @@ SPECTACULAR_SETTINGS = {
     'SCHEMA_PATH_PREFIX': r'/api/v[0-9]',
     'DEFAULT_GENERATOR_CLASS': 'drf_spectacular.generators.SchemaGenerator',
     'SCHEMA_COERCE_PATH_PK_SUFFIX': True,
-    'CONTACT': {'email': 'controller-eng@redhat.com'},
+    'CONTACT': {'email': 'ansible-community@redhat.com'},
     'LICENSE': {'name': 'Apache License'},
     'TERMS_OF_SERVICE': 'https://www.google.com/policies/terms/',
     # Use our custom schema class that handles swagger_topic and deprecated views


### PR DESCRIPTION
Use the ansible-community@redhat.com alias as the contact email address.

##### SUMMARY
Minor change to project settings to change the contact email address to an appropriate alias.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other



##### ADDITIONAL INFORMATION
Related to https://github.com/ansible/awx/pull/16221
