### PR TITLE
Allow edit for remote host headers fields in settings

### DIFF
--- a/awx/conf/registry.py
+++ b/awx/conf/registry.py
@@ -130,6 +130,7 @@ class SettingsRegistry(object):
         unit = field_kwargs.pop('unit', None)
         hidden = field_kwargs.pop('hidden', False)
         warning_text = field_kwargs.pop('warning_text', None)
+        allow_db_override = field_kwargs.pop('allow_db_override', False)
         if getattr(field_kwargs.get('child', None), 'source', None) is not None:
             field_kwargs['child'].source = None
         field_instance = field_class(**field_kwargs)

--- a/awx/conf/settings.py
+++ b/awx/conf/settings.py
@@ -303,9 +303,14 @@ class SettingsWrapper(UserSettingsHolder):
                     except AttributeError:
                         file_default = None
                     if file_default != init_default and file_default is not None:
-                        logger.debug('Setting %s has been marked read-only!', key)
-                        self.registry._registry[key]['read_only'] = True
-                        self.registry._registry[key]['defined_in_file'] = True
+                        # If allow_db_override is True, don't mark this setting as read-only
+                        # even if it was defined in a config file.
+                        if self.registry._registry[key].get('allow_db_override', False):
+                            logger.debug('Setting %s was defined in file but allows DB override.', key)
+                        else:
+                            logger.debug('Setting %s has been marked read-only!', key)
+                            self.registry._registry[key]['read_only'] = True
+                            self.registry._registry[key]['defined_in_file'] = True
                     self.__dict__['_awx_conf_init_readonly'] = True
         # If local preload timer has expired, check to see if another process
         # has already preloaded the cache and skip preloading if so.

--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -487,7 +487,9 @@ def unified_jobs_table(since, full_path, until, **kwargs):
                                        OR (main_unifiedjob.finished > '{0}' AND main_unifiedjob.finished <= '{1}'))
                                        AND main_unifiedjob.launch_type != 'sync'
                                  ORDER BY main_unifiedjob.id ASC) TO STDOUT WITH CSV HEADER
-                        '''.format(since.isoformat(), until.isoformat())
+                        '''.format(
+        since.isoformat(), until.isoformat()
+    )
     return _copy_table(table='unified_jobs', query=unified_job_query, path=full_path)
 
 
@@ -548,7 +550,9 @@ def workflow_job_node_table(since, full_path, until, **kwargs):
                                  ) always_nodes ON main_workflowjobnode.id = always_nodes.from_workflowjobnode_id
                                  WHERE (main_workflowjobnode.modified > '{}' AND main_workflowjobnode.modified <= '{}')
                                  ORDER BY main_workflowjobnode.id ASC) TO STDOUT WITH CSV HEADER
-                              '''.format(since.isoformat(), until.isoformat())
+                              '''.format(
+        since.isoformat(), until.isoformat()
+    )
     return _copy_table(table='workflow_job_node', query=workflow_job_node_query, path=full_path)
 
 

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -76,6 +76,7 @@ register(
     ),
     category=_('System'),
     category_slug='system',
+    allow_db_override=True,
 )
 
 register(

--- a/awx/main/management/commands/bottleneck.py
+++ b/awx/main/management/commands/bottleneck.py
@@ -23,7 +23,8 @@ class Command(BaseCommand):
 
         print('## ' + JobTemplate.objects.get(pk=jt).name + f' (last {history} runs)\n')
         with connection.cursor() as cursor:
-            cursor.execute(f'''
+            cursor.execute(
+                f'''
                 SELECT
                     b.id, b.job_id, b.host_name, b.created - a.created delta,
                     b.task task,
@@ -43,7 +44,8 @@ class Command(BaseCommand):
                         LIMIT {history}
                     )
                 ORDER BY delta DESC;
-                ''')
+                '''
+            )
             slowest_events = cursor.fetchall()
 
         def format_td(x):

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -365,7 +365,8 @@ class Role(models.Model):
                 if len(removals) > 0:
                     for ids in split_ids_for_sqlite(removals):
                         sql_params['ids'] = ','.join(str(x) for x in ids)
-                        cursor.execute('''
+                        cursor.execute(
+                            '''
                             DELETE FROM %(ancestors_table)s
                             WHERE descendent_id IN (%(ids)s)
                                   AND descendent_id != ancestor_id
@@ -377,7 +378,9 @@ class Role(models.Model):
                                        WHERE parents.from_role_id = %(ancestors_table)s.descendent_id
                                              AND %(ancestors_table)s.ancestor_id = inner_ancestors.ancestor_id
                                   )
-                        ''' % sql_params)
+                        '''
+                            % sql_params
+                        )
 
                         delete_ct += cursor.rowcount
 
@@ -385,7 +388,8 @@ class Role(models.Model):
                 if len(additions) > 0:
                     for ids in split_ids_for_sqlite(additions):
                         sql_params['ids'] = ','.join(str(x) for x in ids)
-                        cursor.execute('''
+                        cursor.execute(
+                            '''
                             INSERT INTO %(ancestors_table)s (descendent_id, ancestor_id, role_field, content_type_id, object_id)
                             SELECT from_id, to_id, new_ancestry_list.role_field, new_ancestry_list.content_type_id, new_ancestry_list.object_id FROM  (
                                   SELECT roles.id from_id,
@@ -415,7 +419,9 @@ class Role(models.Model):
                                        AND %(ancestors_table)s.ancestor_id = new_ancestry_list.to_id
                              )
 
-                        ''' % sql_params)
+                        '''
+                            % sql_params
+                        )
                         insert_ct += cursor.rowcount
 
                 if insert_ct == 0 and delete_ct == 0:

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -913,8 +913,10 @@ def awx_periodic_scheduler():
                 continue
             if not can_start:
                 new_unified_job.status = 'failed'
-                new_unified_job.job_explanation = gettext_noop("Scheduled job could not start because it \
-                    was not in the right state or required manual credentials")
+                new_unified_job.job_explanation = gettext_noop(
+                    "Scheduled job could not start because it \
+                    was not in the right state or required manual credentials"
+                )
                 new_unified_job.save(update_fields=['status', 'job_explanation'])
                 new_unified_job.websocket_emit_status("failed")
             emit_channel_notification('schedules-changed', dict(id=schedule.id, group_name="schedules"))

--- a/awx/main/tests/functional/__init__.py
+++ b/awx/main/tests/functional/__init__.py
@@ -59,7 +59,8 @@ def app_post_migration(sender, app_config, **kwargs):
         elif tblname == 'main_systemjobevent':
             unique_columns = "system_job_id integer NOT NULL"
 
-        cur.execute(f"""CREATE TABLE _unpartitioned_{tblname} (
+        cur.execute(
+            f"""CREATE TABLE _unpartitioned_{tblname} (
             id bigint NOT NULL,
             created timestamp with time zone NOT NULL,
             modified timestamp with time zone NOT NULL,
@@ -71,7 +72,8 @@ def app_post_migration(sender, app_config, **kwargs):
             uuid character varying(1024) NOT NULL,
             verbosity integer NOT NULL,
             {unique_columns});
-        """)
+        """
+        )
 
 
 if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3':

--- a/awx/main/tests/unit/test_redact.py
+++ b/awx/main/tests/unit/test_redact.py
@@ -36,7 +36,8 @@ uri = URI(scheme="https", username="myusername", password="mypasswordwith%40", h
 TEST_CLEARTEXT.append(
     {
         'uri': uri,
-        'text': textwrap.dedent("""\
+        'text': textwrap.dedent(
+            """\
         PLAY [all] ********************************************************************
 
         TASK: [delete project directory before update] ********************************
@@ -58,7 +59,9 @@ TEST_CLEARTEXT.append(
 
         localhost                  : ok=0    changed=0    unreachable=0    failed=1
 
-        """ % (uri.username, uri.password, str(uri), str(uri))),
+        """
+            % (uri.username, uri.password, str(uri), str(uri))
+        ),
         'host_occurrences': 2,
     }
 )
@@ -67,7 +70,8 @@ uri = URI(scheme="https", username="Dhh3U47nmC26xk9PKscV", password="PXPfWW8YzYr
 TEST_CLEARTEXT.append(
     {
         'uri': uri,
-        'text': textwrap.dedent("""\
+        'text': textwrap.dedent(
+            """\
         TASK: [update project using git] **
                     failed: [localhost] => {"cmd": "/usr/bin/git ls-remote https://REDACTED:********", "failed": true, "rc": 128}
                     stderr: error: Couldn't resolve host '@%s' while accessing %s
@@ -77,7 +81,9 @@ TEST_CLEARTEXT.append(
                     msg: error: Couldn't resolve host '@%s' while accessing %s
 
                     fatal: HTTP request failed
-        """ % (uri.host, str(uri), uri.host, str(uri))),
+        """
+            % (uri.host, str(uri), uri.host, str(uri))
+        ),
         'host_occurrences': 4,
     }
 )

--- a/awxkit/awxkit/awx/inventory.py
+++ b/awxkit/awxkit/awx/inventory.py
@@ -17,7 +17,9 @@ def upload_inventory(ansible_runner, nhosts=10, ini=False):
         copy_content = '''#!/bin/bash
 cat <<EOF
 %s
-EOF''' % json_inventory(nhosts)
+EOF''' % json_inventory(
+            nhosts
+        )
 
     # Copy script to test system
     contacted = ansible_runner.copy(dest=copy_dest, force=True, mode=copy_mode, content=copy_content)

--- a/awxkit/test/cli/test_format.py
+++ b/awxkit/test/cli/test_format.py
@@ -56,10 +56,12 @@ def test_yaml_import():
     def _dummy_authenticate():
         pass
 
-    yaml_fd = io.StringIO("""
+    yaml_fd = io.StringIO(
+        """
         workflow_job_templates:
           - name: Workflow1
-        """)
+        """
+    )
     yaml_fd.name = 'file.yaml'
     cli = CLI(stdin=yaml_fd)
     cli.parse_args(['--conf.format', 'yaml'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - Collection
 - CLI
 - Docs
 - Other



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how settings are classified as read-only when configured via files; misconfiguration could allow unintended DB overrides for file-managed settings (though currently only applied to `REMOTE_HOST_HEADERS`).
> 
> **Overview**
> Adds an `allow_db_override` registration flag so specific settings can remain editable via the database even when they differ from file-based defaults (i.e., they won’t be auto-marked `read_only` during settings cache preload).
> 
> Enables this behavior for `REMOTE_HOST_HEADERS`, while the rest of the PR is non-functional formatting/parenthesization changes across analytics queries, management commands, RBAC SQL, tasks, and tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45102e252399f22f61c39f80061fbb983bd50851. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->