### PR TITLE
[AAP-59652] Enrich tests against is_ha_environment()

### DIFF
--- a/awx/main/tests/functional/models/test_ha.py
+++ b/awx/main/tests/functional/models/test_ha.py
@@ -10,9 +10,23 @@ from django.test.utils import override_settings
 
 
 @pytest.mark.django_db
-def test_multiple_instances():
-    for i in range(2):
+def test_multiple_hybrid_instances():
+    for i in range(3):
         Instance.objects.create(hostname=f'foo{i}', node_type='hybrid')
+    assert is_ha_environment()
+
+
+@pytest.mark.django_db
+def test_double_control_instances():
+    for i in range(2):
+        Instance.objects.create(hostname=f'foo{i}', node_type='control')
+    assert is_ha_environment()
+
+
+@pytest.mark.django_db
+def test_mix_hybrid_control_instances():
+    Instance.objects.create(hostname='control_node', node_type='control')
+    Instance.objects.create(hostname='hybrid_node', node_type='hybrid')
     assert is_ha_environment()
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->
Given the shift left testing strategy, we (AoC) plan to migrate the `test_ha_config()` Tower QA test to AWX upstream.
https://github.com/ansible/tower-qa/blob/devel/tests/api/cluster/test_control_nodes.py#L17

To be exact, the implementation in Tower QA validates the `ha` value from the `api/controller/v2/ping`  view while the implementation here directly test against the `is_ha_environment()` function. Nevertheless, I think they are functionally the same given the implementation here: https://github.com/ansible/awx/blob/devel/awx/api/views/root.py#L155 , so to some extent I am just enriching tests against `is_ha_environment()` with a white-box logical coverage mindset in order to mark a completion of this migration.

I ran a CI check on my branch with my commit included and it got passed: https://github.com/unnecessary-username/awx/actions/runs/22892831580/job/66419631021


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for high-availability detection across more node combinations: expanded multi-hybrid scenario, added two-control-node and mixed control/hybrid scenarios, and validated that adding an execution-only node does not mark the environment as HA.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->