### PR TITLE
Fix inventory overwrite_vars not removing deleted variables

### DIFF
--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -33,7 +33,7 @@ from awx.main.utils.safe_yaml import sanitize_jinja
 from awx.main.models.rbac import batch_role_ancestor_rebuilding
 from awx.main.utils import ignore_inventory_computed_fields, get_licenser
 from awx.main.utils.execution_environments import get_default_execution_environment
-from awx.main.utils.inventory_vars import update_group_variables
+from awx.main.utils.inventory_vars import update_group_variables, update_host_variables
 from awx.main.signals import disable_activity_stream
 from awx.main.constants import STANDARD_INVENTORY_UPDATE_ENV
 
@@ -499,11 +499,14 @@ class Command(BaseCommand):
             group_names = all_group_names[offset : (offset + self._batch_size)]
             for group in self.inventory.groups.filter(name__in=group_names):
                 mem_group = self.all_group.all_groups[group.name]
-                db_variables = group.variables_dict
-                if self.overwrite_vars:
-                    db_variables = mem_group.variables
-                else:
-                    db_variables.update(mem_group.variables)
+                db_variables = update_group_variables(
+                    group_id=group.pk,
+                    newvars=mem_group.variables,
+                    dbvars=group.variables_dict,
+                    invsrc_id=self.inventory_source.id,
+                    inventory_id=self.inventory.id,
+                    overwrite_vars=self.overwrite_vars,
+                )
                 if db_variables != group.variables_dict:
                     group.variables = json.dumps(db_variables)
                     group.save(update_fields=['variables'])
@@ -548,10 +551,14 @@ class Command(BaseCommand):
                 for var in ('remote_{}_enabled', 'remote_{}_id'):
                     mem_variables.pop(var.format(prefix), None)
 
-        if self.overwrite_vars:
-            db_variables = mem_variables
-        else:
-            db_variables.update(mem_variables)
+        db_variables = update_host_variables(
+            host_id=db_host.pk,
+            newvars=mem_variables,
+            dbvars=db_host.variables_dict,
+            invsrc_id=self.inventory_source.id,
+            inventory_id=self.inventory.id,
+            overwrite_vars=self.overwrite_vars,
+        )
 
         if db_variables != db_host.variables_dict:
             db_host.variables = json.dumps(db_variables)

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -526,6 +526,16 @@ class Command(BaseCommand):
             group = self.inventory.groups.update_or_create(name=group_name, defaults={'variables': json.dumps(mem_group.variables), 'description': group_desc})[
                 0
             ]
+            # Initialize variable history under the real source ID so that
+            # future syncs can correctly attribute and remove variables.
+            update_group_variables(
+                group_id=group.pk,
+                newvars=mem_group.variables,
+                dbvars=None,
+                invsrc_id=self.inventory_source.id,
+                inventory_id=self.inventory.id,
+                overwrite_vars=self.overwrite_vars,
+            )
             logger.debug('Group "%s" added', group.name)
             self._batch_add_m2m(self.inventory_source.groups, group)
         self._batch_add_m2m(self.inventory_source.groups, flush=True)
@@ -699,6 +709,16 @@ class Command(BaseCommand):
             except ValueError as e:
                 raise ValueError(str(e) + ': {}'.format(mem_host_name))
             db_host = self.inventory.hosts.update_or_create(name=mem_host_name, defaults=host_attrs)[0]
+            # Initialize variable history under the real source ID so that
+            # future syncs can correctly attribute and remove variables.
+            update_host_variables(
+                host_id=db_host.pk,
+                newvars=import_vars,
+                dbvars=None,
+                invsrc_id=self.inventory_source.id,
+                inventory_id=self.inventory.id,
+                overwrite_vars=self.overwrite_vars,
+            )
             if enabled is False:
                 logger.debug('Host "%s" added (disabled)', mem_host_name)
             else:

--- a/awx/main/migrations/0205_inventoryhostvariableswithhistory.py
+++ b/awx/main/migrations/0205_inventoryhostvariableswithhistory.py
@@ -1,0 +1,38 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0204_squashed_deletions'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='InventoryHostVariablesWithHistory',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('variables', models.JSONField()),
+                ('inventory', models.ForeignKey(
+                    null=True,
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='inventory_host_variables',
+                    to='main.inventory',
+                )),
+                ('host', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='inventory_host_variables',
+                    to='main.host',
+                )),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name='inventoryhostvariableswithhistory',
+            constraint=models.UniqueConstraint(
+                fields=('inventory', 'host'),
+                name='unique_inventory_host',
+                violation_error_message='Inventory/Host combination must be unique.',
+            ),
+        ),
+    ]

--- a/awx/main/models/__init__.py
+++ b/awx/main/models/__init__.py
@@ -34,6 +34,7 @@ from awx.main.models.inventory import (  # noqa
     InventoryUpdate,
     SmartInventoryMembership,
     InventoryGroupVariablesWithHistory,
+    InventoryHostVariablesWithHistory,
 )
 from awx.main.models.jobs import (  # noqa
     Job,

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1441,3 +1441,39 @@ class InventoryGroupVariablesWithHistory(models.Model):
         on_delete=models.CASCADE,
     )
     variables = models.JSONField()  # The group variables, including their history.
+
+
+class InventoryHostVariablesWithHistory(models.Model):
+    """
+    Represents the inventory variables of one host.
+
+    The purpose of this model is to persist the update history of the host
+    variables. The update history is maintained in the same way as group
+    variables (using `InventoryGroupVariables`), this class here is just a
+    container for the database storage.
+
+    See also: InventoryGroupVariablesWithHistory
+    """
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["inventory", "host"],
+                name="unique_inventory_host",
+                violation_error_message=_("Inventory/Host combination must be unique."),
+            ),
+        ]
+
+    inventory = models.ForeignKey(
+        'Inventory',
+        related_name='inventory_host_variables',
+        null=True,
+        on_delete=models.CASCADE,
+    )
+    host = models.ForeignKey(
+        'Host',
+        related_name='inventory_host_variables',
+        null=False,
+        on_delete=models.CASCADE,
+    )
+    variables = models.JSONField()  # The host variables, including their history.

--- a/awx/main/tests/functional/commands/test_inventory_import.py
+++ b/awx/main/tests/functional/commands/test_inventory_import.py
@@ -319,6 +319,154 @@ class TestINIImports:
 
 @pytest.mark.django_db
 @pytest.mark.inventory_import
+@mock.patch.object(inventory_import.Command, 'check_license', new=mock.MagicMock())
+@mock.patch.object(inventory_import.Command, 'set_logging_level', new=mock_logging)
+class TestOverwriteVarsRemoval:
+    """Tests for https://github.com/ansible/awx/issues/16139
+
+    Verify that variables removed from an inventory source are properly
+    removed from hosts and groups when overwrite_vars is enabled.
+    """
+
+    @mock.patch.object(inventory_import, 'AnsibleInventoryLoader', MockLoader)
+    def test_host_vars_removed_with_overwrite_vars(self, inventory):
+        """When overwrite_vars is True, variables removed from the source
+        should also be removed from the host in AWX."""
+        # First import: host has two variables
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"myhost": {"ansible_python_interpreter": "/usr/bin/python3", "keep_var": "value"}}},
+            "all": {"children": ["ungrouped"]},
+            "ungrouped": {"hosts": ["myhost"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite_vars=True)
+        host = inventory.hosts.get(name='myhost')
+        assert host.variables_dict == {"ansible_python_interpreter": "/usr/bin/python3", "keep_var": "value"}
+
+        # Second import: ansible_python_interpreter removed from source
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"myhost": {"keep_var": "value"}}},
+            "all": {"children": ["ungrouped"]},
+            "ungrouped": {"hosts": ["myhost"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite_vars=True)
+        host.refresh_from_db()
+        assert host.variables_dict == {"keep_var": "value"}, (
+            "ansible_python_interpreter should have been removed when overwrite_vars is True"
+        )
+
+    @mock.patch.object(inventory_import, 'AnsibleInventoryLoader', MockLoader)
+    def test_host_vars_all_removed_with_overwrite_vars(self, inventory):
+        """When all host vars are removed from source, host should have empty vars."""
+        # First import: host has variables
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"myhost": {"ansible_python_interpreter": "/usr/bin/python3"}}},
+            "all": {"children": ["ungrouped"]},
+            "ungrouped": {"hosts": ["myhost"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite_vars=True)
+        host = inventory.hosts.get(name='myhost')
+        assert host.variables_dict == {"ansible_python_interpreter": "/usr/bin/python3"}
+
+        # Second import: all variables removed
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"myhost": {}}},
+            "all": {"children": ["ungrouped"]},
+            "ungrouped": {"hosts": ["myhost"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite_vars=True)
+        host.refresh_from_db()
+        assert host.variables_dict == {}, (
+            "All host variables should have been removed when overwrite_vars is True"
+        )
+
+    @mock.patch.object(inventory_import, 'AnsibleInventoryLoader', MockLoader)
+    def test_group_vars_removed_with_overwrite_vars(self, inventory):
+        """When overwrite_vars is True, variables removed from a group in the
+        source should also be removed from the group in AWX."""
+        # First import: group has two variables
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"myhost": {}}},
+            "all": {"children": ["mygroup"]},
+            "mygroup": {"hosts": ["myhost"], "vars": {"var_a": "a", "var_b": "b"}},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite_vars=True)
+        group = inventory.groups.get(name='mygroup')
+        assert group.variables_dict == {"var_a": "a", "var_b": "b"}
+
+        # Second import: var_a removed from group
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"myhost": {}}},
+            "all": {"children": ["mygroup"]},
+            "mygroup": {"hosts": ["myhost"], "vars": {"var_b": "b"}},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite_vars=True)
+        group.refresh_from_db()
+        assert group.variables_dict == {"var_b": "b"}, (
+            "var_a should have been removed from group when overwrite_vars is True"
+        )
+
+    @mock.patch.object(inventory_import, 'AnsibleInventoryLoader', MockLoader)
+    def test_host_vars_multi_source_overwrite(self, inventory):
+        """With multiple inventory sources, removing a variable from one source
+        should not affect variables contributed by another source."""
+        inv_src_a = InventorySource.objects.create(
+            inventory=inventory, name='source_a', source='file', overwrite_vars=True
+        )
+        inv_src_b = InventorySource.objects.create(
+            inventory=inventory, name='source_b', source='file', overwrite_vars=True
+        )
+
+        # Source A sets var_a and var_shared
+        data_a = {
+            "_meta": {"hostvars": {"myhost": {"var_a": "from_a", "var_shared": "from_a"}}},
+            "all": {"children": ["ungrouped"]},
+            "ungrouped": {"hosts": ["myhost"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.perform_update(
+            dict(overwrite_vars=True), data_a, inv_src_a.create_unified_job()
+        )
+        host = inventory.hosts.get(name='myhost')
+        assert "var_a" in host.variables_dict
+        assert host.variables_dict["var_shared"] == "from_a"
+
+        # Source B sets var_b and var_shared
+        data_b = {
+            "_meta": {"hostvars": {"myhost": {"var_b": "from_b", "var_shared": "from_b"}}},
+            "all": {"children": ["ungrouped"]},
+            "ungrouped": {"hosts": ["myhost"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.perform_update(
+            dict(overwrite_vars=True), data_b, inv_src_b.create_unified_job()
+        )
+        host.refresh_from_db()
+        assert host.variables_dict["var_a"] == "from_a", "var_a from source A should still be present"
+        assert host.variables_dict["var_b"] == "from_b", "var_b from source B should be present"
+        assert host.variables_dict["var_shared"] == "from_b", "var_shared should have value from latest source"
+
+        # Source A removes var_a, only provides var_shared
+        data_a_updated = {
+            "_meta": {"hostvars": {"myhost": {"var_shared": "from_a_v2"}}},
+            "all": {"children": ["ungrouped"]},
+            "ungrouped": {"hosts": ["myhost"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.perform_update(
+            dict(overwrite_vars=True), data_a_updated, inv_src_a.create_unified_job()
+        )
+        host.refresh_from_db()
+        assert "var_a" not in host.variables_dict, "var_a should have been removed since source A no longer provides it"
+        assert host.variables_dict["var_b"] == "from_b", "var_b from source B should still be present"
+        assert host.variables_dict["var_shared"] == "from_a_v2", "var_shared should have value from latest update"
+
+
 class TestEnabledVar:
     """
     Meaning of return values

--- a/awx/main/utils/inventory_vars.py
+++ b/awx/main/utils/inventory_vars.py
@@ -1,7 +1,7 @@
 import logging
 from typing import TypeAlias, Any
 
-from awx.main.models import InventoryGroupVariablesWithHistory
+from awx.main.models import InventoryGroupVariablesWithHistory, InventoryHostVariablesWithHistory
 
 var_value: TypeAlias = Any
 update_queue: TypeAlias = list[tuple[int, var_value]]
@@ -274,3 +274,58 @@ def update_group_variables(
     logger.debug(f"update_group_variables: after update_from_src {model.variables=}")
     logger.debug(f"update_group_variables({group_id=}, {newvars}): {inv_group_vars}")
     return inv_group_vars
+
+
+def update_host_variables(
+    host_id: int,
+    newvars: dict,
+    dbvars: dict | None,
+    invsrc_id: int,
+    inventory_id: int,
+    overwrite_vars: bool = True,
+    reset: bool = False,
+) -> dict[str, var_value]:
+    """
+    Update the inventory variables of one host.
+
+    This works analogously to `update_group_variables` but for host-level
+    variables.  It tracks variable history per-source, ensuring that when a
+    source removes a variable, it is properly cleaned up while preserving
+    variables contributed by other sources.
+
+    :param int host_id: The host id (pk).
+    :param dict newvars: The variables contained in this update.
+    :param dict dbvars: The variables which are already stored in the database
+        for this host. Can be `None`.
+    :param int invsrc_id: The id of the inventory source for this update.
+    :param int inventory_id: The id of the inventory on which this update is
+        applied.
+    :param bool overwrite_vars: If `True`, delete variables which were merged
+        from the same source in a previous update, but are no longer contained
+        in that source. If `False`, such variables would not be removed.
+        Default is `True`.
+    :param bool reset: If `True`, delete all variables from previous updates,
+        therewith making this update overwrite all history. Default is `False`.
+    :return: The variables and their current values as a dict.
+    :rtype: dict
+    """
+    inv_host_vars = InventoryGroupVariables(host_id)
+    # Restore the existing variables state.
+    try:
+        model = InventoryHostVariablesWithHistory.objects.get(inventory_id=inventory_id, host_id=host_id)
+    except InventoryHostVariablesWithHistory.DoesNotExist:
+        model = InventoryHostVariablesWithHistory(inventory_id=inventory_id, host_id=host_id)
+        if dbvars:
+            inv_host_vars.update_from_src(dbvars, -1)  # Assume -1 as inv_source_id for existing vars.
+    else:
+        inv_host_vars.load_state(model.variables)
+    #
+    logger.debug(f"update_host_variables: before update_from_src {model.variables=}")
+    # Apply the new inventory update onto the host variables.
+    inv_host_vars.update_from_src(newvars, invsrc_id, overwrite_vars, reset)
+    # Save the new variables state.
+    model.variables = inv_host_vars.save_state()
+    model.save()
+    logger.debug(f"update_host_variables: after update_from_src {model.variables=}")
+    logger.debug(f"update_host_variables({host_id=}, {newvars}): {inv_host_vars}")
+    return inv_host_vars


### PR DESCRIPTION
## Summary

Fixes #16139 — When variables are removed from an inventory source (e.g., removing `ansible_python_interpreter` from `host_vars/`), they were not being removed from AWX host/group variables even with "Overwrite" and "Overwrite variables" enabled.

**Root cause:** The inventory-level "all" group already used `update_group_variables()` with `InventoryGroupVariablesWithHistory` for proper per-source variable history tracking. However, individual **group** and **host** variable updates used a simple dict replacement/merge that did not track which inventory source contributed which variable. This meant removed variables could persist across syncs.

**Fix:**
- Extended `update_group_variables()` usage to individual groups in `_create_update_groups()`
- Added `update_host_variables()` function (analogous to `update_group_variables()`) with a new `InventoryHostVariablesWithHistory` model for host-level variable tracking
- Added database migration for the new model
- When a source syncs with `overwrite_vars=True` and a variable is no longer present in that source, it is now properly removed from the host/group (unless another source still provides it)

### Changes

| File | Change |
|------|--------|
| `awx/main/models/inventory.py` | Added `InventoryHostVariablesWithHistory` model |
| `awx/main/models/__init__.py` | Export the new model |
| `awx/main/utils/inventory_vars.py` | Added `update_host_variables()` function |
| `awx/main/management/commands/inventory_import.py` | Use `update_group_variables()` for groups, `update_host_variables()` for hosts |
| `awx/main/migrations/0205_...` | Migration for new model |
| `awx/main/tests/functional/commands/test_inventory_import.py` | Tests for variable removal |

### Tests added

- `test_host_vars_removed_with_overwrite_vars` — single var removed from host
- `test_host_vars_all_removed_with_overwrite_vars` — all vars removed from host
- `test_group_vars_removed_with_overwrite_vars` — var removed from group
- `test_host_vars_multi_source_overwrite` — multi-source: removing var from one source preserves vars from other sources

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Track host variable change history during inventory imports.
  * Initialize variable history for newly created hosts/groups under the real source to ensure correct attribution.

* **Improvements**
  * Improved variable overwrite handling to preserve variables from multiple inventory sources and prune removed variables appropriately.

* **Tests**
  * Added comprehensive tests for variable removal, multi-source overwrite behavior, and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->