### PR TITLE
[2.7 backport] AAP-57614 fix: dispatch save_indirect_host_entries from artifacts_handler

### DIFF
--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -6,6 +6,7 @@ from collections import deque
 from typing import Tuple, Optional
 
 from awx.main.models.event_query import EventQuery
+from awx.main.tasks.host_indirect import save_indirect_host_entries
 
 # Django
 from django.conf import settings
@@ -300,6 +301,14 @@ class RunnerCallback:
                 self.delay_update(ansible_version=query_file_contents['ansible_version'])
             else:
                 logger.warning(f'The file {COLLECTION_FILENAME} unexpectedly did not contain ansible_version')
+
+            # Dispatch save_indirect_host_entries to process the EventQuery
+            # records created above. handle_success_and_failure_notifications
+            # may have already run and skipped dispatching because
+            # event_queries_processed defaults to True and artifacts_handler
+            # can run after the notification handler. The task's
+            # select_for_update lock prevents duplicate processing.
+            save_indirect_host_entries.delay(self.instance.id)
 
         self.artifacts_processed = True
 

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -301,14 +301,19 @@ class RunnerCallback:
             else:
                 logger.warning(f'The file {COLLECTION_FILENAME} unexpectedly did not contain ansible_version')
 
-            # Write event_queries_processed=False directly to the DB rather
-            # than using delay_update, because delay_update only writes when
-            # the final job status is saved.  save_indirect_host_entries
-            # checks this column under select_for_update and would bail out
-            # if it still saw the default (True).
+            # Write event_queries_processed and installed_collections directly
+            # to the DB rather than using delay_update alone.  delay_update
+            # only writes when the final job status is saved, but
+            # save_indirect_host_entries needs both values in the DB
+            # immediately: event_queries_processed=False to pass the
+            # select_for_update gate, and installed_collections to find
+            # matching EventQuery records via fetch_job_event_query.
             from awx.main.models import Job
 
-            Job.objects.filter(id=self.instance.id).update(event_queries_processed=False)
+            db_updates = {'event_queries_processed': False}
+            if 'installed_collections' in query_file_contents:
+                db_updates['installed_collections'] = query_file_contents['installed_collections']
+            Job.objects.filter(id=self.instance.id).update(**db_updates)
 
             # Dispatch save_indirect_host_entries to process the EventQuery
             # records created above. handle_success_and_failure_notifications

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -278,7 +278,6 @@ class RunnerCallback:
     def artifacts_handler(self, artifact_dir):
         success, query_file_contents = try_load_query_file(artifact_dir)
         if success:
-            self.delay_update(event_queries_processed=False)
             collections_info = collect_queries(query_file_contents)
             for collection, data in collections_info.items():
                 version = data['version']
@@ -301,6 +300,15 @@ class RunnerCallback:
                 self.delay_update(ansible_version=query_file_contents['ansible_version'])
             else:
                 logger.warning(f'The file {COLLECTION_FILENAME} unexpectedly did not contain ansible_version')
+
+            # Write event_queries_processed=False directly to the DB rather
+            # than using delay_update, because delay_update only writes when
+            # the final job status is saved.  save_indirect_host_entries
+            # checks this column under select_for_update and would bail out
+            # if it still saw the default (True).
+            from awx.main.models import Job
+
+            Job.objects.filter(id=self.instance.id).update(event_queries_processed=False)
 
             # Dispatch save_indirect_host_entries to process the EventQuery
             # records created above. handle_success_and_failure_notifications

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -6,7 +6,6 @@ from collections import deque
 from typing import Tuple, Optional
 
 from awx.main.models.event_query import EventQuery
-from awx.main.tasks.host_indirect import save_indirect_host_entries
 
 # Django
 from django.conf import settings
@@ -302,26 +301,22 @@ class RunnerCallback:
                 logger.warning(f'The file {COLLECTION_FILENAME} unexpectedly did not contain ansible_version')
 
             # Write event_queries_processed and installed_collections directly
-            # to the DB rather than using delay_update alone.  delay_update
-            # only writes when the final job status is saved, but
-            # save_indirect_host_entries needs both values in the DB
-            # immediately: event_queries_processed=False to pass the
-            # select_for_update gate, and installed_collections to find
-            # matching EventQuery records via fetch_job_event_query.
+            # to the DB instead of using delay_update.  delay_update defers
+            # writes until the final job status save, but
+            # events_processed_hook (called from both the task runner after
+            # the final save and the callback receiver after the wrapup
+            # event) needs event_queries_processed=False visible in the DB
+            # to dispatch save_indirect_host_entries.  The field defaults to
+            # True, so without a direct write the hook would see True and
+            # skip the dispatch.  installed_collections is also written
+            # directly so it is available if the callback receiver
+            # dispatches before the final save.
             from awx.main.models import Job
 
             db_updates = {'event_queries_processed': False}
             if 'installed_collections' in query_file_contents:
                 db_updates['installed_collections'] = query_file_contents['installed_collections']
             Job.objects.filter(id=self.instance.id).update(**db_updates)
-
-            # Dispatch save_indirect_host_entries to process the EventQuery
-            # records created above. handle_success_and_failure_notifications
-            # may have already run and skipped dispatching because
-            # event_queries_processed defaults to True and artifacts_handler
-            # can run after the notification handler. The task's
-            # select_for_update lock prevents duplicate processing.
-            save_indirect_host_entries.delay(self.instance.id)
 
         self.artifacts_processed = True
 


### PR DESCRIPTION
## Jira
https://issues.redhat.com/browse/AAP-57614

## Summary
Forward-port of ansible/tower#7376 to `devel` (AAP 2.7).

- Fix race condition where `save_indirect_host_entries` is never dispatched when `artifacts_handler` runs after `handle_success_and_failure_notifications`
- Write `event_queries_processed` and `installed_collections` directly to the DB instead of using `delay_update`, so `events_processed_hook` sees the correct values regardless of execution order
- Remove early dispatch from `artifacts_handler`; rely on the existing `events_processed_hook` which runs after events are in the DB

## Test plan
- [ ] Run integration tests in `test_indirect_node_counting_external_queries.py` via CI pipeline
- [ ] Verify `IndirectManagedNodeAudit` records are created after job completion
- [ ] Verify `event_queries_processed` transitions from `False` to `True` after processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Classification
- Bug, Docs Fix or other nominal change

## Test Results
- [containerized/2.7](https://jenkins-csb-aap-main.dno.corp.redhat.com/job/AAPQA/job/AAPQA%20Provisioner/job/AAPQA-ATF-Test-Suite-Yolo/1750/): All query file tests PASS.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts job completion/indirect host processing coordination by changing when `event_queries_processed` (and related fields) are written, which could impact post-run hooks and task dispatch timing. Scope is small but touches job lifecycle behavior and DB update ordering.
> 
> **Overview**
> Fixes a race in `RunnerCallback.artifacts_handler` where delayed field writes could cause `events_processed_hook` to miss that indirect host processing is required.
> 
> When `ansible_data.json` is present, the handler now **writes `event_queries_processed=False` (and `installed_collections` when available) directly to the `Job` row** instead of relying on `delay_update`, ensuring the flag is visible before wrap-up processing runs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a205af41f84fce21e6170f17aa3235defae806c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->