### PR TITLE
fix: empty string vs nil handling for limit parameter

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -335,7 +335,9 @@ class WorkflowJobNode(WorkflowNodeBase):
             # or labels, because they do not propogate WFJT-->node at all
 
             # Combine WFJT prompts with node here, WFJT at higher level
-            node_prompts_data.update(wj_prompts_data)
+            # Empty string values on the workflow job (e.g. from IaC setting limit: "")
+            # should not override a node's explicit non-empty prompt value
+            node_prompts_data.update({k: v for k, v in wj_prompts_data.items() if v != ''})
             accepted_fields, ignored_fields, errors = ujt_obj._accept_or_ignore_job_kwargs(**node_prompts_data)
             if errors:
                 logger.info(

--- a/awx/main/tests/functional/models/test_workflow.py
+++ b/awx/main/tests/functional/models/test_workflow.py
@@ -291,6 +291,33 @@ class TestWorkflowJob:
         assert set(data['labels']) == set(node_labels)  # as exception, WFJT labels not applied
         assert data['limit'] == 'wj_limit'
 
+    def test_node_limit_not_overridden_by_empty_string_wj_limit(self, project, inventory):
+        """
+        When the workflow job has an empty string limit (e.g., set via IaC with limit: ""),
+        the node-level limit should still be passed to the spawned job, not silently suppressed.
+        """
+        jt = JobTemplate.objects.create(
+            project=project,
+            inventory=inventory,
+            ask_limit_on_launch=True,
+        )
+        # Simulate a workflow job whose WFJT was created via IaC with `limit: ""`
+        # (e.g. awx.awx.workflow_job_template: ... limit: "")
+        # This stores '' in char_prompts instead of treating it as None/"no limit".
+        wj = WorkflowJob.objects.create(name='test-wf-job')
+        wj.limit = ''  # stores {'limit': ''} in char_prompts - the IaC bug scenario
+        wj.save()
+
+        node = WorkflowJobNode.objects.create(workflow_job=wj, unified_job_template=jt)
+        node.limit = 'web_servers'
+        node.save()
+
+        data = node.get_job_kwargs()
+        # The node-level limit should be applied; the WJ's empty string limit is not meaningful
+        assert data.get('limit') == 'web_servers', (
+            "Node-level limit 'web_servers' was not passed to the job. " "Likely caused by an empty string WJ limit overriding the node limit"
+        )
+
 
 @pytest.mark.django_db
 class TestWorkflowJobTemplate:

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -476,7 +476,7 @@ class NullablePromptPseudoField:
         return instance.char_prompts.get(self.field_name, None)
 
     def __set__(self, instance, value):
-        if value in (None, {}, ''):
+        if value in (None, {}):
             instance.char_prompts.pop(self.field_name, None)
         else:
             instance.char_prompts[self.field_name] = value

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -476,7 +476,7 @@ class NullablePromptPseudoField:
         return instance.char_prompts.get(self.field_name, None)
 
     def __set__(self, instance, value):
-        if value in (None, {}):
+        if value in (None, {}, ''):
             instance.char_prompts.pop(self.field_name, None)
         else:
             instance.char_prompts[self.field_name] = value


### PR DESCRIPTION
##### SUMMARY

Treat an empty string as `no value set` for prompted fields and don't store the empty string value. This allows node level fields in a workflow to override them.


<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New or Enhanced Feature


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where empty-string limit values at the workflow job level were incorrectly overriding explicitly configured node-level limits during job execution. Node-level limits are now properly preserved when workflow job limits are empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->