### PR TITLE
AAP-12516 Put node-level upstream artifacts at higher precedence than `WorkflowJob.extra_vars`

### DIFF
--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -366,14 +366,18 @@ class WorkflowJobNode(WorkflowNodeBase):
             data['survey_passwords'] = password_dict
         # process extra_vars
         extra_vars = data.get('extra_vars', {})
+
+        # Workflow Job extra_vars applied first (lower precedence)
+        extra_vars.update(wj_special_vars)
+
+        # Ancestor artifacts (set_stats data from upstream nodes) override
+        # workflow extra_vars, which may contain stale artifacts inherited
+        # from a parent workflow's extra_vars
         if ujt_obj and isinstance(ujt_obj, (JobTemplate, WorkflowJobTemplate)):
             if aa_dict:
                 functional_aa_dict = copy(aa_dict)
                 functional_aa_dict.pop('_ansible_no_log', None)
                 extra_vars.update(functional_aa_dict)
-
-        # Workflow Job extra_vars higher precedence than ancestor artifacts
-        extra_vars.update(wj_special_vars)
         if extra_vars:
             data['extra_vars'] = extra_vars
 

--- a/awx/main/tests/data/projects/debug/set_stats.yml
+++ b/awx/main/tests/data/projects/debug/set_stats.yml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Set artifacts via set_stats
+      ansible.builtin.set_stats:
+        data: "{{ stats_data }}"
+        per_host: false
+        aggregate: false
+      when: stats_data is defined

--- a/awx/main/tests/live/tests/test_nested_workflow_artifacts.py
+++ b/awx/main/tests/live/tests/test_nested_workflow_artifacts.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from awx.main.tests.live.tests.conftest import wait_for_job, unified_job_stdout
+from awx.main.tests.live.tests.conftest import wait_for_job
 
 from awx.main.models import JobTemplate, WorkflowJobTemplate, WorkflowJobTemplateNode
 

--- a/awx/main/tests/live/tests/test_nested_workflow_artifacts.py
+++ b/awx/main/tests/live/tests/test_nested_workflow_artifacts.py
@@ -1,0 +1,125 @@
+import json
+import pytest
+
+from awx.main.tests.live.tests.conftest import wait_for_job, unified_job_stdout
+
+from awx.main.models import JobTemplate, WorkflowJobTemplate, WorkflowJobTemplateNode
+
+JT_NAMES = ('artifact-test-first', 'artifact-test-second', 'artifact-test-reader')
+WFT_NAMES = ('artifact-test-outer-wf', 'artifact-test-inner-wf')
+
+
+@pytest.mark.django_db(transaction=True)
+def test_nested_workflow_set_stats_precedence(live_tmp_folder, demo_inv, project_factory, default_org):
+    """Reproducer for set_stats artifacts from an outer workflow leaking into
+    an inner (child) workflow and overriding the inner workflow's own artifacts.
+
+    Outer WF:  [job_first] --success--> [inner_wf]
+    Inner WF:  [job_second] --success--> [job_reader]
+
+    job_first sets via set_stats:
+        var1: "outer-only"           (only source, should propagate through)
+        var2: "should-be-overridden" (will be overridden by job_second)
+
+    job_second sets via set_stats:
+        var2: "from-inner"           (should override outer's value)
+        var3: "inner-only"           (only source, should be available)
+
+    job_reader runs debug.yml (no set_stats), we inspect its extra_vars:
+        var1 should be "outer-only"           - outer artifacts propagate when uncontested
+        var2 should be "from-inner"           - inner artifacts override outer (THE BUG)
+        var3 should be "inner-only"           - inner-only artifacts propagate normally
+    """
+    # Clean up resources from prior runs (delete individually for signals)
+    for name in WFT_NAMES:
+        for wft in WorkflowJobTemplate.objects.filter(name=name):
+            wft.delete()
+    for name in JT_NAMES:
+        for jt in JobTemplate.objects.filter(name=name):
+            jt.delete()
+
+    proj = project_factory(scm_url=f'file://{live_tmp_folder}/debug')
+    if proj.current_job:
+        wait_for_job(proj.current_job)
+
+    # job_first: sets var1 (outer-only) and var2 (to be overridden by inner)
+    jt_first = JobTemplate.objects.create(
+        name='artifact-test-first',
+        project=proj,
+        playbook='set_stats.yml',
+        inventory=demo_inv,
+        extra_vars=json.dumps({'stats_data': {'var1': 'outer-only', 'var2': 'should-be-overridden'}}),
+    )
+    # job_second: overrides var2, introduces var3
+    jt_second = JobTemplate.objects.create(
+        name='artifact-test-second',
+        project=proj,
+        playbook='set_stats.yml',
+        inventory=demo_inv,
+        extra_vars=json.dumps({'stats_data': {'var2': 'from-inner', 'var3': 'inner-only'}}),
+    )
+    # job_reader: just runs, we check what extra_vars it receives
+    jt_reader = JobTemplate.objects.create(
+        name='artifact-test-reader',
+        project=proj,
+        playbook='debug.yml',
+        inventory=demo_inv,
+    )
+
+    # Inner WFT: job_second -> job_reader
+    inner_wft = WorkflowJobTemplate.objects.create(name='artifact-test-inner-wf', organization=default_org)
+    inner_node_1 = WorkflowJobTemplateNode.objects.create(
+        workflow_job_template=inner_wft,
+        unified_job_template=jt_second,
+        identifier='second',
+    )
+    inner_node_2 = WorkflowJobTemplateNode.objects.create(
+        workflow_job_template=inner_wft,
+        unified_job_template=jt_reader,
+        identifier='reader',
+    )
+    inner_node_1.success_nodes.add(inner_node_2)
+
+    # Outer WFT: job_first -> inner_wf
+    outer_wft = WorkflowJobTemplate.objects.create(name='artifact-test-outer-wf', organization=default_org)
+    outer_node_1 = WorkflowJobTemplateNode.objects.create(
+        workflow_job_template=outer_wft,
+        unified_job_template=jt_first,
+        identifier='first',
+    )
+    outer_node_2 = WorkflowJobTemplateNode.objects.create(
+        workflow_job_template=outer_wft,
+        unified_job_template=inner_wft,
+        identifier='inner',
+    )
+    outer_node_1.success_nodes.add(outer_node_2)
+
+    # Launch and wait
+    outer_wfj = outer_wft.create_unified_job()
+    outer_wfj.signal_start()
+    wait_for_job(outer_wfj, running_timeout=120)
+
+    # Find the reader job inside the inner workflow
+    inner_wf_node = outer_wfj.workflow_job_nodes.get(identifier='inner')
+    inner_wfj = inner_wf_node.job
+    assert inner_wfj is not None, 'Inner workflow job was never created'
+
+    reader_node = inner_wfj.workflow_job_nodes.get(identifier='reader')
+    assert reader_node.job is not None, 'Reader job was never created'
+
+    reader_extra_vars = json.loads(reader_node.job.extra_vars)
+
+    # var1: only set by outer job_first, no conflict — should propagate through
+    assert reader_extra_vars.get('var1') == 'outer-only', f'var1: expected "outer-only" (uncontested outer artifact), ' f'got "{reader_extra_vars.get("var1")}"'
+
+    # var2: set by outer as "should-be-overridden", then by inner as "from-inner"
+    # Inner workflow's own ancestor artifacts should take precedence
+    assert reader_extra_vars.get('var2') == 'from-inner', (
+        f'var2: expected "from-inner" (inner workflow artifact should override outer), '
+        f'got "{reader_extra_vars.get("var2")}". '
+        f'Outer workflow artifacts are leaking via wj_special_vars. '
+        f'reader node ancestor_artifacts={reader_node.ancestor_artifacts}'
+    )
+
+    # var3: only set by inner job_second — should propagate normally
+    assert reader_extra_vars.get('var3') == 'inner-only', f'var3: expected "inner-only" (inner-only artifact), ' f'got "{reader_extra_vars.get("var3")}"'


### PR DESCRIPTION
##### SUMMARY
The live test here should contain a faithful reproducer of the bug, which is kind of hard.

Resource setup:
 - outer workflow
   - job sets artifacts (saved to `artifacts` and `ancestor_artifacts`)
   - nested workflow (gets vars in `extra_vars`)
     - job sets new artifacts, same key (also saved to `artifacts` and `ancestor_artifacts`)
     - job prints the variable from artifacts in "always" node connection

In this real mega-function of `get_job_kwargs`, variables coming from the `WorkflowJob` are truly handled separately from the upstream (path dependent) artifacts from nodes within the same workflow.

The issue with the prior implementation, which was new as of the feature of artifact-passing-in-nested-workflows, https://github.com/ansible/awx/pull/12223, is that a user would reasonably expect that the upstream node within the **inner workflow** would come at higher precedence than the upstream node in the **outer workflow**.

Otherwise it's usually correct that extra_vars should come at higher precedence than artifacts. However, artifacts are truly "closer" to the point of execution. I think that's a good argument, but this is still _slightly_ opinionated when you consider that there's a single workflow case here.
 - workflow is launched with `extra_vars` setting "var1"
   - nodeA sets artifact of "var1" to a different value (the set_stats value)
   - nodeB, downstream of nodeA, prints it

It's important to write this out. I think I'm ok with the "set_stats" value winning. But could be arguable. With the current design & models, there is no way to distinguish these two cases.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes variable precedence when launching jobs from workflow nodes, which can alter runtime behavior for existing nested workflows that relied on the previous `extra_vars`/artifact merge order.
> 
> **Overview**
> Fixes nested workflow variable precedence so upstream node artifacts (`set_stats` via `ancestor_artifacts`) override `WorkflowJob.extra_vars` when constructing downstream job `extra_vars`, preventing outer-workflow artifacts from incorrectly winning inside child workflows.
> 
> Adds a new live regression test (plus a small `set_stats.yml` playbook) that builds an outer+inner workflow chain and asserts inner workflow artifacts override outer ones while non-conflicting artifacts still propagate.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0dcc6c7b9f5d3b1c4c893c3c4d8da7b476363e21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed variable precedence in nested workflows so ancestor workflow artifacts now correctly override template-defined variables.

* **Tests**
  * Added live test verifying variable propagation and precedence across nested workflows.
  * Added a test playbook used to emit and verify aggregated stats during those tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->