### PR TITLE
fix: replace bare except with except Exception in tool scripts

### DIFF
--- a/tools/scripts/config-watcher
+++ b/tools/scripts/config-watcher
@@ -36,7 +36,7 @@ def main():
             continue
         try:
             current_hash = hash(settings_file)
-        except:
+        except Exception:
             sys.stderr.write("Could not open settings.py, skipping config watcher")
             childutils.listener.ok(sys.stdout)
             continue
@@ -54,7 +54,7 @@ def main():
                         sys.stderr.write('Restarting %s\n' % program)
                         rpc.supervisor.stopProcess(program)
                         rpc.supervisor.startProcess(program)
-        except:
+        except Exception:
             sys.stderr.write("No previous hash found")
 
         write_hash(hash_file, current_hash)

--- a/tools/scripts/post_webhook.py
+++ b/tools/scripts/post_webhook.py
@@ -128,7 +128,7 @@ def post_webhook(file, webhook_key, url, verbose, event_type, insecure):
         click.echo("Response body:")
     try:
         click.echo(json.dumps(r.json(), indent=4))
-    except:
+    except Exception:
         click.echo(r.text)
 
 


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in two tool scripts (3 occurrences total).

Bare `except:` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` in addition to regular exceptions, which can mask critical signals.

**Files changed:**
- `tools/scripts/config-watcher` — 2 bare except clauses (lines 39, 57)
- `tools/scripts/post_webhook.py` — 1 bare except clause (line 131)

**Change:**
```python
# Before
        except:

# After
        except Exception:
```

## Testing
No behavior change for normal exceptions — style/correctness fix only.
Prevents accidentally catching `SystemExit` and `KeyboardInterrupt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced exception handling robustness in internal utility scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->