### PR TITLE
Fix linters tox env failing due to setuptools-scm 10.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 isolated_build = True
 
 [testenv:linters]
+skip_install = True
 deps =
   black
   flake8


### PR DESCRIPTION
## Summary
- Add `skip_install = True` to the `[testenv:linters]` section in `tox.ini`
- The linters env (black, flake8, yamllint) doesn't need the `awx` package installed — it only runs against source files
- This avoids the package build step, which broke when `setuptools-scm` 10.x introduced `vcs-versioning` and began requiring a `[tool.setuptools_scm]` section in `pyproject.toml` (intentionally commented out to allow VERSION file overrides)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects only the `tox -e linters` environment behavior. Potential impact is limited to linters no longer running against an installed package, but they still scan source paths directly.
> 
> **Overview**
> **Fixes `tox -e linters` failures** by setting `skip_install = True` for `[testenv:linters]`, preventing `tox` from building/installing the project when running `black`, `flake8`, and `yamllint`.
> 
> This keeps the linter job focused on source-file checks and avoids build-time issues triggered by packaging/tooling changes (e.g., `setuptools-scm`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35b3a82831418f4b54f034d118cfc9d9dc291caa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified test environment configuration to skip package installation during linting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->