### PR TITLE
fix: avoid delete in loop in inventory import

### DIFF
--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -409,10 +409,12 @@ class Command(BaseCommand):
             del_child_group_pks = list(set(db_children_name_pk_map.values()))
             for offset in range(0, len(del_child_group_pks), self._batch_size):
                 child_group_pks = del_child_group_pks[offset : (offset + self._batch_size)]
-                for db_child in db_children.filter(pk__in=child_group_pks):
-                    group_group_count += 1
-                    db_group.children.remove(db_child)
-                    logger.debug('Group "%s" removed from group "%s"', db_child.name, db_group.name)
+                children_to_remove = list(db_children.filter(pk__in=child_group_pks))
+                if children_to_remove:
+                    group_group_count += len(children_to_remove)
+                    db_group.children.remove(*children_to_remove)
+                    for db_child in children_to_remove:
+                        logger.debug('Group "%s" removed from group "%s"', db_child.name, db_group.name)
             # FIXME: Inventory source group relationships
             # Delete group/host relationships not present in imported data.
             db_hosts = db_group.hosts
@@ -441,12 +443,12 @@ class Command(BaseCommand):
             del_host_pks = list(del_host_pks)
             for offset in range(0, len(del_host_pks), self._batch_size):
                 del_pks = del_host_pks[offset : (offset + self._batch_size)]
-                for db_host in db_hosts.filter(pk__in=del_pks):
-                    group_host_count += 1
-                    if db_host not in db_group.hosts.all():
-                        continue
-                    db_group.hosts.remove(db_host)
-                    logger.debug('Host "%s" removed from group "%s"', db_host.name, db_group.name)
+                hosts_to_remove = list(db_hosts.filter(pk__in=del_pks))
+                if hosts_to_remove:
+                    group_host_count += len(hosts_to_remove)
+                    db_group.hosts.remove(*hosts_to_remove)
+                    for db_host in hosts_to_remove:
+                        logger.debug('Host "%s" removed from group "%s"', db_host.name, db_group.name)
         if settings.SQL_DEBUG:
             logger.warning(
                 'group-group and group-host deletions took %d queries for %d relationships',

--- a/awx/main/tests/functional/commands/test_inventory_import.py
+++ b/awx/main/tests/functional/commands/test_inventory_import.py
@@ -306,6 +306,47 @@ class TestINIImports:
         assert has_host_group.hosts.count() == 1
 
     @mock.patch.object(inventory_import, 'AnsibleInventoryLoader', MockLoader)
+    def test_overwrite_removes_stale_memberships(self, inventory):
+        """When overwrite is enabled, host-group and group-group memberships
+        that are no longer in the imported data should be removed."""
+        # First import: parent_group has two children, host_group has two hosts
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"host1": {}, "host2": {}}},
+            "all": {"children": ["ungrouped", "parent_group", "child_a", "child_b", "host_group"]},
+            "parent_group": {"children": ["child_a", "child_b"]},
+            "host_group": {"hosts": ["host1", "host2"]},
+            "ungrouped": {"hosts": []},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite=True)
+
+        parent = inventory.groups.get(name='parent_group')
+        assert set(parent.children.values_list('name', flat=True)) == {'child_a', 'child_b'}
+        host_grp = inventory.groups.get(name='host_group')
+        assert set(host_grp.hosts.values_list('name', flat=True)) == {'host1', 'host2'}
+
+        # Second import: child_b removed from parent_group, host2 moved out of host_group
+        inventory_import.AnsibleInventoryLoader._data = {
+            "_meta": {"hostvars": {"host1": {}, "host2": {}}},
+            "all": {"children": ["ungrouped", "parent_group", "child_a", "child_b", "host_group"]},
+            "parent_group": {"children": ["child_a"]},
+            "host_group": {"hosts": ["host1"]},
+            "ungrouped": {"hosts": ["host2"]},
+        }
+        cmd = inventory_import.Command()
+        cmd.handle(inventory_id=inventory.pk, source=__file__, overwrite=True)
+
+        parent.refresh_from_db()
+        host_grp.refresh_from_db()
+        # child_b should be removed from parent_group
+        assert set(parent.children.values_list('name', flat=True)) == {'child_a'}
+        # host2 should be removed from host_group
+        assert set(host_grp.hosts.values_list('name', flat=True)) == {'host1'}
+        # host2 and child_b should still exist in the inventory, just not in those groups
+        assert inventory.hosts.filter(name='host2').exists()
+        assert inventory.groups.filter(name='child_b').exists()
+
+    @mock.patch.object(inventory_import, 'AnsibleInventoryLoader', MockLoader)
     def test_recursive_group_error(self, inventory):
         inventory_import.AnsibleInventoryLoader._data = {
             "_meta": {"hostvars": {}},


### PR DESCRIPTION
##### SUMMARY

For inventory import, avoid running delete in a loop, this is very slow for when the number of hosts is large. Instead, collect all relations that have to be removed with one query and then pass all ids to delete in one go.

This will still create a number of delete queries for large imports, because the batch size is 500, but it still brings the number of queries down significantly.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overwrite inventory import now reliably removes stale group and host memberships and performs relationship removals more efficiently.

* **Tests**
  * Added a functional test verifying overwrite imports remove stale memberships while preserving the underlying inventory objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->