### PR TITLE
Aap 45980

### DIFF
--- a/awx_collection/plugins/modules/job_template.py
+++ b/awx_collection/plugins/modules/job_template.py
@@ -276,6 +276,7 @@ options:
         - ''
         - 'github'
         - 'gitlab'
+        - 'bitbucket_dc'
     webhook_credential:
       description:
         - Personal Access Token for posting back the status to the service API
@@ -436,7 +437,7 @@ def main():
         scm_branch=dict(),
         ask_scm_branch_on_launch=dict(type='bool'),
         job_slice_count=dict(type='int'),
-        webhook_service=dict(choices=['github', 'gitlab', '']),
+        webhook_service=dict(choices=['github', 'gitlab', 'bitbucket_dc', '']),
         webhook_credential=dict(),
         labels=dict(type="list", elements='str'),
         notification_templates_started=dict(type="list", elements='str'),

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -117,6 +117,7 @@ options:
       choices:
         - github
         - gitlab
+        - bitbucket_dc
     webhook_credential:
       description:
         - Personal Access Token for posting back the status to the service API
@@ -828,7 +829,7 @@ def main():
         ask_inventory_on_launch=dict(type='bool'),
         ask_scm_branch_on_launch=dict(type='bool'),
         ask_limit_on_launch=dict(type='bool'),
-        webhook_service=dict(choices=['github', 'gitlab']),
+        webhook_service=dict(choices=['github', 'gitlab', 'bitbucket_dc']),
         webhook_credential=dict(),
         labels=dict(type="list", elements='str'),
         notification_templates_started=dict(type="list", elements='str'),

--- a/awx_collection/test/awx/test_webhooks.py
+++ b/awx_collection/test/awx/test_webhooks.py
@@ -1,0 +1,124 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+
+from awx.main.models import JobTemplate, WorkflowJobTemplate
+
+
+# The backend supports these webhook services on job/workflow templates
+# (see awx/main/models/mixins.py). The collection modules must accept all of
+# them in their argument_spec ``choices`` list. This test guards against the
+# module's choices drifting from the backend -- see AAP-45980, where
+# ``bitbucket_dc`` had been supported by the API since migration 0188 but was
+# still being rejected by the job_template/workflow_job_template modules.
+WEBHOOK_SERVICES = ['github', 'gitlab', 'bitbucket_dc']
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('webhook_service', WEBHOOK_SERVICES)
+def test_job_template_accepts_webhook_service(run_module, admin_user, project, inventory, webhook_service):
+    result = run_module(
+        'job_template',
+        {
+            'name': 'foo',
+            'playbook': 'helloworld.yml',
+            'project': project.name,
+            'inventory': inventory.name,
+            'webhook_service': webhook_service,
+            'state': 'present',
+        },
+        admin_user,
+    )
+
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed', False), result
+
+    jt = JobTemplate.objects.get(name='foo')
+    assert jt.webhook_service == webhook_service
+
+    # Re-running with the same args must be a no-op (idempotence).
+    result = run_module(
+        'job_template',
+        {
+            'name': 'foo',
+            'playbook': 'helloworld.yml',
+            'project': project.name,
+            'inventory': inventory.name,
+            'webhook_service': webhook_service,
+            'state': 'present',
+        },
+        admin_user,
+    )
+    assert not result.get('failed', False), result.get('msg', result)
+    assert not result.get('changed', True), result
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('webhook_service', WEBHOOK_SERVICES)
+def test_workflow_job_template_accepts_webhook_service(run_module, admin_user, organization, webhook_service):
+    result = run_module(
+        'workflow_job_template',
+        {
+            'name': 'foo-workflow',
+            'organization': organization.name,
+            'webhook_service': webhook_service,
+            'state': 'present',
+        },
+        admin_user,
+    )
+
+    assert not result.get('failed', False), result.get('msg', result)
+    assert result.get('changed', False), result
+
+    wfjt = WorkflowJobTemplate.objects.get(name='foo-workflow')
+    assert wfjt.webhook_service == webhook_service
+
+    # Re-running with the same args must be a no-op (idempotence).
+    result = run_module(
+        'workflow_job_template',
+        {
+            'name': 'foo-workflow',
+            'organization': organization.name,
+            'webhook_service': webhook_service,
+            'state': 'present',
+        },
+        admin_user,
+    )
+    assert not result.get('failed', False), result.get('msg', result)
+    assert not result.get('changed', True), result
+
+
+@pytest.mark.django_db
+def test_job_template_rejects_unknown_webhook_service(run_module, admin_user, project, inventory):
+    result = run_module(
+        'job_template',
+        {
+            'name': 'foo',
+            'playbook': 'helloworld.yml',
+            'project': project.name,
+            'inventory': inventory.name,
+            'webhook_service': 'not_a_real_service',
+            'state': 'present',
+        },
+        admin_user,
+    )
+    assert result.get('failed', False), result
+    assert 'webhook_service' in result.get('msg', '')
+
+
+@pytest.mark.django_db
+def test_workflow_job_template_rejects_unknown_webhook_service(run_module, admin_user, organization):
+    result = run_module(
+        'workflow_job_template',
+        {
+            'name': 'foo-workflow',
+            'organization': organization.name,
+            'webhook_service': 'not_a_real_service',
+            'state': 'present',
+        },
+        admin_user,
+    )
+    assert result.get('failed', False), result
+    assert 'webhook_service' in result.get('msg', '')


### PR DESCRIPTION
##### SUMMARY

Support bitbucket_dc webhooks when creating job_templates using the awx.controller collection.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Bitbucket Data Center as a supported webhook service option for job templates and workflow job templates.

* **Tests**
  * Added tests that verify the new webhook option is accepted, persisted, and idempotent for both job and workflow job templates.
  * Added tests that verify unknown webhook_service values are rejected with an appropriate error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->