### PR TITLE
Fix tower_uuid always null in external log aggregator output

### DIFF
--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -252,8 +252,9 @@ class LogstashFormatter(LogstashFormatterBase):
             log_kind = record.name[len('awx.analytics.') :]
             fields = self.reformat_data_for_log(fields, kind=log_kind)
         # General AWX metadata
-        fields['cluster_host_id'] = self.cluster_host_id
-        fields['tower_uuid'] = self.tower_uuid
+        fields['cluster_host_id'] = settings.CLUSTER_HOST_ID
+        tower_uuid = getattr(settings, 'LOG_AGGREGATOR_TOWER_UUID', None) or getattr(settings, 'INSTALL_UUID', None)
+        fields['tower_uuid'] = tower_uuid
         return fields
 
     def format(self, record):


### PR DESCRIPTION
##### SUMMARY

`LOG_AGGREGATOR_TOWER_UUID` ("Cluster-wide unique identifier") can be `null` in external
aggregator log entries. The `LogstashFormatter.__init__` caches the value before the DB
connection is available. Fix reads it dynamically in `get_extra_fields()`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

1. Set `LOG_AGGREGATOR_TOWER_UUID` via API/UI
2. Restart controller pods
3. Query external aggregator — `tower_uuid` is `null`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log aggregation now reads cluster host and tower identifiers from current runtime configuration instead of relying on previously cached/instance-stored values, ensuring logs include up-to-date identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->