### PR TITLE
Restoration of Token Authentication in AWX CLI

### DIFF
--- a/awx/main/analytics/collectors.py
+++ b/awx/main/analytics/collectors.py
@@ -487,7 +487,9 @@ def unified_jobs_table(since, full_path, until, **kwargs):
                                        OR (main_unifiedjob.finished > '{0}' AND main_unifiedjob.finished <= '{1}'))
                                        AND main_unifiedjob.launch_type != 'sync'
                                  ORDER BY main_unifiedjob.id ASC) TO STDOUT WITH CSV HEADER
-                        '''.format(since.isoformat(), until.isoformat())
+                        '''.format(
+        since.isoformat(), until.isoformat()
+    )
     return _copy_table(table='unified_jobs', query=unified_job_query, path=full_path)
 
 
@@ -548,7 +550,9 @@ def workflow_job_node_table(since, full_path, until, **kwargs):
                                  ) always_nodes ON main_workflowjobnode.id = always_nodes.from_workflowjobnode_id
                                  WHERE (main_workflowjobnode.modified > '{}' AND main_workflowjobnode.modified <= '{}')
                                  ORDER BY main_workflowjobnode.id ASC) TO STDOUT WITH CSV HEADER
-                              '''.format(since.isoformat(), until.isoformat())
+                              '''.format(
+        since.isoformat(), until.isoformat()
+    )
     return _copy_table(table='workflow_job_node', query=workflow_job_node_query, path=full_path)
 
 

--- a/awx/main/management/commands/bottleneck.py
+++ b/awx/main/management/commands/bottleneck.py
@@ -23,7 +23,8 @@ class Command(BaseCommand):
 
         print('## ' + JobTemplate.objects.get(pk=jt).name + f' (last {history} runs)\n')
         with connection.cursor() as cursor:
-            cursor.execute(f'''
+            cursor.execute(
+                f'''
                 SELECT
                     b.id, b.job_id, b.host_name, b.created - a.created delta,
                     b.task task,
@@ -43,7 +44,8 @@ class Command(BaseCommand):
                         LIMIT {history}
                     )
                 ORDER BY delta DESC;
-                ''')
+                '''
+            )
             slowest_events = cursor.fetchall()
 
         def format_td(x):

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -365,7 +365,8 @@ class Role(models.Model):
                 if len(removals) > 0:
                     for ids in split_ids_for_sqlite(removals):
                         sql_params['ids'] = ','.join(str(x) for x in ids)
-                        cursor.execute('''
+                        cursor.execute(
+                            '''
                             DELETE FROM %(ancestors_table)s
                             WHERE descendent_id IN (%(ids)s)
                                   AND descendent_id != ancestor_id
@@ -377,7 +378,9 @@ class Role(models.Model):
                                        WHERE parents.from_role_id = %(ancestors_table)s.descendent_id
                                              AND %(ancestors_table)s.ancestor_id = inner_ancestors.ancestor_id
                                   )
-                        ''' % sql_params)
+                        '''
+                            % sql_params
+                        )
 
                         delete_ct += cursor.rowcount
 
@@ -385,7 +388,8 @@ class Role(models.Model):
                 if len(additions) > 0:
                     for ids in split_ids_for_sqlite(additions):
                         sql_params['ids'] = ','.join(str(x) for x in ids)
-                        cursor.execute('''
+                        cursor.execute(
+                            '''
                             INSERT INTO %(ancestors_table)s (descendent_id, ancestor_id, role_field, content_type_id, object_id)
                             SELECT from_id, to_id, new_ancestry_list.role_field, new_ancestry_list.content_type_id, new_ancestry_list.object_id FROM  (
                                   SELECT roles.id from_id,
@@ -415,7 +419,9 @@ class Role(models.Model):
                                        AND %(ancestors_table)s.ancestor_id = new_ancestry_list.to_id
                              )
 
-                        ''' % sql_params)
+                        '''
+                            % sql_params
+                        )
                         insert_ct += cursor.rowcount
 
                 if insert_ct == 0 and delete_ct == 0:

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -913,8 +913,10 @@ def awx_periodic_scheduler():
                 continue
             if not can_start:
                 new_unified_job.status = 'failed'
-                new_unified_job.job_explanation = gettext_noop("Scheduled job could not start because it \
-                    was not in the right state or required manual credentials")
+                new_unified_job.job_explanation = gettext_noop(
+                    "Scheduled job could not start because it \
+                    was not in the right state or required manual credentials"
+                )
                 new_unified_job.save(update_fields=['status', 'job_explanation'])
                 new_unified_job.websocket_emit_status("failed")
             emit_channel_notification('schedules-changed', dict(id=schedule.id, group_name="schedules"))

--- a/awx/main/tests/functional/__init__.py
+++ b/awx/main/tests/functional/__init__.py
@@ -59,7 +59,8 @@ def app_post_migration(sender, app_config, **kwargs):
         elif tblname == 'main_systemjobevent':
             unique_columns = "system_job_id integer NOT NULL"
 
-        cur.execute(f"""CREATE TABLE _unpartitioned_{tblname} (
+        cur.execute(
+            f"""CREATE TABLE _unpartitioned_{tblname} (
             id bigint NOT NULL,
             created timestamp with time zone NOT NULL,
             modified timestamp with time zone NOT NULL,
@@ -71,7 +72,8 @@ def app_post_migration(sender, app_config, **kwargs):
             uuid character varying(1024) NOT NULL,
             verbosity integer NOT NULL,
             {unique_columns});
-        """)
+        """
+        )
 
 
 if settings.DATABASES['default']['ENGINE'] == 'django.db.backends.sqlite3':

--- a/awx/main/tests/unit/test_redact.py
+++ b/awx/main/tests/unit/test_redact.py
@@ -36,7 +36,8 @@ uri = URI(scheme="https", username="myusername", password="mypasswordwith%40", h
 TEST_CLEARTEXT.append(
     {
         'uri': uri,
-        'text': textwrap.dedent("""\
+        'text': textwrap.dedent(
+            """\
         PLAY [all] ********************************************************************
 
         TASK: [delete project directory before update] ********************************
@@ -58,7 +59,9 @@ TEST_CLEARTEXT.append(
 
         localhost                  : ok=0    changed=0    unreachable=0    failed=1
 
-        """ % (uri.username, uri.password, str(uri), str(uri))),
+        """
+            % (uri.username, uri.password, str(uri), str(uri))
+        ),
         'host_occurrences': 2,
     }
 )
@@ -67,7 +70,8 @@ uri = URI(scheme="https", username="Dhh3U47nmC26xk9PKscV", password="PXPfWW8YzYr
 TEST_CLEARTEXT.append(
     {
         'uri': uri,
-        'text': textwrap.dedent("""\
+        'text': textwrap.dedent(
+            """\
         TASK: [update project using git] **
                     failed: [localhost] => {"cmd": "/usr/bin/git ls-remote https://REDACTED:********", "failed": true, "rc": 128}
                     stderr: error: Couldn't resolve host '@%s' while accessing %s
@@ -77,7 +81,9 @@ TEST_CLEARTEXT.append(
                     msg: error: Couldn't resolve host '@%s' while accessing %s
 
                     fatal: HTTP request failed
-        """ % (uri.host, str(uri), uri.host, str(uri))),
+        """
+            % (uri.host, str(uri), uri.host, str(uri))
+        ),
         'host_occurrences': 4,
     }
 )

--- a/awxkit/awxkit/api/client.py
+++ b/awxkit/awxkit/api/client.py
@@ -12,6 +12,15 @@ class ConnectionException(exc.Common):
     pass
 
 
+class Token_Auth(requests.auth.AuthBase):
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, request):
+        request.headers['Authorization'] = 'Bearer {0.token}'.format(self)
+        return request
+
+
 def log_elapsed(r, *args, **kwargs):  # requests hook to display API elapsed time
     log.debug('"{0.request.method} {0.url}" elapsed: {0.elapsed}'.format(r))
 
@@ -37,7 +46,7 @@ class Connection(object):
         self.get(config.api_base_path)  # this causes a cookie w/ the CSRF token to be set
         return dict(next=next)
 
-    def login(self, username=None, password=None, **kwargs):
+    def login(self, username=None, password=None, token=None, **kwargs):
         if username and password:
             _next = kwargs.get('next')
             if _next:
@@ -52,6 +61,8 @@ class Connection(object):
                 self.uses_session_cookie = True
             else:
                 self.session.auth = (username, password)
+        elif token:
+            self.session.auth = Token_Auth(token)
         else:
             self.session.auth = None
 

--- a/awxkit/awxkit/awx/inventory.py
+++ b/awxkit/awxkit/awx/inventory.py
@@ -17,7 +17,9 @@ def upload_inventory(ansible_runner, nhosts=10, ini=False):
         copy_content = '''#!/bin/bash
 cat <<EOF
 %s
-EOF''' % json_inventory(nhosts)
+EOF''' % json_inventory(
+            nhosts
+        )
 
     # Copy script to test system
     contacted = ansible_runner.copy(dest=copy_dest, force=True, mode=copy_mode, content=copy_content)

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -74,7 +74,7 @@ class CLI(object):
 
     def get_config(self, key):
         """Helper method for looking up the value of a --conf.xyz flag"""
-        return getattr(self.args, 'conf.{}'.format(key))
+        return getattr(self.args, 'conf.{}'.format(key), None)
 
     @property
     def help(self):
@@ -83,13 +83,26 @@ class CLI(object):
     def authenticate(self):
         """Configure the current session for authentication.
 
-        Uses Basic authentication when AWXKIT_FORCE_BASIC_AUTH environment variable
-        is set to true, otherwise defaults to session-based authentication.
+        Authentication priority:
+        1. Token authentication (if --conf.token provided)
+        2. Basic authentication (if AWXKIT_FORCE_BASIC_AUTH=true)
+        3. Session-based authentication (default)
 
         For AAP Gateway environments, set AWXKIT_FORCE_BASIC_AUTH=true to bypass
-        session login restrictions.
+        session login restrictions when using username/password.
         """
-        # Check if Basic auth is forced via environment variable
+        # Token authentication (if token is provided)
+        token = self.get_config('token')
+        if token:
+            config.use_sessions = False
+            self.root.connection.login(
+                None,
+                None,
+                token=token,
+            )
+            return
+
+        # Basic authentication (for AAP Gateway environments)
         if config.get('force_basic_auth', False):
             config.use_sessions = False
 
@@ -112,7 +125,7 @@ class CLI(object):
                 raise RuntimeError(f"Basic authentication failed: {str(e)}. " "Verify credentials and network connectivity.") from e
             return
 
-        # Use session-based authentication (default)
+        # Session-based authentication (default)
         config.use_sessions = True
         self.root.load_session().get()
 

--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -47,6 +47,14 @@ def add_authentication_arguments(parser, env):
         metavar='https://example.awx.org',
     )
 
+    # Token authentication (takes precedence over username/password)
+    auth.add_argument(
+        '--conf.token',
+        default=env.get('CONTROLLER_OAUTH_TOKEN', env.get('TOWER_OAUTH_TOKEN', None)),
+        metavar='TEXT',
+        help='OAuth2/Personal Access Token for authentication (takes precedence over username/password)',
+    )
+
     config_username, config_password = get_config_credentials()
     # options configured via cli args take higher precedence than those from the config
     auth.add_argument(

--- a/awxkit/test/cli/test_authentication.py
+++ b/awxkit/test/cli/test_authentication.py
@@ -44,6 +44,53 @@ def setup_session_auth(cli_args: Optional[List[str]] = None) -> Tuple[CLI, Mock,
     return cli, mock_root, mock_load_session
 
 
+def setup_token_auth(cli_args: Optional[List[str]] = None) -> Tuple[CLI, Mock, Mock]:
+    """Set up CLI with mocked connection for Token auth testing"""
+    cli = CLI()
+    cli.parse_args(cli_args or ['awx', '--conf.token', 'test-token-abc123'])
+
+    mock_root = Mock()
+    mock_connection = Mock()
+    mock_root.connection = mock_connection
+    cli.root = mock_root
+
+    return cli, mock_root, mock_connection
+
+
+# ============================================================================
+# REGRESSION TESTS - Existing Functionality (Must Not Break)
+# ============================================================================
+
+
+def test_token_authentication_preserved(monkeypatch):
+    """
+    REGRESSION TEST: Token authentication must still work (existed in 4.6.12)
+
+    This test documents the customer's working scenario from 4.6.12:
+        awx login --conf.host URL --conf.username USER --conf.password PASS
+        # Returns: {"token": "E*******J"}
+
+        awx --conf.host URL --conf.token E*******J job_templates launch ...
+        # This WORKED in 4.6.12
+
+    BREAKING CHANGE: Version 4.6.21 removed token authentication entirely,
+    causing customer to report: "neither token no username/password are working"
+
+    This test will FAIL with current code and PASS once fixed.
+    """
+    cli, mock_root, mock_connection = setup_token_auth(['awx', '--conf.host', 'https://aap-sbx.cambiahealth.com', '--conf.token', 'E1234567890J'])
+    monkeypatch.setattr(config, 'force_basic_auth', False)
+
+    # Execute authentication
+    cli.authenticate()
+
+    # Token auth should call login with token parameter
+    mock_connection.login.assert_called_once_with(None, None, token='E1234567890J')
+
+    # Should NOT use sessions when token is provided
+    assert not config.use_sessions
+
+
 def test_basic_auth_enabled(monkeypatch):
     """Test that AWXKIT_FORCE_BASIC_AUTH=true enables Basic authentication"""
     cli, mock_root, mock_connection = setup_basic_auth()

--- a/awxkit/test/cli/test_format.py
+++ b/awxkit/test/cli/test_format.py
@@ -56,10 +56,12 @@ def test_yaml_import():
     def _dummy_authenticate():
         pass
 
-    yaml_fd = io.StringIO("""
+    yaml_fd = io.StringIO(
+        """
         workflow_job_templates:
           - name: Workflow1
-        """)
+        """
+    )
     yaml_fd.name = 'file.yaml'
     cli = CLI(stdin=yaml_fd)
     cli.parse_args(['--conf.format', 'yaml'])


### PR DESCRIPTION
##### SUMMARY
REGRESSION FIX: Version 4.6.21 broke token authentication for production customers by accidentally removing the --conf.token argument and token authentication logic during the AAP-46830 fix.

This hotfix restores full authentication support:

Token authentication (was working in 4.6.12, broken in 4.6.21)
Basic authentication (new in 4.6.21 for AAP Gateway, requires AWXKIT_FORCE_BASIC_AUTH=true)
Session authentication (backward compatibility)
Impact: Production users reported that token authentication stopped working in 4.6.21, blocking upgrades from 4.6.12.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Breaking Change 
 - New or Enhanced Feature
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
 - CLI



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new authentication path in the CLI/API client; mistakes could break login behavior or accidentally change auth precedence, though changes are localized and covered by tests.
> 
> **Overview**
> Restores AWXKit CLI token-based auth by adding `--conf.token` (and env fallbacks) and making `CLI.authenticate()` prefer bearer token auth over basic/session flows.
> 
> Extends the API client `Connection.login()` to accept a token and attach `Authorization: Bearer ...` via a new `Token_Auth`, and adds a regression test ensuring token auth disables sessions and calls `login(..., token=...)`. Separately, several unrelated changes are formatting-only (SQL string formatting, test string literals) with no behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8a260f322527bcef7643773e478017ed03defb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->