### PR TITLE
fix: awxkit help flags for detailed & general help

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,11 @@ jobs:
         run: |
           if [ -f "reports/coverage.xml" ]; then
             sed -i '2i<!-- PR ${{ github.event.pull_request.number }} -->' reports/coverage.xml
-            echo "Injected PR number ${{ github.event.pull_request.number }} into coverage.xml"
+            echo "Injected PR number ${{ github.event.pull_request.number }} into reports/coverage.xml"
+          fi
+          if [ -f "awxkit/coverage.xml" ]; then
+            sed -i '2i<!-- PR ${{ github.event.pull_request.number }} -->' awxkit/coverage.xml
+            echo "Injected PR number ${{ github.event.pull_request.number }} into awxkit/coverage.xml"
           fi
 
       - name: Upload test coverage to Codecov
@@ -141,7 +145,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.tests.name }}-artifacts
-          path: reports/coverage.xml
+          path: |
+            reports/coverage.xml
+            awxkit/coverage.xml
           retention-days: 5
 
       - name: >-

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -80,6 +80,28 @@ class CLI(object):
     def help(self):
         return '--help' in self.argv or '-h' in self.argv
 
+    def _get_non_option_args(self, before_help=False):
+        """Extract non-option arguments from argv, optionally only those before help flag."""
+        if before_help and self.help:
+            # Find position of help flag
+            help_pos = next((i for i, arg in enumerate(self.argv) if arg in ('--help', '-h')), len(self.argv))
+            args_to_check = self.argv[:help_pos]
+        else:
+            args_to_check = self.argv
+
+        return [arg for arg in args_to_check if not arg.startswith('-') and arg != 'awx']
+
+    def _is_main_help_request(self):
+        """
+        Determine if help request is for main CLI (awx --help) vs subcommand (awx users create --help).
+        Returns True if this is a main CLI help request that should exit early.
+        """
+        if not self.help:
+            return False
+
+        # If there are non-option arguments before help flag, this is subcommand help
+        return len(self._get_non_option_args(before_help=True)) == 0
+
     def authenticate(self):
         """Configure the current session for authentication.
 
@@ -224,6 +246,16 @@ class CLI(object):
         subparsers = self.subparsers[self.resource].add_subparsers(dest='action', metavar='action')
         subparsers.required = True
 
+        # Add manual help handling for resource-level help
+        # since we disabled add_help=False for resource subparsers
+        if self.help:
+            # Check if this is resource-level help (no action specified)
+            non_option_args = self._get_non_option_args()
+            if len(non_option_args) == 1 and non_option_args[0] == self.resource:
+                # Only resource specified, no action - show resource-level help
+                self.subparsers[self.resource].print_help()
+                return
+
         # parse the action from OPTIONS
         parser = ResourceOptionsParser(self.v2, page, self.resource, subparsers)
         if parser.deprecated:
@@ -231,6 +263,18 @@ class CLI(object):
             if not from_sphinx:
                 description = colored(description, 'yellow')
             self.subparsers[self.resource].description = description
+
+        # parse any action arguments FIRST before attempting to parse
+        if self.resource != 'settings':
+            for method in ('list', 'modify', 'create'):
+                if method in parser.parser.choices:
+                    if method == 'list':
+                        http_method = 'GET'
+                    elif method == 'modify' and 'PUT' in parser.options:
+                        http_method = 'PUT'
+                    else:
+                        http_method = 'POST'
+                    parser.build_query_arguments(method, http_method)
 
         if from_sphinx:
             # Our Sphinx plugin runs `parse_action` for *every* available
@@ -244,23 +288,15 @@ class CLI(object):
                 self.parser.parse_known_args(self.argv)[0]
             except SystemExit:
                 pass
-        else:
-            self.parser.parse_known_args()[0]
-
-        # parse any action arguments
-        if self.resource != 'settings':
-            for method in ('list', 'modify', 'create'):
-                if method in parser.parser.choices:
-                    if method == 'list':
-                        http_method = 'GET'
-                    elif method == 'modify' and 'PUT' in parser.options:
-                        http_method = 'PUT'
-                    else:
-                        http_method = 'POST'
-                    parser.build_query_arguments(method, http_method)
-        if from_sphinx:
             parsed, extra = self.parser.parse_known_args(self.argv)
         else:
+            # Try to parse to determine if help is requested for a specific action
+            try:
+                self.parser.parse_known_args()[0]
+            except SystemExit:
+                # This happens when required arguments are missing, which is expected behavior
+                # Let argparse handle it and show the appropriate help
+                raise
             parsed, extra = self.parser.parse_known_args()
 
         if extra and self.verbose:
@@ -313,6 +349,7 @@ class CLI(object):
         self.argv = argv
         self.parser = HelpfulArgumentParser(add_help=False)
         self.parser.add_argument(
+            '-h',
             '--help',
             action='store_true',
             help='prints usage information for the awx tool',
@@ -322,6 +359,13 @@ class CLI(object):
         add_output_formatting_arguments(self.parser, env)
 
         self.args = self.parser.parse_known_args(self.argv)[0]
+
+        # Early return for help to avoid server connection, but only for main CLI help
+        # Allow subcommand help (like 'awx users create --help') to continue processing
+        if self.help and self._is_main_help_request():
+            self.parser.print_help()
+            sys.exit(0)
+
         self.verbose = self.get_config('verbose')
         if self.verbose:
             logging.basicConfig(level='DEBUG')

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -89,7 +89,32 @@ class CLI(object):
         else:
             args_to_check = self.argv
 
-        return [arg for arg in args_to_check if not arg.startswith('-') and arg != 'awx']
+        non_option_args = []
+        i = 0
+        while i < len(args_to_check):
+            arg = args_to_check[i]
+
+            if arg == 'awx':
+                # Skip 'awx' token
+                i += 1
+            elif arg.startswith('-'):
+                # This is an option
+                if '=' in arg:
+                    # Long option with value: --opt=val
+                    i += 1
+                else:
+                    # Option without embedded value: --opt or -o
+                    i += 1
+                    # Only consume next argument if it exists AND doesn't start with '-'
+                    # This naturally handles flag-only options (like --verbose)
+                    if i < len(args_to_check) and not args_to_check[i].startswith('-'):
+                        i += 1
+            else:
+                # This is a positional argument
+                non_option_args.append(arg)
+                i += 1
+
+        return non_option_args
 
     def _is_main_help_request(self):
         """

--- a/awxkit/awxkit/cli/client.py
+++ b/awxkit/awxkit/cli/client.py
@@ -290,13 +290,6 @@ class CLI(object):
                 pass
             parsed, extra = self.parser.parse_known_args(self.argv)
         else:
-            # Try to parse to determine if help is requested for a specific action
-            try:
-                self.parser.parse_known_args()[0]
-            except SystemExit:
-                # This happens when required arguments are missing, which is expected behavior
-                # Let argparse handle it and show the appropriate help
-                raise
             parsed, extra = self.parser.parse_known_args()
 
         if extra and self.verbose:

--- a/awxkit/awxkit/cli/options.py
+++ b/awxkit/awxkit/cli/options.py
@@ -126,7 +126,7 @@ class ResourceOptionsParser(object):
             if method not in action_map:
                 continue
             method = action_map[method]
-            parser = self.parser.add_parser(method, help='')
+            parser = self.parser.add_parser(method, help='', add_help=True)
             if method == 'list':
                 parser.add_argument(
                     '--all',
@@ -152,7 +152,7 @@ class ResourceOptionsParser(object):
         if 'DELETE' in self.allowed_options:
             allowed.append('delete')
         for method in allowed:
-            parser = self.parser.add_parser(method, help='')
+            parser = self.parser.add_parser(method, help='', add_help=True)
             self.parser.choices[method].add_argument(
                 'id', type=functools.partial(pk_or_name, self.v2, self.resource), help='the ID (or unique name) of the resource'
             )

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -167,7 +167,9 @@ def parse_resource(client, skip_deprecated=False):
                 if k in DEPRECATED_RESOURCES:
                     kwargs['aliases'] = [DEPRECATED_RESOURCES[k]]
 
-            client.subparsers[k] = subparsers.add_parser(k, help='', **kwargs)
+            # Disable automatic help handling for resource subparsers to prevent
+            # premature help display before action subparsers are built
+            client.subparsers[k] = subparsers.add_parser(k, help='', add_help=False, **kwargs)
 
     resource = client.parser.parse_known_args()[0].resource
     if resource in DEPRECATED_RESOURCES.values():

--- a/awxkit/test/cli/test_client.py
+++ b/awxkit/test/cli/test_client.py
@@ -69,13 +69,13 @@ class TestHelpHandling:
         assert result == ['users', 'list']
 
     def test_get_non_option_args_with_flags(self):
-        """Test _get_non_option_args ignores option flags"""
+        """Test _get_non_option_args ignores option flags and their values"""
         cli = CLI()
         cli.argv = ['awx', '--conf.host', 'example.com', 'jobs', 'create', '--name', 'test']
 
         result = cli._get_non_option_args()
-        # Should include all non-option arguments (including flag values) except 'awx'
-        assert result == ['example.com', 'jobs', 'create', 'test']
+        # Should only include positional arguments, not option values
+        assert result == ['jobs', 'create']
 
     def test_get_non_option_args_before_help(self):
         """Test _get_non_option_args with before_help=True stops at help flag"""
@@ -188,3 +188,155 @@ class TestHelpHandling:
         assert len(help_actions) == 1
         assert '-h' in help_actions[0].option_strings
         assert '--help' in help_actions[0].option_strings
+
+    def test_get_non_option_args_with_equals_format(self):
+        """Test _get_non_option_args handles --opt=val format correctly"""
+        cli = CLI()
+        cli.argv = ['awx', 'users', 'create', '--email=john@example.com', '--name=john']
+
+        result = cli._get_non_option_args()
+        assert result == ['users', 'create']
+
+    def test_get_non_option_args_mixed_option_formats(self):
+        """Test _get_non_option_args handles mixed --opt=val and --opt val formats"""
+        cli = CLI()
+        cli.argv = ['awx', 'jobs', 'launch', '--job-template=5', '--extra-vars', '{"key": "value"}', 'extra_arg']
+
+        result = cli._get_non_option_args()
+        assert result == ['jobs', 'launch', 'extra_arg']
+
+    def test_get_non_option_args_short_options(self):
+        """Test _get_non_option_args handles short options correctly"""
+        cli = CLI()
+        cli.argv = ['awx', '-v', '-f', 'json', 'projects', 'list']
+
+        result = cli._get_non_option_args()
+        assert result == ['projects', 'list']
+
+    def test_get_non_option_args_consecutive_options(self):
+        """Test _get_non_option_args with consecutive options"""
+        cli = CLI()
+        cli.argv = ['awx', '--conf.host', 'example.com', '--conf.username', 'admin', 'teams', 'create']
+
+        result = cli._get_non_option_args()
+        assert result == ['teams', 'create']
+
+    def test_get_non_option_args_option_at_end(self):
+        """Test _get_non_option_args with option at the end"""
+        cli = CLI()
+        cli.argv = ['awx', 'users', 'list', '--format', 'table']
+
+        result = cli._get_non_option_args()
+        assert result == ['users', 'list']
+
+    def test_get_non_option_args_flag_only_options(self):
+        """Test _get_non_option_args with flag-only options (no values)"""
+        cli = CLI()
+        # More realistic: flags at the end or grouped together
+        cli.argv = ['awx', 'organizations', 'list', '--verbose', '--insecure', '--monitor']
+
+        result = cli._get_non_option_args()
+        assert result == ['organizations', 'list']
+
+    def test_get_non_option_args_option_value_looks_like_option(self):
+        """Test _get_non_option_args when option value starts with dash"""
+        cli = CLI()
+        cli.argv = ['awx', 'jobs', 'create', '--description', '-some-description-with-dashes', 'template']
+
+        result = cli._get_non_option_args()
+        # Values starting with '-' are treated as options, and 'template' becomes the value for that "option"
+        # Users should use --description="-some-value" format for values starting with dash
+        assert result == ['jobs', 'create']
+
+    def test_get_non_option_args_complex_scenario(self):
+        """Test _get_non_option_args with complex mixed arguments"""
+        cli = CLI()
+        cli.argv = [
+            'awx',
+            '--conf.host=https://example.com',
+            'job_templates',
+            'create',
+            '--name',
+            'my-template',
+            '--job-type=run',
+            '--inventory',
+            '1',
+            '--project=2',
+            '--verbose',
+        ]
+
+        result = cli._get_non_option_args()
+        assert result == ['job_templates', 'create']
+
+    def test_get_non_option_args_before_help_with_options(self):
+        """Test _get_non_option_args before_help=True with options before help"""
+        cli = CLI()
+        cli.argv = ['awx', '--conf.host', 'example.com', 'users', 'create', '--name=test', '--help', 'ignored']
+
+        result = cli._get_non_option_args(before_help=True)
+        assert result == ['users', 'create']
+
+    def test_get_non_option_args_before_help_only_options(self):
+        """Test _get_non_option_args before_help=True with only options before help"""
+        cli = CLI()
+        cli.argv = ['awx', '--verbose', '--conf.host=example.com', '--help', 'users', 'list']
+
+        result = cli._get_non_option_args(before_help=True)
+        assert result == []
+
+    def test_is_main_help_request_with_options_before_help(self):
+        """Test _is_main_help_request with options but no subcommands before help"""
+        cli = CLI()
+        cli.argv = ['awx', '--conf.host=example.com', '--verbose', '--help']
+
+        result = cli._is_main_help_request()
+        assert result is True
+
+    def test_is_main_help_request_false_with_subcommand_and_options(self):
+        """Test _is_main_help_request returns False when subcommand present with options"""
+        cli = CLI()
+        cli.argv = ['awx', '--conf.host', 'example.com', 'users', '--format=json', '--help']
+
+        result = cli._is_main_help_request()
+        assert result is False
+
+    def test_is_main_help_request_false_option_value_looks_like_subcommand(self):
+        """Test _is_main_help_request doesn't mistake option values for subcommands"""
+        cli = CLI()
+        cli.argv = ['awx', '--conf.host', 'users', '--help']  # 'users' is option value, not subcommand
+
+        result = cli._is_main_help_request()
+        assert result is True  # Should be True since 'users' is just an option value
+
+    def test_is_main_help_request_complex_option_scenario(self):
+        """Test _is_main_help_request with complex option scenario"""
+        cli = CLI()
+        cli.argv = ['awx', '--conf.username=admin', '--conf.password', 'secret', 'job_templates', '--help']
+
+        result = cli._is_main_help_request()
+        assert result is False  # 'job_templates' is a real subcommand, not an option value
+
+    def test_empty_args_handling(self):
+        """Test _get_non_option_args handles minimal arguments"""
+        cli = CLI()
+        cli.argv = ['awx']
+
+        result = cli._get_non_option_args()
+        assert result == []
+
+    def test_only_awx_and_options(self):
+        """Test _get_non_option_args with only awx and options"""
+        cli = CLI()
+        cli.argv = ['awx', '--verbose', '--conf.host=example.com']
+
+        result = cli._get_non_option_args()
+        assert result == []
+
+    def test_get_non_option_args_dash_value_with_equals(self):
+        """Test _get_non_option_args handles dash values correctly with equals format"""
+        cli = CLI()
+        cli.argv = ['awx', 'jobs', 'create', '--description=-some-description-with-dashes', 'template']
+
+        result = cli._get_non_option_args()
+        # Using --opt=val format correctly handles values starting with dash
+        assert result == ['jobs', 'create', 'template']

--- a/awxkit/test/cli/test_client.py
+++ b/awxkit/test/cli/test_client.py
@@ -1,5 +1,7 @@
 import pytest
 from requests.exceptions import ConnectionError
+import sys
+from unittest.mock import patch
 
 from awxkit.cli import run, CLI
 
@@ -53,3 +55,136 @@ def test_list_resources(capfd, resource):
     assert "usage:" in out
     for snippet in ('--conf.host https://example.awx.org]', '-v, --verbose'):
         assert snippet in out
+
+
+class TestHelpHandling:
+    """Test suite for improved help handling functionality"""
+
+    def test_get_non_option_args_basic(self):
+        """Test _get_non_option_args extracts non-option arguments correctly"""
+        cli = CLI()
+        cli.argv = ['awx', 'users', 'list', '--verbose']
+
+        result = cli._get_non_option_args()
+        assert result == ['users', 'list']
+
+    def test_get_non_option_args_with_flags(self):
+        """Test _get_non_option_args ignores option flags"""
+        cli = CLI()
+        cli.argv = ['awx', '--conf.host', 'example.com', 'jobs', 'create', '--name', 'test']
+
+        result = cli._get_non_option_args()
+        # Should include all non-option arguments (including flag values) except 'awx'
+        assert result == ['example.com', 'jobs', 'create', 'test']
+
+    def test_get_non_option_args_before_help(self):
+        """Test _get_non_option_args with before_help=True stops at help flag"""
+        cli = CLI()
+        cli.argv = ['awx', 'users', '--help', 'extra', 'args']
+
+        result = cli._get_non_option_args(before_help=True)
+        assert result == ['users']
+
+    def test_get_non_option_args_before_help_short_flag(self):
+        """Test _get_non_option_args with before_help=True stops at -h flag"""
+        cli = CLI()
+        cli.argv = ['awx', 'projects', '-h', 'should', 'not', 'appear']
+
+        result = cli._get_non_option_args(before_help=True)
+        assert result == ['projects']
+
+    def test_get_non_option_args_no_help_flag(self):
+        """Test _get_non_option_args when help flag not present"""
+        cli = CLI()
+        cli.argv = ['awx', 'organizations', 'list']
+
+        result = cli._get_non_option_args(before_help=True)
+        assert result == ['organizations', 'list']
+
+    def test_is_main_help_request_true(self):
+        """Test _is_main_help_request returns True for main CLI help"""
+        cli = CLI()
+        cli.argv = ['awx', '--help']
+
+        result = cli._is_main_help_request()
+        assert result is True
+
+    def test_is_main_help_request_short_flag(self):
+        """Test _is_main_help_request returns True for main CLI help with -h"""
+        cli = CLI()
+        cli.argv = ['awx', '-h']
+
+        result = cli._is_main_help_request()
+        assert result is True
+
+    def test_is_main_help_request_false_subcommand(self):
+        """Test _is_main_help_request returns False for subcommand help"""
+        cli = CLI()
+        cli.argv = ['awx', 'users', '--help']
+
+        result = cli._is_main_help_request()
+        assert result is False
+
+    def test_is_main_help_request_false_action(self):
+        """Test _is_main_help_request returns False for action help"""
+        cli = CLI()
+        cli.argv = ['awx', 'jobs', 'create', '--help']
+
+        result = cli._is_main_help_request()
+        assert result is False
+
+    def test_is_main_help_request_false_no_help(self):
+        """Test _is_main_help_request returns False when no help flag"""
+        cli = CLI()
+        cli.argv = ['awx', 'users', 'list']
+
+        result = cli._is_main_help_request()
+        assert result is False
+
+    def test_early_help_return_main_cli(self):
+        """Test that main CLI help exits early without server connection"""
+        cli = CLI()
+        # Verify that _is_main_help_request works correctly
+        cli.argv = ['awx', '--help']
+        assert cli._is_main_help_request() is True
+
+        # Test that parse_args with main help flag should exit
+        with patch.object(sys, 'exit') as mock_exit:
+            cli.parse_args(['awx', '--help'])
+            mock_exit.assert_called_once_with(0)
+
+    def test_no_early_exit_for_subcommand_help(self):
+        """Test that subcommand help does not exit early"""
+        with patch.object(sys, 'exit') as mock_exit:
+            cli = CLI()
+            # This should not exit early since it's subcommand help
+            cli.parse_args(['awx', 'users', '--help'])
+
+            mock_exit.assert_not_called()
+
+    def test_help_property_detection(self):
+        """Test that help property correctly detects help flags"""
+        cli = CLI()
+
+        cli.argv = ['awx', '--help']
+        assert cli.help is True
+
+        cli.argv = ['awx', '-h']
+        assert cli.help is True
+
+        cli.argv = ['awx', 'users', '--help']
+        assert cli.help is True
+
+        cli.argv = ['awx', 'users', 'list']
+        assert cli.help is False
+
+    def test_short_help_flag_added(self):
+        """Test that -h flag is properly added to argument parser"""
+        cli = CLI()
+        cli.parse_args(['awx'])
+
+        # Verify that both -h and --help are recognized
+        help_actions = [action for action in cli.parser._actions if '--help' in action.option_strings]
+        assert len(help_actions) == 1
+        assert '-h' in help_actions[0].option_strings
+        assert '--help' in help_actions[0].option_strings

--- a/awxkit/test/cli/test_options.py
+++ b/awxkit/test/cli/test_options.py
@@ -251,3 +251,24 @@ class TestSettingsOptions(unittest.TestCase):
         out = StringIO()
         self.parser.choices['modify'].print_help(out)
         assert 'modify [-h] key value' in out.getvalue()
+
+
+class TestHelpParameterChanges(unittest.TestCase):
+    """Test that add_help parameter changes work correctly"""
+
+    def test_add_help_parameter_handling(self):
+        """Test that add_help=True and add_help=False work as expected"""
+        # Test add_help=True (for action parsers like list, create)
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest='action')
+
+        list_parser = subparsers.add_parser('list', help='', add_help=True)
+        out = StringIO()
+        list_parser.print_help(out)
+        help_text = out.getvalue()
+        assert 'show this help message and exit' in help_text
+
+        # Test add_help=False (for resource parsers like users, jobs)
+        resource_parser = subparsers.add_parser('users', help='', add_help=False)
+        help_actions = [action for action in resource_parser._actions if '--help' in action.option_strings]
+        assert len(help_actions) == 0  # Should be 0 because add_help=False

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,7 +21,7 @@ sonar.projectName=awx
 
 # Source directories to analyze
 sonar.sources=.
-sonar.inclusions=awx/**
+sonar.inclusions=awx/**,awxkit/**
 
 # Test directories
 sonar.tests=awx/main/tests
@@ -54,7 +54,7 @@ sonar.sourceEncoding=UTF-8
 # =============================================================================
 
 # Test and coverage reports (paths relative to project root)
-sonar.python.coverage.reportPaths=reports/coverage.xml
+sonar.python.coverage.reportPaths=reports/coverage.xml,awxkit/coverage.xml
 sonar.python.xunit.reportPath=/reports/junit.xml
 
 # External tool reports (add these paths when tools are configured)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR resolves an issue where awx <resource> <action> -h/--help would show brief, unhelpful help messages instead of the detailed help that appears when required arguments are missing.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  
- awx users create -h showed only basic resource-level help instead of detailed action help
- Inconsistent user experience between help flag usage and missing argument scenarios

Solution
- Refactored help handling logic: Added helper methods to cleanly parse command-line arguments and determine help context
- Fixed parser configuration: Disabled automatic help for resource subparsers and enabled it for action subparsers
- Optimized code structure: Consolidated parser creation logic to reduce duplication and improve maintainability
- Preserved all functionality: Main CLI help and resource-level help continue to work as expected

Key Changes
- client.py: Added _get_non_option_args() and optimized _is_main_help_request() helper methods
- resource.py: Disabled add_help=False for resource subparsers to prevent premature help display
- options.py: Added _create_action_parser() method and ensured add_help=True for action subparsers
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI argument parsing and help/exit flow, which can affect many commands and edge-case argv shapes; changes are well-covered by new tests but could still regress uncommon flag/value patterns.
> 
> **Overview**
> Improves `awxkit` CLI help handling so `awx --help` exits early without attempting server connectivity, while `awx <resource> --help` and `awx <resource> <action> --help` show the intended resource/action-specific help output.
> 
> This reconfigures argparse subparsers (**resource parsers `add_help=False`, action parsers `add_help=True`**), adds argv inspection helpers in `cli/client.py`, and adjusts action parsing order to ensure action arguments exist before parsing.
> 
> CI/quality tooling now also injects and uploads `awxkit/coverage.xml`, and Sonar is configured to analyze `awxkit/**` and read coverage from both `reports/coverage.xml` and `awxkit/coverage.xml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa3bbda18c378add62c2e7bbfb08237eea42c2fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CLI help: explicit -h/--help support, global help prints without connecting to server, and clearer resource-level vs subcommand help behavior with controlled subparser help defaults.

* **Tests**
  * Added extensive tests covering non-option argument parsing, main vs subcommand help detection, early global-help exit, and help-flag behavior.

* **Chores**
  * CI updated to record and upload an additional coverage artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->