### PR TITLE
[ANSTRAT-1840] Merge feature branch: Enforce JWT-only authentication for Controller

### DIFF
--- a/awx/settings/__init__.py
+++ b/awx/settings/__init__.py
@@ -63,6 +63,15 @@ assert_production_settings(DYNACONF, settings_dir, settings_file_path)
 # Load envvars at the end to allow them to override everything loaded so far
 load_envvars(DYNACONF)
 
+# When deployed as part of AAP (RESOURCE_SERVER__URL is set), enforce JWT-only
+# authentication. This ensures all requests go through the gateway and prevents
+# direct API access to Controller bypassing the platform's authentication.
+if DYNACONF.get('RESOURCE_SERVER__URL', None):
+    DYNACONF.set(
+        "REST_FRAMEWORK__DEFAULT_AUTHENTICATION_CLASSES",
+        ['ansible_base.jwt_consumer.awx.auth.AwxJWTAuthentication'],
+    )
+
 # This must run after all custom settings are loaded
 DYNACONF.update(
     merge_application_name(DYNACONF),


### PR DESCRIPTION
## Summary

Merges the `feature_anstrat-1840` branch into `devel`, bringing in the auth lockdown change from the original PR:

**Original PR:** https://github.com/ansible/awx/pull/16283

---

### Original PR Description

- When `RESOURCE_SERVER__URL` is set (i.e., deployed as part of AAP with Gateway), override `DEFAULT_AUTHENTICATION_CLASSES` to only allow `AwxJWTAuthentication`
- Applied after all settings files and env vars are loaded, making it immutable
- Same pattern as Hub ([galaxy_ng#288](https://github.com/ansible-automation-platform/galaxy_ng/pull/288)) and EDA ([eda-server#1474](https://github.com/ansible/eda-server/pull/1474))

## Jira

- [AAP-64062](https://issues.redhat.com/browse/AAP-64062)
- [ANSTRAT-1840](https://issues.redhat.com/browse/ANSTRAT-1840)

## Test plan

- [ ] Authenticate directly to Controller using Basic auth → returns 401
- [ ] Authenticate directly using Session auth → returns 401
- [ ] Authenticate directly using OAuth2 token → returns 401
- [ ] Authenticate through Gateway → proxied request with Gateway JWT succeeds
- [ ] Internal service-to-service calls (resource sync, settings sync) continue to work
- [ ] Standalone AWX (no `RESOURCE_SERVER__URL`) retains all auth methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)