### PR TITLE
AAP-64301 [devel] fix: add py311 to make version detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include awx/ui/Makefile
 
-PYTHON := $(notdir $(shell for i in python3.12 python3; do command -v $$i; done|sed 1q))
+PYTHON := $(notdir $(shell for i in python3.12 python3.11 python3; do command -v $$i; done|sed 1q))
 SHELL := bash
 DOCKER_COMPOSE ?= docker compose
 OFFICIAL ?= no


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `PYTHON` variable search for the Makefile was only checking for `python3.12` and `python3`, causing builds to fall back to python3 instead of detecting python3.11 if available.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes newer Python versions in local builds.
> 
> - Updates `PYTHON` detection to search `python3.12`, `python3.11`, then `python3`, ensuring 3.11 is used when available instead of falling back to generic `python3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e210300de1304b7ede68ff03a7bcbfa93ad8162. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->