### PR TITLE
Pin container versions

### DIFF
--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -112,6 +112,8 @@ services:
 {% endfor %}
 {% if control_plane_node_count|int > 1 %}
   haproxy:
+    # NOTE: upgrading past 2.3 requires updating haproxy.cfg (deprecated httpchk syntax)
+    # and may require adding 'no strict-limits' to the global section.
     image: mirror.gcr.io/library/haproxy:2.3
     user: "{{ ansible_user_uid }}"
     volumes:
@@ -130,6 +132,7 @@ services:
 {% endif %}
 {% if enable_splunk|bool %}
   splunk:
+    # NOTE: upgrading to 10.x requires adding SPLUNK_GENERAL_TERMS: --accept-sgt-current-at-splunk-com
     image: mirror.gcr.io/splunk/splunk:9.4.2
     container_name: tools_splunk_1
     hostname: splunk

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -112,7 +112,7 @@ services:
 {% endfor %}
 {% if control_plane_node_count|int > 1 %}
   haproxy:
-    image: mirror.gcr.io/library/haproxy:2.8.18
+    image: mirror.gcr.io/library/haproxy:2.3
     user: "{{ ansible_user_uid }}"
     volumes:
       - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:Z"
@@ -130,7 +130,7 @@ services:
 {% endif %}
 {% if enable_splunk|bool %}
   splunk:
-    image: mirror.gcr.io/splunk/splunk:10.2.1-rhel9
+    image: mirror.gcr.io/splunk/splunk:9.4.2
     container_name: tools_splunk_1
     hostname: splunk
     networks:

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -100,7 +100,7 @@ services:
       - "3000:3001"  # used by the UI dev env
 {% endif %}
   redis_{{ container_postfix }}:
-    image: mirror.gcr.io/library/redis:latest
+    image: mirror.gcr.io/library/redis:7.4.8
     container_name: tools_redis_{{ container_postfix }}
     volumes:
       - "../../redis/redis.conf:/usr/local/etc/redis/redis.conf:Z"
@@ -112,7 +112,7 @@ services:
 {% endfor %}
 {% if control_plane_node_count|int > 1 %}
   haproxy:
-    image: mirror.gcr.io/library/haproxy:2.3
+    image: mirror.gcr.io/library/haproxy:2.8.18
     user: "{{ ansible_user_uid }}"
     volumes:
       - "./haproxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:Z"
@@ -130,7 +130,7 @@ services:
 {% endif %}
 {% if enable_splunk|bool %}
   splunk:
-    image: mirror.gcr.io/splunk/splunk:latest
+    image: mirror.gcr.io/splunk/splunk:10.2.1-rhel9
     container_name: tools_splunk_1
     hostname: splunk
     networks:
@@ -145,7 +145,7 @@ services:
 {% endif %}
 {% if enable_prometheus|bool %}
   prometheus:
-    image: mirror.gcr.io/prom/prometheus:latest
+    image: mirror.gcr.io/prom/prometheus:v3.10.0
     container_name: tools_prometheus_1
     hostname: prometheus
     networks:
@@ -158,7 +158,7 @@ services:
 {% endif %}
 {% if enable_grafana|bool %}
   grafana:
-    image: mirror.gcr.io/grafana/grafana-enterprise:latest
+    image: mirror.gcr.io/grafana/grafana-enterprise:12.3.4
     container_name: tools_grafana_1
     hostname: grafana
     networks:
@@ -199,7 +199,7 @@ services:
        - "${AWX_PG_PORT:-5441}:5432"
 {% if enable_pgbouncer|bool %}
   pgbouncer:
-    image: mirror.gcr.io/bitnami/pgbouncer:latest
+    image: mirror.gcr.io/bitnami/pgbouncer:1.24.0
     container_name: tools_pgbouncer_1
     hostname: pgbouncer
     networks:


### PR DESCRIPTION
##### SUMMARY
We have been getting a lot of CI flake (errors pulling images), and I reproduced:

```
$ docker image pull mirror.gcr.io/library/redis:latest
latest: Pulling from library/redis
206356c42440: Downloading 
214ecf6e5c87: Downloading 
89b1b12d7109: Download complete 
f25f5c85b90d: Download complete 
ae77945b0371: Download complete 
4f4fb700ef54: Download complete 
141e1fc22067: Downloading 
unknown blob
```

Now, the _theory_ is that when a new image (for `:latest`) is being uploaded, they don't add all the layers in exactly the right order. This leads to the tag referencing layers that do not yet exist (or are not ready to download yet). This might be expected if the update to the latest tag is still in progress, like, uploading while you are trying to download.

But past tags should never have this problem! They've been stable for months in most cases. So if the theory is correct, then using these tags should prevent this CI flake from happening again. Only one way to find out.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change, but pinned versions may introduce runtime incompatibilities (e.g., Redis/Splunk/Grafana/Prometheus/pgbouncer behavior changes) that could affect local dev/CI containers.
> 
> **Overview**
> Pins several tool service images in `docker-compose.yml.j2` to explicit versions instead of `:latest` (Redis `7.4.8`, Splunk `9.4.2`, Prometheus `v3.10.0`, Grafana `12.3.4`, pgbouncer `1.24.0`) to stabilize pulls.
> 
> Adds inline upgrade notes for HAProxy and Splunk to document version-related config requirements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6637c7e3eb6a88212669740c2b5ce0aa94ad305. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned container images to specific releases (Redis, HAProxy, Splunk, Prometheus, Grafana, pgbouncer).
  * Added a Redis socket volume mapping to improve local socket access.
* **Documentation**
  * Added inline upgrade/usage notes for several services, including a Splunk terms notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->