### PR TITLE
Null value handling, discovered in production logs

### DIFF
--- a/awx/main/tasks/policy.py
+++ b/awx/main/tasks/policy.py
@@ -393,9 +393,9 @@ def evaluate_policy(instance):
             raise PolicyEvaluationError(_('Following certificate settings are missing for OPA_AUTH_TYPE=Certificate: {}').format(cert_settings_missing))
 
     query_paths = [
-        ('Organization', instance.organization.opa_query_path),
-        ('Inventory', instance.inventory.opa_query_path),
-        ('Job template', instance.job_template.opa_query_path),
+        ('Organization', instance.organization.opa_query_path if instance.organization else None),
+        ('Inventory', instance.inventory.opa_query_path if instance.inventory else None),
+        ('Job template', instance.job_template.opa_query_path if instance.job_template else None),
     ]
     violations = dict()
     errors = dict()

--- a/awx/main/utils/external_logging.py
+++ b/awx/main/utils/external_logging.py
@@ -55,6 +55,8 @@ def construct_rsyslog_conf_template(settings=settings):
     )
 
     def escape_quotes(x):
+        if x is None:
+            return ''
         return x.replace('"', '\\"')
 
     if not enabled:


### PR DESCRIPTION
##### SUMMARY
Observed in logs:

```
2026-03-04 15:09:11,253 INFO     [-] awx.analytics.job_lifecycle projectupdate-27 work unit id received {"type": "projectupdate", "task_id": 27, "state": "work_unit_id_received", "work_unit_id": "383228450DJXG7Hj", "task_name": "Project - WonderSpace\ufffd\ufffd"}
2026-03-04 15:09:11,263 INFO     [-] awx.analytics.job_lifecycle projectupdate-27 work unit id assigned {"type": "projectupdate", "task_id": 27, "state": "work_unit_id_assigned", "work_unit_id": "383228450DJXG7Hj", "task_name": "Project - WonderSpace\ufffd\ufffd"}
2026-03-04 15:09:12,970 ERROR    [-] dispatcherd.worker.task Worker failed to run task awx.main.utils.external_logging.reconfigure_rsyslog(*[], **{}
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/dispatcherd/worker/task.py", line 203, in perform_work
    result = self.run_callable(message)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/dispatcherd/worker/task.py", line 168, in run_callable
    return _call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/main/utils/external_logging.py", line 144, in reconfigure_rsyslog
    tmpl = construct_rsyslog_conf_template()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/main/utils/external_logging.py", line 72, in construct_rsyslog_conf_template
    host = escape_quotes(parsed.hostname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/main/utils/external_logging.py", line 58, in escape_quotes
    return x.replace('"', '\\"')
           ^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'replace'
2026-03-04 15:09:12 ERROR rsyslogd was unresponsive: AttributeError: 'Settings' object has no attribute 'LOG_AGGREGATOR_TYPE'. Did you mean: 'LOG_AGGREGATOR_LEVEL'?
clear_setting_cache of keys ['LOG_AGGREGATOR_HOST', 'LOG_AGGREGATOR_PORT', 'LOG_AGGREGATOR_TYPE', 'LOG_AGGREGATOR_ENABLED']
```

and

```
2026-03-04 17:13:48,685 INFO     [-] awx.analytics.job_lifecycle job-1204 evaluate policy {"type": "job", "task_id": 1204, "state": "evaluate_policy", "work_unit_id": null, "task_name": "Test Job for Public Quay EE"}
2026-03-04 17:13:48,711 ERROR    [-] awx.main.tasks.jobs job 1204 (running) Exception occurred while running task
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/main/tasks/jobs.py", line 601, in run
    evaluate_policy(self.instance)
  File "/var/lib/awx/venv/awx/lib64/python3.12/site-packages/awx/main/tasks/policy.py", line 396, in evaluate_policy
    ('Organization', instance.organization.opa_query_path),
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'opa_query_path'
2026-03-04 17:13:48,712 INFO     [-] awx.analytics.job_lifecycle job-1204 post run {"type": "job", "task_id": 1204, "state": "post_run", "work_unit_id": null, "task_name": "Test Job for Public Quay EE"}
```

So doing the obvious cleanup work.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c9ed2562c2bdad2b8bcca78c2f74b2ea6eab4588. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Policy evaluation system now gracefully handles missing configuration objects.
- External logging functionality improved to properly handle edge cases in configuration data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->