### PR TITLE
fix: align pip version constraint in requirements_dev.txt

### DIFF
--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -23,7 +23,7 @@ gprof2dot
 atomicwrites
 flake8
 yamllint
-pip>=21.3,<=24.0 # PEP 660 – Editable installs for pyproject.toml based builds (wheel based)
+pip>=25.3 # PEP 660 – Editable installs for pyproject.toml based builds (wheel based)
 
 # python debuggers
 debugpy


### PR DESCRIPTION
fixes #16272

requirements.txt pins pip==25.3 while requirements_dev.txt specified pip>=21.3,<=24.0, causing ResolutionImpossible when installing both. updated the constraint to pip>=25.3 to maintain compatibility.

Bug, Docs Fix or other nominal change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pip development dependency to require version 25.3 or higher, removing the previous upper version constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->