### PR TITLE
Drop stale old RBAC FK indexes from model tables

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -188,6 +188,7 @@ class ImplicitRoleField(models.ForeignKey):
         kwargs.setdefault('null', 'True')
         kwargs.setdefault('editable', False)
         kwargs.setdefault('on_delete', models.SET_NULL)
+        kwargs.setdefault('db_index', False)
         super(ImplicitRoleField, self).__init__(*args, **kwargs)
 
     def deconstruct(self):

--- a/awx/main/migrations/0206_remove_implicit_role_field_indexes.py
+++ b/awx/main/migrations/0206_remove_implicit_role_field_indexes.py
@@ -1,0 +1,99 @@
+import awx.main.fields
+import django.db.models.deletion
+from django.db import migrations
+
+IMPLICIT_ROLE_FIELDS = [
+    # Credential
+    ('credential', 'admin_role', ['singleton:system_administrator', 'organization.credential_admin_role']),
+    ('credential', 'use_role', ['admin_role']),
+    ('credential', 'read_role', ['singleton:system_auditor', 'organization.auditor_role', 'use_role', 'admin_role']),
+    # InstanceGroup
+    ('instancegroup', 'admin_role', ['singleton:system_administrator']),
+    ('instancegroup', 'use_role', ['admin_role']),
+    ('instancegroup', 'read_role', ['singleton:system_auditor', 'use_role', 'admin_role']),
+    # Inventory
+    ('inventory', 'admin_role', 'organization.inventory_admin_role'),
+    ('inventory', 'update_role', 'admin_role'),
+    ('inventory', 'adhoc_role', 'admin_role'),
+    ('inventory', 'use_role', 'adhoc_role'),
+    ('inventory', 'read_role', ['organization.auditor_role', 'update_role', 'use_role', 'admin_role']),
+    # JobTemplate
+    ('jobtemplate', 'admin_role', ['organization.job_template_admin_role']),
+    ('jobtemplate', 'execute_role', ['admin_role', 'organization.execute_role']),
+    ('jobtemplate', 'read_role', ['organization.auditor_role', 'inventory.organization.auditor_role', 'execute_role', 'admin_role']),
+    # Organization
+    ('organization', 'admin_role', 'singleton:system_administrator'),
+    ('organization', 'execute_role', 'admin_role'),
+    ('organization', 'project_admin_role', 'admin_role'),
+    ('organization', 'inventory_admin_role', 'admin_role'),
+    ('organization', 'credential_admin_role', 'admin_role'),
+    ('organization', 'workflow_admin_role', 'admin_role'),
+    ('organization', 'notification_admin_role', 'admin_role'),
+    ('organization', 'job_template_admin_role', 'admin_role'),
+    ('organization', 'execution_environment_admin_role', 'admin_role'),
+    ('organization', 'auditor_role', 'singleton:system_auditor'),
+    ('organization', 'member_role', ['admin_role']),
+    (
+        'organization',
+        'read_role',
+        [
+            'member_role',
+            'auditor_role',
+            'execute_role',
+            'project_admin_role',
+            'inventory_admin_role',
+            'workflow_admin_role',
+            'notification_admin_role',
+            'credential_admin_role',
+            'job_template_admin_role',
+            'approval_role',
+            'execution_environment_admin_role',
+        ],
+    ),
+    ('organization', 'approval_role', 'admin_role'),
+    # Project
+    ('project', 'admin_role', ['organization.project_admin_role', 'singleton:system_administrator']),
+    ('project', 'use_role', 'admin_role'),
+    ('project', 'update_role', 'admin_role'),
+    ('project', 'read_role', ['organization.auditor_role', 'singleton:system_auditor', 'use_role', 'update_role']),
+    # Team
+    ('team', 'admin_role', 'organization.admin_role'),
+    ('team', 'member_role', 'admin_role'),
+    ('team', 'read_role', ['organization.auditor_role', 'member_role']),
+    # WorkflowJobTemplate
+    ('workflowjobtemplate', 'admin_role', ['singleton:system_administrator', 'organization.workflow_admin_role']),
+    ('workflowjobtemplate', 'execute_role', ['admin_role', 'organization.execute_role']),
+    ('workflowjobtemplate', 'read_role', ['singleton:system_auditor', 'organization.auditor_role', 'execute_role', 'admin_role', 'approval_role']),
+    ('workflowjobtemplate', 'approval_role', ['organization.approval_role', 'admin_role']),
+]
+
+
+class Migration(migrations.Migration):
+    """Set db_index=False on all ImplicitRoleField ForeignKeys.
+
+    These FK indexes on legacy *_role_id columns have zero scans after
+    the DAB RBAC migration (0192+) and add unnecessary write/VACUUM
+    overhead.  Changing db_index on the field definition keeps Django's
+    migration state in sync with the database.
+    """
+
+    dependencies = [
+        ('main', '0205_add_ordering_to_instancegroup_and_workflow_nodes'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name=model,
+            name=field,
+            field=awx.main.fields.ImplicitRoleField(
+                db_index=False,
+                editable=False,
+                null='True',
+                on_delete=django.db.models.deletion.SET_NULL,
+                parent_role=parent_role,
+                related_name='+',
+                to='main.role',
+            ),
+        )
+        for model, field, parent_role in IMPLICIT_ROLE_FIELDS
+    ]

--- a/awx/main/tests/functional/migrations/test_0206_remove_implicit_role_field_indexes.py
+++ b/awx/main/tests/functional/migrations/test_0206_remove_implicit_role_field_indexes.py
@@ -1,0 +1,53 @@
+from importlib import import_module
+
+from django.db import migrations
+
+
+class TestRemoveImplicitRoleFieldIndexes:
+    """Test migration 0206_remove_implicit_role_field_indexes."""
+
+    def setup_method(self):
+        self.migration_module = import_module('awx.main.migrations.0206_remove_implicit_role_field_indexes')
+
+    def test_migration_dependencies(self):
+        Migration = self.migration_module.Migration
+        assert ('main', '0205_add_ordering_to_instancegroup_and_workflow_nodes') in Migration.dependencies
+
+    def test_migration_uses_alter_field(self):
+        Migration = self.migration_module.Migration
+        for op in Migration.operations:
+            assert isinstance(op, migrations.AlterField)
+
+    def test_migration_targets_correct_field_count(self):
+        assert len(self.migration_module.IMPLICIT_ROLE_FIELDS) == 38
+
+    def test_all_altered_fields_disable_db_index(self):
+        Migration = self.migration_module.Migration
+        for op in Migration.operations:
+            assert op.field.db_index is False
+
+    def test_does_not_target_dab_rbac_fields(self):
+        Migration = self.migration_module.Migration
+        for op in Migration.operations:
+            assert 'dab_rbac' not in op.model_name
+
+    def test_covers_all_model_tables(self):
+        expected_models = {
+            'credential',
+            'instancegroup',
+            'inventory',
+            'jobtemplate',
+            'organization',
+            'project',
+            'team',
+            'workflowjobtemplate',
+        }
+        actual_models = {model for model, _, _ in self.migration_module.IMPLICIT_ROLE_FIELDS}
+        assert actual_models == expected_models
+
+    def test_field_class_sets_db_index_false(self):
+        """Verify the field class itself defaults to db_index=False."""
+        from awx.main.fields import ImplicitRoleField
+
+        field = ImplicitRoleField(parent_role='test')
+        assert field.db_index is False


### PR DESCRIPTION
##### SUMMARY

Sets `db_index=False` on `ImplicitRoleField` and adds migration 0206 with 38 `AlterField` operations to drop stale FK indexes on legacy `*_role_id` columns from model tables. These indexes have zero scans after the DAB RBAC migration (0192+) and add unnecessary write/VACUUM overhead.

This approach keeps Django's migration state in sync with the actual database schema (as suggested in review), rather than using raw `RunSQL` which would create a mismatch between the field definition and the database.

Related #16391

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

Before migration — 38 indexes with zero scans:
```sql
SELECT indexrelname, idx_scan
FROM pg_stat_user_indexes
WHERE indexrelname LIKE '%role_id%'
  AND schemaname = 'public'
  AND idx_scan = 0;
```

Affected tables: main_organization (13), main_inventory (5), main_workflowjobtemplate (4), main_project (4), main_credential (3), main_team (3), main_jobtemplate (3), main_instancegroup (3).

After migration: all 38 indexes removed, write performance and VACUUM improved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed database indexes from role-related fields across multiple models (credentials, instance groups, inventories, job templates, organizations, projects, teams, workflows) and made implicit role fields default to not creating DB indexes.
* **Tests**
  * Added functional tests validating the migration, that affected fields no longer create DB indexes, and that the migration targets the expected set of fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->