### PR TITLE
do not add optional survey fields with empty strings that are not bac…

### DIFF
--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -188,6 +188,10 @@ class SurveyJobTemplateMixin(models.Model):
                             runtime_extra_vars.pop(variable_key)
 
                 if default is not None:
+                    # do not add variables that contain an empty string, are not required and are nor present in extra_vars
+                    if default == '' and not survey_element.get('required') and variable_key not in runtime_extra_vars:
+                        continue
+
                     decrypted_default = default
                     if survey_element['type'] == "password" and isinstance(decrypted_default, str) and decrypted_default.startswith('$encrypted$'):
                         decrypted_default = decrypt_value(get_encryption_key('value', pk=None), decrypted_default)

--- a/awx/main/models/mixins.py
+++ b/awx/main/models/mixins.py
@@ -188,8 +188,14 @@ class SurveyJobTemplateMixin(models.Model):
                             runtime_extra_vars.pop(variable_key)
 
                 if default is not None:
-                    # do not add variables that contain an empty string, are not required and are nor present in extra_vars
-                    if default == '' and not survey_element.get('required') and variable_key not in runtime_extra_vars:
+                    # do not add variables that contain an empty string, are not required and are not present in extra_vars
+                    # password fields must be skipped, because default values have special behaviour
+                    if (
+                        default == ''
+                        and not survey_element.get('required')
+                        and survey_element.get('type') != 'password'
+                        and variable_key not in runtime_extra_vars
+                    ):
                         continue
 
                     decrypted_default = default

--- a/awx/main/tests/unit/models/test_survey_models.py
+++ b/awx/main/tests/unit/models/test_survey_models.py
@@ -176,22 +176,22 @@ def test_display_survey_spec_encrypts_default(survey_spec_factory):
 
 @pytest.mark.survey
 @pytest.mark.parametrize(
-    "question_type,default,min,max,expect_use,expect_value",
+    "question_type,default,min,max,expect_valid,expect_use,expect_value",
     [
-        ("text", "", 0, 0, True, ''),  # default used
-        ("text", "", 1, 0, False, 'N/A'),  # value less than min length
-        ("password", "", 1, 0, False, 'N/A'),  # passwords behave the same as text
-        ("multiplechoice", "", 0, 0, False, 'N/A'),  # historical bug
-        ("multiplechoice", "zeb", 0, 0, False, 'N/A'),  # zeb not in choices
-        ("multiplechoice", "coffee", 0, 0, True, 'coffee'),
-        ("multiselect", None, 0, 0, False, 'N/A'),  # NOTE: Behavior is arguable, value of [] may be prefered
-        ("multiselect", "", 0, 0, False, 'N/A'),
-        ("multiselect", ["zeb"], 0, 0, False, 'N/A'),
-        ("multiselect", ["milk"], 0, 0, True, ["milk"]),
-        ("multiselect", ["orange\nmilk"], 0, 0, False, 'N/A'),  # historical bug
+        ("text", "", 0, 0, True, False, 'N/A'),  # valid but empty default not sent for optional question
+        ("text", "", 1, 0, False, False, 'N/A'),  # value less than min length
+        ("password", "", 1, 0, False, False, 'N/A'),  # passwords behave the same as text
+        ("multiplechoice", "", 0, 0, False, False, 'N/A'),  # historical bug
+        ("multiplechoice", "zeb", 0, 0, False, False, 'N/A'),  # zeb not in choices
+        ("multiplechoice", "coffee", 0, 0, True, True, 'coffee'),
+        ("multiselect", None, 0, 0, False, False, 'N/A'),  # NOTE: Behavior is arguable, value of [] may be prefered
+        ("multiselect", "", 0, 0, False, False, 'N/A'),
+        ("multiselect", ["zeb"], 0, 0, False, False, 'N/A'),
+        ("multiselect", ["milk"], 0, 0, True, True, ["milk"]),
+        ("multiselect", ["orange\nmilk"], 0, 0, False, False, 'N/A'),  # historical bug
     ],
 )
-def test_optional_survey_question_defaults(survey_spec_factory, question_type, default, min, max, expect_use, expect_value):
+def test_optional_survey_question_defaults(survey_spec_factory, question_type, default, min, max, expect_valid, expect_use, expect_value):
     spec = survey_spec_factory(
         [
             {
@@ -208,7 +208,7 @@ def test_optional_survey_question_defaults(survey_spec_factory, question_type, d
     jt = JobTemplate(name="test-jt", survey_spec=spec, survey_enabled=True)
     defaulted_extra_vars = jt._update_unified_job_kwargs({}, {})
     element = spec['spec'][0]
-    if expect_use:
+    if expect_valid:
         assert jt._survey_element_validation(element, {element['variable']: element['default']}) == []
     else:
         assert jt._survey_element_validation(element, {element['variable']: element['default']})
@@ -216,6 +216,28 @@ def test_optional_survey_question_defaults(survey_spec_factory, question_type, d
         assert json.loads(defaulted_extra_vars['extra_vars'])['c'] == expect_value
     else:
         assert 'c' not in defaulted_extra_vars['extra_vars']
+
+
+@pytest.mark.survey
+def test_optional_survey_empty_default_with_runtime_extra_var(survey_spec_factory):
+    """When a user explicitly provides an empty string at runtime for an optional
+    survey question, the variable should still be included in extra_vars."""
+    spec = survey_spec_factory(
+        [
+            {
+                "required": False,
+                "default": "",
+                "choices": "",
+                "variable": "c",
+                "min": 0,
+                "max": 0,
+                "type": "text",
+            },
+        ]
+    )
+    jt = JobTemplate(name="test-jt", survey_spec=spec, survey_enabled=True)
+    defaulted_extra_vars = jt._update_unified_job_kwargs({}, {'extra_vars': json.dumps({'c': ''})})
+    assert json.loads(defaulted_extra_vars['extra_vars'])['c'] == ''
 
 
 @pytest.mark.survey


### PR DESCRIPTION
##### SUMMARY

When survey fields are optional and not filled out and not backed by a variable in extra_vars, do not inlcude them at all for the job launch.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ignore empty-string survey defaults for optional, non-password questions when no runtime value is provided, so runtime values take proper precedence and defaults don't override user input.

* **Tests**
  * Expanded survey unit tests and parameterization; added a case ensuring an explicitly provided empty string at runtime is preserved in runtime variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->