### PR TITLE
Do not ignore errors on activity stream connection

### DIFF
--- a/awx/main/registrar.py
+++ b/awx/main/registrar.py
@@ -19,13 +19,8 @@ class ActivityStreamRegistrar(object):
             pre_delete.connect(activity_stream_delete, sender=model, dispatch_uid=str(self.__class__) + str(model) + "_delete")
 
             for m2mfield in model._meta.many_to_many:
-                try:
-                    m2m_attr = getattr(model, m2mfield.name)
-                    m2m_changed.connect(
-                        activity_stream_associate, sender=m2m_attr.through, dispatch_uid=str(self.__class__) + str(m2m_attr.through) + "_associate"
-                    )
-                except AttributeError:
-                    pass
+                m2m_attr = getattr(model, m2mfield.name)
+                m2m_changed.connect(activity_stream_associate, sender=m2m_attr.through, dispatch_uid=str(self.__class__) + str(m2m_attr.through) + "_associate")
 
     def disconnect(self, model):
         if model in self.models:


### PR DESCRIPTION
##### SUMMARY
Alternative to https://github.com/ansible/awx/pull/16341

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stops swallowing `AttributeError` during activity-stream m2m signal registration, which could cause startup/registration failures if any registered model has an unexpected many-to-many attribute setup.
> 
> **Overview**
> Removes the `try/except AttributeError` guard when wiring `m2m_changed` handlers for activity stream registration in `ActivityStreamRegistrar.connect`, so failures to resolve a model’s many-to-many relation (or its `through` model) are no longer silently ignored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aec8d8a8f199db94530465f97a095566d1822f32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error handling to ensure system failures are caught and reported explicitly instead of being silently ignored, enabling faster troubleshooting and issue detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->