### PR TITLE
Stop writing tmp test files that are not cleaned up

### DIFF
--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import tempfile
-import shutil
 
 import pytest
 from unittest import mock
@@ -32,13 +30,12 @@ from ansible_base.lib.workload_identity.controller import AutomationControllerJo
 
 
 @pytest.fixture
-def private_data_dir():
-    private_data = tempfile.mkdtemp(prefix='awx_')
+def private_data_dir(tmp_path):
+    private_data = tmp_path / 'awx_pdd'
+    private_data.mkdir()
     for subfolder in ('inventory', 'env'):
-        runner_subfolder = os.path.join(private_data, subfolder)
-        os.makedirs(runner_subfolder, exist_ok=True)
-    yield private_data
-    shutil.rmtree(private_data, True)
+        (private_data / subfolder).mkdir()
+    return str(private_data)
 
 
 @pytest.fixture
@@ -101,6 +98,8 @@ def test_pre_post_run_hook_facts(mock_create_partition, mock_facts_settings, pri
     proj = mock.MagicMock(spec=Project, pk=1, organization=org)
     job = mock.MagicMock(
         spec=Job,
+        pk=1,
+        id=1,
         use_fact_cache=True,
         project=proj,
         organization=org,
@@ -170,6 +169,8 @@ def test_pre_post_run_hook_facts_deleted_sliced(
 
     # Mock job object
     job = mock.MagicMock(spec=Job)
+    job.pk = 2
+    job.id = 2
     job.use_fact_cache = True
     job.project = proj
     job.organization = org

--- a/awx/main/tests/unit/tasks/test_jobs.py
+++ b/awx/main/tests/unit/tasks/test_jobs.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-
 import pytest
 from unittest import mock
 

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
 import os
-import shutil
-import tempfile
 from pathlib import Path
 
 import fcntl
@@ -60,14 +58,12 @@ class TestJobExecution(object):
 
 
 @pytest.fixture
-def private_data_dir():
-    private_data = tempfile.mkdtemp(prefix='awx_')
+def private_data_dir(tmp_path):
+    private_data = tmp_path / 'awx_pdd'
+    private_data.mkdir()
     for subfolder in ('inventory', 'env'):
-        runner_subfolder = os.path.join(private_data, subfolder)
-        if not os.path.exists(runner_subfolder):
-            os.mkdir(runner_subfolder)
-    yield private_data
-    shutil.rmtree(private_data, True)
+        (private_data / subfolder).mkdir()
+    return str(private_data)
 
 
 @pytest.fixture

--- a/awx/main/tests/unit/utils/test_execution_environments.py
+++ b/awx/main/tests/unit/utils/test_execution_environments.py
@@ -1,6 +1,4 @@
-import shutil
 import os
-from uuid import uuid4
 
 import pytest
 
@@ -24,17 +22,11 @@ def test_switch_paths(container_path, host_path):
     assert get_incontainer_path(host_path, private_data_dir) == container_path
 
 
-def test_symlink_isolation_dir(request):
-    rand_str = str(uuid4())[:8]
-    dst_path = f'/tmp/ee_{rand_str}_symlink_dst'
-    src_path = f'/tmp/ee_{rand_str}_symlink_src'
+def test_symlink_isolation_dir(tmp_path):
+    src_path = tmp_path / 'symlink_src'
+    dst_path = tmp_path / 'symlink_dst'
 
-    def remove_folders():
-        os.unlink(dst_path)
-        shutil.rmtree(src_path)
-
-    request.addfinalizer(remove_folders)
-    os.mkdir(src_path)
+    src_path.mkdir()
     os.symlink(src_path, dst_path)
 
     pdd = f'{dst_path}/awx_xxx'


### PR DESCRIPTION
##### SUMMARY
I run tests on my computer, and because of that, I know that the test runs will leave temporary files around at the end of the run without cleaning them up.

Lately, it started creating a very annoying `MagicMock/` folder right in the AWX directory. So I wanted to clean this up. Here is the agent summary of the change in more specific technical terms, all of the changes align with the general form that I had expected.

```
  1. awx/main/tests/unit/test_tasks.py — private_data_dir fixture                                                   
  - Removed import shutil, tempfile
  - Changed from tempfile.mkdtemp() + manual shutil.rmtree cleanup to using pytest's tmp_path fixture, which        
  auto-cleans up                                                                                                  
                                                                                                                    
  2. awx/main/tests/unit/tasks/test_jobs.py — private_data_dir fixture + MagicMock bug
  - Removed import tempfile, shutil                                                                                 
  - Changed private_data_dir fixture to use tmp_path (same pattern)                                                 
  - Fixed MagicMock bug: Set pk=1, id=1 on the mock Job in test_pre_post_run_hook_facts and pk=2, id=2 in           
  test_pre_post_run_hook_facts_deleted_sliced. Previously job.id was an auto-generated MagicMock, so str(job.id)
  produced strings like <MagicMock name='mock.id' id='140295935928656'> which were used in
  os.path.join(private_data_dir, 'artifacts', str(job.id)) inside start_fact_cache / finish_fact_cache — creating
  directories with MagicMock in the name

  3. awx/main/tests/unit/utils/test_execution_environments.py — test_symlink_isolation_dir
  - Removed import shutil and from uuid import uuid4
  - Changed from manually creating /tmp/ee_{uuid}_symlink_src and /tmp/ee_{uuid}_symlink_dst with
  request.addfinalizer cleanup to using tmp_path, which is simpler and auto-cleans up

  About the MagicMock/ directory

  The MagicMock/ directory in the repo root contains paths like
  MagicMock/bulk_update_sorted_by_id/<id>/artifacts/<MagicMock name='mock.id' ...>/host_cache_summary.json. This was
   created by the start_fact_cache function when str(job.id) evaluated to a MagicMock string. The job.id fix
  prevents this from happening again. The existing MagicMock/ directory is already gitignored (untracked) — you can
  safely delete it.

```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to unit tests and temporary directory handling, plus a small test-mock fix to prevent creating stray `MagicMock/` artifact directories.
> 
> **Overview**
> Stops unit tests from creating and leaking temp files by switching `private_data_dir` and symlink temp directory setup from `tempfile`/manual cleanup to pytest’s `tmp_path` (auto-cleaned).
> 
> Also fixes `Job` mocks in fact-cache tests to set real `id`/`pk` values so artifact paths don’t include `MagicMock` strings (preventing accidental `MagicMock/` directories from being created during test runs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec2994aeac26d91f85578b73e53ae5b56fa8872c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to use pytest tmp_path fixtures for temporary directories.
  * Simplified setup and cleanup by removing manual temp-file management and path generation.
  * Made directory initialization more reliable using Path-based operations.
  * Added explicit identifiers to mocked job objects to stabilize test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->