### PR TITLE
fix: allow requirements/updater.sh to run outside the AWX container

### DIFF
--- a/requirements/updater.sh
+++ b/requirements/updater.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -ue
 
 requirements_in="$(readlink -f ./requirements.in)"
@@ -18,12 +18,29 @@ generate_requirements() {
   local input_reqs="$1"
   venv="$(pwd)/venv"
   echo "$venv"
-  /usr/bin/python3.12 -m venv "${venv}"
+  _python312=$( [ -x /usr/bin/python3.12 ] && echo /usr/bin/python3.12 || echo python3.12 )
+  "${_python312}" -m venv "${venv}"
   # shellcheck disable=SC1090
   source "${venv}/bin/activate"
 
   # pip version must match the version used in AWX venv (see README.md UPGRADE BLOCKERs)
-  "${venv}/bin/python3" -m pip install -U 'pip==25.3' pip-tools
+  "${venv}/bin/python3" -m pip install -U 'pip==25.3'
+
+  _pip_compile_bin=""
+  if _found=$(find "${PYENV_ROOT:-$HOME/.pyenv}/versions" -name pip-compile -path "*/3.12*" 2>/dev/null | head -1) && [[ -n "${_found}" ]]; then
+    _pip_compile_bin="${_found}"
+  elif _found=$(pyenv which pip-compile 2>/dev/null) && [[ -n "${_found}" ]]; then
+    _pip_compile_bin="${_found}"
+  elif _found=$(command -v pip-compile 2>/dev/null) && [[ -n "${_found}" ]]; then
+    _pip_compile_bin="${_found}"
+  fi
+  if [[ -n "${_pip_compile_bin}" ]]; then
+    # Use external pip-compile (same Python version), re-apply flags from global pip_compile
+    _extra_flags="${pip_compile#pip-compile}"
+    pip_compile="${_pip_compile_bin}${_extra_flags}"
+  else
+    "${venv}/bin/python3" -m pip install pip-tools
+  fi
 
   ${pip_compile} ${input_reqs} --output-file requirements.txt
   # consider the git requirements for purposes of resolving deps
@@ -48,7 +65,7 @@ main() {
   dest_requirements="${requirements}"
   input_requirements="${requirements_in} ${requirements_git}"
 
-  _tmp=$(python -c "import tempfile; print(tempfile.mkdtemp(suffix='.awx-requirements', dir='/tmp'))")
+  _tmp=$(python3 -c "import tempfile; print(tempfile.mkdtemp(suffix='.awx-requirements', dir='/tmp'))")
 
   trap _cleanup INT TERM EXIT
 
@@ -90,11 +107,6 @@ main() {
     echo "dev       Pin the development requirements file"
     echo ""
     exit
-  fi
-
-  if [[ ! -d /awx_devel ]] ; then
-      echo "This script should be run inside the awx container" >&2
-      exit
   fi
 
   if [[ ! -z "$(tail -c 1 "${requirements_git}")" ]]


### PR DESCRIPTION
## Summary

- Prefer `/usr/bin/python3.12` when available (as in the container), fall back to `python3.12` from PATH otherwise
- Use `python3` instead of `python` for tempfile creation
- Detect `pip-compile` from pyenv or PATH and reuse it (preserving flags like `--upgrade`) to avoid a network download of pip-tools when already available; falls back to installing pip-tools into the venv if not found
- Remove the `/awx_devel` guard that blocked execution outside the container

## Test plan

- [x] Tested `bash updater.sh run` outside the container — resolves pip-compile from host pyenv, generates correct `requirements.txt` with paths normalized to `/awx_devel/requirements/`
- [x] Tested `bash updater.sh run` inside the AWX docker-compose container — uses `/usr/bin/python3.12`, installs pip-tools from PyPI, generates correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the dependency pinning workflow by altering interpreter/tool selection (python3.12/pip-compile), which could produce different `requirements.txt` output depending on the host environment. Impact is limited to build/dependency maintenance tooling, not runtime application code.
> 
> **Overview**
> Makes `requirements/updater.sh` runnable outside the AWX container by switching to `bash`, removing the `/awx_devel` execution guard, and using `python3` for temp-dir creation.
> 
> Updates the venv/tooling setup to prefer `/usr/bin/python3.12` when available (fallback to `python3.12` on PATH), pin only `pip==25.3` in the venv, and *reuse an existing* `pip-compile` from pyenv/PATH (preserving flags like `--upgrade`) before falling back to installing `pip-tools`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c101bfd84f91becd7ef3e83e697fc1f9250df36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the updater script to run under bash and made virtual environment creation more flexible to select the appropriate Python 3.12 interpreter.
  * Improved dependency compilation to prefer an external pip-compile tool with sensible fallbacks, reducing in-venv installs.
  * Use python3 for temporary directory handling and removed the enforced container-specific execution guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->