### PR TITLE
fix import for refactored method

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -65,7 +65,7 @@ from ansible_base.lib.workload_identity.controller import AutomationControllerJo
 from flags.state import flag_enabled
 
 # AWX
-from awx.main.tasks.jobs import retrieve_workload_identity_jwt_with_claims
+from awx.main.utils.workload_identity import retrieve_workload_identity_jwt_with_claims
 from awx.main.tasks.system import send_notifications, update_inventory_computed_fields
 from awx.main.access import get_user_queryset
 from awx.api.generics import (


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
retrieve_workload_identity_jwt_with_claims is now in a separate utility file, not in jobs.py

the code still works because jobs.py itself is importing `retrieve_workload_identity_jwt_with_claims`
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk import-path fix only; runtime behavior should be unchanged aside from ensuring the API references the refactored utility directly.
> 
> **Overview**
> Updates `awx/api/views/__init__.py` to import `retrieve_workload_identity_jwt_with_claims` from `awx.main.utils.workload_identity` instead of `awx.main.tasks.jobs`, aligning the API with the refactored location of the helper and avoiding reliance on the task module as a re-export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6a55c028b4fc0fca7ae514d95cdc1734aadd91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code organization for workload identity JWT retrieval functionality. No user-facing changes or impact to existing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->