### PR TITLE
Fix a stray trailing backslash post `false` in the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
       - name: Checkout awx-operator
         uses: actions/checkout@v4
         with:
-          show-progress: false\
+          show-progress: false
           repository: ansible/awx-operator
           path: awx-operator
 


### PR DESCRIPTION
This was a typo introduced in #15322.

<!-- Bug, Docs Fix or other nominal change -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor syntax correction in CI/CD configuration to ensure proper workflow execution.

**Note:** This release contains internal maintenance updates with no end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->