### PR TITLE
[AAP-62693] Obtain workload identity tokens when feature is enabled

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -107,11 +107,6 @@ def populate_claims_for_workload(unified_job) -> dict:
     Extract JWT claims from a Controller workload for the aap_controller_automation_job scope.
     """
 
-    # Related objects in the UnifiedJob model, applies to all job types
-    organization = getattr_dne(unified_job, 'organization')
-    ujt = getattr_dne(unified_job, 'unified_job_template')
-    instance_group = getattr_dne(unified_job, 'instance_group')
-
     claims = {
         AutomationControllerJobScope.CLAIM_JOB_ID: unified_job.id,
         AutomationControllerJobScope.CLAIM_JOB_NAME: unified_job.name,

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -632,7 +632,7 @@ class BaseTask(object):
 
             self.runner_callback.job_created = str(self.instance.created)
 
-            ### BEGIN Workload Identity Token integration
+            # BEGIN Workload Identity Token integration
             # This code obtains a workload identity token for the current job from the token issuer.
             #
             # The implementation will be extended once the credential interface is finalized. In its current
@@ -645,7 +645,7 @@ class BaseTask(object):
                 except Exception as exc:
                     logger.error(f'Failed to retrieve workload identity token for task id {self.instance.id}: {str(exc)}')
                     raise RuntimeError(f'Unable to retrieve workload identity token for task id {self.instance.id}')
-            #### END Workload Identity Token integration
+            # END Workload Identity Token integration
 
             credentials = self.build_credentials_list(self.instance)
 

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -643,7 +643,7 @@ class BaseTask(object):
                     _ = retrieve_workload_identity_jwt(self.instance, 'test-audience', AutomationControllerJobScope.name)  # type: ignore
                     logger.info(f'Retrieved workload identity token for task id {self.instance.id}')
                 except Exception as exc:
-                    logger.error(f'Failed to retrieve workload identity token for task id {self.instance.id}: {exc.strerror}')
+                    logger.error(f'Failed to retrieve workload identity token for task id {self.instance.id}: {exc}')
                     raise RuntimeError(f'Unable to retrieve workload identity token for task id {self.instance.id}')
             #### END Workload Identity Token integration
 

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -643,7 +643,7 @@ class BaseTask(object):
                     _ = retrieve_workload_identity_jwt(self.instance, 'test-audience', AutomationControllerJobScope.name)  # type: ignore
                     logger.info(f'Retrieved workload identity token for task id {self.instance.id}')
                 except Exception as exc:
-                    logger.error(f'Failed to retrieve workload identity token for task id {self.instance.id}: {exc}')
+                    logger.error(f'Failed to retrieve workload identity token for task id {self.instance.id}: {str(exc)}')
                     raise RuntimeError(f'Unable to retrieve workload identity token for task id {self.instance.id}')
             #### END Workload Identity Token integration
 

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -632,6 +632,12 @@ class BaseTask(object):
 
             self.runner_callback.job_created = str(self.instance.created)
 
+            if flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
+                workload_identity_token = retrieve_workload_identity_jwt(self.instance, # type: ignore
+                                                                         'test-audience',
+                                                                         AutomationControllerJobScope.name)
+                logger.info(f'Retrieved token {workload_identity_token}')
+
             credentials = self.build_credentials_list(self.instance)
 
             container_root = None

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -632,11 +632,20 @@ class BaseTask(object):
 
             self.runner_callback.job_created = str(self.instance.created)
 
+            ### BEGIN Workload Identity Token integration
+            # This code obtains a workload identity token for the current job from the token issuer.
+            #
+            # The implementation will be extended once the credential interface is finalized. In its current
+            # state the goal is to make sure the integration with the token issuer is working as expected
+            # when FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED is True
             if flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
-                workload_identity_token = retrieve_workload_identity_jwt(self.instance, # type: ignore
-                                                                         'test-audience',
-                                                                         AutomationControllerJobScope.name)
-                logger.info(f'Retrieved token {workload_identity_token}')
+                try:
+                    _ = retrieve_workload_identity_jwt(self.instance, 'test-audience', AutomationControllerJobScope.name)  # type: ignore
+                    logger.info(f'Retrieved workload identity token for task id {self.instance.id}')
+                except Exception as exc:
+                    logger.error(f'Failed to retrieve workload identity token for task id {self.instance.id}: {exc.strerror}')
+                    raise RuntimeError(f'Unable to retrieve workload identity token for task id {self.instance.id}')
+            #### END Workload Identity Token integration
 
             credentials = self.build_credentials_list(self.instance)
 

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -28,6 +28,7 @@ from awx.main.models import (
     AdHocCommand,
 )
 from awx.main.tasks import jobs
+from ansible_base.lib.testing.util import feature_flag_enabled, feature_flag_disabled
 from ansible_base.lib.workload_identity.controller import AutomationControllerJobScope
 
 
@@ -488,7 +489,7 @@ def test_retrieve_workload_identity_jwt_raises_when_client_not_configured(mock_g
 # Tests for workload identity token integration in BaseTask.run()
 
 
-@mock.patch('awx.main.tasks.jobs.flag_enabled', return_value=True)
+@pytest.mark.django_db
 @mock.patch('awx.main.tasks.jobs.retrieve_workload_identity_jwt')
 @mock.patch('awx.main.tasks.jobs.build_safe_env')
 @mock.patch('awx.main.tasks.jobs.BaseTask.build_project_dir')
@@ -518,7 +519,6 @@ def test_run_retrieves_workload_identity_token_when_flag_enabled(
     mock_build_project_dir,
     mock_build_safe_env,
     mock_retrieve_jwt,
-    mock_flag_enabled,
 ):
     """When FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED is True, run() retrieves workload identity token."""
     # Setup: create a mock job
@@ -548,11 +548,12 @@ def test_run_retrieves_workload_identity_token_when_flag_enabled(
     task.runner_callback = mock.MagicMock()
 
     # Execute with feature flag enabled - expect it to fail at some point but after token retrieval
-    try:
-        task.run(mock_job.id)
-    except Exception:
-        # We expect this to fail at some point, we just care about the token retrieval
-        pass
+    with feature_flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
+        try:
+            task.run(mock_job.id)
+        except Exception:
+            # We expect this to fail at some point, we just care about the token retrieval
+            pass
 
     # Assert: retrieve_workload_identity_jwt was called with correct parameters
     mock_retrieve_jwt.assert_called_once()
@@ -562,7 +563,7 @@ def test_run_retrieves_workload_identity_token_when_flag_enabled(
     assert call_args[0][2] == AutomationControllerJobScope.name
 
 
-@mock.patch('awx.main.tasks.jobs.flag_enabled', return_value=False)
+@pytest.mark.django_db
 @mock.patch('awx.main.tasks.jobs.retrieve_workload_identity_jwt')
 @mock.patch('awx.main.tasks.jobs.build_safe_env')
 @mock.patch('awx.main.tasks.jobs.BaseTask.build_project_dir')
@@ -592,7 +593,6 @@ def test_run_skips_token_retrieval_when_flag_disabled(
     mock_build_project_dir,
     mock_build_safe_env,
     mock_retrieve_jwt,
-    mock_flag_enabled,
 ):
     """When FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED is False, run() does not retrieve workload identity token."""
     # Setup: create a mock job
@@ -621,11 +621,12 @@ def test_run_skips_token_retrieval_when_flag_disabled(
     task.runner_callback = mock.MagicMock()
 
     # Execute with feature flag disabled
-    try:
-        task.run(mock_job.id)
-    except Exception:
-        # We expect this to fail at some point, we just care that token retrieval was skipped
-        pass
+    with feature_flag_disabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
+        try:
+            task.run(mock_job.id)
+        except Exception:
+            # We expect this to fail at some point, we just care that token retrieval was skipped
+            pass
 
     # Assert: retrieve_workload_identity_jwt was never called
     mock_retrieve_jwt.assert_not_called()

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -483,3 +483,149 @@ def test_retrieve_workload_identity_jwt_raises_when_client_not_configured(mock_g
 
     with pytest.raises(RuntimeError, match="Workload identity client is not configured"):
         jobs.retrieve_workload_identity_jwt(unified_job, audience='test_audience', scope='test_scope')
+
+
+# Tests for workload identity token integration in BaseTask.run()
+
+
+@mock.patch('awx.main.tasks.jobs.flag_enabled', return_value=True)
+@mock.patch('awx.main.tasks.jobs.retrieve_workload_identity_jwt')
+@mock.patch('awx.main.tasks.jobs.build_safe_env')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_project_dir')
+@mock.patch('awx.main.tasks.jobs.evaluate_policy')
+@mock.patch('awx.main.tasks.jobs.BaseTask.pre_run_hook')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data_dir')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data_files')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_passwords')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_extra_vars_file')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_args')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_env')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_credentials_list')
+@mock.patch('awx.main.tasks.jobs.os.path.exists', return_value=True)
+def test_run_retrieves_workload_identity_token_when_flag_enabled(
+    mock_path_exists,
+    mock_build_creds,
+    mock_build_env,
+    mock_build_args,
+    mock_build_extra_vars,
+    mock_build_passwords,
+    mock_build_private_data,
+    mock_build_private_data_files,
+    mock_build_private_data_dir,
+    mock_pre_run_hook,
+    mock_evaluate_policy,
+    mock_build_project_dir,
+    mock_build_safe_env,
+    mock_retrieve_jwt,
+    mock_flag_enabled,
+):
+    """When FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED is True, run() retrieves workload identity token."""
+    # Setup: create a mock job
+    mock_job = mock.MagicMock(spec=Job)
+    mock_job.id = 123
+    mock_job.status = 'running'
+    mock_job.cancel_flag = False
+    mock_job.is_container_group_task = False
+    mock_job.created = mock.MagicMock()
+    mock_job.spawned_by_workflow = False
+
+    # Setup mock return values
+    mock_retrieve_jwt.return_value = 'eyJ.test.jwt'
+    mock_build_private_data.return_value = ('/tmp/private_data', {})
+    mock_build_private_data_dir.return_value = '/tmp/private_data'
+    mock_build_private_data_files.return_value = ({}, None)
+    mock_build_passwords.return_value = {}
+    mock_build_args.return_value = []
+    mock_build_env.return_value = {}
+    mock_build_safe_env.return_value = {}
+    mock_build_creds.return_value = []
+
+    # Create a minimal task that will fail early (before actual runner execution)
+    task = jobs.BaseTask()
+    task.instance = mock_job
+    task.update_model = mock.Mock(return_value=mock_job)
+    task.runner_callback = mock.MagicMock()
+
+    # Execute with feature flag enabled - expect it to fail at some point but after token retrieval
+    try:
+        task.run(mock_job.id)
+    except Exception:
+        # We expect this to fail at some point, we just care about the token retrieval
+        pass
+
+    # Assert: retrieve_workload_identity_jwt was called with correct parameters
+    mock_retrieve_jwt.assert_called_once()
+    call_args = mock_retrieve_jwt.call_args
+    assert call_args[0][0] == mock_job
+    assert call_args[0][1] == 'test-audience'
+    assert call_args[0][2] == AutomationControllerJobScope.name
+
+
+@mock.patch('awx.main.tasks.jobs.flag_enabled', return_value=False)
+@mock.patch('awx.main.tasks.jobs.retrieve_workload_identity_jwt')
+@mock.patch('awx.main.tasks.jobs.build_safe_env')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_project_dir')
+@mock.patch('awx.main.tasks.jobs.evaluate_policy')
+@mock.patch('awx.main.tasks.jobs.BaseTask.pre_run_hook')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data_dir')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data_files')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_passwords')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_extra_vars_file')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_args')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_env')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_credentials_list')
+@mock.patch('awx.main.tasks.jobs.os.path.exists', return_value=True)
+def test_run_skips_token_retrieval_when_flag_disabled(
+    mock_path_exists,
+    mock_build_creds,
+    mock_build_env,
+    mock_build_args,
+    mock_build_extra_vars,
+    mock_build_passwords,
+    mock_build_private_data,
+    mock_build_private_data_files,
+    mock_build_private_data_dir,
+    mock_pre_run_hook,
+    mock_evaluate_policy,
+    mock_build_project_dir,
+    mock_build_safe_env,
+    mock_retrieve_jwt,
+    mock_flag_enabled,
+):
+    """When FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED is False, run() does not retrieve workload identity token."""
+    # Setup: create a mock job
+    mock_job = mock.MagicMock(spec=Job)
+    mock_job.id = 789
+    mock_job.status = 'running'
+    mock_job.cancel_flag = False
+    mock_job.is_container_group_task = False
+    mock_job.created = mock.MagicMock()
+    mock_job.spawned_by_workflow = False
+
+    # Setup mock return values
+    mock_build_private_data.return_value = ('/tmp/private_data', {})
+    mock_build_private_data_dir.return_value = '/tmp/private_data'
+    mock_build_private_data_files.return_value = ({}, None)
+    mock_build_passwords.return_value = {}
+    mock_build_args.return_value = []
+    mock_build_env.return_value = {}
+    mock_build_safe_env.return_value = {}
+    mock_build_creds.return_value = []
+
+    # Create task
+    task = jobs.BaseTask()
+    task.instance = mock_job
+    task.update_model = mock.Mock(return_value=mock_job)
+    task.runner_callback = mock.MagicMock()
+
+    # Execute with feature flag disabled
+    try:
+        task.run(mock_job.id)
+    except Exception:
+        # We expect this to fail at some point, we just care that token retrieval was skipped
+        pass
+
+    # Assert: retrieve_workload_identity_jwt was never called
+    mock_retrieve_jwt.assert_not_called()

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -30,6 +30,7 @@ from awx.main.models import (
 from awx.main.tasks import jobs
 from ansible_base.lib.testing.util import feature_flag_enabled, feature_flag_disabled
 from ansible_base.lib.workload_identity.controller import AutomationControllerJobScope
+from ansible_base.resource_registry.workload_identity_client import TokenRequestError
 
 
 @pytest.fixture
@@ -630,3 +631,76 @@ def test_run_skips_token_retrieval_when_flag_disabled(
 
     # Assert: retrieve_workload_identity_jwt was never called
     mock_retrieve_jwt.assert_not_called()
+
+
+@pytest.mark.django_db
+@mock.patch('awx.main.tasks.jobs.retrieve_workload_identity_jwt')
+@mock.patch('awx.main.tasks.jobs.build_safe_env')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_project_dir')
+@mock.patch('awx.main.tasks.jobs.evaluate_policy')
+@mock.patch('awx.main.tasks.jobs.BaseTask.pre_run_hook')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data_dir')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data_files')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_private_data')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_passwords')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_extra_vars_file')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_args')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_env')
+@mock.patch('awx.main.tasks.jobs.BaseTask.build_credentials_list')
+@mock.patch('awx.main.tasks.jobs.os.path.exists', return_value=True)
+def test_run_raises_exception_when_token_request_fails(
+    mock_path_exists,
+    mock_build_creds,
+    mock_build_env,
+    mock_build_args,
+    mock_build_extra_vars,
+    mock_build_passwords,
+    mock_build_private_data,
+    mock_build_private_data_files,
+    mock_build_private_data_dir,
+    mock_pre_run_hook,
+    mock_evaluate_policy,
+    mock_build_project_dir,
+    mock_build_safe_env,
+    mock_retrieve_jwt,
+):
+    """When retrieve_workload_identity_jwt raises TokenRequestError, the exception propagates."""
+    # Setup: create a mock job
+    mock_job = mock.MagicMock(spec=Job)
+    mock_job.id = 456
+    mock_job.status = 'running'
+    mock_job.cancel_flag = False
+    mock_job.is_container_group_task = False
+    mock_job.created = mock.MagicMock()
+    mock_job.spawned_by_workflow = False
+
+    # Setup mock return values
+    mock_retrieve_jwt.side_effect = TokenRequestError("Failed to obtain token")
+    mock_build_private_data.return_value = ('/tmp/private_data', {})
+    mock_build_private_data_dir.return_value = '/tmp/private_data'
+    mock_build_private_data_files.return_value = ({}, None)
+    mock_build_passwords.return_value = {}
+    mock_build_args.return_value = []
+    mock_build_env.return_value = {}
+    mock_build_safe_env.return_value = {}
+    mock_build_creds.return_value = []
+
+    # Create task
+    task = jobs.BaseTask()
+    task.instance = mock_job
+    task.update_model = mock.Mock(return_value=mock_job)
+    task.runner_callback = mock.MagicMock()
+
+    # Execute with feature flag enabled and expect an exception to be raised
+    with feature_flag_enabled('FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED'):
+        exception_raised = False
+        try:
+            task.run(mock_job.id)
+        except Exception:
+            # We expect this to fail due to TokenRequestError
+            exception_raised = True
+
+    # Assert: retrieve_workload_identity_jwt was called
+    mock_retrieve_jwt.assert_called_once()
+    # Assert: an exception was raised
+    assert exception_raised, "Expected an exception to be raised when token request fails"


### PR DESCRIPTION
##### SUMMARY

Updates the Job `run()` method to obtain a workload identity token if `FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED` is True.

The token is not yet used or injected into a credential (See #16286). This patch is small[^1] (integrating a function added in #16296) but connects the critical pieces to show that on job launch, we can obtain a signed token identifying the job.

AAP-62693

##### ISSUE TYPE
- New or Enhanced Feature

##### COMPONENT NAME
- API

[^1]: The code changes are minimal. They are in `BaseTask.run()`, and I didn't find existing unit tests for that. Claude was able to `@mock.patch` 14 things to write a test. I prompted it to look at functional tests instead but that didn't work out either. Certainly open to feedback on the testing approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload Identity Token support for job runs, toggleable via feature flag; jobs attempt token retrieval during execution when enabled.

* **Behavior**
  * Token retrieval occurs before credential handling; failures now raise an error and can abort job execution.

* **Tests**
  * Added tests covering flag-enabled, flag-disabled, and token-request failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->