### PR TITLE
Add management command to reload CredentialTypes

### DIFF
--- a/awx/main/management/commands/reload_awx_plugins.py
+++ b/awx/main/management/commands/reload_awx_plugins.py
@@ -1,0 +1,14 @@
+from awx.main.models import CredentialType
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = 'Reload CredentialTypes to pull new ones into existing AWX installs.'
+
+    def handle(self, *args, **options):
+        try:
+            CredentialType.setup_tower_managed_defaults()
+        except Exception as e:
+            self.stdout.write(f"Ran into exception: {e}, while reloading Credential Types")
+        self.stdout.write(self.style.SUCCESS(f"Credential Types have been reloaded."))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
We're planning to add more credentials options, and currently when they're backported we have to add migrations to load them. This PR adds a management command to make reloading the credentials easier. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new management command to reload credential types in AWX installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->