### PR TITLE
Fix server error from PATCH to inventory source

### DIFF
--- a/awx/api/fields.py
+++ b/awx/api/fields.py
@@ -89,7 +89,7 @@ class DeprecatedCredentialField(serializers.IntegerField):
     def to_internal_value(self, pk):
         try:
             pk = int(pk)
-        except ValueError:
+        except (ValueError, TypeError):
             self.fail('invalid')
         try:
             Credential.objects.get(pk=pk)

--- a/awx/main/tests/functional/api/test_inventory.py
+++ b/awx/main/tests/functional/api/test_inventory.py
@@ -463,6 +463,26 @@ class TestInventorySourceCredential:
         assert 'Cloud-based inventory sources (such as ec2)' in r.data['credential'][0]
         assert 'require credentials for the matching cloud service' in r.data['credential'][0]
 
+    def test_credential_dict_value_returns_400(self, inventory, admin_user, put):
+        """Passing a dict for the credential field should return 400, not 500.
+
+        Reproduces a bug where int() raises TypeError on non-scalar types
+        (dict, list) which was uncaught, resulting in a 500 Internal Server Error.
+        """
+        inv_src = InventorySource.objects.create(name='test-src', inventory=inventory, source='ec2')
+        r = put(
+            url=reverse('api:inventory_source_detail', kwargs={'pk': inv_src.pk}),
+            data={
+                'name': 'test-src',
+                'inventory': inventory.pk,
+                'source': 'ec2',
+                'credential': {'username': 'admin', 'password': 'secret'},
+            },
+            user=admin_user,
+            expect=400,
+        )
+        assert r.status_code == 400
+
     def test_vault_credential_not_allowed(self, project, inventory, vault_credential, admin_user, post):
         """Vault credentials cannot be associated via the deprecated field"""
         # TODO: when feature is added, add tests to use the related credentials

--- a/awx/main/tests/unit/api/test_fields.py
+++ b/awx/main/tests/unit/api/test_fields.py
@@ -1,0 +1,49 @@
+import pytest
+from collections import OrderedDict
+from unittest import mock
+
+from rest_framework.exceptions import ValidationError
+
+from awx.api.fields import DeprecatedCredentialField
+
+
+class TestDeprecatedCredentialField:
+    """Test that DeprecatedCredentialField handles unexpected input types gracefully."""
+
+    def test_dict_value_raises_validation_error(self):
+        """Passing a dict instead of an integer should return a 400 validation error, not a 500 TypeError."""
+        field = DeprecatedCredentialField()
+        with pytest.raises(ValidationError):
+            field.to_internal_value({"username": "admin", "password": "secret"})
+
+    def test_ordered_dict_value_raises_validation_error(self):
+        """Passing an OrderedDict should return a 400 validation error, not a 500 TypeError."""
+        field = DeprecatedCredentialField()
+        with pytest.raises(ValidationError):
+            field.to_internal_value(OrderedDict([("username", "admin")]))
+
+    def test_list_value_raises_validation_error(self):
+        """Passing a list should return a 400 validation error, not a 500 TypeError."""
+        field = DeprecatedCredentialField()
+        with pytest.raises(ValidationError):
+            field.to_internal_value([1, 2, 3])
+
+    def test_string_value_raises_validation_error(self):
+        """Passing a non-numeric string should return a 400 validation error."""
+        field = DeprecatedCredentialField()
+        with pytest.raises(ValidationError):
+            field.to_internal_value("not_a_number")
+
+    @mock.patch('awx.api.fields.Credential.objects')
+    def test_valid_integer_value_works(self, mock_cred_objects):
+        """Passing a valid integer PK should work when the credential exists."""
+        mock_cred_objects.get.return_value = mock.MagicMock()
+        field = DeprecatedCredentialField()
+        assert field.to_internal_value(42) == 42
+
+    @mock.patch('awx.api.fields.Credential.objects')
+    def test_valid_string_integer_value_works(self, mock_cred_objects):
+        """Passing a numeric string PK should work when the credential exists."""
+        mock_cred_objects.get.return_value = mock.MagicMock()
+        field = DeprecatedCredentialField()
+        assert field.to_internal_value("42") == 42


### PR DESCRIPTION
##### SUMMARY
Tests observed a 500 error, @TheRealHaoLiu got traceback

```
[11:14 AM]2026-02-11 11:51:40,529 ERROR    [f3eb25a57a464fdf8f5de4fd5e3b6633] django.request Internal Server Error: /api/controller/v2/inventory_sources/125/
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/contextlib.py", line 81, in inner
    return func(*args, **kwds)
           ^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/views/decorators/csrf.py", line 56, in wrapper_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/django/views/generic/base.py", line 105, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/api/generics.py", line 374, in dispatch
    return super(APIView, self).dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/generics.py", line 259, in put
    return self.update(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/api/generics.py", line 820, in update
    return super(RetrieveUpdateAPIView, self).update(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/mixins.py", line 67, in update
    serializer.is_valid(raise_exception=True)
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/serializers.py", line 223, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/api/serializers.py", line 615, in run_validation
    return super(BaseSerializer, self).run_validation(data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/serializers.py", line 442, in run_validation
    value = self.to_internal_value(data)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/serializers.py", line 499, in to_internal_value
    validated_value = field.run_validation(primitive_value)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/rest_framework/fields.py", line 538, in run_validation
    value = self.to_internal_value(data)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/api/fields.py", line 105, in to_internal_value
    pk = int(pk)
         ^^^^^^^
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'collections.OrderedDict'
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted error-handling change in request validation plus tests; behavior only changes for malformed `credential` inputs, converting a 500 into a 400.
> 
> **Overview**
> Fixes an API crash when updating an inventory source with an invalid `credential` payload (e.g., dict/list/OrderedDict) by treating `TypeError` from `int()` conversion as a normal validation failure in `DeprecatedCredentialField`.
> 
> Adds functional and unit tests to ensure these invalid input types consistently return HTTP 400 (and that valid integer / numeric-string values continue to work).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16ce2e9cf9cacba810a95d6deef10d7989bc97cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid credential field inputs now return proper 400-level error responses instead of 500 errors.

* **Tests**
  * Added tests for credential field validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->