### PR TITLE
fix: add missing try/except in ActivityStreamRegistrar.disconnect()

### DIFF
--- a/awx/main/registrar.py
+++ b/awx/main/registrar.py
@@ -35,8 +35,11 @@ class ActivityStreamRegistrar(object):
             self.models.remove(model)
 
             for m2mfield in model._meta.many_to_many:
-                m2m_attr = getattr(model, m2mfield.name)
-                m2m_changed.disconnect(dispatch_uid=str(self.__class__) + str(m2m_attr.through) + "_associate")
+                try:
+                    m2m_attr = getattr(model, m2mfield.name)
+                    m2m_changed.disconnect(dispatch_uid=str(self.__class__) + str(m2m_attr.through) + "_associate")
+                except AttributeError:
+                    pass
 
 
 activity_stream_registrar = ActivityStreamRegistrar()


### PR DESCRIPTION
## Summary

- `connect()` wraps M2M `getattr` in `try/except AttributeError` but `disconnect()` does not
- If a model has a problematic M2M field, `connect()` succeeds silently but `disconnect()` crashes with `AttributeError`
- Add the same guard to `disconnect()` for symmetry

### Files changed

| File | Change |
|------|--------|
| `awx/main/registrar.py` | Add `try/except AttributeError` in `disconnect()` M2M loop |

Fixes: AAP-68046

## Test plan

- [ ] Verify activity stream disconnect works for all registered models
- [ ] Verify models with problematic M2M fields can be disconnected without crash

## Change Type
- Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when processing data relationships by gracefully handling cases where expected attributes are unavailable. The system now safely skips missing attributes instead of encountering errors during disconnect operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->