### PR TITLE
Add awx-logos instructions to Docker development setup docs

### DIFF
--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -37,6 +37,13 @@ Notable files:
 - [Ansible](https://docs.ansible.com/projects/ansible/latest/installation_guide/intro_installation.html) will need to be installed as we use it to template files needed for the docker-compose.
 - OpenSSL.
 
+### AWX Logos
+AWX uses branding assets provided by the 'awx-logos' repository.
+Clone the repo before starting development environment:
+
+'''bash
+git clone https://github.com/ansible/awx-logos.git
+
 ### Tested Operating Systems
 
 The docker-compose development environment is regularly used and should work on x86_64 systems running:


### PR DESCRIPTION
Adds documentation for cloning the awx-logos repository when using the
Docker development environment.
The AWX UI depends on branding assets provided by the awx-logos repository,
but the current documentation does not mention this step. This change adds
instructions to clone the repository so developers can properly set up the
environment without missing assets.

Fixes #11593

Issue Type
- Bug, Docs Fix or other nominal change

Component Name
-Docs

Steps to reproduce and extra info
-The Docker development documentation does not currently mention cloning the
awx-logos repository. This may lead to missing branding assets when running
AWX locally. This change adds a short section explaining that the awx-logos repository
should be cloned before starting the development environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new section with information about AWX branding assets and instructions for accessing the awx-logos repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->