### PR TITLE
[Devel] Addition of logic to trigger worflow dispatch on release_4.6 and stable-2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ env:
   LC_ALL: "C.UTF-8" # prevent ERROR: Ansible could not initialize the preferred locale: unsupported locale setting
   CI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   DEV_DOCKER_OWNER: ${{ github.repository_owner }}
-  COMPOSE_TAG: ${{ github.base_ref || 'devel' }}
+  COMPOSE_TAG: ${{ github.base_ref || github.ref_name || 'devel' }}
   UPSTREAM_REPOSITORY_ID: 91594105
 on:
   pull_request:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,27 @@ on:
     branches:
       - devel  # needed to publish code coverage post-merge
   schedule:
-    - cron: '0 13,18 * * *'
+    - cron: '0 12,18 * * 1-5'
+  workflow_dispatch: {}
 jobs:
+  trigger-release-branches:
+    name: "Dispatch CI to release branches"
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger CI on release_4.6
+        run: gh workflow run ci.yml --ref release_4.6
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+      - name: Trigger CI on stable-2.6 
+        run: gh workflow run ci.yml --ref stable-2.6
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+
   common-tests:
     name: ${{ matrix.tests.name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,26 @@ jobs:
       actions: write
     steps:
       - name: Trigger CI on release_4.6
+        id: dispatch_release_46
+        continue-on-error: true
         run: gh workflow run ci.yml --ref release_4.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-      - name: Trigger CI on stable-2.6 
+      - name: Trigger CI on stable-2.6
+        id: dispatch_stable_26
+        continue-on-error: true
         run: gh workflow run ci.yml --ref stable-2.6
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+      - name: Check dispatch results
+        if: steps.dispatch_release_46.outcome == 'failure' || steps.dispatch_stable_26.outcome == 'failure'
+        run: |
+          echo "One or more dispatches failed:"
+          echo "  release_4.6: ${{ steps.dispatch_release_46.outcome }}"
+          echo "  stable-2.6: ${{ steps.dispatch_stable_26.outcome }}"
+          exit 1
 
   common-tests:
     name: ${{ matrix.tests.name }}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/AAP-64263

##### SUMMARY
Added logic to activate workflow dispatch on both release_4.6 and stable-2.6 to trigger ci runs in release branches for cron schedule

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions scheduling/dispatch logic and permissions, with no production runtime code impact.
> 
> **Overview**
> Updates the `CI` GitHub Actions workflow to support both scheduled and manual (`workflow_dispatch`) runs, and fixes `COMPOSE_TAG` resolution to fall back to `github.ref_name` when `base_ref` is unavailable.
> 
> Scheduled runs are changed to weekdays and now include a new job that uses `gh workflow run` to **dispatch CI executions** on `release_4.6` and `stable-2.6`, failing the schedule if either dispatch fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 569431b4874281951d38219b74ff94be29f71d7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI schedule adjusted to run on weekdays at two daily times.
  * Added a manual trigger to run the CI workflow on demand.
  * Updated CI tag fallback logic to include branch name and default to 'devel' when unset.
  * Added a scheduled job that dispatches CI runs to specified release branches, continues on individual errors, and fails if any dispatch ultimately fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->