### PR TITLE
Address unused variables issue

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -107,11 +107,6 @@ def populate_claims_for_workload(unified_job) -> dict:
     Extract JWT claims from a Controller workload for the aap_controller_automation_job scope.
     """
 
-    # Related objects in the UnifiedJob model, applies to all job types
-    organization = getattr_dne(unified_job, 'organization')
-    ujt = getattr_dne(unified_job, 'unified_job_template')
-    instance_group = getattr_dne(unified_job, 'instance_group')
-
     claims = {
         AutomationControllerJobScope.CLAIM_JOB_ID: unified_job.id,
         AutomationControllerJobScope.CLAIM_JOB_NAME: unified_job.name,


### PR DESCRIPTION
##### SUMMARY
SonarCloud keeps complaining about this on other PRs.

This was my mistake I introduced some time ago with OIDC related merges.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only cleanup that does not change claim contents or workload identity behavior; minimal risk beyond potential accidental edit in the claims builder.
> 
> **Overview**
> Removes unused local variables in `populate_claims_for_workload()` (previously assigned related objects like `organization`, `unified_job_template`, and `instance_group` but never used), relying solely on the existing conditional `getattr_dne` lookups when populating OIDC workload JWT claims.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f79cd89af15ddde7c1f932ae022b64503271b343. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized task processing efficiency by implementing conditional resource loading. Related objects are now loaded on-demand during workflow operations rather than retrieved upfront, reducing unnecessary overhead and improving system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->