### PR TITLE
[Devel] Removal of Token Auth From Devel

### DIFF
--- a/awxkit/awxkit/api/client.py
+++ b/awxkit/awxkit/api/client.py
@@ -12,15 +12,6 @@ class ConnectionException(exc.Common):
     pass
 
 
-class TokenAuth(requests.auth.AuthBase):
-    def __init__(self, token):
-        self.token = token
-
-    def __call__(self, request):
-        request.headers['Authorization'] = 'Bearer {0.token}'.format(self)
-        return request
-
-
 def log_elapsed(r, *args, **kwargs):  # requests hook to display API elapsed time
     log.debug('"{0.request.method} {0.url}" elapsed: {0.elapsed}'.format(r))
 
@@ -46,7 +37,7 @@ class Connection(object):
         self.get(config.api_base_path)  # this causes a cookie w/ the CSRF token to be set
         return dict(next=next)
 
-    def login(self, username=None, password=None, token=None, **kwargs):
+    def login(self, username=None, password=None, **kwargs):
         if username and password:
             _next = kwargs.get('next')
             if _next:
@@ -66,8 +57,6 @@ class Connection(object):
                 self.uses_session_cookie = True
             else:
                 self.session.auth = (username, password)
-        elif token:
-            self.session.auth = TokenAuth(token)
         else:
             self.session.auth = None
 

--- a/awxkit/awxkit/api/client.py
+++ b/awxkit/awxkit/api/client.py
@@ -12,6 +12,15 @@ class ConnectionException(exc.Common):
     pass
 
 
+class TokenAuth(requests.auth.AuthBase):
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, request):
+        request.headers['Authorization'] = 'Bearer {0.token}'.format(self)
+        return request
+
+
 def log_elapsed(r, *args, **kwargs):  # requests hook to display API elapsed time
     log.debug('"{0.request.method} {0.url}" elapsed: {0.elapsed}'.format(r))
 
@@ -37,7 +46,7 @@ class Connection(object):
         self.get(config.api_base_path)  # this causes a cookie w/ the CSRF token to be set
         return dict(next=next)
 
-    def login(self, username=None, password=None, **kwargs):
+    def login(self, username=None, password=None, token=None, **kwargs):
         if username and password:
             _next = kwargs.get('next')
             if _next:
@@ -57,6 +66,8 @@ class Connection(object):
                 self.uses_session_cookie = True
             else:
                 self.session.auth = (username, password)
+        elif token:
+            self.session.auth = TokenAuth(token)
         else:
             self.session.auth = None
 

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -83,23 +83,12 @@ class CLI(object):
     def authenticate(self):
         """Configure the current session for authentication.
 
-        Authentication priority:
-        1. Token authentication (if --conf.token provided)
-        2. Basic authentication (if AWXKIT_FORCE_BASIC_AUTH=true)
-        3. Session-based authentication (default)
-
+        Uses Basic authentication when AWXKIT_FORCE_BASIC_AUTH environment variable
+        is set to true, otherwise defaults to session-based authentication.
 
         For AAP Gateway environments, set AWXKIT_FORCE_BASIC_AUTH=true to bypass
-        session login restrictions when using username/password.
-
+        session login restrictions.
         """
-        # Token authentication (if token is provided)
-        token = self.get_config('token')
-        if token:
-            config.use_sessions = False
-            self.root.connection.login(None, None, token=token)
-            return
-
         # Check if Basic auth is forced via environment variable
         if config.get('force_basic_auth', False):
             config.use_sessions = False

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -84,23 +84,13 @@ class CLI(object):
         """Configure the current session for authentication.
 
         Authentication priority:
-        1. Token authentication (if --conf.token provided)
-        2. Basic authentication (if AWXKIT_FORCE_BASIC_AUTH=true)
-        3. Session-based authentication (default)
-
+        1. Basic authentication (if AWXKIT_FORCE_BASIC_AUTH=true)
+        2. Session-based authentication (default)
 
         For AAP Gateway environments, set AWXKIT_FORCE_BASIC_AUTH=true to bypass
         session login restrictions when using username/password.
 
         """
-        # Token authentication (if token is provided)
-        token = self.get_config('token')
-        if token:
-            config.use_sessions = False
-            self.root.connection.login(None, None, token=token)
-            return
-
-        # Check if Basic auth is forced via environment variable
         if config.get('force_basic_auth', False):
             config.use_sessions = False
 

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -84,13 +84,23 @@ class CLI(object):
         """Configure the current session for authentication.
 
         Authentication priority:
-        1. Basic authentication (if AWXKIT_FORCE_BASIC_AUTH=true)
-        2. Session-based authentication (default)
+        1. Token authentication (if --conf.token provided)
+        2. Basic authentication (if AWXKIT_FORCE_BASIC_AUTH=true)
+        3. Session-based authentication (default)
+
 
         For AAP Gateway environments, set AWXKIT_FORCE_BASIC_AUTH=true to bypass
         session login restrictions when using username/password.
 
         """
+        # Token authentication (if token is provided)
+        token = self.get_config('token')
+        if token:
+            config.use_sessions = False
+            self.root.connection.login(None, None, token=token)
+            return
+
+        # Check if Basic auth is forced via environment variable
         if config.get('force_basic_auth', False):
             config.use_sessions = False
 

--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -59,12 +59,6 @@ def add_authentication_arguments(parser, env):
         default=env.get('CONTROLLER_PASSWORD', env.get('TOWER_PASSWORD', config_password)),
         metavar='TEXT',
     )
-    auth.add_argument(
-        '--conf.token',
-        default=env.get('CONTROLLER_OAUTH_TOKEN', env.get('TOWER_OAUTH_TOKEN', None)),
-        metavar='TEXT',
-        help='OAuth2 token for authentication (takes precedence over username/password)',
-    )
 
     auth.add_argument(
         '-k',

--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -60,13 +60,6 @@ def add_authentication_arguments(parser, env):
         metavar='TEXT',
     )
     auth.add_argument(
-        '--conf.token',
-        default=env.get('CONTROLLER_OAUTH_TOKEN', env.get('TOWER_OAUTH_TOKEN', None)),
-        metavar='TEXT',
-        help='OAuth2 token for authentication (takes precedence over username/password)',
-    )
-
-    auth.add_argument(
         '-k',
         '--conf.insecure',
         help='Allow insecure server connections when using SSL',

--- a/awxkit/awxkit/cli/format.py
+++ b/awxkit/awxkit/cli/format.py
@@ -60,6 +60,13 @@ def add_authentication_arguments(parser, env):
         metavar='TEXT',
     )
     auth.add_argument(
+        '--conf.token',
+        default=env.get('CONTROLLER_OAUTH_TOKEN', env.get('TOWER_OAUTH_TOKEN', None)),
+        metavar='TEXT',
+        help='OAuth2 token for authentication (takes precedence over username/password)',
+    )
+
+    auth.add_argument(
         '-k',
         '--conf.insecure',
         help='Allow insecure server connections when using SSL',

--- a/awxkit/test/cli/test_authentication.py
+++ b/awxkit/test/cli/test_authentication.py
@@ -44,6 +44,48 @@ def setup_session_auth(cli_args: Optional[List[str]] = None) -> Tuple[CLI, Mock,
     return cli, mock_root, mock_load_session
 
 
+def setup_token_auth(cli_args: Optional[List[str]] = None) -> Tuple[CLI, Mock, Mock]:
+    """Set up CLI with mocked connection for Token auth testing"""
+    cli = CLI()
+    cli.parse_args(cli_args or ['awx', '--conf.token', 'test-token-abc123'])
+
+    mock_root = Mock()
+    mock_connection = Mock()
+    mock_root.connection = mock_connection
+    cli.root = mock_root
+
+    return cli, mock_root, mock_connection
+
+
+def test_token_auth_preserved(monkeypatch):
+    """
+    REGRESSION TEST: Token authentication must still work (existed in 4.6.12)
+
+    This test documents the customer's working scenario from 4.6.12:
+        awx login --conf.host URL --conf.username USER --conf.password PASS
+        # Returns: {"token": "E*******J"}
+
+        awx --conf.host URL --conf.token E*******J job_templates launch ...
+        # This WORKED in 4.6.12
+
+    BREAKING CHANGE: Version 4.6.21 removed token authentication entirely,
+    causing customer to report: "neither token no username/password are working"
+
+    This test will FAIL with current code and PASS once fixed.
+    """
+    cli, mock_root, mock_connection = setup_token_auth(['awx', '--conf.host', 'https://aap-sbx.testbank.com', '--conf.token', 'E1234567890J'])
+    monkeypatch.setattr(config, 'force_basic_auth', False)
+
+    # Execute authentication
+    cli.authenticate()
+
+    # Token auth should call login with token parameter
+    mock_connection.login.assert_called_once_with(None, None, token='E1234567890J')
+
+    # Should NOT use sessions when token is provided
+    assert not config.use_sessions
+
+
 def test_basic_auth_enabled(monkeypatch):
     """Test that AWXKIT_FORCE_BASIC_AUTH=true enables Basic authentication"""
     cli, mock_root, mock_connection = setup_basic_auth()

--- a/awxkit/test/cli/test_authentication.py
+++ b/awxkit/test/cli/test_authentication.py
@@ -44,48 +44,6 @@ def setup_session_auth(cli_args: Optional[List[str]] = None) -> Tuple[CLI, Mock,
     return cli, mock_root, mock_load_session
 
 
-def setup_token_auth(cli_args: Optional[List[str]] = None) -> Tuple[CLI, Mock, Mock]:
-    """Set up CLI with mocked connection for Token auth testing"""
-    cli = CLI()
-    cli.parse_args(cli_args or ['awx', '--conf.token', 'test-token-abc123'])
-
-    mock_root = Mock()
-    mock_connection = Mock()
-    mock_root.connection = mock_connection
-    cli.root = mock_root
-
-    return cli, mock_root, mock_connection
-
-
-def test_token_auth_preserved(monkeypatch):
-    """
-    REGRESSION TEST: Token authentication must still work (existed in 4.6.12)
-
-    This test documents the customer's working scenario from 4.6.12:
-        awx login --conf.host URL --conf.username USER --conf.password PASS
-        # Returns: {"token": "E*******J"}
-
-        awx --conf.host URL --conf.token E*******J job_templates launch ...
-        # This WORKED in 4.6.12
-
-    BREAKING CHANGE: Version 4.6.21 removed token authentication entirely,
-    causing customer to report: "neither token no username/password are working"
-
-    This test will FAIL with current code and PASS once fixed.
-    """
-    cli, mock_root, mock_connection = setup_token_auth(['awx', '--conf.host', 'https://aap-sbx.testbank.com', '--conf.token', 'E1234567890J'])
-    monkeypatch.setattr(config, 'force_basic_auth', False)
-
-    # Execute authentication
-    cli.authenticate()
-
-    # Token auth should call login with token parameter
-    mock_connection.login.assert_called_once_with(None, None, token='E1234567890J')
-
-    # Should NOT use sessions when token is provided
-    assert not config.use_sessions
-
-
 def test_basic_auth_enabled(monkeypatch):
     """Test that AWXKIT_FORCE_BASIC_AUTH=true enables Basic authentication"""
     cli, mock_root, mock_connection = setup_basic_auth()


### PR DESCRIPTION
##### SUMMARY
Token based authentication was mistakenly added in devel by https://github.com/ansible/awx/pull/16281
As it is no longer supported, this PR removes it.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an intentional breaking change that removes an auth mechanism; existing scripts relying on `--conf.token`/Bearer tokens will stop working, though the remaining auth paths are unchanged.
> 
> **Overview**
> **Token-based authentication has been removed from awxkit.** The API `Connection.login()` no longer accepts a `token` parameter and the `TokenAuth` helper has been deleted.
> 
> The CLI no longer exposes `--conf.token` (or related env defaults) and drops the token-auth priority path in `CLI.authenticate()`, so auth now only uses forced Basic auth (`AWXKIT_FORCE_BASIC_AUTH=true`) or the default session-based login. Token-auth regression tests were removed accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22e6562fb192f860602317ce4c3a2bbec0d4838c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Token-based authentication removed; users must sign in with username/password or use session-based auth.
  * CLI no longer accepts a token configuration option.

* **Tests**
  * Token-auth related tests removed; coverage now focuses on basic and session auth flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->