### PR TITLE
fix schema generator

### DIFF
--- a/awx/api/schema.py
+++ b/awx/api/schema.py
@@ -9,7 +9,12 @@ from drf_spectacular.views import (
 )
 
 
-def filter_credential_type_schema(result, _generator, _request, _public):
+def filter_credential_type_schema(
+    result,
+    generator,  # NOSONAR
+    request,  # NOSONAR
+    public,  # NOSONAR
+):
     """
     Postprocessing hook to filter CredentialType kind enum values.
 
@@ -22,9 +27,7 @@ def filter_credential_type_schema(result, _generator, _request, _public):
 
     Args:
         result: The OpenAPI schema dict to be modified
-        _generator: Schema generator instance (required by drf-spectacular, unused)
-        _request: Request object (required by drf-spectacular, unused)
-        _public: Public schema flag (required by drf-spectacular, unused)
+        generator, request, public: Required by drf-spectacular interface (unused)
 
     Returns:
         The modified OpenAPI schema dict


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix schema generator

Sonar is complaining about no usage of the parameter but those are needed to the drf-spectacular as is now.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature/docstring-only change for an OpenAPI postprocessing hook; no runtime API behavior or data handling logic is modified.
> 
> **Overview**
> Fixes the `filter_credential_type_schema` drf-spectacular postprocessing hook signature to use the expected `generator`, `request`, and `public` parameters (previously underscored/ignored), and updates the docstring accordingly.
> 
> This is a non-functional change intended to avoid schema generation/tooling issues while keeping the existing OpenAPI `CredentialTypeRequest`/`PatchedCredentialTypeRequest` enum filtering behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c2672e448d27949a06e5b30f7af2b8d12f417d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->