### PR TITLE
Fix pod crash when hostname changes (AAP-47144)

### DIFF
--- a/awx/main/analytics/subsystem_metrics.py
+++ b/awx/main/analytics/subsystem_metrics.py
@@ -344,7 +344,9 @@ class Metrics(MetricsNamespace):
         instance_names = [self.instance_name]
         for m in self.conn.scan_iter(root_key + '-' + self._namespace + '_instance_*'):
             instance_names.append(m.decode('UTF-8').split('_instance_')[1])
-        instance_names.sort()
+        # Fix for issue #AAP-47144 - Hostname changes in redis metrics data payload
+        # Remove duplicated instance names
+        instance_names = sorted(set(instance_names))
         # load data, including data from the this local instance
         instance_data = {}
         for instance in instance_names:
@@ -353,6 +355,10 @@ class Metrics(MetricsNamespace):
                 # data from other instances may not be available. That is OK.
                 if instance_data_from_redis:
                     instance_data[instance] = json.loads(instance_data_from_redis.decode('UTF-8'))
+            # Fix for issue #AAP-47144 - Hostname changes in redis metrics data payload
+            # Fallback for the local instance
+            elif instance == self.instance_name:
+                instance_data[instance] = {}
         return instance_data
 
     def generate_metrics(self, request):
@@ -453,13 +459,15 @@ class CustomToPrometheusMetricsCollector(prometheus_client.registry.Collector):
         my_hostname = settings.CLUSTER_HOST_ID
 
         instance_data = self._metrics.load_other_metrics(Request(HttpRequest()))
+        # Fix for issue #AAP-47144 - Hostname changes in redis metrics data payload
+        # Use empty return to graceefully exit the generator instead of returning NONE which will cause an error in the prometheus client.
         if not instance_data:
             logger.debug(f"No metric data not found in redis for metric namespace '{self._metrics._namespace}'")
-            return None
-
+            return 
+        # Use an emptty return as well for missing hostname
         if not (host_metrics := instance_data.get(my_hostname)):
             logger.debug(f"Metric data for this node '{my_hostname}' not found in redis for metric namespace '{self._metrics._namespace}'")
-            return None
+            return 
 
         for _, metric in self._metrics.METRICS.items():
             entry = host_metrics.get(metric.field)


### PR DESCRIPTION
##### SUMMARY
When a pod's hostname changes, metrics keys in Redis still reference the old hostname, causing missing data and crashes. Changes made:

- Deduplicate instance names in load_other_metrics() using sorted(set(...)) to handle both old and new hostnames present in Redis keys
- Add fallback for local instance: when Redis has no data for current hostname, populate empty dict instead of omitting it
- In CustomToPrometheusMetricsCollector.collect(), replace `return None` with `return` when instance_data is empty or current hostname is missing. Returning None violates the generator protocol and crashes the Prometheus client; yielding nothing exits gracefully.

 - Bug Fix or other nominal change

##### COMPONENT NAME
- analytics

##### STEPS TO REPRODUCE AND EXTRA INFO
Once you change the hostname of your AAP host, the automation-controller-task container will be stuck in a reboot loop.

To fix this the redis inside the automation-controller-web container needs to be flushed:
> `redis-cli -s /run/redis/redis.sock`
> `flushall`

Steps to Reproduce

    Install Containerized AAP
    Change hostname
    Re-run Installer

Actual Behavior

Reboot loop

New Behavior

Running using new FQDN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of metrics collection by deduplicating instance names
  * Added fallback handling for local instance data when unavailable
  * Enhanced error handling to gracefully process missing metric data
  * Refined metrics collection control flow for improved robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->