### PR TITLE
AAP-68153 Add workload identity for inventory sync jobs

### DIFF
--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1056,16 +1056,18 @@ class InventorySourceOptions(BaseModel):
                     break
         return credential
 
-    def get_extra_credentials(self):
+    def get_extra_credentials(self, base_qs=None):
         """Return all credentials that are not used by the inventory source injector.
         These are all credentials that should run their own inject_credential logic.
         """
+        if base_qs is None:
+            base_qs = self.credentials.all()
         special_cred = None
         if self.source in discover_available_cloud_provider_plugin_names():
             # these have special injection logic associated with them
             special_cred = self.get_cloud_credential()
         extra_creds = []
-        for cred in self.credentials.all():
+        for cred in base_qs:
             if special_cred is None or cred.pk != special_cred.pk:
                 extra_creds.append(cred)
         return extra_creds

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1872,10 +1872,19 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
         return None
 
     def build_credentials_list(self, inventory_update):
-        # Include all credentials (cloud + extra) with prefetch so that
-        # populate_workload_identity_tokens() can generate OIDC JWTs for
-        # credentials whose input sources reference an OIDC external credential.
-        return inventory_update.credentials.prefetch_related('input_sources__source_credential').all()
+        # Use prefetched queryset so populate_workload_identity_tokens() can
+        # access input_sources for OIDC JWT generation.
+        base_qs = inventory_update.credentials.prefetch_related('input_sources__source_credential').all()
+        creds = inventory_update.get_extra_credentials(base_qs=base_qs)
+        # The cloud credential is excluded by get_extra_credentials() but must
+        # be in _credentials so populate_workload_identity_tokens() can generate
+        # an OIDC JWT for it when it has an external credential input source.
+        cloud_cred = inventory_update.get_cloud_credential()
+        if cloud_cred and cloud_cred.pk not in {c.pk for c in creds}:
+            # Use the prefetched instance so input_sources are already loaded
+            prefetched = next((c for c in base_qs if c.pk == cloud_cred.pk), cloud_cred)
+            creds.append(prefetched)
+        return creds
 
     def build_project_dir(self, inventory_update, private_data_dir):
         source_project = None

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1728,6 +1728,16 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
         env['INVENTORY_UPDATE_ID'] = str(inventory_update.pk)
         env.update(STANDARD_INVENTORY_UPDATE_ENV)
 
+        # The injector's _get_shared_env() calls inventory_update.get_cloud_credential()
+        # which does a fresh DB fetch, losing the OIDC context populated by
+        # populate_workload_identity_tokens(). Override it on this instance to return
+        # the credential from self._credentials which already has the context.
+        cloud_cred = inventory_update.get_cloud_credential()
+        if cloud_cred and self._credentials:
+            contexted_cred = next((c for c in self._credentials if c.pk == cloud_cred.pk), None)
+            if contexted_cred is not None:
+                inventory_update.get_cloud_credential = lambda _cred=contexted_cred: _cred
+
         injector = None
         if inventory_update.source in InventorySource.injectors:
             injector = InventorySource.injectors[inventory_update.source]()
@@ -1862,8 +1872,10 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
         return None
 
     def build_credentials_list(self, inventory_update):
-        # All credentials not used by inventory source injector
-        return inventory_update.get_extra_credentials()
+        # Include all credentials (cloud + extra) with prefetch so that
+        # populate_workload_identity_tokens() can generate OIDC JWTs for
+        # credentials whose input sources reference an OIDC external credential.
+        return inventory_update.credentials.prefetch_related('input_sources__source_credential').all()
 
     def build_project_dir(self, inventory_update, private_data_dir):
         source_project = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds OIDC workload identity support to inventory sync jobs.

RunInventoryUpdate had two gaps preventing OIDC workload identity tokens from reaching the cloud credential during inventory sync:

1. build_credentials_list() called get_extra_credentials() which excludes the cloud credential, so populate_workload_identity_tokens() never generated a JWT for it.

2. The inventory plugin injector calls inventory_update.get_cloud_credential() internally, which does a fresh DB fetch that loses the OIDC context set by populate_workload_identity_tokens().

Fix (1) by returning all credentials with prefetched input sources.
Fix (2) by overriding get_cloud_credential() on the instance to return the credential that already carries the OIDC context.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other (awx/main/tasks/jobs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented loss of cloud credential context during inventory updates so identity tokens remain valid throughout the workflow.
  * Ensured credential data needed for input sources is reliably available, avoiding intermittent failures when generating workload identity tokens.
  * Improved credential retrieval to reduce unnecessary database lookups and boost stability during inventory synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->