### PR TITLE
AAP-62693 Integrate workload identity client to request JWTs

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -168,8 +168,13 @@ def populate_claims_for_workload(unified_job) -> dict:
 
 
 def retrieve_workload_identity_jwt(unified_job: UnifiedJob, audience: str, scope: str) -> str:
-    """Retrieve JWT token from workload claims."""
+    """Retrieve JWT token from workload claims.
+    Raises:
+        RuntimeError: if the workload identity client is not configured.
+    """
     client = get_workload_identity_client()
+    if client is None:
+        raise RuntimeError("Workload identity client is not configured.")
     claims = populate_claims_for_workload(unified_job)
     return client.request_workload_jwt(claims=claims, scope=scope, audience=audience).jwt
 

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -96,6 +96,10 @@ from flags.state import flag_enabled
 # Workload Identity
 from ansible_base.lib.workload_identity.controller import AutomationControllerJobScope
 
+from ansible_base.resource_registry.workload_identity_client import (
+    get_workload_identity_client,
+)
+
 logger = logging.getLogger('awx.main.tasks.jobs')
 
 
@@ -161,6 +165,13 @@ def populate_claims_for_workload(unified_job) -> dict:
         claims[AutomationControllerJobScope.CLAIM_LAUNCHED_BY_ID] = launched_by['id']
 
     return claims
+
+
+def retrieve_workload_identity_jwt(unified_job: UnifiedJob, audience: str, scope: str) -> str:
+    """Retrieve JWT token from workload claims."""
+    client = get_workload_identity_client()
+    claims = populate_claims_for_workload(unified_job)
+    return client.request_workload_jwt(claims=claims, scope=scope, audience=audience).jwt
 
 
 def with_path_cleanup(f):

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -174,7 +174,7 @@ def retrieve_workload_identity_jwt(unified_job: UnifiedJob, audience: str, scope
     """
     client = get_workload_identity_client()
     if client is None:
-        raise RuntimeError("Workload identity client is not configured.")
+        raise RuntimeError("Workload identity client is not configured")
     claims = populate_claims_for_workload(unified_job)
     return client.request_workload_jwt(claims=claims, scope=scope, audience=audience).jwt
 

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -427,3 +427,50 @@ def test_populate_claims_for_adhoc_command(workload_attrs, expected_claims):
 
     claims = jobs.populate_claims_for_workload(adhoc_command)
     assert claims == expected_claims
+
+
+@mock.patch('awx.main.tasks.jobs.get_workload_identity_client')
+def test_retrieve_workload_identity_jwt_returns_jwt_from_client(mock_get_client):
+    """retrieve_workload_identity_jwt returns the JWT string from the client."""
+    mock_client = mock.MagicMock()
+    mock_response = mock.MagicMock()
+    mock_response.jwt = 'eyJ.test.jwt'
+    mock_client.request_workload_jwt.return_value = mock_response
+    mock_get_client.return_value = mock_client
+
+    unified_job = Job()
+    unified_job.id = 42
+    unified_job.name = 'Test Job'
+    unified_job.launch_type = 'manual'
+    unified_job.organization = Organization(id=1, name='Test Org')
+    unified_job.unified_job_template = None
+    unified_job.instance_group = None
+
+    result = jobs.retrieve_workload_identity_jwt(
+        unified_job, audience='https://api.example.com', scope='aap_controller_automation_job'
+    )
+
+    assert result == 'eyJ.test.jwt'
+    mock_client.request_workload_jwt.assert_called_once()
+    call_kwargs = mock_client.request_workload_jwt.call_args[1]
+    assert call_kwargs['audience'] == 'https://api.example.com'
+    assert call_kwargs['scope'] == 'aap_controller_automation_job'
+    assert 'claims' in call_kwargs
+    assert call_kwargs['claims'][AutomationControllerJobScope.CLAIM_JOB_ID] == 42
+    assert call_kwargs['claims'][AutomationControllerJobScope.CLAIM_JOB_NAME] == 'Test Job'
+
+
+@mock.patch('awx.main.tasks.jobs.get_workload_identity_client')
+def test_retrieve_workload_identity_jwt_passes_audience_and_scope(mock_get_client):
+    """retrieve_workload_identity_jwt passes audience and scope to the client."""
+    mock_client = mock.MagicMock()
+    mock_client.request_workload_jwt.return_value = mock.MagicMock(jwt='token')
+    mock_get_client.return_value = mock_client
+
+    unified_job = mock.MagicMock()
+    audience = 'custom_audience'
+    scope = 'custom_scope'
+    with mock.patch('awx.main.tasks.jobs.populate_claims_for_workload', return_value={'job_id': 1}):
+        jobs.retrieve_workload_identity_jwt(unified_job, audience=audience, scope=scope)
+
+    mock_client.request_workload_jwt.assert_called_once_with(claims={'job_id': 1}, scope=scope, audience=audience)

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -481,5 +481,5 @@ def test_retrieve_workload_identity_jwt_raises_when_client_not_configured(mock_g
 
     unified_job = mock.MagicMock()
 
-    with pytest.raises(RuntimeError, match="Workload identity client is not configured."):
+    with pytest.raises(RuntimeError, match="Workload identity client is not configured"):
         jobs.retrieve_workload_identity_jwt(unified_job, audience='test_audience', scope='test_scope')

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -446,9 +446,7 @@ def test_retrieve_workload_identity_jwt_returns_jwt_from_client(mock_get_client)
     unified_job.unified_job_template = None
     unified_job.instance_group = None
 
-    result = jobs.retrieve_workload_identity_jwt(
-        unified_job, audience='https://api.example.com', scope='aap_controller_automation_job'
-    )
+    result = jobs.retrieve_workload_identity_jwt(unified_job, audience='https://api.example.com', scope='aap_controller_automation_job')
 
     assert result == 'eyJ.test.jwt'
     mock_client.request_workload_jwt.assert_called_once()

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -472,3 +472,14 @@ def test_retrieve_workload_identity_jwt_passes_audience_and_scope(mock_get_clien
         jobs.retrieve_workload_identity_jwt(unified_job, audience=audience, scope=scope)
 
     mock_client.request_workload_jwt.assert_called_once_with(claims={'job_id': 1}, scope=scope, audience=audience)
+
+
+@mock.patch('awx.main.tasks.jobs.get_workload_identity_client')
+def test_retrieve_workload_identity_jwt_raises_when_client_not_configured(mock_get_client):
+    """retrieve_workload_identity_jwt raises RuntimeError when client is None."""
+    mock_get_client.return_value = None
+
+    unified_job = mock.MagicMock()
+
+    with pytest.raises(RuntimeError, match="Workload identity client is not configured."):
+        jobs.retrieve_workload_identity_jwt(unified_job, audience='test_audience', scope='test_scope')


### PR DESCRIPTION
Supersedes #12277 

##### SUMMARY
This PR adds a function to jobs.py that will call the WorkloadIdentityClient defined in DAB lib module that other modules will call to request JWTs for a given job.

There's no need to trigger it at job launch because the responsibility of doing this is encapsulated in this PR: #16286.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

<!--- Paste verbatim command output below, e.g. before and after your change -->
```bash
Tests run:
$ pytest awx/main/tests/unit/tasks/test_jobs.py
[...]
awx/main/tests/unit/tasks/test_jobs.py::test_retrieve_workload_identity_jwt_returns_jwt_from_client PASSED                                           [ 92%]
awx/main/tests/unit/tasks/test_jobs.py::test_retrieve_workload_identity_jwt_passes_audience_and_scope PASSED                                         [100%]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Jobs can obtain workload identity JWTs with configurable audience and scope; issued claims include job identifiers and metadata. A clear error is raised when the workload identity integration is not configured.

* **Tests**
  * Added unit tests for successful JWT retrieval, proper propagation of audience/scope/claims, and the error path when the identity client is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->