### PR TITLE
Do not write to dispatcher.log from AWX application code

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -774,7 +774,7 @@ LOGGING = {
         'awx.conf.settings': {'handlers': ['null'], 'level': 'WARNING'},
         'awx.main': {'handlers': ['null']},
         'awx.main.commands.run_callback_receiver': {'handlers': ['callback_receiver'], 'level': 'INFO'},  # very noisey debug-level logs
-        'awx.main.dispatch': {'handlers': ['dispatcher']},
+        'awx.main.dispatch': {'handlers': ['task_system']},
         'awx.main.consumers': {'handlers': ['console', 'file', 'tower_warnings'], 'level': 'INFO'},
         'awx.main.rsyslog_configurer': {'handlers': ['rsyslog_configurer']},
         'awx.main.cache_clear': {'handlers': ['cache_clear']},


### PR DESCRIPTION
##### SUMMARY
I was going through SOS reports and I realized that I was seeing AWX tracebacks (like related to jobs) in the `dispatcher.log` file. I would not like to see this. We have another file `task_system.log` that is perfectly good and a more appropriate place for this information.

Further in this file we have:

```python
        'dispatcherd': {'handlers': ['dispatcher', 'console'], 'level': 'INFO'},
```

So basically I would like for this python path (dispatcherd.**) to be sole user of this file. Otherwise, we're going to have contention between the dispatcher main process and the workers, trying to grab the lock to write to the file and stuff.

And we really want to avoid any inter-dependencies for the main dispatcher process, due to performance reasons. So that is a strong argument for this change.

What remains in `awx.main.dispatch` is mostly configuration and any app-specific stuff hooked into the dispatcher, and callback receiver corner cases and stuff (though not usually for this)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, configuration-only logging change; main risk is shifted log location potentially affecting existing log monitoring/alerts.
> 
> **Overview**
> Stops AWX application code under `awx.main.dispatch` from writing to `dispatcher.log` by switching that logger’s handler from `dispatcher` to `task_system` in `awx/settings/defaults.py`.
> 
> This keeps `dispatcher.log` reserved for the `dispatcherd` process and reduces file-lock contention/noisy tracebacks in dispatcher logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d6283c3301d1efe35a6ae8c0fcd711e6302f34d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging configuration to route dispatch-related logs through an alternate handler system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->