### PR TITLE
Remove stale api:schema-swagger-ui reference from API root

### DIFF
--- a/awx/api/views/root.py
+++ b/awx/api/views/root.py
@@ -25,7 +25,6 @@ import requests
 
 from ansible_base.lib.utils.schema import extend_schema_if_available
 
-from awx import MODE
 from awx.api.generics import APIView
 from awx.conf.registry import settings_registry
 from awx.main.analytics import all_collectors
@@ -33,7 +32,7 @@ from awx.main.ha import is_ha_environment
 from awx.main.tasks.system import clear_setting_cache
 from awx.main.utils import get_awx_version, get_custom_venv_choices
 from awx.main.utils.licensing import validate_entitlement_manifest
-from awx.api.versioning import URLPathVersioning, reverse, drf_reverse
+from awx.api.versioning import URLPathVersioning, reverse
 from awx.main.constants import PRIVILEGE_ESCALATION_METHODS
 from awx.main.models import Project, Organization, Instance, InstanceGroup, JobTemplate
 from awx.main.utils import set_environ
@@ -62,8 +61,6 @@ class ApiRootView(APIView):
         data['custom_logo'] = settings.CUSTOM_LOGO
         data['custom_login_info'] = settings.CUSTOM_LOGIN_INFO
         data['login_redirect_override'] = settings.LOGIN_REDIRECT_OVERRIDE
-        if MODE == 'development':
-            data['docs'] = drf_reverse('api:schema-swagger-ui')
         return Response(data)
 
 


### PR DESCRIPTION
## Summary
- Remove the dead `drf_reverse('api:schema-swagger-ui')` call from `ApiRootView` that causes a `NoReverseMatch` error in development mode
- The `schema-swagger-ui` URL name was removed in d7eb714859 ("Remove custom docs endpoint in DAB now") when schema endpoints moved to the DAB `api_documentation` app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to the API root payload and unused imports; no auth, data, or behavior changes beyond removing a dead link.
> 
> **Overview**
> Removes the development-mode `docs` field from `ApiRootView` that attempted to reverse the now-removed `api:schema-swagger-ui` URL, preventing `NoReverseMatch` failures.
> 
> Cleans up related imports by dropping `MODE`, `drf_reverse`, and the unused `schema-swagger-ui` reverse path usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32028335af4f235345932d8b00266c7230d82cbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The documentation URL has been removed from the API root response; it will no longer be returned in any environment.
  * Impact: API root responses are now consistent across environments and no longer expose the docs link, reducing noise for clients expecting a stable payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->