### PR TITLE
Bump wheel to address CVE-2026-24049

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ RECEPTOR_IMAGE ?= quay.io/ansible/receptor:devel
 SRC_ONLY_PKGS ?= cffi,pycparser,psycopg,twilio
 # These should be upgraded in the AWX and Ansible venv before attempting
 # to install the actual requirements
-VENV_BOOTSTRAP ?= pip==25.3 setuptools==80.9.0 setuptools_scm[toml]==9.2.2 wheel==0.45.1 cython==3.1.3
+VENV_BOOTSTRAP ?= pip==25.3 setuptools==80.9.0 setuptools_scm[toml]==9.2.2 wheel==0.46.3 cython==3.1.3
 
 NAME ?= awx
 

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -65,7 +65,7 @@ twisted[tls]>=24.7.0  # CVE-2024-41810
 urllib3>=2.6.3 # CVE-2024-37891
 uWSGI>=2.0.28
 uwsgitop
-wheel>=0.38.1  # CVE-2022-40898
+wheel>=0.46.2  # CVE-2026-24049
 pip==25.3  # see UPGRADE BLOCKERs
 setuptools==80.9.0  # see UPGRADE BLOCKERs
 setuptools-scm[toml]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -336,6 +336,7 @@ packaging==25.0
     #   django-guid
     #   opentelemetry-instrumentation
     #   setuptools-scm
+    #   wheel
 pbr==7.0.1
     # via -r /awx_devel/requirements/requirements.in
 pexpect==4.9.0
@@ -533,7 +534,7 @@ uwsgitop==0.12
     # via -r /awx_devel/requirements/requirements.in
 websocket-client==1.8.0
     # via kubernetes
-wheel==0.45.1
+wheel==0.46.3
     # via -r /awx_devel/requirements/requirements.in
 wrapt==1.17.3
     # via opentelemetry-instrumentation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Bump wheel to address CVE-2026-24049
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump of `wheel` in build/venv bootstrap and pinned requirements; low behavioral risk but could affect packaging/build edge cases.
> 
> **Overview**
> Updates the `wheel` dependency to newer patched versions to address CVE-2026-24049.
> 
> This bumps `wheel` in `requirements.in` (and regenerates `requirements.txt` pins) and also updates the venv bootstrap toolchain in the `Makefile` so newly created venvs install the updated `wheel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 292262e14fc66883d97b46f84a9ef891c153e2b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->