### PR TITLE
Bind the install bundle to the ansible.receptor collection 2.0.8 version

### DIFF
--- a/awx/api/templates/instance_install_bundle/requirements.yml
+++ b/awx/api/templates/instance_install_bundle/requirements.yml
@@ -1,4 +1,4 @@
 ---
 collections:
   - name: ansible.receptor
-    version: 2.0.6
+    version: 2.0.8


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Bind the install bundle to the ansible.receptor collection 2.0.8 version。

As per https://github.com/ansible/receptor-collection/releases , the ansible.receptor collection 2.0.7 & 2.0.8 mainly extend support for RHEL 10 mesh nodes and comply with Certified Content requirements. 

It looks like during https://redhat.atlassian.net/browse/ANSTRAT-1732 , @PabloHiro directly backported such update to AAP 2.6. From an AoC perspective, we think this is still required for AAP 2.7.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Install RHEL 10 instances as execution nodes to AAP Controller with the ansible.receptor collection 2.0.6 version without fuse-overlayfs and slirp4netns pre-installed will finally fail to run jobs/playbooks on them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the ansible.receptor collection to version 2.0.8 to keep installation components current and address compatibility/maintenance needs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->