### PR TITLE
Add ability to run project updates on mesh nodes

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1382,6 +1382,7 @@ class ProjectSerializer(UnifiedJobTemplateSerializer, ProjectOptionsSerializer):
                 access_list=self.reverse('api:project_access_list', kwargs={'pk': obj.pk}),
                 object_roles=self.reverse('api:project_object_roles_list', kwargs={'pk': obj.pk}),
                 copy=self.reverse('api:project_copy', kwargs={'pk': obj.pk}),
+                instance_groups=self.reverse('api:project_instance_groups_list', kwargs={'pk': obj.pk}),
             )
         )
         if obj.organization:

--- a/awx/api/urls/project.py
+++ b/awx/api/urls/project.py
@@ -19,6 +19,7 @@ from awx.api.views import (
     ProjectNotificationTemplatesSuccessList,
     ProjectObjectRolesList,
     ProjectAccessList,
+    ProjectInstanceGroupsList,
     ProjectCopy,
 )
 
@@ -48,6 +49,7 @@ urls = [
     ),
     re_path(r'^(?P<pk>[0-9]+)/object_roles/$', ProjectObjectRolesList.as_view(), name='project_object_roles_list'),
     re_path(r'^(?P<pk>[0-9]+)/access_list/$', ProjectAccessList.as_view(), name='project_access_list'),
+    re_path(r'^(?P<pk>[0-9]+)/instance_groups/$', ProjectInstanceGroupsList.as_view(), name='project_instance_groups_list'),
     re_path(r'^(?P<pk>[0-9]+)/copy/$', ProjectCopy.as_view(), name='project_copy'),
 ]
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1211,6 +1211,15 @@ class ProjectCopy(CopyAPIView):
     resource_purpose = 'copy of a project'
 
 
+class ProjectInstanceGroupsList(SubListAttachDetachAPIView):
+    model = models.InstanceGroup
+    serializer_class = serializers.InstanceGroupSerializer
+    parent_model = models.Project
+    relationship = 'instance_groups'
+    filter_read_permission = False
+    resource_purpose = 'instance groups of a project'
+
+
 class UserList(ListCreateAPIView):
     model = models.User
     serializer_class = serializers.UserSerializer

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1399,6 +1399,20 @@ class ProjectAccess(NotificationAttachMixin, BaseAccess):
     def can_delete(self, obj):
         return self.can_change(obj, None)
 
+    @check_superuser
+    def can_attach(self, obj, sub_obj, relationship, data, skip_sub_obj_read_check=False):
+        if relationship == "instance_groups":
+            if not obj.organization:
+                return False
+            return self.user in sub_obj.use_role and self.user in obj.admin_role
+        return super(ProjectAccess, self).can_attach(obj, sub_obj, relationship, data, skip_sub_obj_read_check=skip_sub_obj_read_check)
+
+    @check_superuser
+    def can_unattach(self, obj, sub_obj, relationship, *args, **kwargs):
+        if relationship == "instance_groups":
+            return self.can_attach(obj, sub_obj, relationship, *args, **kwargs)
+        return super(ProjectAccess, self).can_unattach(obj, sub_obj, relationship, *args, **kwargs)
+
 
 class ProjectUpdateAccess(BaseAccess):
     """

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -671,6 +671,26 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
     def get_notification_friendly_name(self):
         return "Project Update"
 
+    @property
+    def preferred_instance_groups(self):
+        """Return instance groups for this project update."""
+        if self.project and self.project.instance_groups.exists():
+            return list(self.project.instance_groups.all())
+        # No instance groups - use control plane (current behavior)
+        return self.control_plane_instance_group
+
+    @property
+    def capacity_type(self):
+        """Return capacity type - 'execution' if project has instance groups."""
+        if self.project and self.project.instance_groups.exists():
+            return 'execution'
+        return 'control'
+
+    @property
+    def is_remote_update(self):
+        """Returns True if running on a remote mesh node."""
+        return bool(self.execution_node and self.controller_node and self.execution_node != self.controller_node)
+
     def save(self, *args, **kwargs):
         added_update_fields = []
         if not self.job_tags:

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -309,6 +309,28 @@ class RunnerCallbackForProjectUpdate(RunnerCallback):
         super(RunnerCallbackForProjectUpdate, self).__init__(*args, **kwargs)
         self.playbook_new_revision = None
         self.host_map = {}
+        self.project_artifact_path = None
+        self.roles_artifact_path = None
+        self.collections_artifact_path = None
+
+    def artifacts_handler(self, artifact_dir):
+        """Process artifacts including project files for remote updates."""
+        super().artifacts_handler(artifact_dir)
+
+        project_update_path = os.path.join(artifact_dir, 'project_update')
+        if os.path.exists(project_update_path):
+            self.project_artifact_path = project_update_path
+            logger.debug(f'Found project artifacts at {project_update_path}')
+
+        project_roles_path = os.path.join(artifact_dir, 'project_roles')
+        if os.path.exists(project_roles_path):
+            self.roles_artifact_path = project_roles_path
+            logger.debug(f'Found roles artifacts at {project_roles_path}')
+
+        project_collections_path = os.path.join(artifact_dir, 'project_collections')
+        if os.path.exists(project_collections_path):
+            self.collections_artifact_path = project_collections_path
+            logger.debug(f'Found collections artifacts at {project_collections_path}')
 
     def event_handler(self, event_data):
         super_return_value = super(RunnerCallbackForProjectUpdate, self).event_handler(event_data)

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -198,6 +198,30 @@ def with_path_cleanup(f):
     return _wrapped
 
 
+def select_execution_node_by_capacity(instances):
+    """
+    Helper function for spawn_project_sync jobs since they need to work outside task manager context.
+    """
+    best_instance = None
+    best_remaining = -1
+
+    for instance in instances:
+        if instance.capacity <= 0:
+            continue
+        remaining = instance.remaining_capacity
+        if remaining >= 0 and remaining > best_remaining:
+            best_instance = instance
+            best_remaining = remaining
+
+    # Fallback: return least-loaded node even if all are over capacity
+    if best_instance is None:
+        valid = [i for i in instances if i.capacity > 0]
+        if valid:
+            best_instance = max(valid, key=lambda i: i.remaining_capacity)
+
+    return best_instance
+
+
 @task(on_duplicate='queue_one', bind=True, queue=get_task_queuename)
 def dispatch_waiting_jobs(binder):
     for uj in UnifiedJob.objects.filter(status='waiting', controller_node=settings.CLUSTER_HOST_ID).only('id', 'status', 'polymorphic_ctype', 'celery_task_id'):
@@ -832,8 +856,28 @@ class SourceControlMixin(BaseTask):
         return sync_needs
 
     def spawn_project_sync(self, project, sync_needs, scm_branch=None):
-        pu_ig = self.instance.instance_group
-        pu_en = Instance.objects.my_hostname()
+        cn = Instance.objects.my_hostname()
+
+        # Check if project has instance groups configured
+        if project.instance_groups.exists():
+            # Use the project's first instance group
+            project_ig = project.instance_groups.first()
+            # Find an execution node from the instance group with most remaining capacity
+            candidate_instances = project_ig.instances.filter(enabled=True, node_type__in=['execution', 'hybrid'])
+            execution_instance = select_execution_node_by_capacity(candidate_instances)
+
+            if execution_instance and execution_instance.hostname != cn:
+                # Remote execution on mesh node
+                pu_ig = project_ig
+                pu_en = execution_instance.hostname
+            else:
+                # Fallback to original workflow
+                pu_ig = self.instance.instance_group
+                pu_en = cn
+        else:
+            # No project instance groups - use existing workflow
+            pu_ig = self.instance.instance_group
+            pu_en = cn
 
         sync_metafields = dict(
             launch_type="sync",
@@ -842,7 +886,7 @@ class SourceControlMixin(BaseTask):
             status='running',
             instance_group=pu_ig,
             execution_node=pu_en,
-            controller_node=pu_en,
+            controller_node=cn,
             celery_task_id=self.instance.celery_task_id,
         )
         if scm_branch and scm_branch != project.scm_branch:
@@ -1384,8 +1428,15 @@ class RunProjectUpdate(BaseTask):
         args = []
         if getattr(settings, 'PROJECT_UPDATE_VVV', False):
             args.append('-vvv')
-        if project_update.job_tags:
-            args.extend(['-t', project_update.job_tags])
+
+        job_tags = project_update.job_tags
+
+        # Add remote_update tag for automation mesh execution. (value set in pre_run_hook)
+        if getattr(self, '_is_remote_update', False):
+            job_tags = f"{job_tags},remote_update" if job_tags else "remote_update"
+
+        if job_tags:
+            args.extend(['-t', job_tags])
         return args
 
     def build_extra_vars_file(self, project_update, private_data_dir):
@@ -1458,6 +1509,9 @@ class RunProjectUpdate(BaseTask):
     def pre_run_hook(self, instance, private_data_dir):
         super(RunProjectUpdate, self).pre_run_hook(instance, private_data_dir)
         # re-create root project folder if a natural disaster has destroyed it
+        # Store remote update decision for use in build_args and post_run_hook
+        self.private_data_dir = private_data_dir
+        self._is_remote_update = instance.is_remote_update
         project_path = instance.project.get_project_path(check_if_exists=False)
 
         if instance.launch_type != 'sync':
@@ -1537,6 +1591,11 @@ class RunProjectUpdate(BaseTask):
                 instance.scm_revision = self.runner_callback.playbook_new_revision
                 instance.save(update_fields=['scm_revision'])
 
+            # Handle remote execution - copy project from artifacts
+            if getattr(self, '_is_remote_update', False) and status == 'successful':
+                self._copy_project_from_artifacts(instance)
+                self._copy_requirements_from_artifacts(instance)
+
             # Roles and collection folders copy to durable cache
             base_path = instance.get_cache_path()
             stage_path = os.path.join(base_path, 'stage')
@@ -1572,6 +1631,52 @@ class RunProjectUpdate(BaseTask):
             p.playbook_files = p.playbooks
             p.inventory_files = p.inventories
             p.save(update_fields=['scm_revision', 'playbook_files', 'inventory_files'])
+
+    def _copy_project_from_artifacts(self, instance):
+        """Copy project files from artifacts to projects_root after remote execution."""
+        artifacts_project_path = self.runner_callback.project_artifact_path
+
+        if not artifacts_project_path:
+            logger.debug(f'{instance.log_format} no project artifacts to copy')
+            return
+
+        if not os.path.exists(artifacts_project_path):
+            logger.warning(f'{instance.log_format} project artifacts not found at: {artifacts_project_path}')
+            return
+
+        project_path = instance.get_project_path(check_if_exists=False)
+
+        if os.path.exists(project_path):
+            shutil.rmtree(project_path)
+
+        shutil.copytree(artifacts_project_path, project_path, symlinks=True)
+
+        logger.info(f'Copied project from remote execution for {instance.log_format}')
+
+    def _copy_requirements_from_artifacts(self, instance):
+        """Copy roles and collections from artifacts to cache stage directory after remote execution."""
+        base_path = instance.get_cache_path()
+        stage_path = os.path.join(base_path, 'stage')
+
+        # Mapping: artifact path attribute -> destination subdirectory
+        artifact_mappings = [
+            ('roles_artifact_path', 'requirements_roles'),
+            ('collections_artifact_path', 'requirements_collections'),
+        ]
+
+        for attr, dest_subdir in artifact_mappings:
+            artifact_path = getattr(self.runner_callback, attr, None)
+            if not artifact_path:
+                continue
+
+            if not os.path.exists(artifact_path):
+                logger.debug(f'{instance.log_format} {attr} path does not exist: {artifact_path}')
+                continue
+
+            dest_path = os.path.join(stage_path, dest_subdir)
+            shutil.copytree(artifact_path, dest_path, symlinks=True, dirs_exist_ok=True)
+
+            logger.info(f'{instance.log_format} copied {dest_subdir} from remote execution artifacts')
 
     def build_execution_environment_params(self, instance, private_data_dir):
         if settings.IS_K8S:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -858,26 +858,18 @@ class SourceControlMixin(BaseTask):
     def spawn_project_sync(self, project, sync_needs, scm_branch=None):
         cn = Instance.objects.my_hostname()
 
-        # Check if project has instance groups configured
-        if project.instance_groups.exists():
-            # Use the project's first instance group
-            project_ig = project.instance_groups.first()
-            # Find an execution node from the instance group with most remaining capacity
-            candidate_instances = project_ig.instances.filter(enabled=True, node_type__in=['execution', 'hybrid'])
-            execution_instance = select_execution_node_by_capacity(candidate_instances)
+        pu_ig = self.instance.instance_group
+        pu_en = cn
 
-            if execution_instance and execution_instance.hostname != cn:
-                # Remote execution on mesh node
-                pu_ig = project_ig
-                pu_en = execution_instance.hostname
-            else:
-                # Fallback to original workflow
-                pu_ig = self.instance.instance_group
-                pu_en = cn
-        else:
-            # No project instance groups - use existing workflow
-            pu_ig = self.instance.instance_group
-            pu_en = cn
+        if project.instance_groups.exists():
+            for project_ig in project.instance_groups.all():
+                candidate_instances = project_ig.instances.filter(enabled=True, node_type__in=['execution', 'hybrid'])
+                execution_instance = select_execution_node_by_capacity(candidate_instances)
+
+                if execution_instance and execution_instance.hostname != cn:
+                    pu_ig = project_ig
+                    pu_en = execution_instance.hostname
+                    break
 
         sync_metafields = dict(
             launch_type="sync",
@@ -1636,7 +1628,7 @@ class RunProjectUpdate(BaseTask):
         """Copy project files from artifacts to projects_root after remote execution."""
         artifacts_project_path = self.runner_callback.project_artifact_path
 
-        if not os.path.exists(artifacts_project_path):
+        if artifacts_project_path is None or not os.path.exists(artifacts_project_path):
             raise PostRunError(
                 f'{instance.log_format} project artifacts not found after remote update: {artifacts_project_path}',
                 status='error',
@@ -1672,7 +1664,7 @@ class RunProjectUpdate(BaseTask):
         for attr, dest_subdir in artifact_mappings:
             artifact_path = getattr(self.runner_callback, attr, None)
 
-            if not os.path.exists(artifact_path):
+            if artifact_path is None or not os.path.exists(artifact_path):
                 logger.debug(f'{instance.log_format} {attr} path does not exist: {artifact_path}')
                 continue
 

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1636,20 +1636,25 @@ class RunProjectUpdate(BaseTask):
         """Copy project files from artifacts to projects_root after remote execution."""
         artifacts_project_path = self.runner_callback.project_artifact_path
 
-        if not artifacts_project_path:
-            logger.debug(f'{instance.log_format} no project artifacts to copy')
-            return
-
         if not os.path.exists(artifacts_project_path):
-            logger.warning(f'{instance.log_format} project artifacts not found at: {artifacts_project_path}')
-            return
+            raise PostRunError(
+                f'{instance.log_format} project artifacts not found after remote update: {artifacts_project_path}',
+                status='error',
+            )
 
         project_path = instance.get_project_path(check_if_exists=False)
 
-        if os.path.exists(project_path):
-            shutil.rmtree(project_path)
+        try:
+            if os.path.exists(project_path):
+                shutil.rmtree(project_path)
 
-        shutil.copytree(artifacts_project_path, project_path, symlinks=True)
+            shutil.copytree(artifacts_project_path, project_path, symlinks=True)
+        except Exception:
+            raise PostRunError(
+                f'{instance.log_format} failed to copy project artifacts to {project_path}',
+                status='error',
+                tb=traceback.format_exc(),
+            )
 
         logger.info(f'Copied project from remote execution for {instance.log_format}')
 
@@ -1666,15 +1671,20 @@ class RunProjectUpdate(BaseTask):
 
         for attr, dest_subdir in artifact_mappings:
             artifact_path = getattr(self.runner_callback, attr, None)
-            if not artifact_path:
-                continue
 
             if not os.path.exists(artifact_path):
                 logger.debug(f'{instance.log_format} {attr} path does not exist: {artifact_path}')
                 continue
 
             dest_path = os.path.join(stage_path, dest_subdir)
-            shutil.copytree(artifact_path, dest_path, symlinks=True, dirs_exist_ok=True)
+            try:
+                shutil.copytree(artifact_path, dest_path, symlinks=True, dirs_exist_ok=True)
+            except Exception:
+                raise PostRunError(
+                    f'{instance.log_format} failed to copy {dest_subdir} from remote execution artifacts',
+                    status='error',
+                    tb=traceback.format_exc(),
+                )
 
             logger.info(f'{instance.log_format} copied {dest_subdir} from remote execution artifacts')
 

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -45,12 +45,14 @@
         - update_insights
         - update_svn
         - update_git
+        - install_roles
+        - install_collections
         - delete
 
 - hosts: localhost
   gather_facts: false
   connection: local
-  name: Update the default working path for automation mesh
+  name: Set the default working path for automation mesh
   tasks:
     - name: Update the default working path for automation mesh
       ansible.builtin.set_fact:

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -147,7 +147,7 @@
             insights_url: "{{ insights_url }}"
             username: "{{ scm_username | default(omit) }}"
             password: "{{ scm_password | default(omit) }}"
-            project_update_path: "{{ project_update_path }}"
+            project_path: "{{ project_update_path }}"
             awx_license_type: "{{ awx_license_type }}"
             awx_version: "{{ awx_version }}"
             client_id: "{{ client_id | default(omit) }}"
@@ -184,7 +184,7 @@
         - name: Unpack archive
           project_archive:
             src: "{{ get_archive.dest }}"
-            project_update_path: "{{ project_update_path | quote }}"
+            project_path: "{{ project_update_path | quote }}"
             force: "{{ scm_clean }}"
           when: get_archive.changed or scm_clean
           register: unarchived
@@ -224,7 +224,7 @@
   tasks:
     - name: Verify project content using GPG signature
       verify_project:
-        project_update_path: "{{ project_update_path | quote }}"
+        project_path: "{{ project_update_path | quote }}"
         validation_type: gpg
         gpg_pubkey: "{{ gpg_pubkey }}"
       tags:
@@ -232,7 +232,7 @@
 
     - name: Verify project content against checksum manifest
       verify_project:
-        project_update_path: "{{ project_update_path | quote }}"
+        project_path: "{{ project_update_path | quote }}"
         validation_type: checksum_manifest
       tags:
         - validation_checksum_manifest

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -28,6 +28,49 @@
 - hosts: localhost
   gather_facts: false
   connection: local
+  name: Set the default working path
+  tasks:
+    - name: Set the default working path
+      ansible.builtin.set_fact:
+        project_update_path: "{{ project_path }}"
+        # Put the local tmp directory in same volume as collection destination
+        # otherwise, files cannot be moved accross volumes and will cause error
+        ansible_local_temp: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/tmp"
+        # These paths control where ansible-galaxy installs collections and roles on top the filesystem
+        ansible_roles_path: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_roles"
+        ansible_collections_path: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_collections"
+
+      tags:
+        - update_archive
+        - update_insights
+        - update_svn
+        - update_git
+        - delete
+
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  name: Update the default working path for automation mesh
+  tasks:
+    - name: Update the default working path for automation mesh
+      ansible.builtin.set_fact:
+        project_update_path: "{{ lookup('ansible.builtin.env', 'AWX_ISOLATED_DATA_DIR') + '/project_update/' }}"
+        ansible_local_temp: "{{ lookup('ansible.builtin.env', 'AWX_ISOLATED_DATA_DIR') + '/tmp/' }}"
+        ansible_roles_path: "{{ lookup('ansible.builtin.env', 'AWX_ISOLATED_DATA_DIR') + '/project_roles/' }}"
+        ansible_collections_path: "{{ lookup('ansible.builtin.env', 'AWX_ISOLATED_DATA_DIR') + '/project_collections/' }}"
+      tags:
+        - remote_update
+
+    - name: Create the directory in case we have a delete operation to avoid errors
+      ansible.builtin.file:
+        path: "{{ project_update_path }}"
+        state: directory
+      tags:
+        - remote_update
+
+- hosts: localhost
+  gather_facts: false
+  connection: local
   name: Update source tree if necessary
   tasks:
     - name: Delete project directory before update
@@ -35,7 +78,7 @@
       register: reg
       changed_when: reg.stdout_lines | length > 1
       args:
-        chdir: "{{ project_path }}"
+        chdir: "{{ project_update_path }}"
       tags:
         - delete
 
@@ -45,7 +88,7 @@
       block:
         - name: Update project using git
           ansible.builtin.git:
-            dest: "{{ project_path | quote }}"
+            dest: "{{ project_update_path | quote }}"
             repo: "{{ scm_url }}"
             version: "{{ scm_branch | quote }}"
             refspec: "{{ scm_refspec | default(omit) }}"
@@ -65,7 +108,7 @@
       block:
         - name: Update project using svn
           ansible.builtin.subversion:
-            dest: "{{ project_path | quote }}"
+            dest: "{{ project_update_path | quote }}"
             repo: "{{ scm_url | quote }}"
             revision: "{{ scm_branch | quote }}"
             force: "{{ scm_clean }}"
@@ -93,7 +136,7 @@
       block:
         - name: Ensure the project directory is present
           ansible.builtin.file:
-            dest: "{{ project_path | quote }}"
+            dest: "{{ project_update_path | quote }}"
             state: directory
             mode: '0755'
 
@@ -102,7 +145,7 @@
             insights_url: "{{ insights_url }}"
             username: "{{ scm_username | default(omit) }}"
             password: "{{ scm_password | default(omit) }}"
-            project_path: "{{ project_path }}"
+            project_update_path: "{{ project_update_path }}"
             awx_license_type: "{{ awx_license_type }}"
             awx_version: "{{ awx_version }}"
             client_id: "{{ client_id | default(omit) }}"
@@ -122,14 +165,14 @@
       block:
         - name: Ensure the project archive directory is present
           ansible.builtin.file:
-            dest: "{{ project_path | quote }}/.archive"
+            dest: "{{ project_update_path | quote }}/.archive"
             state: directory
             mode: '0755'
 
         - name: Get archive from url
           ansible.builtin.get_url:
             url: "{{ scm_url | quote }}"
-            dest: "{{ project_path | quote }}/.archive/"
+            dest: "{{ project_update_path | quote }}/.archive/"
             url_username: "{{ scm_username | default(omit) }}"
             url_password: "{{ scm_password | default(omit) }}"
             force_basic_auth: true
@@ -139,14 +182,14 @@
         - name: Unpack archive
           project_archive:
             src: "{{ get_archive.dest }}"
-            project_path: "{{ project_path | quote }}"
+            project_update_path: "{{ project_update_path | quote }}"
             force: "{{ scm_clean }}"
           when: get_archive.changed or scm_clean
           register: unarchived
 
         - name: Find previous archives
           ansible.builtin.find:
-            paths: "{{ project_path | quote }}/.archive/"
+            paths: "{{ project_update_path | quote }}/.archive/"
             excludes:
               - "{{ get_archive.dest | basename }}"
           when: unarchived.changed
@@ -179,7 +222,7 @@
   tasks:
     - name: Verify project content using GPG signature
       verify_project:
-        project_path: "{{ project_path | quote }}"
+        project_update_path: "{{ project_update_path | quote }}"
         validation_type: gpg
         gpg_pubkey: "{{ gpg_pubkey }}"
       tags:
@@ -187,7 +230,7 @@
 
     - name: Verify project content against checksum manifest
       verify_project:
-        project_path: "{{ project_path | quote }}"
+        project_update_path: "{{ project_update_path | quote }}"
         validation_type: checksum_manifest
       tags:
         - validation_checksum_manifest
@@ -200,12 +243,9 @@
     galaxy_task_env:  # configured in settings
     # additional_galaxy_env contains environment variables are used for installing roles and collections and will take precedence over items in galaxy_task_env
     additional_galaxy_env:
-      # These paths control where ansible-galaxy installs collections and roles on top the filesystem
-      ANSIBLE_COLLECTIONS_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_collections"
-      ANSIBLE_ROLES_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_roles"
-      # Put the local tmp directory in same volume as collection destination
-      # otherwise, files cannot be moved accross volumes and will cause error
-      ANSIBLE_LOCAL_TEMP: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/tmp"
+      ANSIBLE_COLLECTIONS_PATH: "{{ ansible_collections_path }}"
+      ANSIBLE_ROLES_PATH: "{{ ansible_roles_path }}"
+      ANSIBLE_LOCAL_TEMP: "{{ ansible_local_temp }}"
   tasks:
     - name: Check content sync settings
       when: not roles_enabled | bool and not collections_enabled | bool
@@ -230,8 +270,8 @@
             req_file: "{{ lookup('ansible.builtin.first_found', req_candidates, skip=True) }}"
             req_candidates:
               files:
-                - "{{ project_path | quote }}/roles/requirements.yml"
-                - "{{ project_path | quote }}/roles/requirements.yaml"
+                - "{{ project_update_path | quote }}/roles/requirements.yml"
+                - "{{ project_update_path | quote }}/roles/requirements.yaml"
               skip: True
           changed_when: "'was installed successfully' in galaxy_result.stdout"
           when:
@@ -248,8 +288,8 @@
             req_file: "{{ lookup('ansible.builtin.first_found', req_candidates, skip=True) }}"
             req_candidates:
               files:
-                - "{{ project_path | quote }}/collections/requirements.yml"
-                - "{{ project_path | quote }}/collections/requirements.yaml"
+                - "{{ project_update_path | quote }}/collections/requirements.yml"
+                - "{{ project_update_path | quote }}/collections/requirements.yaml"
               skip: True
           changed_when: "'Nothing to do.' not in galaxy_collection_result.stdout"
           when:
@@ -268,8 +308,8 @@
             req_file: "{{ lookup('ansible.builtin.first_found', req_candidates, skip=True) }}"
             req_candidates:
               files:
-                - "{{ project_path | quote }}/requirements.yaml"
-                - "{{ project_path | quote }}/requirements.yml"
+                - "{{ project_update_path | quote }}/requirements.yaml"
+                - "{{ project_update_path | quote }}/requirements.yml"
               skip: True
           changed_when: "'Nothing to do.' not in galaxy_combined_result.stdout"
           when:
@@ -282,7 +322,7 @@
             - install_roles
       module_defaults:
         ansible.builtin.command:
-          chdir: "{{ project_path | quote }}"
+          chdir: "{{ project_update_path | quote }}"
 
       # We combine our additional_galaxy_env into galaxy_task_env so that our values are preferred over anything a user would set
       environment: "{{ galaxy_task_env | combine(additional_galaxy_env) }}"


### PR DESCRIPTION
##### SUMMARY

This pull request adds support to run project updates on automation mesh nodes.  This aligns the functionality of project updates to other aspects of the platform.

Assisted-by: Claude Code (Claude Opus 4.6)

##### WHY

Automation mesh is the solution to handle complex networking and security controls.  The current requirement of project updates running on the control plane often means jumping through additional hoops to meet business requirements.  This feature can allow users to work with their current mesh networking to gain greater control over networking and security.

##### HOW

Project updates are done with a simple playbook.  They are an Ansible automation job!

The goal of this work was to ensure the current workflow was left untouched as possible.  As such, this builds on the current workflow to identify when a project is associated with an instance group.  In that scenario, the instance group will be used to run the project update playbook.  The artifacts of the playbook update are returned to the control plane and post hook processing of the project update job moves the project data into the appropriate place.  Projects without an association with an instance group will continue to use the control plane for update operations.

##### CAVEATS

Performing project updates on the automation mesh is slower than a control update.  You can't beat physics!  The data is being transferred over the automation mesh and eventually needs to be processed on the control plane.  

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API
 - Other

##### ADDITIONAL INFORMATION

Start by associating an instance group with a project.  This is done using an API call that aligns with current API patterns.

`POST /api/v2/projects/{project_id}/instance_groups/`

The payload should be use the same format for managing instance groups with inventories, organizations, etc.

Project updates whether directly initiated or triggered by a playbook should then run on the instance group.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API: Projects now expose an instance-groups endpoint to list/manage a project's instance groups.
  * Remote execution: Project updates can run on selected execution nodes when instance groups exist; capacity-aware node selection improves placement.
  * Artifacts & sync: Project, roles, and collections artifacts produced during remote updates are tracked and synchronized back to the controller.
  * Workspace isolation: Project update operations use an isolated workspace for temporary files and galaxy operations.

* **Chore**
  * Attach/unattach permissions for project–instance_group operations now enforce organization- and role-based checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->