### PR TITLE
Add awx-tui make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ VAULT_TLS ?= false
 OTEL ?= false
 # If set to true docker-compose will also start a Loki instance
 LOKI ?= false
+# Path to the awx-tui repo for `make awx-tui`
+AWX_TUI_PATH ?= $(shell cd .. && pwd)/awx-tui
+AWX_TUI_REPO ?= git@github.com:ansible-community/awx-tui.git
 # If set to true docker-compose will install editable dependencies
 EDITABLE_DEPENDENCIES ?= false
 # If set to true, use tls for postgres connection
@@ -570,6 +573,24 @@ docker-compose-runtest: awx/projects docker-compose-sources
 
 docker-compose-build-schema: awx/projects docker-compose-sources
 	$(DOCKER_COMPOSE) -f tools/docker-compose/_sources/docker-compose.yml run --rm --service-ports --no-deps awx_1 make genschema
+
+awx-tui:
+	@if [ ! -d "$(AWX_TUI_PATH)" ]; then \
+	    echo "awx-tui not found at $(AWX_TUI_PATH), cloning..."; \
+	    git clone $(AWX_TUI_REPO) $(AWX_TUI_PATH); \
+	else \
+	    echo "Updating awx-tui at $(AWX_TUI_PATH)..."; \
+	    git -C $(AWX_TUI_PATH) pull --ff-only 2>/dev/null || echo "Could not fast-forward, using existing checkout"; \
+	fi
+	@echo "Installing awx-tui dependencies..."
+	$(PYTHON) -m pip install -r $(AWX_TUI_PATH)/requirements.txt -q
+	@echo "Launching awx-tui..."
+	PYTHONPATH=$(AWX_TUI_PATH) \
+	AWX_HOST=https://localhost:8043 \
+	AWX_USER=admin \
+	AWX_PASSWORD=$$(grep -oP "admin_password: '\K[^']*" tools/docker-compose/_sources/secrets/admin_password.yml 2>/dev/null || echo "admin") \
+	AWX_VERIFY_SSL=false \
+	$(PYTHON) -m awx_tui.main --no-verify-ssl --host https://localhost:8043
 
 SCHEMA_DIFF_BASE_FOLDER ?= awx
 SCHEMA_DIFF_BASE_BRANCH ?= devel

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ OTEL ?= false
 LOKI ?= false
 # Path to the awx-tui repo for `make awx-tui`
 AWX_TUI_PATH ?= $(shell cd .. && pwd)/awx-tui
-AWX_TUI_REPO ?= git@github.com:ansible-community/awx-tui.git
+AWX_TUI_REPO ?= https://github.com/ansible-community/awx-tui.git
 # If set to true docker-compose will install editable dependencies
 EDITABLE_DEPENDENCIES ?= false
 # If set to true, use tls for postgres connection
@@ -588,7 +588,7 @@ awx-tui:
 	PYTHONPATH=$(AWX_TUI_PATH) \
 	AWX_HOST=https://localhost:8043 \
 	AWX_USER=admin \
-	AWX_PASSWORD=$$(grep -oP "admin_password: '\K[^']*" tools/docker-compose/_sources/secrets/admin_password.yml 2>/dev/null || echo "admin") \
+	AWX_PASSWORD=$$(awk -F"'" '/^admin_password:/{print $$2}' tools/docker-compose/_sources/secrets/admin_password.yml 2>/dev/null || echo "admin") \
 	AWX_VERIFY_SSL=false \
 	$(PYTHON) -m awx_tui.main --no-verify-ssl --host https://localhost:8043
 


### PR DESCRIPTION
This PR adds a new make target to start the awx-tui and attaches it to an existing docker-compose dev environment. New target will fetch the latest and also clone if the code is not present. Will always update to latest commit as well. `AWX_TUI_PATH` and `AWX_TUI_REPO` can be overridden if desired/code is in a different place. 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### STEPS TO REPRODUCE AND EXTRA INFO
- clone repo
-  start dev cluster `make docker-compose`
- get into a new shell/terminal window at root of awx source `make awx-tui`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
make awx-tui
Updating awx-tui at /home/thedoubl3j/ansible/awx-tui...
Already up to date. (will look different if you haven't cloned the repo)
Installing awx-tui dependencies...
python3.11 -m pip install -r /home/thedoubl3j/ansible/awx-tui/requirements.txt -q

Launching awx-tui...
PYTHONPATH=/home/thedoubl3j/ansible/awx-tui \
AWX_HOST=https://localhost:8043 \
AWX_USER=admin \
AWX_PASSWORD=$(grep -oP "admin_password: '\K[^']*" tools/docker-compose/_sources/secrets/admin_password.yml 2>/dev/null || echo "admin") \
AWX_VERIFY_SSL=false \
python3.11 -m awx_tui.main --no-verify-ssl --host https://localhost:8043

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new make command to launch the AWX terminal UI: it will fetch or update the TUI repo, install its dependencies, and start the interface.
  * The command defaults to a local AWX endpoint with admin credentials (falls back to a safe default if unavailable) and runs with SSL verification disabled for local development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->