### PR TITLE
Update hash for related action update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
           && github.event_name == 'push'
           && env.UPSTREAM_REPOSITORY_ID == github.repository_id
           && github.ref_name == github.event.repository.default_branch
-        uses: ansible/gh-action-record-test-results@fc552f81bf7e734cdebe6d04f9f608e2e2b4759e
+        uses: ansible/gh-action-record-test-results@3784db66a1b7fb3809999a7251c8a7203a7ffbe8
         with:
           aggregation-server-url: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}
           http-auth-password: >-
@@ -328,7 +328,7 @@ jobs:
           && github.event_name == 'push'
           && env.UPSTREAM_REPOSITORY_ID == github.repository_id
           && github.ref_name == github.event.repository.default_branch
-        uses: ansible/gh-action-record-test-results@fc552f81bf7e734cdebe6d04f9f608e2e2b4759e
+        uses: ansible/gh-action-record-test-results@3784db66a1b7fb3809999a7251c8a7203a7ffbe8
         with:
           aggregation-server-url: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}
           http-auth-password: >-


### PR DESCRIPTION
##### SUMMARY
Pulls in https://github.com/ansible/gh-action-record-test-results/pull/3

We're going to keep going until it works.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that bumps a pinned third-party GitHub Action; risk is limited to potential CI reporting/upload behavior differences.
> 
> **Overview**
> Updates `.github/workflows/ci.yml` to pin `ansible/gh-action-record-test-results` to a newer commit SHA for uploading jUnit test reports to the unified dashboard (in both the common test matrix and `collection-sanity` job).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10f7a4beb94b5d417a7f4687ae56e265fbee1a76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the continuous integration workflow to use an improved version of the test results upload action. This change affects test result processing in both the main push workflow and collection sanity checks, enhancing pipeline reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->