### PR TITLE
Reorder URLs so that Django debug toolbar can work

### DIFF
--- a/awx/urls.py
+++ b/awx/urls.py
@@ -36,7 +36,6 @@ def get_urlpatterns(prefix=None):
         re_path(r'^login/', handle_login_redirect),
         # want api/v2/doesnotexist to return a 404, not match the ui urls,
         # so use a negative lookahead assertion here
-        re_path(r'^(?!api/).*', include('awx.ui.urls', namespace='ui')),
     ]
 
     if settings.DYNACONF.is_development_mode:
@@ -46,6 +45,10 @@ def get_urlpatterns(prefix=None):
             urlpatterns += [re_path(r'^__debug__/', include(debug_toolbar.urls))]
         except ImportError:
             pass
+
+    urlpatterns += [
+        re_path(r'^(?!api/).*', include('awx.ui.urls', namespace='ui')),
+    ]
 
     return urlpatterns
 

--- a/awx/urls.py
+++ b/awx/urls.py
@@ -34,8 +34,6 @@ def get_urlpatterns(prefix=None):
         re_path(r'^(?:api/)?500.html$', handle_500),
         re_path(r'^csp-violation/', handle_csp_violation),
         re_path(r'^login/', handle_login_redirect),
-        # want api/v2/doesnotexist to return a 404, not match the ui urls,
-        # so use a negative lookahead assertion here
     ]
 
     if settings.DYNACONF.is_development_mode:
@@ -46,6 +44,8 @@ def get_urlpatterns(prefix=None):
         except ImportError:
             pass
 
+    # want api/v2/doesnotexist to return a 404, not match the ui urls,
+    # so use a negative lookahead assertion in the pattern below
     urlpatterns += [
         re_path(r'^(?!api/).*', include('awx.ui.urls', namespace='ui')),
     ]


### PR DESCRIPTION
##### SUMMARY
Go discover your internal IP and then put in:

```diff
diff --git a/awx/settings/defaults.py b/awx/settings/defaults.py
index 1f6b7ae2b2..c6d7c64117 100644
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -149,7 +149,8 @@ else:
 
 # Hosts/domain names that are valid for this site; required if DEBUG is False
 # See https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
+
 
 # HTTP headers and meta keys to search to determine remote host name or IP. Add
 # additional items to this list, such as "HTTP_X_FORWARDED_FOR", if behind a
@@ -356,7 +357,7 @@ INSTALLED_APPS = [
 ]
 
 
-INTERNAL_IPS = ('127.0.0.1',)
+INTERNAL_IPS = ('172.18.0.1')
 
 MAX_PAGE_SIZE = 200
 REST_FRAMEWORK = {
```

and then try and use the django debug toolbar, was giving this when looking for the SQL:

> Data for this panel isn't available anymore. Please reload the page and retry

This fixes it.

The issue is that the UI urls were getting included unconditionally before the DDT urls, and that means that it would match the /__debug__/ URL that's necessary for the thing to work.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk URLconf reordering that primarily affects development mode routing; potential impact is limited to which handler matches non-API paths first (notably `__debug__/`).
> 
> **Overview**
> Moves the UI catch-all `re_path(r'^(?!api/).*'...)` to be appended *after* the development-mode Django Debug Toolbar routes, so `__debug__/` is no longer captured by the UI include.
> 
> This preserves the negative lookahead behavior for non-existent API paths (returning API 404s) while fixing Debug Toolbar panel endpoints in development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7349017055ee9466dd37f2696c7ee91a5b24446e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal routing registration order adjusted to improve configuration structure.
  * No changes to site behavior or user-facing routes; development-mode tooling and functionality remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->