### PR TITLE
AAP-66379 Include scaledown fix from dispatcherd

### DIFF
--- a/awx/main/dispatch/config.py
+++ b/awx/main/dispatch/config.py
@@ -27,6 +27,10 @@ def get_dispatcherd_config(for_service: bool = False, mock_publish: bool = False
             "pool_kwargs": {
                 "min_workers": settings.JOB_EVENT_WORKERS,
                 "max_workers": max_workers,
+                # This must be less than max_workers to make sense, which is usually 4
+                # With reserve of 1, after a burst of tasks, load needs to down to 4-1=3
+                # before we return to min_workers
+                "scaledown_reserve": 1,
             },
             "main_kwargs": {"node_id": settings.CLUSTER_HOST_ID},
             "process_manager_cls": "ForkServerManager",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -116,7 +116,7 @@ cython==3.1.3
     # via -r /awx_devel/requirements/requirements.in
 daphne==4.2.1
     # via -r /awx_devel/requirements/requirements.in
-dispatcherd[pg-notify]==2026.01.27
+dispatcherd[pg-notify]==2026.02.26
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
This is intended to fix problems with persistently high memory use from using too many workers.

Worried about this changing to be _too_ aggressive scaling down workers, I added a `scaledown_reserve`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispatcherd worker-pool scaling behavior and upgrades the dispatcherd dependency, which could impact throughput/latency or worker churn under load if the new defaults are too aggressive or not aggressive enough.
> 
> **Overview**
> Reduces persistent dispatcher worker growth by passing a new `scaledown_reserve` setting in the dispatcherd service `pool_kwargs`, so the pool only scales back to `min_workers` once load drops below a reserved threshold.
> 
> Also bumps `dispatcherd[pg-notify]` from `2026.01.27` to `2026.02.26` to pick up the upstream scale-down fix this configuration relies on.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd7f6027a7903d76b0244926cda50f01d308e5ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dispatcher dependency to the latest version, bringing potential performance improvements and bug fixes.
  * Optimized worker scaling behavior for improved resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->