### PR TITLE
[AAP-68258] Fix SonarCloud Reliability issues

### DIFF
--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -77,13 +77,13 @@ class CallbackBrokerWorker:
 
     MAX_RETRIES = 2
     INDIVIDUAL_EVENT_RETRIES = 3
-    last_stats = time.time()
-    last_flush = time.time()
     total = 0
     last_event = ''
     prof = None
 
     def __init__(self):
+        self.last_stats = time.time()
+        self.last_flush = time.time()
         self.buff = {}
         self.redis = get_redis_client()
         self.subsystem_metrics = s_metrics.CallbackReceiverMetrics(auto_pipe_execute=False)

--- a/awx/main/tests/functional/commands/test_callback_receiver.py
+++ b/awx/main/tests/functional/commands/test_callback_receiver.py
@@ -48,7 +48,7 @@ class TestCallbackBrokerWorker(TransactionTestCase):
         worker = CallbackBrokerWorker()
         events = [InventoryUpdateEvent(uuid=str(uuid4()), **self.event_create_kwargs())]
         worker.buff = {InventoryUpdateEvent: events}
-        worker.flush()
+        worker.flush(force=True)
         assert worker.buff.get(InventoryUpdateEvent, []) == []
         assert InventoryUpdateEvent.objects.filter(uuid=events[0].uuid).count() == 1
 
@@ -61,7 +61,7 @@ class TestCallbackBrokerWorker(TransactionTestCase):
             InventoryUpdateEvent(uuid=str(uuid4()), stdout='good2', **kwargs),
         ]
         worker.buff = {InventoryUpdateEvent: events.copy()}
-        worker.flush()
+        worker.flush(force=True)
         assert InventoryUpdateEvent.objects.filter(uuid=events[0].uuid).count() == 1
         assert InventoryUpdateEvent.objects.filter(uuid=events[1].uuid).count() == 0
         assert InventoryUpdateEvent.objects.filter(uuid=events[2].uuid).count() == 1
@@ -71,7 +71,7 @@ class TestCallbackBrokerWorker(TransactionTestCase):
         worker = CallbackBrokerWorker()
         events = [InventoryUpdateEvent(uuid=str(uuid4()), **self.event_create_kwargs())]
         worker.buff = {InventoryUpdateEvent: events.copy()}
-        worker.flush()
+        worker.flush(force=True)
 
         # put current saved event in buffer (error case)
         worker.buff = {InventoryUpdateEvent: [InventoryUpdateEvent.objects.get(uuid=events[0].uuid)]}
@@ -113,7 +113,7 @@ class TestCallbackBrokerWorker(TransactionTestCase):
 
         with mock.patch.object(InventoryUpdateEvent.objects, 'bulk_create', side_effect=ValueError):
             with mock.patch.object(events[0], 'save', side_effect=ValueError):
-                worker.flush()
+                worker.flush(force=True)
 
             assert "\x00" not in events[0].stdout
 

--- a/awxkit/awxkit/api/mixins/has_create.py
+++ b/awxkit/awxkit/api/mixins/has_create.py
@@ -61,7 +61,7 @@ def separate_async_optionals(creation_order):
             continue
         by_count = defaultdict(set)
         has_creates = [cand for cand in group if hasattr(cand, 'dependencies')]
-        counts = {has_create: 0 for has_create in has_creates}
+        counts = dict.fromkeys(has_creates, 0)
         for has_create in has_creates:
             for dependency in has_create.dependencies:
                 for compared in [cand for cand in has_creates if cand != has_create]:
@@ -212,7 +212,7 @@ class HasCreate(object):
         dependency_store = kw.get('ds')
         if dependency_store is None:
             deps = self.dependencies + self.optional_dependencies
-            self._dependency_store = {base_subclass: None for base_subclass in deps}
+            self._dependency_store = dict.fromkeys(deps)
             self.ds = DSAdapter(self.__class__.__name__, self._dependency_store)
         else:
             self._dependency_store = dependency_store.dependency_store


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
  Fix 4 open SonarCloud Reliability issues in the ansible_awx project:            
                                                      
  Critical — S8434: Time-dependent class attributes (callback.py)                 
  - Moved last_stats = time.time() and last_flush = time.time() from class-level  
  attributes to __init__ in CallbackBrokerWorker
  - These were evaluated once at class definition (import time), not per-instance
  — meaning all workers shared the same stale timestamp

  Minor — S7519: Dict comprehensions with constant values (has_create.py)
  - Replaced {has_create: 0 for has_create in has_creates} with
  dict.fromkeys(has_creates, 0) (line 64)
  - Replaced {base_subclass: None for base_subclass in deps} with
  dict.fromkeys(deps) (line 215)

  Not addressed — S8443: check_migrations.py (false positive)
  - Command inherits from MakeMigrations, which itself inherits from BaseCommand —
   the indirect inheritance is intentional

  Verification:
  - All fixes confirmed clean by SonarCloud's analyze_code_snippet — zero issues
  on the patched code
  - 209 awxkit unit tests pass
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor to initialization/state handling and small internal data-structure cleanups; behavior change is limited to per-worker timing and test determinism.
> 
> **Overview**
> Fixes callback receiver worker state initialization by moving `last_stats`/`last_flush` from class attributes to instance attributes in `CallbackBrokerWorker`, preventing workers from sharing stale timestamps.
> 
> Updates callback receiver functional tests to call `flush(force=True)` so assertions don’t depend on elapsed time, and simplifies two `awxkit` dependency-store dict initializations using `dict.fromkeys()` to satisfy reliability linting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9559d1a013e91c5712f313d68fdda56d628224dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Avoided shared state between instances to improve reliability of background callback processing.

* **Chores**
  * Simplified internal mappings initialization for cleaner, more consistent behavior.

* **Tests**
  * Updated tests to force processing of callback events in key cases, increasing test reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->