### PR TITLE
Give error details of sliced jobs if they error in live tests

### DIFF
--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -18,7 +18,7 @@ from awx.main.tests.functional.conftest import *  # noqa
 from awx.main.tests.conftest import load_all_credentials  # noqa: F401; pylint: disable=unused-import
 from awx.main.tests import data
 
-from awx.main.models import Project, JobTemplate, Organization, Inventory
+from awx.main.models import Project, JobTemplate, Organization, Inventory, WorkflowJob, UnifiedJob
 from awx.main.tasks.system import clear_setting_cache
 
 logger = logging.getLogger(__name__)
@@ -100,6 +100,21 @@ def wait_for_events(uj, timeout=2):
 
 
 def unified_job_stdout(uj):
+    if type(uj) is UnifiedJob:
+        uj = uj.get_real_instance()
+    if isinstance(uj, WorkflowJob):
+        outputs = []
+        for node in uj.workflow_job_nodes.all().select_related('job').order_by('id'):
+            if node.job is None:
+                continue
+            outputs.append(
+                'workflow node {node_id} job {job_id} output:\n{output}'.format(
+                    node_id=node.id,
+                    job_id=node.job.id,
+                    output=unified_job_stdout(node.job),
+                )
+            )
+        return '\n'.join(outputs)
     wait_for_events(uj)
     return '\n'.join([event.stdout for event in uj.get_event_queryset().order_by('created')])
 


### PR DESCRIPTION
##### SUMMARY
In the process of debugging things, I had workflow jobs (due to bulk & sliced jobs) that had jobs in them failing. This actually gave a lot of problem due to type mainly, `WorkflowJob` vs `Job` so it just hits some unrelated and incomprehensible test error. This is intended to solve that.

Passing `UnifiedJob` also gives errors, thus the `get_real_instance` to convert to `Job`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that affect how stdout is collected/printed on failures; low risk aside from potentially larger/more expensive debug output generation for workflow jobs.
> 
> **Overview**
> Live test diagnostics now handle `UnifiedJob` and `WorkflowJob` objects when building failure output, avoiding confusing type-related errors.
> 
> `unified_job_stdout` unwraps `UnifiedJob` via `get_real_instance()` and, for workflow jobs, aggregates and labels stdout from each workflow node’s underlying job to surface the actual failing child job output in assertion messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e54a729da0ddcbc2a8a1b47b3cae0e646b23ba4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixtures for workflow and job output handling to support enhanced testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->