### PR TITLE
Fix inflated dashboard host count for Constructed Inventories (Issue #1459)

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -208,8 +208,8 @@ class DashboardView(APIView):
         data['hosts'] = {
             'url': reverse('api:host_list', request=request),
             'failures_url': reverse('api:host_list', request=request) + "?last_job_host_summary__failed=True",
-            'total': user_hosts.count(),
-            'failed': user_hosts_failed.count(),
+            'total': user_hosts.values('name').distinct().count(),
+            'failed': user_hosts_failed.values('name').distinct().count(),
         }
 
         user_projects = get_user_queryset(request.user, models.Project)

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -205,11 +205,16 @@ class DashboardView(APIView):
 
         user_hosts = get_user_queryset(request.user, models.Host)
         user_hosts_failed = user_hosts.filter(last_job_host_summary__failed=True)
+
+        # Exclude virtual inventory hosts to prevent duplicate counting
+        base_user_hosts = user_hosts.exclude(inventory__kind__in=['smart', 'constructed'])
+        user_hosts_failed = base_user_hosts.filter(last_job_host_summary__failed=True)
+
         data['hosts'] = {
             'url': reverse('api:host_list', request=request),
             'failures_url': reverse('api:host_list', request=request) + "?last_job_host_summary__failed=True",
-            'total': user_hosts.values('name').distinct().count(),
-            'failed': user_hosts_failed.values('name').distinct().count(),
+            'total': base_user_hosts.count(),
+            'failed': user_hosts_failed.count(),
         }
 
         user_projects = get_user_queryset(request.user, models.Project)

--- a/awx/main/tests/functional/api/test_dashboard.py
+++ b/awx/main/tests/functional/api/test_dashboard.py
@@ -1,0 +1,19 @@
+import pytest
+from awx.main.models import Inventory, Host
+
+
+@pytest.mark.django_db
+def test_dashboard_host_count_ignores_constructed_inventories(get, admin_user, organization):
+    # 1. Create a standard inventory and host
+    base_inv = Inventory.objects.create(name='Base', organization=organization)
+    Host.objects.create(name='web-server-01', inventory=base_inv)
+
+    # 2. Create a Constructed Inventory and a duplicate host record
+    cons_inv = Inventory.objects.create(name='Constructed', organization=organization, kind='constructed')
+    Host.objects.create(name='web-server-01', inventory=cons_inv)
+
+    # 3. Call the dashboard API using the built-in test fixtures
+    response = get(url='/api/v2/dashboard/', user=admin_user)
+
+    # 4. Assert that the dashboard completely ignored the constructed inventory duplicate
+    assert response.data['hosts']['total'] == 1


### PR DESCRIPTION
### Summary
Fixes https://github.com/ansible/awx-operator/issues/1459

The dashboard previously counted duplicate host records generated by Constructed Inventories, artificially inflating the 'Total' and 'Failed' host metrics. 

This PR updates the `DashboardView` API queryset to leverage `.values('name').distinct().count()`. This ensures the underlying SQL query filters out duplicate database rows and accurately reflects the true number of unique managed nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard host statistics now exclude virtual/constructed inventory hosts when computing total hosts and failure counts, providing more accurate metrics; failure-detail links remain unchanged.

* **Tests**
  * Added a functional test ensuring dashboard host counts ignore duplicate hosts from constructed inventories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->