### PR TITLE
fix: NameError in wsrelay when JSON decode fails with DEBUG logging

### DIFF
--- a/awx/main/wsrelay.py
+++ b/awx/main/wsrelay.py
@@ -139,7 +139,7 @@ class WebsocketRelayConnection:
                 except json.JSONDecodeError:
                     logmsg = "Failed to decode message from web node"
                     if logger.isEnabledFor(logging.DEBUG):
-                        logmsg = "{} {}".format(logmsg, payload)
+                        logmsg = "{} {}".format(logmsg, msg.data)
                     logger.warning(logmsg)
                     continue
 
@@ -242,7 +242,7 @@ class WebSocketRelayManager(object):
                 except json.JSONDecodeError:
                     logmsg = "Failed to decode message from pg_notify channel `web_ws_heartbeat`"
                     if logger.isEnabledFor(logging.DEBUG):
-                        logmsg = "{} {}".format(logmsg, payload)
+                        logmsg = "{} {}".format(logmsg, notif.payload)
                     logger.warning(logmsg)
                     continue
 


### PR DESCRIPTION
## Summary

- `run_connection()` referenced `payload` in the `JSONDecodeError` handler, but `payload` was never assigned because `json.loads()` is what failed
- Raises `NameError` when DEBUG logging is enabled
- Fix: use `msg.data` instead of `payload` to log the raw message content

### Files changed

| File | Change |
|------|--------|
| `awx/main/wsrelay.py` | `payload` → `msg.data` in error handler |

Fixes: AAP-68045

## Test plan

- [ ] Verify WebSocket relay handles malformed JSON messages without crashing
- [ ] Verify debug logging shows the raw message data on decode failure

## Change Type
- Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging for JSON parsing failures: logs now include the actual raw payloads involved in the failures (in two affected locations), yielding clearer and more accurate diagnostic information to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->