### PR TITLE
Correctly restrict push actions to ownership repos

### DIFF
--- a/.github/workflows/_repo-owns-branch.yml
+++ b/.github/workflows/_repo-owns-branch.yml
@@ -5,7 +5,7 @@ name: Repo Owns Branch
 # owns the current branch for push operations.
 #
 # Ownership rules:
-#   - Repos ending in /awx own: devel, feature_*
+#   - ansible/awx owns: devel, feature_*
 #   - ansible/tower owns: stable-*, release_*
 #   - workflow_dispatch is always allowed
 #
@@ -37,8 +37,8 @@ jobs:
             exit 0
           fi
 
-          # Repos ending in /awx own devel and feature_* branches
-          if [[ "$REPO" == */awx ]] && [[ "$BRANCH" == "devel" || "$BRANCH" == feature_* ]]; then
+          # ansible/awx owns devel and feature_* branches
+          if [[ "$REPO" == "ansible/awx" ]] && [[ "$BRANCH" == "devel" || "$BRANCH" == feature_* ]]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
             echo "Repository '$REPO' owns branch '$BRANCH'"
             exit 0

--- a/.github/workflows/_repo-owns-branch.yml
+++ b/.github/workflows/_repo-owns-branch.yml
@@ -1,0 +1,55 @@
+---
+name: Repo Owns Branch
+
+# Reusable workflow that determines whether the current repository
+# owns the current branch for push operations.
+#
+# Ownership rules:
+#   - Repos ending in /awx own: devel, feature_*
+#   - ansible/tower owns: stable-*, release_*
+#   - workflow_dispatch is always allowed
+#
+# All other repo/branch combinations are skipped.
+
+on:
+  workflow_call:
+    outputs:
+      should_run:
+        description: Whether this repo owns the current branch
+        value: ${{ jobs.check.outputs.should_run }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - name: Check branch ownership
+        id: check
+        run: |
+          REPO="${{ github.repository }}"
+          BRANCH="${{ github.ref_name }}"
+          EVENT="${{ github.event_name }}"
+
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "Manual trigger — allowed"
+            exit 0
+          fi
+
+          # Repos ending in /awx own devel and feature_* branches
+          if [[ "$REPO" == */awx ]] && [[ "$BRANCH" == "devel" || "$BRANCH" == feature_* ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "Repository '$REPO' owns branch '$BRANCH'"
+            exit 0
+          fi
+
+          # ansible/tower owns stable-* and release_* branches
+          if [[ "$REPO" == "ansible/tower" ]] && [[ "$BRANCH" == stable-* || "$BRANCH" == release_* ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "Repository '$REPO' owns branch '$BRANCH'"
+            exit 0
+          fi
+
+          echo "should_run=false" >> $GITHUB_OUTPUT
+          echo "Repository '$REPO' does not own branch '$BRANCH' — skipping"

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -13,6 +13,10 @@ on:
       - stable-*
 jobs:
   push-development-images:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (endsWith(github.repository, '/awx') && (github.ref_name == 'devel' || startsWith(github.ref_name, 'feature_'))) ||
+      (github.repository == 'ansible/tower' && (startsWith(github.ref_name, 'stable-') || startsWith(github.ref_name, 'release_')))
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
@@ -29,12 +33,6 @@ jobs:
           - image-name: awx
             make-target: awx-kube-buildx
     steps:
-
-      - name: Skipping build of awx image for non-awx repository
-        run: |
-          echo "Skipping build of awx image for non-awx repository"
-          exit 0
-        if: matrix.build-targets.image-name == 'awx' && !endsWith(github.repository, '/awx')
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -12,11 +12,12 @@ on:
       - feature_*
       - stable-*
 jobs:
+  check-ownership:
+    uses: ./.github/workflows/_repo-owns-branch.yml
+
   push-development-images:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (endsWith(github.repository, '/awx') && (github.ref_name == 'devel' || startsWith(github.ref_name, 'feature_'))) ||
-      (github.repository == 'ansible/tower' && (startsWith(github.ref_name, 'stable-') || startsWith(github.ref_name, 'release_')))
+    needs: check-ownership
+    if: needs.check-ownership.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:

--- a/.github/workflows/spec-sync-on-merge.yml
+++ b/.github/workflows/spec-sync-on-merge.yml
@@ -16,8 +16,8 @@ on:
   push:
     branches:
       - devel
-      - stable-*
-      - release_*
+      - 'stable-2.[6-9]'
+      - 'stable-2.[1-9][0-9]'
   workflow_dispatch: # Allow manual triggering for testing
 jobs:
   check-ownership:

--- a/.github/workflows/spec-sync-on-merge.yml
+++ b/.github/workflows/spec-sync-on-merge.yml
@@ -20,12 +20,13 @@ on:
       - release_*
   workflow_dispatch: # Allow manual triggering for testing
 jobs:
+  check-ownership:
+    uses: ./.github/workflows/_repo-owns-branch.yml
+
   sync-openapi-spec:
+    needs: check-ownership
+    if: needs.check-ownership.outputs.should_run == 'true'
     name: Sync OpenAPI spec to central repo
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (endsWith(github.repository, '/awx') && github.ref_name == 'devel') ||
-      (github.repository == 'ansible/tower' && (startsWith(github.ref_name, 'stable-') || startsWith(github.ref_name, 'release_')))
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/spec-sync-on-merge.yml
+++ b/.github/workflows/spec-sync-on-merge.yml
@@ -16,10 +16,16 @@ on:
   push:
     branches:
       - devel
+      - stable-*
+      - release_*
   workflow_dispatch: # Allow manual triggering for testing
 jobs:
   sync-openapi-spec:
     name: Sync OpenAPI spec to central repo
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (endsWith(github.repository, '/awx') && github.ref_name == 'devel') ||
+      (github.repository == 'ansible/tower' && (startsWith(github.ref_name, 'stable-') || startsWith(github.ref_name, 'release_')))
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -14,6 +14,10 @@ on:
       - stable-**
 jobs:
   push:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (endsWith(github.repository, '/awx') && (github.ref_name == 'devel' || startsWith(github.ref_name, 'feature_'))) ||
+      (github.repository == 'ansible/tower' && (startsWith(github.ref_name, 'stable-') || startsWith(github.ref_name, 'release_')))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -13,11 +13,12 @@ on:
       - feature_**
       - stable-**
 jobs:
+  check-ownership:
+    uses: ./.github/workflows/_repo-owns-branch.yml
+
   push:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (endsWith(github.repository, '/awx') && (github.ref_name == 'devel' || startsWith(github.ref_name, 'feature_'))) ||
-      (github.repository == 'ansible/tower' && (startsWith(github.ref_name, 'stable-') || startsWith(github.ref_name, 'release_')))
+    needs: check-ownership
+    if: needs.check-ownership.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
##### SUMMARY
We are _still_ seeing frequent errors in various places on-push because the actions are not smart enough to know if the thing is already pushed by a repo. Generally, the actions do not know that it is running from a _clone_ of AWX. This gives it the smarts to do that.

Example of such a problem is "Log in to Quay"

```
Run echo "" | docker login quay.io -u  --password-stdin
Error: Cannot perform an interactive login from a non TTY device
Error: Process completed with exit code 1.
```

Yeah, of course a _clone_ of AWX can't log into quay because it doesn't have the secrets. It is not supposed to.

This also solves the problem of double-pushing that people probably didn't know about. The `awx_devel` images were getting built multiple times by multiple repos for the same commit and pushed again and again.

This still retains support for `feature_*` branches, if you want to have github build your images and have push access to the main repo(s).

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes when CI runs on `push`, which can unintentionally skip required publishes/spec syncs if branch patterns or repo names don’t match. The logic is centralized and simple, limiting blast radius to GitHub Actions behavior only.
> 
> **Overview**
> Introduces a reusable workflow (`_repo-owns-branch.yml`) that decides whether the current repo *owns* the current branch (or is manually triggered) and exposes a `should_run` output.
> 
> Updates image build/push, schema upload, and OpenAPI spec sync workflows to run their push jobs only when `should_run` is true, removing the previous per-matrix skip for the `awx` image. Expands `spec-sync-on-merge` branch triggers to include `stable-2.6+` patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdd6263bb222e379dd2f3af88e4f9f3822ecb2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable branch-ownership check for CI.
  * Multiple CI jobs (builds, image pushes, spec syncs, schema uploads) are now gated by that ownership check and run only when appropriate for the repository/branch.
  * The workflow exposes a single boolean output used to control whether downstream jobs execute.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->