### PR TITLE
AAP-64432 Fix wrong field rename for github app

### DIFF
--- a/awx/main/migrations/0201_create_managed_creds.py
+++ b/awx/main/migrations/0201_create_managed_creds.py
@@ -21,6 +21,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(setup_tower_managed_defaults),
-        migrations.RunPython(setup_rbac_role_system_administrator),
+        migrations.RunPython(setup_tower_managed_defaults, migrations.RunPython.noop),
+        migrations.RunPython(setup_rbac_role_system_administrator, migrations.RunPython.noop),
     ]

--- a/awx/main/migrations/0202_convert_controller_role_definitions.py
+++ b/awx/main/migrations/0202_convert_controller_role_definitions.py
@@ -98,5 +98,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(convert_controller_role_definitions),
+        migrations.RunPython(convert_controller_role_definitions, migrations.RunPython.noop),
     ]

--- a/awx/main/migrations/0204_squashed_deletions.py
+++ b/awx/main/migrations/0204_squashed_deletions.py
@@ -12,7 +12,7 @@ def update_github_app_kind(apps, schema_editor):
     """
     CredentialType = apps.get_model('main', 'CredentialType')
     db_alias = schema_editor.connection.alias
-    CredentialType.objects.using(db_alias).filter(kind='github_app').update(kind='github_app_lookup')
+    CredentialType.objects.using(db_alias).filter(namespace='github_app').update(namespace='github_app_lookup')
 
 
 # --- END of function merged from 0203_rename_github_app_kind.py ---

--- a/awx/main/migrations/0204_squashed_deletions.py
+++ b/awx/main/migrations/0204_squashed_deletions.py
@@ -3,19 +3,15 @@ from django.db import migrations, models
 from awx.main.migrations._create_system_jobs import delete_clear_tokens_sjt
 
 
-# --- START of function merged from 0203_rename_github_app_kind.py ---
 def update_github_app_kind(apps, schema_editor):
     """
-    Updates the 'kind' field for CredentialType records
+    Updates the 'namespace' field for CredentialType records
     from 'github_app' to 'github_app_lookup'.
     This addresses a change in the entry point key for the GitHub App plugin.
     """
     CredentialType = apps.get_model('main', 'CredentialType')
     db_alias = schema_editor.connection.alias
     CredentialType.objects.using(db_alias).filter(namespace='github_app').update(namespace='github_app_lookup')
-
-
-# --- END of function merged from 0203_rename_github_app_kind.py ---
 
 
 class Migration(migrations.Migration):
@@ -118,7 +114,5 @@ class Migration(migrations.Migration):
                 max_length=32,
             ),
         ),
-        # --- START of operations merged from 0203_rename_github_app_kind.py ---
         migrations.RunPython(update_github_app_kind, migrations.RunPython.noop),
-        # --- END of operations merged from 0203_rename_github_app_kind.py ---
     ]

--- a/awx/main/tests/functional/test_migrations.py
+++ b/awx/main/tests/functional/test_migrations.py
@@ -173,3 +173,54 @@ class TestMigrationSmoke:
         assert Role.objects.filter(
             singleton_name='system_administrator', role_field='system_administrator'
         ).exists(), "expected to find a system_administrator singleton role"
+
+
+@pytest.mark.django_db
+class TestGithubAppBug:
+    """
+    Tests that `awx-manage createsuperuser` runs successfully after
+    the `github_app` CredentialType kind is updated to `github_app_lookup`
+    via the migration.
+    """
+
+    def test_after_github_app_kind_migration(self, migrator):
+        """
+        Verifies that `createsuperuser` does not raise a KeyError
+        after the 0204_squashed_deletions migration (which includes
+        the `update_github_app_kind` logic) is applied.
+        """
+        # 1. Apply migrations up to the point *before* the 0204_squashed_deletions migration.
+        # This simulates the state where the problematic CredentialType might exist.
+        # We use 0203_remove_team_of_teams as the direct predecessor.
+        old_state = migrator.apply_tested_migration(('main', '0203_remove_team_of_teams'))
+
+        # Get the CredentialType model from the historical state.
+        CredentialType = old_state.apps.get_model('main', 'CredentialType')
+
+        # Create a CredentialType with the old, problematic 'namespace' value
+        CredentialType.objects.create(
+            name='Legacy GitHub App Credential',
+            kind='external',
+            namespace='github_app',  # The namespace that causes the KeyError in the registry lookup
+            managed=True,
+            created=now(),
+            modified=now(),
+        )
+
+        # Apply the migration that includes the fix (0204_squashed_deletions).
+        new_state = migrator.apply_tested_migration(('main', '0204_squashed_deletions'))
+
+        # Verify that the CredentialType with the old 'kind' no longer exists
+        # and the 'kind' has been updated to the new value.
+        CredentialType = new_state.apps.get_model('main', 'CredentialType')  # Get CredentialType model from the new state
+
+        # Assertion 1: The CredentialType with the old 'github_app' kind should no longer exist.
+        assert not CredentialType.objects.filter(
+            namespace='github_app'
+        ).exists(), "CredentialType with old 'github_app' kind should no longer exist after migration."
+
+        # Assertion 2: The CredentialType should now exist with the new 'github_app_lookup' kind
+        # and retain its original name.
+        assert CredentialType.objects.filter(
+            namespace='github_app_lookup', name='Legacy GitHub App Credential'
+        ).exists(), "CredentialType should be updated to 'github_app_lookup' and retain its name."


### PR DESCRIPTION
* Multiple credentialtype's have the same kind and kind values look like: cloud, network, machine, etc.
* namespace is the field that we want to rename

Jira: https://issues.redhat.com/browse/AAP-64432

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Migration-only changes with a targeted data update and added tests; risk is limited to upgrade paths where `CredentialType.namespace` values are rewritten.
> 
> **Overview**
> Fixes the GitHub App credential-type migration in `0204_squashed_deletions` to update `CredentialType.namespace` from `github_app` to `github_app_lookup` (instead of incorrectly updating `kind`).
> 
> Makes several `RunPython` migrations explicitly reversible in tests by adding `migrations.RunPython.noop` reverse functions (in `0201_create_managed_creds`, `0202_convert_controller_role_definitions`, and the GitHub App update step). Adds a functional migration regression test that creates a legacy `namespace='github_app'` record, applies `0204`, and asserts the value is rewritten to prevent the `createsuperuser` KeyError.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7799104453fb7e539dc8bcb1df525f4f0894e49f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed credential-type mapping for GitHub App credentials during upgrades.

* **Chores**
  * Improved database migration handling to ensure cleaner, more reliable upgrade paths.

* **Tests**
  * Added functional test coverage for credential-type migrations and post-migration superuser creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->