### PR TITLE
[2.7] Forward-ported AAP-58441 ext query files

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -370,6 +370,19 @@ class BaseTask(object):
                     private_data_files['credentials'][credential] = self.write_private_data_file(private_data_dir, None, data, sub_dir='env')
             for credential, data in private_data.get('certificates', {}).items():
                 self.write_private_data_file(private_data_dir, 'ssh_key_data-cert.pub', data, sub_dir=os.path.join('artifacts', str(self.instance.id)))
+
+        # Copy vendor collections to private_data_dir for indirect node counting
+        # This makes external query files available to the callback plugin in EEs
+        if flag_enabled("FEATURE_INDIRECT_NODE_COUNTING_ENABLED"):
+            vendor_src = '/var/lib/awx/vendor_collections'
+            vendor_dest = os.path.join(private_data_dir, 'vendor_collections')
+            if os.path.exists(vendor_src):
+                try:
+                    shutil.copytree(vendor_src, vendor_dest)
+                    logger.debug(f"Copied vendor collections from {vendor_src} to {vendor_dest}")
+                except Exception as e:
+                    logger.warning(f"Failed to copy vendor collections: {e}")
+
         return private_data_files, ssh_key_data
 
     def build_passwords(self, instance, runtime_passwords):
@@ -1064,6 +1077,11 @@ class RunJob(SourceControlMixin, BaseTask):
             env['ANSIBLE_CALLBACKS_ENABLED'] = 'indirect_instance_count'
             if 'callbacks_enabled' in config_values:
                 env['ANSIBLE_CALLBACKS_ENABLED'] += ':' + config_values['callbacks_enabled']
+                
+            # Add vendor collections path for external query file discovery
+            vendor_collections_path = os.path.join(CONTAINER_ROOT, 'vendor_collections')
+            env['ANSIBLE_COLLECTIONS_PATH'] = f"{vendor_collections_path}:{env['ANSIBLE_COLLECTIONS_PATH']}"
+            logger.debug(f"ANSIBLE_COLLECTIONS_PATH updated for vendor collections: {env['ANSIBLE_COLLECTIONS_PATH']}")
 
         return env
 

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1077,7 +1077,7 @@ class RunJob(SourceControlMixin, BaseTask):
             env['ANSIBLE_CALLBACKS_ENABLED'] = 'indirect_instance_count'
             if 'callbacks_enabled' in config_values:
                 env['ANSIBLE_CALLBACKS_ENABLED'] += ':' + config_values['callbacks_enabled']
-                
+
             # Add vendor collections path for external query file discovery
             vendor_collections_path = os.path.join(CONTAINER_ROOT, 'vendor_collections')
             env['ANSIBLE_COLLECTIONS_PATH'] = f"{vendor_collections_path}:{env['ANSIBLE_COLLECTIONS_PATH']}"


### PR DESCRIPTION
##### SUMMARY
Addressed [AAP-62881](https://issues.redhat.com/browse/AAP-62881) - Forward-ported https://github.com/ansible/tower/pull/7208/changes from stable-2.6

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API


##### STEPS TO REPRODUCE AND EXTRA INFO
See additional detail in https://github.com/ansible/tower/pull/7208


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feature-flagged changes to job preparation and `ANSIBLE_COLLECTIONS_PATH` can affect how collections are discovered when indirect node counting is enabled, and the new copy step may impact disk usage/performance or fail on permission/path issues.
> 
> **Overview**
> When `FEATURE_INDIRECT_NODE_COUNTING_ENABLED` is enabled, job setup now copies `/var/lib/awx/vendor_collections` into the job `private_data_dir` so execution environments have access to external query files needed by the *indirect node counting* callback.
> 
> For the same feature flag, `RunJob.build_env()` now prepends `/runner/vendor_collections` to `ANSIBLE_COLLECTIONS_PATH` (and logs the updated path), ensuring those vendor collections are discoverable during playbook execution.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bdaa55022c532a81677d925a401fce92941c686f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced vendor collections management in job execution environments when indirect node counting is enabled. Vendor collections are now properly configured with improved path handling for better discovery capabilities in jobs. The implementation includes error handling and logging for reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->