### PR TITLE
Fix OpenAPI schema validation message mismatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,7 +581,7 @@ detect-schema-change: genschema
 
 validate-openapi-schema: genschema
 	@echo "Validating OpenAPI schema from schema.json..."
-	@python3 -c "from openapi_spec_validator import validate; import json; spec = json.load(open('schema.json')); validate(spec); print('✓ OpenAPI Schema is valid!')"
+	@python3 -c "from openapi_spec_validator import validate; import json; spec = json.load(open('schema.json')); validate(spec); print('✓ Schema is valid')"
 
 docker-compose-clean: awx/projects
 	$(DOCKER_COMPOSE) -f tools/docker-compose/_sources/docker-compose.yml rm -sf


### PR DESCRIPTION
## Summary
- Fixed mismatch between validation check message and actual output
- Workflow now correctly detects when OpenAPI schema validation passes

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

## Details
The GitHub Actions workflow at `.github/workflows/api_schema_check.yml:66` checks for the message "✓ Schema is valid", but the Makefile was printing "✓ OpenAPI Schema is valid!". This mismatch caused the workflow to always report validation as FAILED even when the schema was actually valid.

Updated `Makefile:584` to print the exact message the workflow expects, ensuring proper detection of successful validation.

## Test plan
- [x] Code change reviewed
- [ ] Verify workflow correctly shows validation passing when schema is valid
- [ ] Verify workflow correctly shows validation failing when schema is invalid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line output change in a Makefile target; no runtime behavior changes beyond CI log matching.
> 
> **Overview**
> Updates `make validate-openapi-schema` to print the success string `✓ Schema is valid` (instead of `✓ OpenAPI Schema is valid!`) so the `api_schema_check` GitHub Actions workflow correctly detects and reports passing OpenAPI schema validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43c8626bff187004bb9f6e9bc7af209dbd391002. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenAPI schema validation success message for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->