### PR TITLE
Improve transactional integrity for starting controller jobs in dispatcherd

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -557,6 +557,7 @@ class BaseTask(object):
         """
         Run the job/task and capture its output.
         """
+
         if not self.instance:  # Used to skip fetch for local runs
             # Load the instance
             self.instance = self.update_model(pk)
@@ -573,7 +574,8 @@ class BaseTask(object):
 
         if self.instance.cancel_flag:
             self.instance = self.update_model(pk, status='canceled')
-            raise RuntimeError('not starting %s task' % self.instance.status)
+            self.instance.websocket_emit_status('canceled')
+            return
 
         self.instance.websocket_emit_status("running")
         status, rc = 'error', None

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -17,7 +17,6 @@ import urllib.parse as urlparse
 
 # Django
 from django.conf import settings
-from django.db import transaction
 
 # Shared code for the AWX platform
 from awx_plugins.interfaces._temporary_private_container_api import CONTAINER_ROOT, get_incontainer_path
@@ -205,6 +204,7 @@ def dispatch_waiting_jobs(binder):
         if not kwargs:
             kwargs = {}
         binder.control('run', data={'task': serialize_task(uj._get_task_class()), 'args': [uj.id], 'kwargs': kwargs, 'uuid': uj.celery_task_id})
+        UnifiedJob.objects.filter(pk=uj.pk, status='waiting').update(status='running', start_args='')
 
 
 class BaseTask(object):
@@ -551,31 +551,6 @@ class BaseTask(object):
     def should_use_fact_cache(self):
         return False
 
-    def transition_status(self, pk: int) -> bool:
-        """Atomically transition status to running, if False returned, another process got it"""
-        with transaction.atomic():
-            # Explanation of parts for the fetch:
-            # .values - avoid loading a full object, this is known to lead to deadlocks due to signals
-            #   the signals load other related rows which another process may be locking, and happens in practice
-            # of=('self',) - keeps FK tables out of the lock list, another way deadlocks can happen
-            # .get - just load the single job
-            instance_data = UnifiedJob.objects.select_for_update(of=('self',)).values('status', 'cancel_flag').get(pk=pk)
-
-            # If status is not waiting (obtained under lock) then this process does not have clearence to run
-            if instance_data['status'] == 'waiting':
-                if instance_data['cancel_flag']:
-                    updated_status = 'canceled'
-                else:
-                    updated_status = 'running'
-                # Explanation of the update:
-                # .filter - again, do not load the full object
-                # .update - a bulk update on just that one row, avoid loading unintended data
-                UnifiedJob.objects.filter(pk=pk).update(status=updated_status, start_args='')
-            elif instance_data['status'] == 'running':
-                logger.info(f'Job {pk} is being ran by another process, exiting')
-                return False
-        return True
-
     @with_path_cleanup
     @with_signal_handling
     def run(self, pk, **kwargs):
@@ -583,15 +558,22 @@ class BaseTask(object):
         Run the job/task and capture its output.
         """
         if not self.instance:  # Used to skip fetch for local runs
-            if not self.transition_status(pk):
-                logger.info(f'Job {pk} is being ran by another process, exiting')
-                return
+            # Load the instance
+            self.instance = self.update_model(pk)
 
-        # Load the instance
-        self.instance = self.update_model(pk)
+        # status should be "running" from dispatch_waiting_jobs,
+        # but may still be "waiting" if the worker picked this up before the status update landed.
+        if self.instance.status == 'waiting':
+            UnifiedJob.objects.filter(pk=pk).update(status="running", start_args='')
+            self.instance.refresh_from_db()
+
         if self.instance.status != 'running':
             logger.error(f'Not starting {self.instance.status} task pk={pk} because its status "{self.instance.status}" is not expected')
             return
+
+        if self.instance.cancel_flag:
+            self.instance = self.update_model(pk, status='canceled')
+            raise RuntimeError('not starting %s task' % self.instance.status)
 
         self.instance.websocket_emit_status("running")
         status, rc = 'error', None

--- a/awx/main/tests/functional/tasks/test_tasks_jobs.py
+++ b/awx/main/tests/functional/tasks/test_tasks_jobs.py
@@ -29,3 +29,30 @@ def test_cancel_flag_on_start(jt_linked, caplog):
 
     job = Job.objects.get(id=job.id)
     assert job.status == 'canceled'
+
+
+@pytest.mark.django_db
+def test_runjob_run_can_accept_waiting_status(jt_linked, mocker):
+    """Test that RunJob.run() can accept a job in 'waiting' status and transition it to 'running'
+    before the pre_run_hook is called"""
+    job = jt_linked.create_unified_job()
+    job.status = 'waiting'
+    job.save()
+
+    status_at_pre_run = None
+
+    def capture_status(instance, private_data_dir):
+        nonlocal status_at_pre_run
+        instance.refresh_from_db()
+        status_at_pre_run = instance.status
+
+    mock_pre_run = mocker.patch.object(RunJob, 'pre_run_hook', side_effect=capture_status)
+
+    task = RunJob()
+    try:
+        task.run(job.id)
+    except Exception:
+        pass
+
+    mock_pre_run.assert_called_once()
+    assert status_at_pre_run == 'running'


### PR DESCRIPTION
## Summary
- Remove `SELECT FOR UPDATE` / `transaction.atomic()` from `BaseTask.transition_status` which was causing increased database transaction rollbacks observed in perfscale testing
- Move status transition into `dispatch_waiting_jobs`, using a conditional `filter().update()` that is atomic at the DB level without explicit row locks
- Delete the `transition_status` method entirely — it was an artifact of the feature flag era and unnecessary given `dispatch_waiting_jobs` is already a singleton (`on_duplicate='queue_one'`) scoped to the local node
- Status is now updated after task submission to dispatcherd, so the job's UUID is in the dispatch pipeline before being marked `running` — this prevents the reaper from incorrectly reaping jobs during the handoff window
- `BaseTask.run` handles the race where a worker picks up the task before the status update lands by accepting `waiting` and transitioning it to `running` itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core job start/cancel state transitions and could affect edge-case concurrency (e.g., fast workers or reaping timing), though changes are localized and covered by new tests.
> 
> **Overview**
> **Job start status handling is refactored to reduce DB locking and tighten the dispatch-to-execution handoff.** `dispatch_waiting_jobs` now conditionally updates `UnifiedJob` rows from `waiting` to `running` immediately after submitting the task to dispatcherd.
> 
> `BaseTask.run` removes the `transaction.atomic()`/`select_for_update()`-based `transition_status` logic (and deletes the method), and instead tolerates `waiting` on worker pickup by flipping it to `running` before continuing; it also explicitly cancels early if `cancel_flag` is set. Adds a functional test asserting a `waiting` job is `running` by the time `pre_run_hook` executes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72f291b9eef0c0060ab4f2491b8c7ae83988f891. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined job dispatch and execution status handling with unified status transition logic.

* **Breaking Changes**
  * Removed a public method from the job task API that handled manual status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->