### PR TITLE
fix: SimpleDAG.__contains__ references self.node which does not exist

### DIFF
--- a/awx/main/scheduler/dag_simple.py
+++ b/awx/main/scheduler/dag_simple.py
@@ -49,9 +49,7 @@ class SimpleDAG(object):
         self.node_to_edges_by_label = dict()
 
     def __contains__(self, obj):
-        if self.node['node_object'] in self.node_obj_to_node_index:
-            return True
-        return False
+        return obj in self.node_obj_to_node_index
 
     def __len__(self):
         return len(self.nodes)


### PR DESCRIPTION
## Summary

- `SimpleDAG.__contains__` referenced `self.node` (not an attribute) and ignored the `obj` parameter
- Always raised `AttributeError` when called — broken since introduction
- Fix to check `obj` against `self.node_obj_to_node_index`

### Files changed

| File | Change |
|------|--------|
| `awx/main/scheduler/dag_simple.py` | Fix `__contains__` to use `obj` parameter |

Fixes: AAP-68044

## Test plan

- [ ] Verify `in` operator works on SimpleDAG instances
- [ ] Verify WorkflowDAG (subclass) `in` operator works

## Change Type
- Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scheduler DAG containment logic to ensure more reliable scheduling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->