### PR TITLE
update bindep.txt to versionles dependencies

### DIFF
--- a/awx_collection/bindep.txt
+++ b/awx_collection/bindep.txt
@@ -1,8 +1,8 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
-python38-pytz [platform:centos-8 platform:rhel-8]
+python3-pytz [platform:centos-8 platform:rhel-8 platform:centos-9 platform:rhel-9]
 
 # awxkit
-python38-requests [platform:centos-8 platform:rhel-8]
-python38-pyyaml [platform:centos-8 platform:rhel-8]
+python3-requests [platform:centos-8 platform:rhel-8 platform:centos-9 platform:rhel-9]
+python3-pyyaml [platform:centos-8 platform:rhel-8 platform:centos-9 platform:rhel-9]


### PR DESCRIPTION
##### SUMMARY

Update the bindep.txt file for the awx collection to use versionles prefixes for both, RHEL 8 and 9 and the respective CentOS flavoured distribitions.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependencies to support additional platforms (CentOS 9, RHEL 9) alongside existing platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->