### PR TITLE
[AAP-64062] Enforce JWT-only authentication for Controller when deployed as part of AAP

### DIFF
--- a/awx/settings/__init__.py
+++ b/awx/settings/__init__.py
@@ -63,6 +63,15 @@ assert_production_settings(DYNACONF, settings_dir, settings_file_path)
 # Load envvars at the end to allow them to override everything loaded so far
 load_envvars(DYNACONF)
 
+# When deployed as part of AAP (RESOURCE_SERVER__URL is set), enforce JWT-only
+# authentication. This ensures all requests go through the gateway and prevents
+# direct API access to Controller bypassing the platform's authentication.
+if DYNACONF.get('RESOURCE_SERVER__URL', None):
+    DYNACONF.set(
+        "REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES",
+        ['ansible_base.jwt_consumer.awx.auth.AwxJWTAuthentication'],
+    )
+
 # This must run after all custom settings are loaded
 DYNACONF.update(
     merge_application_name(DYNACONF),


### PR DESCRIPTION
## Summary

- When `RESOURCE_SERVER__URL` is set (i.e., deployed as part of AAP with Gateway), override `DEFAULT_AUTHENTICATION_CLASSES` to only allow `AwxJWTAuthentication`
- Applied after all settings files and env vars are loaded, making it immutable
- Same pattern as Hub ([galaxy_ng#288](https://github.com/ansible-automation-platform/galaxy_ng/pull/288)) and EDA ([eda-server#1474](https://github.com/ansible/eda-server/pull/1474))

## Jira

- [AAP-64062](https://issues.redhat.com/browse/AAP-64062)
- [ANSTRAT-1840](https://issues.redhat.com/browse/ANSTRAT-1840)

## Test plan

- [ ] Authenticate directly to Controller using Basic auth → returns 401
- [ ] Authenticate directly using Session auth → returns 401
- [ ] Authenticate directly using OAuth2 token → returns 401
- [ ] Authenticate through Gateway → proxied request with Gateway JWT succeeds
- [ ] Internal service-to-service calls (resource sync, settings sync) continue to work
- [ ] Standalone AWX (no `RESOURCE_SERVER__URL`) retains all auth methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication behavior for all API requests in AAP deployments; misconfiguration or unexpected dependencies on other auth mechanisms could block access or integrations.
> 
> **Overview**
> When `RESOURCE_SERVER__URL` is present (AAP/Gateway deployments), AWX now **forces DRF `DEFAULT_AUTHENTICATION_CLASSES` to only** `AwxJWTAuthentication`, preventing direct non-gateway access methods (e.g., basic/session/token) from being accepted.
> 
> This override is applied after settings files and environment variables are loaded, making the JWT-only behavior effectively mandatory in that deployment mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab6fd4533fd34e068836fe9225efefb363181910. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->