### PR TITLE
feat: integrate awx-tui to the awx_devel image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,12 @@ else
  DOCKER_KUBE_CACHE_FLAG=$(DOCKER_CACHE)
 endif
 
+# AWX TUI variables
+AWX_HOST ?= https://localhost:8043
+AWX_USER ?= admin
+AWX_PASSWORD ?= $$(awk -F"'" '/^admin_password:/{print $$2}' tools/docker-compose/_sources/secrets/admin_password.yml 2>/dev/null || echo "admin")
+AWX_VERIFY_SSL ?= false
+
 .PHONY: awx-link clean clean-tmp clean-venv requirements requirements_dev \
 	update_requirements upgrade_requirements update_requirements_dev \
 	docker_update_requirements docker_upgrade_requirements docker_update_requirements_dev \
@@ -570,6 +576,20 @@ docker-compose-runtest: awx/projects docker-compose-sources
 
 docker-compose-build-schema: awx/projects docker-compose-sources
 	$(DOCKER_COMPOSE) -f tools/docker-compose/_sources/docker-compose.yml run --rm --service-ports --no-deps awx_1 make genschema
+
+awx-tui:
+	@if ! command -v awx-tui > /dev/null 2>&1; then \
+		$(PYTHON) -m pip install awx-tui; \
+	fi
+	@if [ -f "$(HOME)/.config/awx-tui/config.yaml" ]; then \
+		$(PYTHON) -m awx_tui.main; \
+	else \
+		AWX_HOST=$(AWX_HOST) \
+		AWX_USER=$(AWX_USER) \
+		AWX_PASSWORD=$(AWX_PASSWORD) \
+		AWX_VERIFY_SSL=$(AWX_VERIFY_SSL) \
+		$(PYTHON) -m awx_tui.main --host $(AWX_HOST); \
+	fi
 
 SCHEMA_DIFF_BASE_FOLDER ?= awx
 SCHEMA_DIFF_BASE_BRANCH ?= devel

--- a/requirements/requirements_dev.txt
+++ b/requirements/requirements_dev.txt
@@ -24,6 +24,7 @@ atomicwrites
 flake8
 yamllint
 pip>=25.3 # PEP 660 – Editable installs for pyproject.toml based builds (wheel based)
+awx-tui
 
 # python debuggers
 debugpy

--- a/tools/docker-compose/bootstrap_development.sh
+++ b/tools/docker-compose/bootstrap_development.sh
@@ -35,6 +35,30 @@ if output=$(ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage createsuperuser --noi
 fi
 echo "Admin password: ${DJANGO_SUPERUSER_PASSWORD}"
 
+# Configure awx-tui to connect to the local AWX instance
+AWX_TUI_CONFIG_DIR="${HOME}/.config/awx-tui"
+AWX_TUI_CONFIG_FILE="${AWX_TUI_CONFIG_DIR}/config.yaml"
+mkdir -p "${AWX_TUI_CONFIG_DIR}"
+python3 -c "
+import yaml, os
+config = {
+    'instances': {
+        'local': {
+            'url': 'https://localhost:8043',
+            'auth': {
+                'method': 'password',
+                'username': 'admin',
+                'password': os.environ['DJANGO_SUPERUSER_PASSWORD'],
+            },
+            'verify_ssl': False,
+        }
+    }
+}
+with open('${AWX_TUI_CONFIG_FILE}', 'w') as f:
+    yaml.dump(config, f, default_flow_style=False)
+"
+chmod 600 "${AWX_TUI_CONFIG_FILE}"
+
 ANSIBLE_REVERSE_RESOURCE_SYNC=false awx-manage create_preload_data
 awx-manage register_default_execution_environments
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
  - Add awx-tui to the devel image via requirements_dev.txt (installed from git since the PyPI beta is missing CSS    
  assets)
  - Auto-generate ~/.config/awx-tui/config.yaml during bootstrap so the TUI connects to the local AWX instance out of the box
  - Add make awx-tui target that uses the config file when available, falls back to env vars on the host
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other

##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Run `make awx-tui`, from the local host or the `awx_devel` container.
<!--- Paste verbatim command output below, e.g. before and after your change -->



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to development tooling (Makefile/dev requirements/docker-compose bootstrap) and do not affect runtime application logic; main risk is accidental credential exposure, mitigated by writing the config with `chmod 600`.
> 
> **Overview**
> Adds first-class support for running `awx-tui` against the local docker-compose AWX instance.
> 
> The dev image now includes `awx-tui` via `requirements_dev.txt`, `bootstrap_development.sh` auto-generates `~/.config/awx-tui/config.yaml` pointing at `https://localhost:8043` using the created admin password, and the Makefile adds an `awx-tui` target that runs with the saved config when present or falls back to `AWX_HOST/AWX_USER/AWX_PASSWORD/AWX_VERIFY_SSL` variables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55cca3cd283cd15ce0c8e285fc5e34dc25dede2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a terminal-based AWX UI workflow with a Make target that ensures the tool is installed and runs using configurable connection settings (host, user, password, SSL verification). It prefers existing user config when present.

* **Chores**
  * Development setup now bootstraps and secures a default config for the terminal UI.
  * Added the terminal UI as a development dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->