### PR TITLE
feat: force password reset at first login

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -120,6 +120,9 @@ class LoggedLoginView(auth_views.LoginView):
                 'userLoggedIn', 'true', secure=getattr(settings, 'SESSION_COOKIE_SECURE', False), samesite=getattr(settings, 'USER_COOKIE_SAMESITE', 'Lax')
             )
             ret.setdefault('X-API-Session-Cookie-Name', getattr(settings, 'SESSION_COOKIE_NAME', 'awx_sessionid'))
+            # Signal clients/UI that a forced password change is required (session is established).
+            if getattr(request.user, 'password_reset_required', False):
+                ret['X-API-Password-Reset-Required'] = 'true'
 
             return ret
         else:

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1036,6 +1036,9 @@ class UnifiedJobStdoutSerializer(UnifiedJobSerializer):
 class UserSerializer(BaseSerializer):
     password = serializers.CharField(required=False, default='', allow_blank=True, help_text=_('Field used to change the password.'))
     is_system_auditor = serializers.BooleanField(default=False)
+    password_reset_required = serializers.BooleanField(
+        default=False, help_text=_('Force the user to reset their password at next login.')
+    )
     show_capabilities = ['edit', 'delete']
 
     class Meta:
@@ -1050,6 +1053,7 @@ class UserSerializer(BaseSerializer):
             'email',
             'is_superuser',
             'is_system_auditor',
+            'password_reset_required',
             'password',
             'last_login',
         )
@@ -1135,7 +1139,13 @@ class UserSerializer(BaseSerializer):
     def _update_password(self, obj, new_password):
         if new_password and new_password != '$encrypted$':
             obj.set_password(new_password)
-            obj.save(update_fields=['password'])
+            update_fields = ['password']
+            # Clear force-reset after a successful password change on an existing user.
+            # (On create, admins may set a temp password and password_reset_required together.)
+            if self.instance is not None and getattr(obj, 'password_reset_required', False):
+                obj.password_reset_required = False
+                update_fields.append('password_reset_required')
+            obj.save(update_fields=update_fields)
 
             # Cycle the session key, but if the requesting user is the same
             # as the modified user then inject a session key derived from
@@ -1151,19 +1161,29 @@ class UserSerializer(BaseSerializer):
     def create(self, validated_data):
         new_password = validated_data.pop('password', None)
         is_system_auditor = validated_data.pop('is_system_auditor', None)
+        password_reset_required = validated_data.pop('password_reset_required', None)
         obj = super(UserSerializer, self).create(validated_data)
         self._update_password(obj, new_password)
         if is_system_auditor is not None:
             obj.is_system_auditor = is_system_auditor
+        if password_reset_required is not None:
+            obj.password_reset_required = password_reset_required
+            obj.save(update_fields=['password_reset_required'])
         return obj
 
     def update(self, obj, validated_data):
         new_password = validated_data.pop('password', None)
         is_system_auditor = validated_data.pop('is_system_auditor', None)
+        password_reset_required = validated_data.pop('password_reset_required', None)
         obj = super(UserSerializer, self).update(obj, validated_data)
         self._update_password(obj, new_password)
         if is_system_auditor is not None:
             obj.is_system_auditor = is_system_auditor
+        # Apply after _update_password so an admin can set a new temp password
+        # and re-assert password_reset_required=True in the same request.
+        if password_reset_required is not None:
+            obj.password_reset_required = password_reset_required
+            obj.save(update_fields=['password_reset_required'])
         return obj
 
     def get_related(self, obj):

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1350,7 +1350,7 @@ class UserDetail(RetrieveUpdateDestroyAPIView):
         can_admin = request.user.can_access(models.User, 'admin', obj, request.data)
 
         su_only_edit_fields = ('is_superuser', 'is_system_auditor')
-        admin_only_edit_fields = ('username', 'is_active')
+        admin_only_edit_fields = ('username', 'is_active', 'password_reset_required')
 
         fields_to_check = ()
         if not request.user.is_superuser:

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -97,6 +97,60 @@ class DisableLocalAuthMiddleware(MiddlewareMixin):
             logout(request)
 
 
+class ForcePasswordChangeMiddleware(MiddlewareMixin):
+    """
+    When a user has password_reset_required, block API access until they change
+    their password. Session login is still allowed so they can reach the change
+    flow; only their own user record (and me/logout) remain reachable.
+    """
+
+    def process_request(self, request):
+        from django.http import JsonResponse
+
+        user = getattr(request, 'user', None)
+        if user is None or not getattr(user, 'is_authenticated', False) or not user.pk:
+            return None
+        if not getattr(user, 'password_reset_required', False):
+            return None
+
+        path = request.path
+        # Non-API routes (UI static assets, SPA) stay reachable.
+        if not path.startswith('/api/'):
+            return None
+
+        method = request.method.upper()
+        if method == 'OPTIONS':
+            return None
+
+        allowed_prefixes = (
+            '/api/login',
+            '/api/logout',
+            '/api/v2/me',
+            f'/api/v2/users/{user.pk}',
+        )
+        optional_prefix = getattr(settings, 'OPTIONAL_API_URLPATTERN_PREFIX', '') or ''
+        if optional_prefix:
+            allowed_prefixes = allowed_prefixes + (
+                f'/api/{optional_prefix}/v2/me',
+                f'/api/{optional_prefix}/v2/users/{user.pk}',
+            )
+
+        for prefix in allowed_prefixes:
+            if path == prefix or path.startswith(prefix + '/') or path.startswith(prefix + '?'):
+                # Own user detail: only read + password update, not delete.
+                if f'/users/{user.pk}' in path and method == 'DELETE':
+                    break
+                return None
+
+        return JsonResponse(
+            {
+                'detail': 'Password reset is required before you can continue.',
+                'password_reset_required': True,
+            },
+            status=403,
+        )
+
+
 class URLModificationMiddleware(MiddlewareMixin):
     @staticmethod
     def _hijack_for_old_jt_name(node, kwargs, named_url):

--- a/awx/main/migrations/0209_user_password_reset_required.py
+++ b/awx/main/migrations/0209_user_password_reset_required.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+
+def _column_names(schema_editor, table):
+    connection = schema_editor.connection
+    with connection.cursor() as cursor:
+        if table not in connection.introspection.table_names(cursor):
+            return None
+        return {col.name for col in connection.introspection.get_table_description(cursor, table)}
+
+
+def add_password_reset_required(apps, schema_editor):
+    """Add password_reset_required column on Django's auth_user table."""
+    columns = _column_names(schema_editor, 'auth_user')
+    if columns is None or 'password_reset_required' in columns:
+        return
+
+    vendor = schema_editor.connection.vendor
+    if vendor == 'postgresql':
+        schema_editor.execute(
+            'ALTER TABLE auth_user ADD COLUMN password_reset_required boolean DEFAULT false NOT NULL;'
+        )
+    elif vendor == 'sqlite':
+        schema_editor.execute(
+            'ALTER TABLE auth_user ADD COLUMN password_reset_required bool NOT NULL DEFAULT 0;'
+        )
+    else:
+        schema_editor.execute(
+            'ALTER TABLE auth_user ADD COLUMN password_reset_required bool NOT NULL DEFAULT 0;'
+        )
+
+
+def remove_password_reset_required(apps, schema_editor):
+    columns = _column_names(schema_editor, 'auth_user')
+    if columns is None or 'password_reset_required' not in columns:
+        return
+    schema_editor.execute('ALTER TABLE auth_user DROP COLUMN password_reset_required;')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('auth', '0012_alter_user_first_name_max_length'),
+        ('main', '0208_fix_system_auditor_migration'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_password_reset_required, remove_password_reset_required),
+    ]

--- a/awx/main/models/__init__.py
+++ b/awx/main/models/__init__.py
@@ -97,6 +97,7 @@ from awx.main.models.workflow import (  # noqa
 
 # Add custom methods to User model for permissions checks.
 from django.contrib.auth.models import User  # noqa
+from django.db import models as django_models  # noqa
 from awx.main.access import get_user_queryset, check_user_access, check_user_access_with_errors  # noqa
 
 User.add_to_class('get_queryset', get_user_queryset)
@@ -104,6 +105,15 @@ User.add_to_class('can_access', check_user_access)
 User.add_to_class('can_access_with_errors', check_user_access_with_errors)
 User.add_to_class('resource', AnsibleResourceField(primary_key_field="id"))
 User.add_to_class('summary_fields', user_summary_fields)
+# Persisted on auth_user via migration 0209; not part of Django's stock User.
+if not hasattr(User, 'password_reset_required'):
+    User.add_to_class(
+        'password_reset_required',
+        django_models.BooleanField(
+            default=False,
+            help_text='Force the user to reset their password at next login.',
+        ),
+    )
 
 
 def convert_jsonfields():

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -1,11 +1,14 @@
 from unittest import mock
+import json
 
 import pytest
 
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
 from django.test.utils import override_settings
 
 from awx.main.models import User
+from awx.main.middleware import ForcePasswordChangeMiddleware
 from awx.api.versioning import reverse
 
 #
@@ -272,3 +275,114 @@ def test_admin_user_not_shown_in_org_users(admin_user, get, organization):
         url = reverse(f'api:{view_name}', kwargs={'pk': organization.pk})
         r = get(url, user=admin_user, expect=200)
         assert admin_user.pk not in [u['id'] for u in r.data['results']]
+
+
+@pytest.mark.django_db
+def test_create_user_with_password_reset_required(post, get, admin):
+    """Admins can create users that must reset password on next login."""
+    data = dict(EXAMPLE_USER_DATA, password_reset_required=True)
+    response = post(reverse('api:user_list'), data, admin, middleware=SessionMiddleware(mock.Mock()))
+    assert response.status_code == 201
+    assert response.data['password_reset_required'] is True
+    user = User.objects.get(pk=response.data['id'])
+    assert user.password_reset_required is True
+
+    # Flag is persisted and visible on detail/me-style reads.
+    detail = get(reverse('api:user_detail', kwargs={'pk': user.pk}), admin)
+    assert detail.status_code == 200
+    assert detail.data['password_reset_required'] is True
+
+
+@pytest.mark.django_db
+def test_update_password_reset_required_flag(post, patch, admin):
+    response = post(reverse('api:user_list'), EXAMPLE_USER_DATA, admin, middleware=SessionMiddleware(mock.Mock()))
+    assert response.status_code == 201
+    user_id = response.data['id']
+    assert response.data['password_reset_required'] is False
+
+    response = patch(
+        reverse('api:user_detail', kwargs={'pk': user_id}),
+        {'password_reset_required': True},
+        admin,
+        middleware=SessionMiddleware(mock.Mock()),
+    )
+    assert response.status_code == 200
+    assert response.data['password_reset_required'] is True
+    assert User.objects.get(pk=user_id).password_reset_required is True
+
+
+@pytest.mark.django_db
+def test_password_change_clears_password_reset_required(post, patch, admin):
+    """Changing password on an existing user clears the force-reset flag."""
+    data = dict(EXAMPLE_USER_DATA, password_reset_required=True)
+    response = post(reverse('api:user_list'), data, admin, middleware=SessionMiddleware(mock.Mock()))
+    assert response.status_code == 201
+    user_id = response.data['id']
+    assert User.objects.get(pk=user_id).password_reset_required is True
+
+    response = patch(
+        reverse('api:user_detail', kwargs={'pk': user_id}),
+        {'password': 'nEwP@ssw0rd!xyz'},
+        admin,
+        middleware=SessionMiddleware(mock.Mock()),
+    )
+    assert response.status_code == 200
+    user = User.objects.get(pk=user_id)
+    assert user.password_reset_required is False
+    assert user.check_password('nEwP@ssw0rd!xyz')
+
+
+@pytest.mark.django_db
+def test_create_with_temp_password_keeps_reset_flag(post, admin):
+    """Create may set a temporary password and still require reset."""
+    data = dict(EXAMPLE_USER_DATA, password_reset_required=True, password='T3mpP@ssw0rd!')
+    response = post(reverse('api:user_list'), data, admin, middleware=SessionMiddleware(mock.Mock()))
+    assert response.status_code == 201
+    user = User.objects.get(pk=response.data['id'])
+    assert user.password_reset_required is True
+    assert user.check_password('T3mpP@ssw0rd!')
+
+
+@pytest.mark.django_db
+def test_force_password_change_middleware_blocks_other_api(alice):
+    alice.password_reset_required = True
+    alice.save(update_fields=['password_reset_required'])
+
+    request = RequestFactory().get('/api/v2/organizations/')
+    request.user = alice
+    response = ForcePasswordChangeMiddleware(lambda r: None).process_request(request)
+    assert response is not None
+    assert response.status_code == 403
+    body = json.loads(response.content.decode('utf-8'))
+    assert body['password_reset_required'] is True
+
+
+@pytest.mark.django_db
+def test_force_password_change_middleware_allows_own_user_and_me(alice):
+    alice.password_reset_required = True
+    alice.save(update_fields=['password_reset_required'])
+    mw = ForcePasswordChangeMiddleware(lambda r: None)
+
+    for path in (
+        reverse('api:user_me_list'),
+        reverse('api:user_detail', kwargs={'pk': alice.pk}),
+        '/api/login/',
+        '/api/logout/',
+        '/static/foo.js',
+    ):
+        request = RequestFactory().get(path)
+        request.user = alice
+        assert mw.process_request(request) is None, path
+
+    # Password update on own user is allowed.
+    request = RequestFactory().patch(reverse('api:user_detail', kwargs={'pk': alice.pk}))
+    request.user = alice
+    assert mw.process_request(request) is None
+
+
+@pytest.mark.django_db
+def test_force_password_change_middleware_noop_without_flag(alice):
+    assert alice.password_reset_required is False
+    request = RequestFactory().get('/api/v2/organizations/')
+    request.user = alice
+    assert ForcePasswordChangeMiddleware(lambda r: None).process_request(request) is None

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -907,6 +907,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'awx.main.middleware.DisableLocalAuthMiddleware',
+    'awx.main.middleware.ForcePasswordChangeMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'awx.main.middleware.OptionalURLPrefixPath',
     'crum.CurrentRequestUserMiddleware',

--- a/awx_collection/plugins/modules/user.py
+++ b/awx_collection/plugins/modules/user.py
@@ -60,6 +60,11 @@ options:
       description:
         - Write-only field used to change the password.
       type: str
+    password_reset_required:
+      description:
+        - Designates that this user must reset their password on next login.
+        - Useful when provisioning users with a temporary shared password.
+      type: bool
     update_secrets:
       description:
         - C(true) will always change password if user specifies password, even if API gives $encrypted$ for password.
@@ -105,6 +110,14 @@ EXAMPLES = '''
     state: present
     controller_config_file: "~/tower_cli.cfg"
 
+- name: Add user who must reset password at first login
+  user:
+    username: jdoe
+    password: temporary-shared-password
+    email: jdoe@example.org
+    password_reset_required: true
+    state: present
+
 - name: Add user as a member of an organization (permissions on the organization are required)
   user:
     username: jdoe
@@ -135,6 +148,7 @@ def main():
         is_superuser=dict(type='bool', aliases=['superuser']),
         is_system_auditor=dict(type='bool', aliases=['auditor']),
         password=dict(no_log=True),
+        password_reset_required=dict(type='bool'),
         update_secrets=dict(type='bool', default=True, no_log=False),
         organization=dict(),
         state=dict(choices=['present', 'absent', 'exists'], default='present'),
@@ -152,6 +166,7 @@ def main():
     is_superuser = module.params.get('is_superuser')
     is_system_auditor = module.params.get('is_system_auditor')
     password = module.params.get('password')
+    password_reset_required = module.params.get('password_reset_required')
     organization = module.params.get('organization')
     state = module.params.get('state')
 
@@ -180,6 +195,8 @@ def main():
         new_fields['is_system_auditor'] = is_system_auditor
     if password is not None:
         new_fields['password'] = password
+    if password_reset_required is not None:
+        new_fields['password_reset_required'] = password_reset_required
 
     if organization:
         org_id = module.resolve_name_to_id('organizations', organization)


### PR DESCRIPTION
##### SUMMARY

Fixes #15766. End-to-end **force password reset at first/next login** for AWX users.

Previously this PR only exposed a serializer field with no model/DB backing or enforcement. This completes the vertical slice:

1. **Model + migration** — `password_reset_required` BooleanField on Django `auth.User` via `contribute_to_class`, column added on `auth_user` in `0209_user_password_reset_required`
2. **API** — User serializer create/update/read; admins may set the flag; non-admins cannot edit it (`UserDetail.update_filter`)
3. **Enforcement** — `ForcePasswordChangeMiddleware` returns `403` with `password_reset_required: true` for other API routes while the flag is set. Allowed: login/logout, `/api/v2/me/`, own user detail (for password change), non-API UI assets
4. **Clear on change** — successful password change on an existing user clears the flag (create can still set temp password + flag together)
5. **Login signal** — `X-API-Password-Reset-Required: true` response header on session login when flag is set
6. **Collection** — `awx.awx.user` module option + docs/example
7. **Tests** — API persistence, clear-on-password-change, middleware allow/block

##### ISSUE TYPE
- New or Enhanced Feature

##### COMPONENT NAME
- API
- Collection

##### ADDITIONAL INFORMATION
Admins (or automation via `awx.awx.user`) can create users with a temporary password and `password_reset_required: true`. Users can still establish a session, but other API access is blocked until they PATCH their own user with a new password.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark user accounts as requiring a password reset on next login.
  * Affected users are prompted to change their password and have limited access until it is updated.
  * Added support for managing this setting through user automation tools.
  * Added optional filtering of artifacts and extra variables from unified job lists.
  * Improved host job status and summary information to reflect the latest results.
* **Bug Fixes**
  * Improved validation for schedules, host creation, and launch prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->