### PR TITLE
fix: use hmac.compare_digest() for timing-safe HMAC comparison

### DIFF
--- a/awx/main/consumers.py
+++ b/awx/main/consumers.py
@@ -59,7 +59,7 @@ class WebsocketSecretAuthHelper:
 
         secret_serialized = hmac.new(force_bytes(settings.BROADCAST_WEBSOCKET_SECRET), msg=force_bytes(payload_serialized), digestmod='sha256').hexdigest()
 
-        if secret_serialized != secret_parsed:
+        if not hmac.compare_digest(secret_serialized, secret_parsed):
             raise ValueError("Invalid secret")
 
         # Avoid timing attack and check the nonce after all the heavy lifting


### PR DESCRIPTION
## Summary

- `WebsocketSecretAuthHelper.verify_secret()` compared HMAC digests using `!=` which is vulnerable to timing attacks
- Replace with `hmac.compare_digest()` for constant-time comparison
- `hmac` is already imported — this is a one-line fix

### Files changed

| File | Change |
|------|--------|
| `awx/main/consumers.py` | `!=` → `hmac.compare_digest()` |

Fixes: AAP-68043

## Test plan

- [ ] Verify WebSocket relay connections still authenticate successfully
- [ ] Verify invalid secrets are still rejected

## Change Type
- Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret verification security to protect against timing-based attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->