### PR TITLE
Only request read permission for PR scan

### DIFF
--- a/.github/workflows/pr_body_check.yml
+++ b/.github/workflows/pr_body_check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
-      packages: write
+      packages: read
       contents: read
     steps:
       - name: Check for each of the lines


### PR DESCRIPTION
##### SUMMARY
attempted fix for the approval button

<img width="1012" height="138" alt="Screenshot From 2026-02-18 15-16-22" src="https://github.com/user-attachments/assets/9709c8ea-0907-4a90-8855-b3df721ab302" />


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only GitHub Actions workflow permissions, reducing `packages` access from write to read with no functional logic changes.
> 
> **Overview**
> Tightens the `pr_body_check.yml` GitHub Actions workflow by reducing its permissions from `packages: write` to `packages: read` while leaving the PR-body keyword scanning behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b45ad254b7daed2b8a0d5e235b6d04ac5e9a007. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI workflow permissions by reducing package operation access from write to read.
  * No other workflow behavior, steps, or control flow were changed.
  * Minor configuration tweak with low impact on functionality; improves security posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->