### PR TITLE
Align log message of workload identity tokens with other task messages

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -684,7 +684,7 @@ class BaseTask(object):
                 raise RuntimeError('AWX_ISOLATION_BASE_PATH=%s does not exist' % settings.AWX_ISOLATION_BASE_PATH)
 
             if flag_enabled("FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED"):
-                logger.info(f'Generating workload identity tokens for job {self.instance.id}')
+                logger.info(f'Generating workload identity tokens for {self.instance.log_format}')
                 self.populate_workload_identity_tokens()
                 if self.instance.status == 'error':
                     raise RuntimeError('not starting %s task' % self.instance.status)


### PR DESCRIPTION
##### SUMMARY
Aligning the log message. Now it prints `job 8`, where `8` is the id of the job. Whereas every other log prints `job-8`.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging output format for workload identity token generation events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->