### PR TITLE
Fix LoggedLogoutView for Django 5.2 GET removal

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -131,7 +131,13 @@ class LoggedLoginView(auth_views.LoginView):
 
 
 class LoggedLogoutView(auth_views.LogoutView):
+    # Override http_method_names to allow GET requests (Django 5.2+ defaults to POST only)
+    http_method_names = ["get", "post", "options"]
     success_url_allowed_hosts = set(settings.LOGOUT_ALLOWED_HOSTS.split(",")) if settings.LOGOUT_ALLOWED_HOSTS else set()
+
+    def get(self, request, *args, **kwargs):
+        """Handle GET requests for logout (for backward compatibility)."""
+        return self.post(request, *args, **kwargs)
 
     def dispatch(self, request, *args, **kwargs):
         if is_proxied_request():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
  Django 5.2 restricts LogoutView to POST only (deprecated in 4.1,
  removed in 5.0+). Without this fix, GET requests to /api/logout/
  return 405 Method Not Allowed.

  Add http_method_names override and a get() method that delegates
  to post() where auth_logout() actually runs
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 4.6.20
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches logout handling in an authentication-related view and re-enables GET-based logout, which can affect CSRF/logout semantics, though the change is narrowly scoped and delegates to existing POST logic.
> 
> **Overview**
> Fixes `/api/logout/` returning `405 Method Not Allowed` on Django 5.2+ by updating `LoggedLogoutView` to explicitly allow `GET`.
> 
> `LoggedLogoutView` now overrides `http_method_names` and adds a `get()` implementation that delegates to `post()`, preserving the existing logout execution path and behavior while keeping the proxied-request redirect in `dispatch()` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20ce3ff201f531d8e92e59c3e73f80dfddb3a208. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The logout endpoint now accepts GET requests in addition to POST, increasing flexibility for clients that cannot issue POST calls.
  * GET-based logout requests are processed identically to POST-based logouts for backward-compatible behavior.
  * Logout now also responds to OPTIONS requests to improve preflight and client compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->