### PR TITLE
Fix awx CLI modify command for users with object-level permissions

### DIFF
--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -221,7 +221,13 @@ class CLI(object):
         if self.resource != 'settings':
             for method in ('list', 'modify', 'create'):
                 if method in parser.parser.choices:
-                    parser.build_query_arguments(method, 'GET' if method == 'list' else 'POST')
+                    if method == 'list':
+                        http_method = 'GET'
+                    elif method == 'modify' and 'PUT' in parser.options:
+                        http_method = 'PUT'
+                    else:
+                        http_method = 'POST'
+                    parser.build_query_arguments(method, http_method)
         if from_sphinx:
             parsed, extra = self.parser.parse_known_args(self.argv)
         else:

--- a/awxkit/awxkit/cli/options.py
+++ b/awxkit/awxkit/cli/options.py
@@ -105,6 +105,18 @@ class ResourceOptionsParser(object):
         if '299' in warning and 'deprecated' in warning:
             self.deprecated = True
         self.allowed_options = options.headers.get('Allow', '').split(', ')
+        # If the user can PUT on the detail endpoint but doesn't have
+        # POST on the list endpoint, use the detail endpoint's
+        # action schema so that 'modify' fields are populated.
+        if 'POST' not in self.options and 'PUT' in self.allowed_options:
+            try:
+                detail_actions = options.json().get('actions', {})
+            except Exception:
+                detail_actions = {}
+            if 'PUT' in detail_actions:
+                self.options['PUT'] = detail_actions['PUT']
+            elif 'GET' in detail_actions:
+                self.options['PUT'] = detail_actions['GET']
 
     def build_list_actions(self):
         action_map = {
@@ -112,6 +124,10 @@ class ResourceOptionsParser(object):
             'POST': 'create',
         }
         for method, action in self.options.items():
+            # Skip 'PUT', which may be added by get_allowed_options
+            # and is handled separately by build_detail_actions
+            if method not in action_map:
+                continue
             method = action_map[method]
             parser = self.parser.add_parser(method, help='')
             if method == 'list':

--- a/awxkit/test/cli/test_options.py
+++ b/awxkit/test/cli/test_options.py
@@ -11,6 +11,24 @@ class ResourceOptionsParser(ResourceOptionsParser):
         self.allowed_options = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
 
 
+class NoPostResourceOptionsParser(ResourceOptionsParser):
+    """Simulates a user with object-level PUT but no list-level POST."""
+
+    detail_put_actions = {}
+
+    def get_allowed_options(self):
+        self.allowed_options = ['GET', 'PUT', 'PATCH', 'DELETE']
+        # Simulate the logic from the real get_allowed_options that
+        # falls back to the detail endpoint's PUT schema when POST
+        # is not available on the list endpoint.
+        if 'POST' not in self.options and 'PUT' in self.allowed_options:
+            if self.detail_put_actions:
+                self.options['PUT'] = self.detail_put_actions
+
+    def handle_custom_actions(self):
+        pass
+
+
 class OptionsPage(Page):
     def options(self):
         return self
@@ -184,6 +202,30 @@ class TestOptions(unittest.TestCase):
             out = StringIO()
             self.parser.choices[method].print_help(out)
             assert 'positional arguments:\n  id' in out.getvalue()
+
+    def test_modify_without_list_post(self):
+        """User with object-level PUT but no list-level POST can still modify."""
+        page = OptionsPage.from_json(
+            {
+                'actions': {
+                    'GET': {},
+                }
+            }
+        )
+        NoPostResourceOptionsParser.detail_put_actions = {
+            'scm_branch': {'type': 'string', 'help_text': 'SCM branch'},
+            'description': {'type': 'string', 'help_text': 'Description'},
+        }
+        options = NoPostResourceOptionsParser(None, page, 'projects', self.parser)
+
+        assert 'modify' in self.parser.choices
+        assert 'create' not in self.parser.choices
+
+        options.build_query_arguments('modify', 'PUT')
+        out = StringIO()
+        self.parser.choices['modify'].print_help(out)
+        assert '--scm_branch TEXT' in out.getvalue()
+        assert '--description TEXT' in out.getvalue()
 
 
 class TestSettingsOptions(unittest.TestCase):


### PR DESCRIPTION
## TLDR
awx cli is making assumptions about a user's permissions based on list level endpoints, e.g. api/v2/projects/ but not specific resources like api/v2/projects/1/. This resulted in a bug where a normal user with project admin permission could not update said project using the cli, yet it does work with the api.

## Summary
- The awx CLI `modify` command was unusable for users with object-level admin permissions (e.g., Project Admin) but no list-level POST permission, because it derived available fields from the list endpoint's POST action schema
- Falls back to the detail endpoint's action schema (GET fields) when POST is unavailable, and prefers PUT over POST when building modify arguments
- Adds a unit test covering the no-list-POST scenario

## Reproducer
Create a normal user, copy a project, and assign the user as Project Admin:
```bash
curl -sk -u admin:pass https://localhost:8043/api/v2/users/ -H "Content-Type: application/json" \
  -d '{"username": "bob", "password": "bob"}'
curl -sk -u admin:pass https://localhost:8043/api/v2/projects/6/copy/ -H "Content-Type: application/json" \
  -d '{"name": "Demo Project - Copy"}'
curl -sk -u admin:pass https://localhost:8043/api/v2/users/3/roles/ -H "Content-Type: application/json" \
  -d '{"id": <admin_role_id>}'
```

Before fix — `modify` shows no field flags:
```
$ awx -k --conf.host https://localhost:8043 --conf.username bob --conf.password bob \
    projects modify "Demo Project - Copy" --scm_branch "dummy_branch"
usage: awx projects modify [-h] id
```

After fix — `modify` works:
```
$ awx -k --conf.host https://localhost:8043 --conf.username bob --conf.password bob \
    projects modify "Demo Project - Copy" --scm_branch "dummy_branch"
{
     "id": 9,
     "scm_branch": "dummy_branch",
     ...
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI adapts to servers that disallow list endpoint POST by using object-level modify actions (PUT when available) so users can modify resources even when collection create is restricted.
  * Improved selection of HTTP methods for list/modify operations to better match server capabilities.

* **Tests**
  * Added test coverage validating modify without "list endpoint POST permissions" scenarios and related help output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to CLI option discovery/arg parsing; risk is limited to how `modify` arguments are derived from API `OPTIONS` responses.
> 
> **Overview**
> Ensures the CLI can build `modify` flags for users with **object-level update permissions** but no **list-level create (`POST`) permission** by falling back to the detail endpoint’s `PUT` (or `GET`) action schema when needed.
> 
> Updates action argument generation to prefer `PUT` over `POST` when populating `modify` parameters, avoids incorrectly treating injected `PUT` schemas as list actions, and adds a unit test covering the no-list-`POST` scenario.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5f29c0db708e3f5e03bbba154a5f7322862f01d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->