### PR TITLE
🧪 Integrate Zizmor checks into GHA CI/CD 🌈

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -488,3 +488,11 @@ jobs:
         with:
           name: awx-collection-integration-coverage-html
           path: ~/.ansible/collections/ansible_collections/awx/awx/tests/output/reports/coverage
+
+  zizmor:
+    name: 🌈 zizmor
+    permissions:
+      security-events: write
+
+    # yamllint disable-line rule:line-length
+    uses: zizmorcore/workflow/.github/workflows/reusable-zizmor.yml@1e20adb0862e932363a4d85d68c92e5cc6fcb5d4


### PR DESCRIPTION
This linter guards against common insecure setups in GitHub Actions and Workflows. It is authored and maintained by a member of the PyPA, contributor to PyPI, former employee of the Trail Of Bits.

Ref: https://zizmor.sh

<!-- Bug, Docs Fix or other nominal change -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new CI job to the pipeline to standardize checks across runs.
  * Configured the job with explicit permissions to allow automated reporting of security-related events.
  * The job reuses an existing shared workflow to ensure consistent behavior and simplify maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->