### PR TITLE
awxkit: Add `packaging` dependency

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -88,6 +88,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
+        'packaging',
         'PyYAML',
         'requests',
         'setuptools',


### PR DESCRIPTION
##### SUMMARY
Add `packaging` dependency - this dependency is used in a couple of places, but was never declared as dependency.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - CLI



##### STEPS TO REPRODUCE AND EXTRA INFO

In Bazel, I'm doing something like
```
load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_console_script_binary")

py_console_script_binary(
    name = "awx",
    env = {"CONTROLLER_HOST": "https://awx.internal.company.tld/"},
    pkg = "@pypi//awxkit",
    visibility = ["//visibility:public"],
)
```

Before:
```
  File "/home/user/.cache/bazel/_bazel_user/fa93f079bfa192f0c08be5359885d53a/execroot/_main/bazel-out/k8-fastbuild/bin/third_party/awxkit/awx.runfiles/_main/third_party/awxkit/awx_entry_point.py", line 11, in <module>
    from awxkit.cli import run
  File "/home/user/.cache/bazel/_bazel_user/fa93f079bfa192f0c08be5359885d53a/execroot/_main/bazel-out/k8-fastbuild/bin/third_party/awxkit/awx.runfiles/rules_python++pip+pypi_313_awxkit/site-packages/awxkit/__init__.py", line 3, in <module>
    from awxkit import awx  # NOQA
    ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.cache/bazel/_bazel_user/fa93f079bfa192f0c08be5359885d53a/execroot/_main/bazel-out/k8-fastbuild/bin/third_party/awxkit/awx.runfiles/rules_python++pip+pypi_313_awxkit/site-packages/awxkit/awx/__init__.py", line 1, in <module>
    from packaging.version import Version
ModuleNotFoundError: No module named 'packaging'
```

After:
```
❯ bazel run //third_party/awxkit -- --version 2>/dev/null
0.1.dev34867+gb387b3084
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to support enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->