### PR TITLE
AAP-63668 Fix security hot spot by deleting it

### DIFF
--- a/awx/main/notifications/webhook_backend.py
+++ b/awx/main/notifications/webhook_backend.py
@@ -84,11 +84,6 @@ class WebhookBackend(AWXBaseEmailBackend, CustomNotificationBase):
                 if resp.status_code not in [301, 307]:
                     break
 
-                # we've hit a redirect. extract the redirect URL out of the first response header and try again
-                logger.warning(
-                    f"Received a {resp.status_code} from {url}, trying to reach redirect url {resp.headers.get('Location', None)}; attempt #{retries+1}"
-                )
-
                 # take the first redirect URL in the response header and try that
                 url = resp.headers.get("Location", None)
 


### PR DESCRIPTION
Trigger sonar cube runs. I've deleted the "security hotspot". I want to see if sonarcube recognizes the issue as fixed and how it informs me of that in it's UI.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Collection
 - CLI
 - Docs
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, non-functional change limited to logging in webhook notifications; main risk is reduced visibility into unexpected redirect behavior during troubleshooting.
> 
> **Overview**
> Removes the `logger.warning(...)` emitted when webhook delivery receives a `301`/`307` redirect; the backend still retries by following the `Location` header up to `MAX_RETRIES`.
> 
> This reduces logging/observability around redirects without changing delivery behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d292e2409f554d19c0fd2b9f1089bd6e85d70bb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->