### PR TITLE
fix: narrow vendor_collections_dir fixture teardown scope

### DIFF
--- a/awx/main/tests/live/tests/test_indirect_counting_external_queries.py
+++ b/awx/main/tests/live/tests/test_indirect_counting_external_queries.py
@@ -111,8 +111,8 @@ def vendor_collections_dir():
 
     yield base
 
-    # Cleanup
-    shutil.rmtree(VENDOR_COLLECTIONS_BASE, ignore_errors=True)
+    # Cleanup: only remove the collection we created, not the entire vendor root
+    shutil.rmtree(base, ignore_errors=True)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
Forward-port of ansible/tower#7350.

- The `vendor_collections_dir` fixture teardown removed the entire `/var/lib/awx/vendor_collections/` directory tree
- Changed to only remove the specific collection directory the fixture created (`redhat/indirect_accounting`), leaving the vendor root intact
- Prevents accidental deletion of vendor collections installed by the build process

## Test plan
- [ ] Verify external query live tests still pass (fixture cleanup still works)
- [ ] Verify dev-env CI passes

Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only teardown change that narrows filesystem deletion scope; low risk aside from potential leftover directories if the fixture path changes.
> 
> **Overview**
> Updates the `vendor_collections_dir` fixture in `test_indirect_counting_external_queries.py` to **only remove the specific mock collection directory** it creates (`.../ansible_collections/redhat/indirect_accounting`) during teardown, instead of deleting the entire `/var/lib/awx/vendor_collections` tree.
> 
> This reduces the chance of tests accidentally wiping vendor collections installed by the build/deployment environment while keeping the fixture cleanup behavior intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcc47b44944b54a6b25bcde14c782b2d9b858702. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test fixture cleanup to remove only test-specific resources instead of all vendor resources, enhancing test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->