### PR TITLE
Fix workload identity project updates

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1386,6 +1386,8 @@ class RunProjectUpdate(BaseTask):
         """
         passwords = super(RunProjectUpdate, self).build_passwords(project_update, runtime_passwords)
         if project_update.credential:
+            # Use credential from self._credentials (has populated context with workload identity tokens)
+            # instead of project_update.credential (fresh DB fetch). Fallback for unit tests.
             if self.instance:
                 credential = next((c for c in self._credentials if c.pk == project_update.credential.pk), project_update.credential)
             else:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1386,15 +1386,9 @@ class RunProjectUpdate(BaseTask):
         """
         passwords = super(RunProjectUpdate, self).build_passwords(project_update, runtime_passwords)
         if project_update.credential:
-            # Use credential from self._credentials (has populated context with workload identity tokens)
-            # instead of project_update.credential (fresh DB fetch). Fallback for unit tests.
-            if self.instance:
-                credential = next((c for c in self._credentials if c.pk == project_update.credential.pk), project_update.credential)
-            else:
-                credential = project_update.credential
-            passwords['scm_key_unlock'] = credential.get_input('ssh_key_unlock', default='')
-            passwords['scm_username'] = credential.get_input('username', default='')
-            passwords['scm_password'] = credential.get_input('password', default='')
+            passwords['scm_key_unlock'] = project_update.credential.get_input('ssh_key_unlock', default='')
+            passwords['scm_username'] = project_update.credential.get_input('username', default='')
+            passwords['scm_password'] = project_update.credential.get_input('password', default='')
         return passwords
 
     def build_env(self, project_update, private_data_dir, private_data_files=None):

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1386,9 +1386,13 @@ class RunProjectUpdate(BaseTask):
         """
         passwords = super(RunProjectUpdate, self).build_passwords(project_update, runtime_passwords)
         if project_update.credential:
-            passwords['scm_key_unlock'] = project_update.credential.get_input('ssh_key_unlock', default='')
-            passwords['scm_username'] = project_update.credential.get_input('username', default='')
-            passwords['scm_password'] = project_update.credential.get_input('password', default='')
+            if self.instance:
+                credential = next((c for c in self._credentials if c.pk == project_update.credential.pk), project_update.credential)
+            else:
+                credential = project_update.credential
+            passwords['scm_key_unlock'] = credential.get_input('ssh_key_unlock', default='')
+            passwords['scm_username'] = credential.get_input('username', default='')
+            passwords['scm_password'] = credential.get_input('password', default='')
         return passwords
 
     def build_env(self, project_update, private_data_dir, private_data_files=None):
@@ -1682,7 +1686,7 @@ class RunProjectUpdate(BaseTask):
         return params
 
     def build_credentials_list(self, project_update):
-        if project_update.scm_type == 'insights' and project_update.credential:
+        if project_update.credential:
             return [project_update.credential]
         return []
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fix workload identity credentials for project updates with non-insights SCM types.

  Project updates using OIDC workload identity credentials (e.g., retrieving git passwords from HashiCorp Vault) were failing with "Token, Username/Password, AppRole, Kubernetes, or TLS authentication parameters must be set" because:

  1. `build_credentials_list()` only returned credentials for `scm_type == 'insights'`, preventing `populate_workload_identity_tokens()` from generating tokens for git/svn/archive projects

  **Changes:**
  - Remove insights-only restriction in `RunProjectUpdate.build_credentials_list()`

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO
See [AAP-67476](https://redhat.atlassian.net/browse/AAP-67476) for details and linked testing PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Project update operations now include stored SCM credentials consistently across SCM types.
  * Project-level credentials are applied as a fallback when instance context is absent.
  * Credential listing for project updates no longer excludes non-insights SCM credentials, making behavior uniform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->