### PR TITLE
AAP-70288 Catch errors on re-compute of schedule RRULE computed fields

### DIFF
--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -339,8 +339,6 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
                 self.rrule,
                 e,
             )
-            self.next_run = None
-            self.dtend = None
             raise
 
         if self.enabled:

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -91,7 +91,17 @@ def _fast_forward_rrule(rrule, ref_dt=None):
 
     interval_aligned_offset = datetime.timedelta(seconds=(seconds_since_dtstart // interval) * interval)
     new_start = rrule._dtstart + interval_aligned_offset
-    new_rrule = rrule.replace(dtstart=new_start)
+    try:
+        new_rrule = rrule.replace(dtstart=new_start)
+    except ValueError:
+        logger.warning(
+            "Fast-forward of rrule failed due to invalid byxxx constraint "
+            "with new dtstart=%s (original dtstart=%s). "
+            "Returning original rrule without fast-forward.",
+            new_start,
+            rrule._dtstart,
+        )
+        return rrule
     return new_rrule
 
 
@@ -311,7 +321,18 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         for field_name in affects_fields:
             starting_values[field_name] = getattr(self, field_name)
 
-        future_rs = Schedule.rrulestr(self.rrule)
+        try:
+            future_rs = Schedule.rrulestr(self.rrule)
+        except ValueError:
+            logger.error(
+                "Schedule id=%s has an invalid rrule that cannot be parsed: %s. Setting next_run to None to prevent further errors.",
+                self.id,
+                self.rrule,
+            )
+            self.next_run = None
+            self.dtend = None
+            changed = any(getattr(self, field_name) != starting_values[field_name] for field_name in affects_fields)
+            return changed
 
         if self.enabled:
             next_run_actual = future_rs.after(now())

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -178,7 +178,11 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
     def timezone(self):
         utc = tzutc()
         # All rules in a ruleset will have the same dtstart so we can just take the first rule
-        tzinfo = Schedule.rrulestr(self.rrule)._rrule[0]._dtstart.tzinfo
+        try:
+            tzinfo = Schedule.rrulestr(self.rrule)._rrule[0]._dtstart.tzinfo
+        except ValueError as e:
+            logger.warning("Schedule id=%s has an invalid rrule, cannot determine timezone: %s", self.id, e)
+            return ''
         if tzinfo is utc:
             return 'UTC'
         all_zones = Schedule.get_zoneinfo()
@@ -196,7 +200,12 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
     def until(self):
         # The UNTIL= datestamp (if any) coerced from UTC to the local naive time
         # of the DTSTART
-        for r in Schedule.rrulestr(self.rrule)._rrule:
+        try:
+            rrules = Schedule.rrulestr(self.rrule)._rrule
+        except ValueError as e:
+            logger.warning("Schedule id=%s has an invalid rrule, cannot determine until: %s", self.id, e)
+            return ''
+        for r in rrules:
             if r._until:
                 local_until = r._until.astimezone(r._dtstart.tzinfo)
                 naive_until = local_until.replace(tzinfo=None)
@@ -323,11 +332,12 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
 
         try:
             future_rs = Schedule.rrulestr(self.rrule)
-        except ValueError:
+        except ValueError as e:
             logger.error(
-                "Schedule id=%s has an invalid rrule that cannot be parsed: %s. Setting next_run to None to prevent further errors.",
+                "Schedule id=%s has an invalid rrule that cannot be parsed: %s. Setting next_run to None to prevent further errors. Error: %s",
                 self.id,
                 self.rrule,
+                e,
             )
             self.next_run = None
             self.dtend = None

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -24,20 +24,24 @@ from awx.main.models.jobs import LaunchTimeConfig
 from awx.main.utils import ignore_inventory_computed_fields
 from awx.main.consumers import emit_channel_notification
 
-logger = logging.getLogger('awx.main.models.schedule')
+logger = logging.getLogger("awx.main.models.schedule")
 
-__all__ = ['Schedule']
+__all__ = ["Schedule"]
 
 
 UTC_TIMEZONES = {x: tzutc() for x in dateutil.parser.parserinfo().UTCZONE}
 
 
 def _assert_timezone_id_is_valid(rrules) -> None:
-    broken_rrules = [str(rrule) for rrule in rrules if rrule._dtstart and rrule._dtstart.tzinfo is None]
+    broken_rrules = [
+        str(rrule)
+        for rrule in rrules
+        if rrule._dtstart and rrule._dtstart.tzinfo is None
+    ]
     if not broken_rrules:
         return
     raise ValueError(
-        f'A valid TZID must be provided (e.g., America/New_York). Invalid: {broken_rrules}',
+        f"A valid TZID must be provided (e.g., America/New_York). Invalid: {broken_rrules}",
     ) from None
 
 
@@ -48,7 +52,7 @@ def _fast_forward_rrules(rrules, ref_dt=None):
 
 
 def _fast_forward_rrule(rrule, ref_dt=None):
-    '''
+    """
     Utility to fast forward an rrule, maintaining consistency in the resulting
     occurrences.
 
@@ -61,7 +65,7 @@ def _fast_forward_rrule(rrule, ref_dt=None):
     then back to the original timezone at the end.
 
     Returns a new rrule with a new dtstart
-    '''
+    """
 
     if rrule._freq not in {dateutil.rrule.HOURLY, dateutil.rrule.MINUTELY}:
         return rrule
@@ -89,7 +93,9 @@ def _fast_forward_rrule(rrule, ref_dt=None):
 
     seconds_since_dtstart = (ref_dt - rrule._dtstart).total_seconds()
 
-    interval_aligned_offset = datetime.timedelta(seconds=(seconds_since_dtstart // interval) * interval)
+    interval_aligned_offset = datetime.timedelta(
+        seconds=(seconds_since_dtstart // interval) * interval
+    )
     new_start = rrule._dtstart + interval_aligned_offset
     try:
         new_rrule = rrule.replace(dtstart=new_start)
@@ -132,33 +138,54 @@ class ScheduleManager(ScheduleFilterMethods, models.Manager):
 
 class Schedule(PrimordialModel, LaunchTimeConfig):
     class Meta:
-        app_label = 'main'
-        ordering = [models.F('next_run').desc(nulls_last=True), 'id']
-        unique_together = ('unified_job_template', 'name')
+        app_label = "main"
+        ordering = [models.F("next_run").desc(nulls_last=True), "id"]
+        unique_together = ("unified_job_template", "name")
 
     objects = ScheduleManager()
 
     unified_job_template = models.ForeignKey(
-        'UnifiedJobTemplate',
-        related_name='schedules',
+        "UnifiedJobTemplate",
+        related_name="schedules",
         on_delete=models.CASCADE,
     )
     name = models.CharField(
         max_length=512,
     )
-    enabled = models.BooleanField(default=True, help_text=_("Enables processing of this schedule."))
-    dtstart = models.DateTimeField(null=True, default=None, editable=False, help_text=_("The first occurrence of the schedule occurs on or after this time."))
-    dtend = models.DateTimeField(
-        null=True, default=None, editable=False, help_text=_("The last occurrence of the schedule occurs before this time, aftewards the schedule expires.")
+    enabled = models.BooleanField(
+        default=True, help_text=_("Enables processing of this schedule.")
     )
-    rrule = models.TextField(help_text=_("A value representing the schedules iCal recurrence rule."))
-    next_run = models.DateTimeField(null=True, default=None, editable=False, help_text=_("The next time that the scheduled action will run."))
+    dtstart = models.DateTimeField(
+        null=True,
+        default=None,
+        editable=False,
+        help_text=_(
+            "The first occurrence of the schedule occurs on or after this time."
+        ),
+    )
+    dtend = models.DateTimeField(
+        null=True,
+        default=None,
+        editable=False,
+        help_text=_(
+            "The last occurrence of the schedule occurs before this time, aftewards the schedule expires."
+        ),
+    )
+    rrule = models.TextField(
+        help_text=_("A value representing the schedules iCal recurrence rule.")
+    )
+    next_run = models.DateTimeField(
+        null=True,
+        default=None,
+        editable=False,
+        help_text=_("The next time that the scheduled action will run."),
+    )
     instance_groups = OrderedManyToManyField(
-        'InstanceGroup',
-        related_name='schedule_instance_groups',
+        "InstanceGroup",
+        related_name="schedule_instance_groups",
         blank=True,
         editable=False,
-        through='ScheduleInstanceGroupMembership',
+        through="ScheduleInstanceGroupMembership",
     )
 
     @classmethod
@@ -181,19 +208,23 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         try:
             tzinfo = Schedule.rrulestr(self.rrule)._rrule[0]._dtstart.tzinfo
         except ValueError as e:
-            logger.warning("Schedule id=%s has an invalid rrule, cannot determine timezone: %s", self.id, e)
-            return ''
+            logger.warning(
+                "Schedule id=%s has an invalid rrule, cannot determine timezone: %s",
+                self.id,
+                e,
+            )
+            return ""
         if tzinfo is utc:
-            return 'UTC'
+            return "UTC"
         all_zones = Schedule.get_zoneinfo()
         all_zones.sort(key=lambda x: -len(x))
-        fname = getattr(tzinfo, '_filename', None)
+        fname = getattr(tzinfo, "_filename", None)
         if fname:
             for zone in all_zones:
                 if fname.endswith(zone):
                     return zone
-        logger.warning('Could not detect valid zoneinfo for {}'.format(self.rrule))
-        return ''
+        logger.warning("Could not detect valid zoneinfo for {}".format(self.rrule))
+        return ""
 
     @property
     # TODO: How would we handle multiple until parameters? The UI is currently using this on the edit screen of a schedule
@@ -203,14 +234,18 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         try:
             rrules = Schedule.rrulestr(self.rrule)._rrule
         except ValueError as e:
-            logger.warning("Schedule id=%s has an invalid rrule, cannot determine until: %s", self.id, e)
-            return ''
+            logger.warning(
+                "Schedule id=%s has an invalid rrule, cannot determine until: %s",
+                self.id,
+                e,
+            )
+            return ""
         for r in rrules:
             if r._until:
                 local_until = r._until.astimezone(r._dtstart.tzinfo)
                 naive_until = local_until.replace(tzinfo=None)
                 return naive_until.isoformat()
-        return ''
+        return ""
 
     @classmethod
     def coerce_naive_until(cls, rrule):
@@ -231,41 +266,61 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         #
 
         # Find the DTSTART rule or raise an error, its usually the first rule but that is not strictly enforced
-        start_date_rule = re.sub(r'^.*(DTSTART[^\s]+)\s.*$', r'\1', rrule)
+        start_date_rule = re.sub(r"^.*(DTSTART[^\s]+)\s.*$", r"\1", rrule)
         if not start_date_rule:
-            raise ValueError('A DTSTART field needs to be in the rrule')
+            raise ValueError("A DTSTART field needs to be in the rrule")
 
-        rules = re.split(r'\s+', rrule)
+        rules = re.split(r"\s+", rrule)
         for index in range(0, len(rules)):
             rule = rules[index]
-            if 'until=' in rule.lower():
+            if "until=" in rule.lower():
                 # if DTSTART;TZID= is used, coerce "naive" UNTIL values
                 # to the proper UTC date
-                match_until = re.match(r".*?(?P<until>UNTIL\=[0-9]+T[0-9]+)(?P<utcflag>Z?)", rule)
-                if not len(match_until.group('utcflag')):
+                match_until = re.match(
+                    r".*?(?P<until>UNTIL\=[0-9]+T[0-9]+)(?P<utcflag>Z?)", rule
+                )
+                if not len(match_until.group("utcflag")):
                     # rule = DTSTART;TZID=America/New_York:20200601T120000 RRULE:...;UNTIL=20200601T170000
 
                     # Find the UNTIL=N part of the string
                     # naive_until = UNTIL=20200601T170000
-                    naive_until = match_until.group('until')
+                    naive_until = match_until.group("until")
 
                     # What is the DTSTART timezone for:
                     # DTSTART;TZID=America/New_York:20200601T120000 RRULE:...;UNTIL=20200601T170000Z
                     # local_tz = tzfile('/usr/share/zoneinfo/America/New_York')
                     # We are going to construct a 'dummy' rule for parsing which will include the DTSTART and the rest of the rule
-                    temp_rule = "{} {}".format(start_date_rule, rule.replace(naive_until, naive_until + 'Z'))
+                    temp_rule = "{} {}".format(
+                        start_date_rule, rule.replace(naive_until, naive_until + "Z")
+                    )
                     # If the rule is an EX rule we have to add an RRULE to it because an EX rule alone will not manifest into a ruleset
-                    if rule.lower().startswith('ex'):
-                        temp_rule = "{} {}".format(temp_rule, 'RRULE:FREQ=MINUTELY;INTERVAL=1;UNTIL=20380601T170000Z')
-                    local_tz = dateutil.rrule.rrulestr(temp_rule, tzinfos=UTC_TIMEZONES, **{'forceset': True})._rrule[0]._dtstart.tzinfo
+                    if rule.lower().startswith("ex"):
+                        temp_rule = "{} {}".format(
+                            temp_rule,
+                            "RRULE:FREQ=MINUTELY;INTERVAL=1;UNTIL=20380601T170000Z",
+                        )
+                    local_tz = (
+                        dateutil.rrule.rrulestr(
+                            temp_rule, tzinfos=UTC_TIMEZONES, **{"forceset": True}
+                        )
+                        ._rrule[0]
+                        ._dtstart.tzinfo
+                    )
 
                     # Make a datetime object with tzinfo=<the DTSTART timezone>
                     # localized_until = datetime.datetime(2020, 6, 1, 17, 0, tzinfo=tzfile('/usr/share/zoneinfo/America/New_York'))
-                    localized_until = make_aware(datetime.datetime.strptime(re.sub('^UNTIL=', '', naive_until), "%Y%m%dT%H%M%S"), local_tz)
+                    localized_until = make_aware(
+                        datetime.datetime.strptime(
+                            re.sub("^UNTIL=", "", naive_until), "%Y%m%dT%H%M%S"
+                        ),
+                        local_tz,
+                    )
 
                     # Coerce the datetime to UTC and format it as a string w/ Zulu format
                     # utc_until = UNTIL=20200601T220000Z
-                    utc_until = 'UNTIL=' + localized_until.astimezone(datetime.timezone.utc).strftime('%Y%m%dT%H%M%SZ')
+                    utc_until = "UNTIL=" + localized_until.astimezone(
+                        datetime.timezone.utc
+                    ).strftime("%Y%m%dT%H%M%SZ")
 
                     # rule was:    DTSTART;TZID=America/New_York:20200601T120000 RRULE:...;UNTIL=20200601T170000
                     # rule is now: DTSTART;TZID=America/New_York:20200601T120000 RRULE:...;UNTIL=20200601T220000Z
@@ -278,7 +333,7 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         Apply our own custom rrule parsing requirements
         """
         rrule = Schedule.coerce_naive_until(rrule)
-        kwargs['forceset'] = True
+        kwargs["forceset"] = True
         rruleset = dateutil.rrule.rrulestr(rrule, tzinfos=UTC_TIMEZONES, **kwargs)
 
         _assert_timezone_id_is_valid(rruleset._rrule)
@@ -295,17 +350,24 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
         return rruleset
 
     def __str__(self):
-        return u'%s_t%s_%s_%s' % (self.name, self.unified_job_template.id, self.id, self.next_run)
+        return "%s_t%s_%s_%s" % (
+            self.name,
+            self.unified_job_template.id,
+            self.id,
+            self.next_run,
+        )
 
     def get_absolute_url(self, request=None):
-        return reverse('api:schedule_detail', kwargs={'pk': self.pk}, request=request)
+        return reverse("api:schedule_detail", kwargs={"pk": self.pk}, request=request)
 
     def get_job_kwargs(self):
         config_data = self.prompts_dict()
-        job_kwargs, rejected, errors = self.unified_job_template._accept_or_ignore_job_kwargs(**config_data)
+        job_kwargs, rejected, errors = (
+            self.unified_job_template._accept_or_ignore_job_kwargs(**config_data)
+        )
         if errors:
-            logger.info('Errors creating scheduled job: {}'.format(errors))
-        job_kwargs['_eager_fields'] = {'launch_type': 'scheduled', 'schedule': self}
+            logger.info("Errors creating scheduled job: {}".format(errors))
+        job_kwargs["_eager_fields"] = {"launch_type": "scheduled", "schedule": self}
         return job_kwargs
 
     def get_end_date(ruleset):
@@ -325,7 +387,7 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
             return None
 
     def update_computed_fields_no_save(self):
-        affects_fields = ['next_run', 'dtstart', 'dtend']
+        affects_fields = ["next_run", "dtstart", "dtend"]
         starting_values = {}
         for field_name in affects_fields:
             starting_values[field_name] = getattr(self, field_name)
@@ -359,28 +421,35 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
                 self.dtstart = None
         self.dtend = Schedule.get_end_date(future_rs)
 
-        changed = any(getattr(self, field_name) != starting_values[field_name] for field_name in affects_fields)
+        changed = any(
+            getattr(self, field_name) != starting_values[field_name]
+            for field_name in affects_fields
+        )
         return changed
 
     def update_computed_fields(self):
         changed = self.update_computed_fields_no_save()
         if not changed:
             return
-        emit_channel_notification('schedules-changed', dict(id=self.id, group_name='schedules'))
+        emit_channel_notification(
+            "schedules-changed", dict(id=self.id, group_name="schedules")
+        )
         # Must save self here before calling unified_job_template computed fields
         # in order for that method to be correct
         # by adding modified to update fields, we avoid updating modified time
-        super(Schedule, self).save(update_fields=['next_run', 'dtstart', 'dtend', 'modified'])
+        super(Schedule, self).save(
+            update_fields=["next_run", "dtstart", "dtend", "modified"]
+        )
         with ignore_inventory_computed_fields():
             self.unified_job_template.update_computed_fields()
 
     def save(self, *args, **kwargs):
         self.rrule = Schedule.coerce_naive_until(self.rrule)
         changed = self.update_computed_fields_no_save()
-        if changed and 'update_fields' in kwargs:
-            for field_name in ['next_run', 'dtstart', 'dtend']:
-                if field_name not in kwargs['update_fields']:
-                    kwargs['update_fields'].append(field_name)
+        if changed and "update_fields" in kwargs:
+            for field_name in ["next_run", "dtstart", "dtend"]:
+                if field_name not in kwargs["update_fields"]:
+                    kwargs["update_fields"].append(field_name)
         super(Schedule, self).save(*args, **kwargs)
         if changed:
             with ignore_inventory_computed_fields():

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -334,15 +334,14 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
             future_rs = Schedule.rrulestr(self.rrule)
         except ValueError as e:
             logger.error(
-                "Schedule id=%s has an invalid rrule that cannot be parsed: %s. Setting next_run to None to prevent further errors. Error: %s",
+                "Schedule id=%s has an invalid rrule that cannot be parsed: %s. Error: %s",
                 self.id,
                 self.rrule,
                 e,
             )
             self.next_run = None
             self.dtend = None
-            changed = any(getattr(self, field_name) != starting_values[field_name] for field_name in affects_fields)
-            return changed
+            raise
 
         if self.enabled:
             next_run_actual = future_rs.after(now())

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -72,18 +72,27 @@ from awx.main.models import (
 from awx.main.models.credential import CredentialType
 from awx.main.tasks.helpers import is_run_threshold_reached
 from awx.main.tasks.host_indirect import save_indirect_host_entries
-from awx.main.tasks.receptor import administrative_workunit_reaper, get_receptor_ctl, worker_cleanup, worker_info, write_receptor_config
-from awx.main.utils.common import ignore_inventory_computed_fields, ignore_inventory_group_removal
+from awx.main.tasks.receptor import (
+    administrative_workunit_reaper,
+    get_receptor_ctl,
+    worker_cleanup,
+    worker_info,
+    write_receptor_config,
+)
+from awx.main.utils.common import (
+    ignore_inventory_computed_fields,
+    ignore_inventory_group_removal,
+)
 from awx.main.utils.migration import is_database_synchronized
 from awx.main.utils.reload import stop_local_services
 
-logger = logging.getLogger('awx.main.tasks.system')
+logger = logging.getLogger("awx.main.tasks.system")
 
-OPENSSH_KEY_ERROR = u'''\
+OPENSSH_KEY_ERROR = """\
 It looks like you're trying to use a private key in OpenSSH format, which \
 isn't supported by the installed version of OpenSSH on this instance. \
 Try upgrading OpenSSH or providing your private key in an different format. \
-'''
+"""
 
 
 def _sync_credential_types_to_db():
@@ -102,7 +111,7 @@ def _run_dispatch_startup_common():
     This includes updating schedules, syncing instance membership, and starting
     local reaping and resetting metrics.
     """
-    startup_logger = logging.getLogger('awx.main.tasks')
+    startup_logger = logging.getLogger("awx.main.tasks")
 
     # TODO: Enable this on VM installs
     if settings.IS_K8S:
@@ -177,19 +186,24 @@ def inform_cluster_of_shutdown():
     """
     try:
         inst = Instance.objects.get(hostname=settings.CLUSTER_HOST_ID)
-        inst.mark_offline(update_last_seen=True, errors=_('Instance received normal shutdown signal'))
+        inst.mark_offline(
+            update_last_seen=True, errors=_("Instance received normal shutdown signal")
+        )
     except Instance.DoesNotExist:
         logger.exception("Cluster host not found: %s", settings.CLUSTER_HOST_ID)
         return
 
     logger.debug("No extra reaping required for instance %s", inst.hostname)
-    logger.warning("Normal shutdown processed for instance %s; instance removed from capacity pool.", inst.hostname)
+    logger.warning(
+        "Normal shutdown processed for instance %s; instance removed from capacity pool.",
+        inst.hostname,
+    )
 
 
 @task(queue=get_task_queuename, timeout=3600 * 5)
 def migrate_jsonfield(table, pkfield, columns):
     batchsize = 10000
-    with advisory_lock(f'json_migration_{table}', wait=False) as acquired:
+    with advisory_lock(f"json_migration_{table}", wait=False) as acquired:
         if not acquired:
             return
 
@@ -207,13 +221,19 @@ def migrate_jsonfield(table, pkfield, columns):
         with connection.cursor() as cursor:
             for i in itertools.count(0, batchsize):
                 # Are there even any rows in the table beyond this point?
-                cursor.execute(f"select count(1) from {table} where {pkfield} >= %s limit 1;", (i,))
+                cursor.execute(
+                    f"select count(1) from {table} where {pkfield} >= %s limit 1;", (i,)
+                )
                 if not cursor.fetchone()[0]:
                     break
 
-                column_expr = ', '.join(f"{colname} = {colname}_old::jsonb" for colname in columns)
+                column_expr = ", ".join(
+                    f"{colname} = {colname}_old::jsonb" for colname in columns
+                )
                 # If any of the old columns have non-null values, the data needs to be cast and copied over.
-                empty_expr = ' or '.join(f"{colname}_old is not null" for colname in columns)
+                empty_expr = " or ".join(
+                    f"{colname}_old is not null" for colname in columns
+                )
                 cursor.execute(  # Only clobber the new fields if there is non-null data in the old ones.
                     f"""
                     update {table}
@@ -224,65 +244,101 @@ def migrate_jsonfield(table, pkfield, columns):
                     (i, i + batchsize),
                 )
                 rows = cursor.rowcount
-                logger.debug(f"Batch {i} to {i + batchsize} copied on {table}, {rows} rows affected.")
+                logger.debug(
+                    f"Batch {i} to {i + batchsize} copied on {table}, {rows} rows affected."
+                )
 
-            column_expr = ', '.join(f"DROP COLUMN {column}_old" for column in columns)
+            column_expr = ", ".join(f"DROP COLUMN {column}_old" for column in columns)
             cursor.execute(f"ALTER TABLE {table} {column_expr};")
 
         logger.warning(f"Migration of {table} to jsonb is finished.")
 
 
-@task(queue=get_task_queuename, timeout=3600, on_duplicate='queue_one')
+@task(queue=get_task_queuename, timeout=3600, on_duplicate="queue_one")
 def apply_cluster_membership_policies():
     from awx.main.signals import disable_activity_stream
 
     started_waiting = time.time()
-    with advisory_lock('cluster_policy_lock', wait=True):
+    with advisory_lock("cluster_policy_lock", wait=True):
         lock_time = time.time() - started_waiting
         if lock_time > 1.0:
             to_log = logger.info
         else:
             to_log = logger.debug
-        to_log('Waited {} seconds to obtain lock name: cluster_policy_lock'.format(lock_time))
+        to_log(
+            "Waited {} seconds to obtain lock name: cluster_policy_lock".format(
+                lock_time
+            )
+        )
         started_compute = time.time()
         # Hop nodes should never get assigned to an InstanceGroup.
-        all_instances = list(Instance.objects.exclude(node_type='hop').order_by('id'))
-        all_groups = list(InstanceGroup.objects.prefetch_related('instances'))
+        all_instances = list(Instance.objects.exclude(node_type="hop").order_by("id"))
+        all_groups = list(InstanceGroup.objects.prefetch_related("instances"))
 
         total_instances = len(all_instances)
         actual_groups = []
         actual_instances = []
-        Group = namedtuple('Group', ['obj', 'instances', 'prior_instances'])
-        Node = namedtuple('Instance', ['obj', 'groups'])
+        Group = namedtuple("Group", ["obj", "instances", "prior_instances"])
+        Node = namedtuple("Instance", ["obj", "groups"])
 
         # Process policy instance list first, these will represent manually managed memberships
         instance_hostnames_map = {inst.hostname: inst for inst in all_instances}
         for ig in all_groups:
             # we don't want to allow execution nodes in the control plane
-            exclude_type = 'execution' if ig.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME else 'control'
-            group_actual = Group(obj=ig, instances=[], prior_instances=[instance.pk for instance in ig.instances.all()])  # obtained in prefetch
+            exclude_type = (
+                "execution"
+                if ig.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME
+                else "control"
+            )
+            group_actual = Group(
+                obj=ig,
+                instances=[],
+                prior_instances=[instance.pk for instance in ig.instances.all()],
+            )  # obtained in prefetch
             for hostname in ig.policy_instance_list:
                 if hostname not in instance_hostnames_map:
-                    logger.info("Unknown instance {} in {} policy list".format(hostname, ig.name))
+                    logger.info(
+                        "Unknown instance {} in {} policy list".format(
+                            hostname, ig.name
+                        )
+                    )
                     continue
                 inst = instance_hostnames_map[hostname]
                 if inst.node_type == exclude_type:
-                    logger.info("Instance {} is excluded in {} policy list".format(hostname, ig.name))
+                    logger.info(
+                        "Instance {} is excluded in {} policy list".format(
+                            hostname, ig.name
+                        )
+                    )
                     continue
                 group_actual.instances.append(inst.id)
                 # NOTE: arguable behavior: policy-list-group is not added to
                 # instance's group count for consideration in minimum-policy rules
             if group_actual.instances:
-                logger.debug("Policy List, adding Instances {} to Group {}".format(group_actual.instances, ig.name))
+                logger.debug(
+                    "Policy List, adding Instances {} to Group {}".format(
+                        group_actual.instances, ig.name
+                    )
+                )
 
             actual_groups.append(group_actual)
 
         # Process Instance minimum policies next, since it represents a concrete lower bound to the
         # number of instances to make available to instance groups
-        actual_instances = [Node(obj=i, groups=[]) for i in all_instances if i.managed_by_policy]
-        logger.debug("Total instances: {}, available for policy: {}".format(total_instances, len(actual_instances)))
+        actual_instances = [
+            Node(obj=i, groups=[]) for i in all_instances if i.managed_by_policy
+        ]
+        logger.debug(
+            "Total instances: {}, available for policy: {}".format(
+                total_instances, len(actual_instances)
+            )
+        )
         for g in sorted(actual_groups, key=lambda x: len(x.instances)):
-            exclude_type = 'execution' if g.obj.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME else 'control'
+            exclude_type = (
+                "execution"
+                if g.obj.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME
+                else "control"
+            )
             policy_min_added = []
             for i in sorted(actual_instances, key=lambda x: len(x.groups)):
                 if i.obj.node_type == exclude_type:
@@ -297,12 +353,22 @@ def apply_cluster_membership_policies():
                 i.groups.append(g.obj.id)
                 policy_min_added.append(i.obj.id)
             if policy_min_added:
-                logger.debug("Policy minimum, adding Instances {} to Group {}".format(policy_min_added, g.obj.name))
+                logger.debug(
+                    "Policy minimum, adding Instances {} to Group {}".format(
+                        policy_min_added, g.obj.name
+                    )
+                )
 
         # Finally, process instance policy percentages
         for g in sorted(actual_groups, key=lambda x: len(x.instances)):
-            exclude_type = 'execution' if g.obj.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME else 'control'
-            candidate_pool_ct = sum(1 for i in actual_instances if i.obj.node_type != exclude_type)
+            exclude_type = (
+                "execution"
+                if g.obj.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME
+                else "control"
+            )
+            candidate_pool_ct = sum(
+                1 for i in actual_instances if i.obj.node_type != exclude_type
+            )
             if not candidate_pool_ct:
                 continue
             policy_per_added = []
@@ -313,13 +379,20 @@ def apply_cluster_membership_policies():
                     # If the instance is already _in_ the group, it was
                     # applied earlier via a minimum policy or policy list
                     continue
-                if 100 * float(len(g.instances)) / candidate_pool_ct >= g.obj.policy_instance_percentage:
+                if (
+                    100 * float(len(g.instances)) / candidate_pool_ct
+                    >= g.obj.policy_instance_percentage
+                ):
                     break
                 g.instances.append(i.obj.id)
                 i.groups.append(g.obj.id)
                 policy_per_added.append(i.obj.id)
             if policy_per_added:
-                logger.debug("Policy percentage, adding Instances {} to Group {}".format(policy_per_added, g.obj.name))
+                logger.debug(
+                    "Policy percentage, adding Instances {} to Group {}".format(
+                        policy_per_added, g.obj.name
+                    )
+                )
 
         # Determine if any changes need to be made
         needs_change = False
@@ -328,7 +401,11 @@ def apply_cluster_membership_policies():
                 needs_change = True
                 break
         if not needs_change:
-            logger.debug('Cluster policy no-op finished in {} seconds'.format(time.time() - started_compute))
+            logger.debug(
+                "Cluster policy no-op finished in {} seconds".format(
+                    time.time() - started_compute
+                )
+            )
             return
 
         # On a differential basis, apply instances to groups
@@ -336,17 +413,33 @@ def apply_cluster_membership_policies():
             with disable_activity_stream():
                 for g in actual_groups:
                     if g.obj.is_container_group:
-                        logger.debug('Skipping containerized group {} for policy calculation'.format(g.obj.name))
+                        logger.debug(
+                            "Skipping containerized group {} for policy calculation".format(
+                                g.obj.name
+                            )
+                        )
                         continue
                     instances_to_add = set(g.instances) - set(g.prior_instances)
                     instances_to_remove = set(g.prior_instances) - set(g.instances)
                     if instances_to_add:
-                        logger.debug('Adding instances {} to group {}'.format(list(instances_to_add), g.obj.name))
+                        logger.debug(
+                            "Adding instances {} to group {}".format(
+                                list(instances_to_add), g.obj.name
+                            )
+                        )
                         g.obj.instances.add(*instances_to_add)
                     if instances_to_remove:
-                        logger.debug('Removing instances {} from group {}'.format(list(instances_to_remove), g.obj.name))
+                        logger.debug(
+                            "Removing instances {} from group {}".format(
+                                list(instances_to_remove), g.obj.name
+                            )
+                        )
                         g.obj.instances.remove(*instances_to_remove)
-        logger.debug('Cluster policy computation finished in {} seconds'.format(time.time() - started_compute))
+        logger.debug(
+            "Cluster policy computation finished in {} seconds".format(
+                time.time() - started_compute
+            )
+        )
 
 
 def _resolve_setting_dependents(key):
@@ -354,43 +447,49 @@ def _resolve_setting_dependents(key):
 
 
 def _post_setting_invalidation(invalidated_keys):
-    if 'LOG_AGGREGATOR_LEVEL' in invalidated_keys:
+    if "LOG_AGGREGATOR_LEVEL" in invalidated_keys:
         ctl = get_control_from_settings()
         ctl.queuename = get_task_queuename()
-        ctl.control('set_log_level', data={'level': settings.LOG_AGGREGATOR_LEVEL})
+        ctl.control("set_log_level", data={"level": settings.LOG_AGGREGATOR_LEVEL})
 
 
-@task(queue='tower_settings_change', timeout=600)
+@task(queue="tower_settings_change", timeout=600)
 def clear_setting_cache(setting_keys):
-    dab_clear_cache(setting_keys, _resolve_setting_dependents, _post_setting_invalidation)
+    dab_clear_cache(
+        setting_keys, _resolve_setting_dependents, _post_setting_invalidation
+    )
 
 
-@task(queue='tower_broadcast_all', timeout=600)
+@task(queue="tower_broadcast_all", timeout=600)
 def delete_project_files(project_path):
     # TODO: possibly implement some retry logic
-    lock_file = project_path + '.lock'
+    lock_file = project_path + ".lock"
     if os.path.exists(project_path):
         try:
             shutil.rmtree(project_path)
-            logger.debug('Success removing project files {}'.format(project_path))
+            logger.debug("Success removing project files {}".format(project_path))
         except Exception:
-            logger.exception('Could not remove project directory {}'.format(project_path))
+            logger.exception(
+                "Could not remove project directory {}".format(project_path)
+            )
     if os.path.exists(lock_file):
         try:
             os.remove(lock_file)
-            logger.debug('Success removing {}'.format(lock_file))
+            logger.debug("Success removing {}".format(lock_file))
         except Exception:
-            logger.exception('Could not remove lock file {}'.format(lock_file))
+            logger.exception("Could not remove lock file {}".format(lock_file))
 
 
-@task(queue='tower_broadcast_all')
+@task(queue="tower_broadcast_all")
 def profile_sql(threshold=1, minutes=1):
     if threshold <= 0:
-        cache.delete('awx-profile-sql-threshold')
-        logger.error('SQL PROFILING DISABLED')
+        cache.delete("awx-profile-sql-threshold")
+        logger.error("SQL PROFILING DISABLED")
     else:
-        cache.set('awx-profile-sql-threshold', threshold, timeout=minutes * 60)
-        logger.error('SQL QUERIES >={}s ENABLED FOR {} MINUTE(S)'.format(threshold, minutes))
+        cache.set("awx-profile-sql-threshold", threshold, timeout=minutes * 60)
+        logger.error(
+            "SQL QUERIES >={}s ENABLED FOR {} MINUTE(S)".format(threshold, minutes)
+        )
 
 
 @task(queue=get_task_queuename, timeout=1800)
@@ -405,9 +504,11 @@ def send_notifications(notification_list, job_id=None):
         job_actual.notifications.add(*notifications)
 
     for notification in notifications:
-        update_fields = ['status', 'notifications_sent']
+        update_fields = ["status", "notifications_sent"]
         try:
-            sent = notification.notification_template.send(notification.subject, notification.body)
+            sent = notification.notification_template.send(
+                notification.subject, notification.body
+            )
             notification.status = "successful"
             notification.notifications_sent = sent
             if job_id is not None:
@@ -416,39 +517,51 @@ def send_notifications(notification_list, job_id=None):
             logger.exception("Send Notification Failed {}".format(e))
             notification.status = "failed"
             notification.error = smart_str(e)
-            update_fields.append('error')
+            update_fields.append("error")
         finally:
             try:
                 notification.save(update_fields=update_fields)
             except Exception:
-                logger.exception('Error saving notification {} result.'.format(notification.id))
+                logger.exception(
+                    "Error saving notification {} result.".format(notification.id)
+                )
 
 
 def events_processed_hook(unified_job):
     """This method is intended to be called for every unified job
     after the playbook_on_stats/EOF event is processed and final status is saved
     Either one of these events could happen before the other, or there may be no events"""
-    unified_job.send_notification_templates('succeeded' if unified_job.status == 'successful' else 'failed')
-    if isinstance(unified_job, Job) and flag_enabled("FEATURE_INDIRECT_NODE_COUNTING_ENABLED"):
+    unified_job.send_notification_templates(
+        "succeeded" if unified_job.status == "successful" else "failed"
+    )
+    if isinstance(unified_job, Job) and flag_enabled(
+        "FEATURE_INDIRECT_NODE_COUNTING_ENABLED"
+    ):
         if unified_job.event_queries_processed is True:
             # If this is called from callback receiver, it likely does not have updated model data
             # a refresh now is formally robust
-            unified_job.refresh_from_db(fields=['event_queries_processed'])
+            unified_job.refresh_from_db(fields=["event_queries_processed"])
         if unified_job.event_queries_processed is False:
             save_indirect_host_entries.delay(unified_job.id)
 
 
-@task(queue=get_task_queuename, timeout=3600 * 5, on_duplicate='discard')
+@task(queue=get_task_queuename, timeout=3600 * 5, on_duplicate="discard")
 def gather_analytics():
-    if is_run_threshold_reached(getattr(settings, 'AUTOMATION_ANALYTICS_LAST_GATHER', None), settings.AUTOMATION_ANALYTICS_GATHER_INTERVAL):
+    if is_run_threshold_reached(
+        getattr(settings, "AUTOMATION_ANALYTICS_LAST_GATHER", None),
+        settings.AUTOMATION_ANALYTICS_GATHER_INTERVAL,
+    ):
         analytics.gather()
 
 
-@task(queue=get_task_queuename, timeout=600, on_duplicate='queue_one')
+@task(queue=get_task_queuename, timeout=600, on_duplicate="queue_one")
 def purge_old_stdout_files():
     nowtime = time.time()
     for f in os.listdir(settings.JOBOUTPUT_ROOT):
-        if os.path.getctime(os.path.join(settings.JOBOUTPUT_ROOT, f)) < nowtime - settings.LOCAL_STDOUT_EXPIRE_TIME:
+        if (
+            os.path.getctime(os.path.join(settings.JOBOUTPUT_ROOT, f))
+            < nowtime - settings.LOCAL_STDOUT_EXPIRE_TIME
+        ):
             os.unlink(os.path.join(settings.JOBOUTPUT_ROOT, f))
             logger.debug("Removing {}".format(os.path.join(settings.JOBOUTPUT_ROOT, f)))
 
@@ -457,14 +570,24 @@ class CleanupImagesAndFiles:
     @classmethod
     def get_first_control_instance(cls) -> Instance | None:
         return (
-            Instance.objects.filter(node_type__in=['hybrid', 'control'], node_state=Instance.States.READY, enabled=True, capacity__gt=0)
-            .order_by('-hostname')
+            Instance.objects.filter(
+                node_type__in=["hybrid", "control"],
+                node_state=Instance.States.READY,
+                enabled=True,
+                capacity__gt=0,
+            )
+            .order_by("-hostname")
             .first()
         )
 
     @classmethod
     def get_execution_instances(cls) -> QuerySet[Instance]:
-        return Instance.objects.filter(node_type='execution', node_state=Instance.States.READY, enabled=True, capacity__gt=0)
+        return Instance.objects.filter(
+            node_type="execution",
+            node_state=Instance.States.READY,
+            enabled=True,
+            capacity__gt=0,
+        )
 
     @classmethod
     def run_local(cls, this_inst: Instance, **kwargs):
@@ -472,13 +595,15 @@ class CleanupImagesAndFiles:
             return
         runner_cleanup_kwargs = this_inst.get_cleanup_task_kwargs(**kwargs)
         if runner_cleanup_kwargs:
-            stdout = ''
+            stdout = ""
             with StringIO() as buffer:
                 with redirect_stdout(buffer):
                     ansible_runner.cleanup.run_cleanup(runner_cleanup_kwargs)
                     stdout = buffer.getvalue()
-            if '(changed: True)' in stdout:
-                logger.info(f'Performed local cleanup with kwargs {kwargs}, output:\n{stdout}')
+            if "(changed: True)" in stdout:
+                logger.info(
+                    f"Performed local cleanup with kwargs {kwargs}, output:\n{stdout}"
+                )
 
     @classmethod
     def run_remote(cls, this_inst: Instance, **kwargs):
@@ -492,10 +617,14 @@ class CleanupImagesAndFiles:
                     continue
                 try:
                     stdout = worker_cleanup(inst.hostname, runner_cleanup_kwargs)
-                    if '(changed: True)' in stdout:
-                        logger.info(f'Performed cleanup on execution node {inst.hostname} with output:\n{stdout}')
+                    if "(changed: True)" in stdout:
+                        logger.info(
+                            f"Performed cleanup on execution node {inst.hostname} with output:\n{stdout}"
+                        )
                 except RuntimeError:
-                    logger.exception(f'Error running cleanup on execution node {inst.hostname}')
+                    logger.exception(
+                        f"Error running cleanup on execution node {inst.hostname}"
+                    )
 
     @classmethod
     def run(cls, **kwargs):
@@ -506,103 +635,121 @@ class CleanupImagesAndFiles:
         cls.run_remote(this_inst, **kwargs)
 
 
-@task(queue='tower_broadcast_all', timeout=3600)
+@task(queue="tower_broadcast_all", timeout=3600)
 def handle_removed_image(remove_images=None):
     """Special broadcast invocation of this method to handle case of deleted EE"""
-    CleanupImagesAndFiles.run(remove_images=remove_images, file_pattern='')
+    CleanupImagesAndFiles.run(remove_images=remove_images, file_pattern="")
 
 
-@task(queue=get_task_queuename, timeout=3600, on_duplicate='queue_one')
+@task(queue=get_task_queuename, timeout=3600, on_duplicate="queue_one")
 def cleanup_images_and_files():
     CleanupImagesAndFiles.run(image_prune=True)
 
 
-@task(queue=get_task_queuename, timeout=600, on_duplicate='queue_one')
+@task(queue=get_task_queuename, timeout=600, on_duplicate="queue_one")
 def execution_node_health_check(node):
-    if node == '':
-        logger.warning('Remote health check incorrectly called with blank string')
+    if node == "":
+        logger.warning("Remote health check incorrectly called with blank string")
         return
     try:
         instance = Instance.objects.get(hostname=node)
     except Instance.DoesNotExist:
-        logger.warning(f'Instance record for {node} missing, could not check capacity.')
+        logger.warning(f"Instance record for {node} missing, could not check capacity.")
         return
 
-    if instance.node_type != 'execution':
-        logger.warning(f'Execution node health check ran against {instance.node_type} node {instance.hostname}')
+    if instance.node_type != "execution":
+        logger.warning(
+            f"Execution node health check ran against {instance.node_type} node {instance.hostname}"
+        )
         return
 
-    if instance.node_state not in (Instance.States.READY, Instance.States.UNAVAILABLE, Instance.States.INSTALLED):
-        logger.warning(f"Execution node health check ran against node {instance.hostname} in state {instance.node_state}")
+    if instance.node_state not in (
+        Instance.States.READY,
+        Instance.States.UNAVAILABLE,
+        Instance.States.INSTALLED,
+    ):
+        logger.warning(
+            f"Execution node health check ran against node {instance.hostname} in state {instance.node_state}"
+        )
         return
 
     data = worker_info(node)
 
     prior_capacity = instance.capacity
     instance.save_health_data(
-        version='ansible-runner-' + data.get('runner_version', '???'),
-        cpu=data.get('cpu_count', 0),
-        memory=data.get('mem_in_bytes', 0),
-        uuid=data.get('uuid'),
-        errors='\n'.join(data.get('errors', [])),
+        version="ansible-runner-" + data.get("runner_version", "???"),
+        cpu=data.get("cpu_count", 0),
+        memory=data.get("mem_in_bytes", 0),
+        uuid=data.get("uuid"),
+        errors="\n".join(data.get("errors", [])),
     )
 
-    if data['errors']:
+    if data["errors"]:
         formatted_error = "\n".join(data["errors"])
         if prior_capacity:
-            logger.warning(f'Health check marking execution node {node} as lost, errors:\n{formatted_error}')
+            logger.warning(
+                f"Health check marking execution node {node} as lost, errors:\n{formatted_error}"
+            )
         else:
-            logger.info(f'Failed to find capacity of new or lost execution node {node}, errors:\n{formatted_error}')
+            logger.info(
+                f"Failed to find capacity of new or lost execution node {node}, errors:\n{formatted_error}"
+            )
     else:
-        logger.info('Set capacity of execution node {} to {}, worker info data:\n{}'.format(node, instance.capacity, json.dumps(data, indent=2)))
+        logger.info(
+            "Set capacity of execution node {} to {}, worker info data:\n{}".format(
+                node, instance.capacity, json.dumps(data, indent=2)
+            )
+        )
 
     return data
 
 
 def inspect_established_receptor_connections(mesh_status):
-    '''
+    """
     Flips link state from ADDING to ESTABLISHED
     If the InstanceLink source and target match the entries
     in Known Connection Costs, flip to Established.
-    '''
+    """
     from awx.main.models import InstanceLink
 
     all_links = InstanceLink.objects.filter(link_state=InstanceLink.States.ADDING)
     if not all_links.exists():
         return
-    active_receptor_conns = mesh_status['KnownConnectionCosts']
+    active_receptor_conns = mesh_status["KnownConnectionCosts"]
     update_links = []
     for link in all_links:
         if link.link_state != InstanceLink.States.REMOVING:
-            if link.target.instance.hostname in active_receptor_conns.get(link.source.hostname, {}):
+            if link.target.instance.hostname in active_receptor_conns.get(
+                link.source.hostname, {}
+            ):
                 if link.link_state is not InstanceLink.States.ESTABLISHED:
                     link.link_state = InstanceLink.States.ESTABLISHED
                     update_links.append(link)
 
-    InstanceLink.objects.bulk_update(update_links, ['link_state'])
+    InstanceLink.objects.bulk_update(update_links, ["link_state"])
 
 
 def inspect_execution_and_hop_nodes(instance_list):
-    with advisory_lock('inspect_execution_and_hop_nodes_lock', wait=False):
+    with advisory_lock("inspect_execution_and_hop_nodes_lock", wait=False):
         node_lookup = {inst.hostname: inst for inst in instance_list}
         try:
             ctl = get_receptor_ctl()
         except FileNotFoundError:
-            logger.error('Receptor daemon not running, skipping execution node check')
+            logger.error("Receptor daemon not running, skipping execution node check")
             return
         try:
-            mesh_status = ctl.simple_command('status')
+            mesh_status = ctl.simple_command("status")
         except ValueError as exc:
-            logger.error(f'Error running receptorctl status command, error: {str(exc)}')
+            logger.error(f"Error running receptorctl status command, error: {str(exc)}")
             return
 
         inspect_established_receptor_connections(mesh_status)
 
         nowtime = now()
-        workers = mesh_status['Advertisements']
+        workers = mesh_status["Advertisements"]
 
         for ad in workers:
-            hostname = ad['NodeID']
+            hostname = ad["NodeID"]
 
             if hostname in node_lookup:
                 instance = node_lookup[hostname]
@@ -614,31 +761,49 @@ def inspect_execution_and_hop_nodes(instance_list):
             if instance.node_type in (Instance.Types.CONTROL, Instance.Types.HYBRID):
                 continue
 
-            last_seen = parse_date(ad['Time'])
+            last_seen = parse_date(ad["Time"])
             if instance.last_seen and instance.last_seen >= last_seen:
                 continue
             instance.last_seen = last_seen
-            instance.save(update_fields=['last_seen'])
+            instance.save(update_fields=["last_seen"])
 
             # Only execution nodes should be dealt with by execution_node_health_check
             if instance.node_type == Instance.Types.HOP:
-                if instance.node_state in (Instance.States.UNAVAILABLE, Instance.States.INSTALLED):
-                    logger.warning(f'Hop node {hostname}, has rejoined the receptor mesh')
-                    instance.save_health_data(errors='')
+                if instance.node_state in (
+                    Instance.States.UNAVAILABLE,
+                    Instance.States.INSTALLED,
+                ):
+                    logger.warning(
+                        f"Hop node {hostname}, has rejoined the receptor mesh"
+                    )
+                    instance.save_health_data(errors="")
                 continue
 
-            if instance.node_state in (Instance.States.UNAVAILABLE, Instance.States.INSTALLED):
+            if instance.node_state in (
+                Instance.States.UNAVAILABLE,
+                Instance.States.INSTALLED,
+            ):
                 # if the instance *was* lost, but has appeared again,
                 # attempt to re-establish the initial capacity and version
                 # check
-                logger.warning(f'Execution node attempting to rejoin as instance {hostname}.')
+                logger.warning(
+                    f"Execution node attempting to rejoin as instance {hostname}."
+                )
                 execution_node_health_check.apply_async([hostname])
-            elif (instance.capacity == 0 or (instance.cpu == 0 and instance.memory == 0)) and instance.enabled:
+            elif (
+                instance.capacity == 0 or (instance.cpu == 0 and instance.memory == 0)
+            ) and instance.enabled:
                 # nodes with proven connection but need remediation run health checks are reduced frequency
-                if not instance.last_health_check or (nowtime - instance.last_health_check).total_seconds() >= settings.EXECUTION_NODE_REMEDIATION_CHECKS:
+                if (
+                    not instance.last_health_check
+                    or (nowtime - instance.last_health_check).total_seconds()
+                    >= settings.EXECUTION_NODE_REMEDIATION_CHECKS
+                ):
                     # Periodically re-run the health check of errored nodes, in case someone fixed it
                     # TODO: perhaps decrease the frequency of these checks
-                    logger.debug(f'Restarting health check for execution node {hostname} with known errors.')
+                    logger.debug(
+                        f"Restarting health check for execution node {hostname} with known errors."
+                    )
                     execution_node_health_check.apply_async([hostname])
 
 
@@ -674,7 +839,9 @@ def cluster_node_heartbeat(binder):
     logger.debug(f"Running reaper with {len(active_task_ids)} excluded UUIDs")
     reaper.reap(instance=this_inst, excluded_uuids=active_task_ids, ref_time=ref_time)
     # If waiting jobs are hanging out, resubmit them
-    if UnifiedJob.objects.filter(controller_node=settings.CLUSTER_HOST_ID, status='waiting').exists():
+    if UnifiedJob.objects.filter(
+        controller_node=settings.CLUSTER_HOST_ID, status="waiting"
+    ).exists():
         from awx.main.tasks.jobs import dispatch_waiting_jobs
 
         dispatch_waiting_jobs.apply_async(queue=get_task_queuename())
@@ -690,25 +857,26 @@ def _get_active_task_ids_from_dispatcherd(binder):
     """
     active_task_ids = []
     try:
-
         logger.debug("Querying dispatcherd API for running tasks")
-        data = binder.control('running')
+        data = binder.control("running")
 
         # Extract UUIDs from the running data
         # Process running data: first item is a dict with node_id and task entries
-        data.pop('node_id', None)
+        data.pop("node_id", None)
 
         # Extract task UUIDs from data structure
         for task_key, task_value in data.items():
-            if isinstance(task_value, dict) and 'uuid' in task_value:
-                active_task_ids.append(task_value['uuid'])
+            if isinstance(task_value, dict) and "uuid" in task_value:
+                active_task_ids.append(task_value["uuid"])
                 logger.debug(f"Found active task with UUID: {task_value['uuid']}")
             elif isinstance(task_key, str):
                 # Handle case where UUID might be the key
                 active_task_ids.append(task_key)
                 logger.debug(f"Found active task with key: {task_key}")
 
-        logger.debug(f"Retrieved {len(active_task_ids)} active task IDs from dispatcherd")
+        logger.debug(
+            f"Retrieved {len(active_task_ids)} active task IDs from dispatcherd"
+        )
         return active_task_ids
     except Exception:
         logger.exception("Failed to get running tasks from dispatcherd")
@@ -719,7 +887,15 @@ def _heartbeat_instance_management():
     """Common logic for heartbeat instance management."""
     logger.debug("Cluster node heartbeat task.")
     nowtime = now()
-    instance_list = list(Instance.objects.filter(node_state__in=(Instance.States.READY, Instance.States.UNAVAILABLE, Instance.States.INSTALLED)))
+    instance_list = list(
+        Instance.objects.filter(
+            node_state__in=(
+                Instance.States.READY,
+                Instance.States.UNAVAILABLE,
+                Instance.States.INSTALLED,
+            )
+        )
+    )
     this_inst = None
     lost_instances = []
 
@@ -742,17 +918,31 @@ def _heartbeat_instance_management():
         last_last_seen = this_inst.last_seen
         this_inst.local_health_check()
         if startup_event and this_inst.capacity != 0:
-            logger.warning(f'Rejoining the cluster as instance {this_inst.hostname}. Prior last_seen {last_last_seen}')
+            logger.warning(
+                f"Rejoining the cluster as instance {this_inst.hostname}. Prior last_seen {last_last_seen}"
+            )
             return None, None, None  # Early return case
         elif not last_last_seen:
-            logger.warning(f'Instance does not have recorded last_seen, updating to {nowtime}')
-        elif (nowtime - last_last_seen) > timedelta(seconds=settings.CLUSTER_NODE_HEARTBEAT_PERIOD + 2):
-            logger.warning(f'Heartbeat skew - interval={(nowtime - last_last_seen).total_seconds():.4f}, expected={settings.CLUSTER_NODE_HEARTBEAT_PERIOD}')
+            logger.warning(
+                f"Instance does not have recorded last_seen, updating to {nowtime}"
+            )
+        elif (nowtime - last_last_seen) > timedelta(
+            seconds=settings.CLUSTER_NODE_HEARTBEAT_PERIOD + 2
+        ):
+            logger.warning(
+                f"Heartbeat skew - interval={(nowtime - last_last_seen).total_seconds():.4f}, expected={settings.CLUSTER_NODE_HEARTBEAT_PERIOD}"
+            )
     else:
         if settings.AWX_AUTO_DEPROVISION_INSTANCES:
-            changed, this_inst = Instance.objects.register(ip_address=os.environ.get('MY_POD_IP'), node_type='control', node_uuid=settings.SYSTEM_UUID)
+            changed, this_inst = Instance.objects.register(
+                ip_address=os.environ.get("MY_POD_IP"),
+                node_type="control",
+                node_uuid=settings.SYSTEM_UUID,
+            )
             if changed:
-                logger.warning(f'Recreated instance record {this_inst.hostname} after unexpected removal')
+                logger.warning(
+                    f"Recreated instance record {this_inst.hostname} after unexpected removal"
+                )
             this_inst.local_health_check()
         else:
             logger.error("Cluster Host Not Found: {}".format(settings.CLUSTER_HOST_ID))
@@ -764,14 +954,21 @@ def _heartbeat_instance_management():
 def _heartbeat_check_versions(this_inst, instance_list):
     """Check versions across instances and determine if shutdown is needed."""
     for other_inst in instance_list:
-        if other_inst.node_type in ('execution', 'hop'):
+        if other_inst.node_type in ("execution", "hop"):
             continue
-        if other_inst.version == "" or other_inst.version.startswith('ansible-runner'):
+        if other_inst.version == "" or other_inst.version.startswith("ansible-runner"):
             continue
-        if Version(other_inst.version.split('-', 1)[0]) > Version(awx_application_version.split('-', 1)[0]) and not settings.DEBUG:
+        if (
+            Version(other_inst.version.split("-", 1)[0])
+            > Version(awx_application_version.split("-", 1)[0])
+            and not settings.DEBUG
+        ):
             logger.error(
                 "Host {} reports version {}, but this node {} is at {}, shutting down".format(
-                    other_inst.hostname, other_inst.version, this_inst.hostname, this_inst.version
+                    other_inst.hostname,
+                    other_inst.version,
+                    this_inst.hostname,
+                    this_inst.version,
                 )
             )
             # Shutdown signal will set the capacity to zero to ensure no Jobs get added to this instance.
@@ -788,34 +985,63 @@ def _heartbeat_handle_lost_instances(lost_instances, this_inst):
             explanation = "Job reaped due to instance shutdown"
             reaper.reap(other_inst, job_explanation=explanation)
             # Any jobs that were waiting to be processed by this node will be handed back to task manager
-            UnifiedJob.objects.filter(status='waiting', controller_node=other_inst.hostname).update(status='pending', controller_node='', execution_node='')
+            UnifiedJob.objects.filter(
+                status="waiting", controller_node=other_inst.hostname
+            ).update(status="pending", controller_node="", execution_node="")
         except Exception:
-            logger.exception('failed to re-process jobs for lost instance {}'.format(other_inst.hostname))
+            logger.exception(
+                "failed to re-process jobs for lost instance {}".format(
+                    other_inst.hostname
+                )
+            )
         try:
-            if settings.AWX_AUTO_DEPROVISION_INSTANCES and other_inst.node_type == "control":
+            if (
+                settings.AWX_AUTO_DEPROVISION_INSTANCES
+                and other_inst.node_type == "control"
+            ):
                 deprovision_hostname = other_inst.hostname
                 other_inst.delete()  # FIXME: what about associated inbound links?
-                logger.info("Host {} Automatically Deprovisioned.".format(deprovision_hostname))
+                logger.info(
+                    "Host {} Automatically Deprovisioned.".format(deprovision_hostname)
+                )
             elif other_inst.node_state == Instance.States.READY:
-                other_inst.mark_offline(errors=_('Another cluster node has determined this instance to be unresponsive'))
-                logger.error("Host {} last checked in at {}, marked as lost.".format(other_inst.hostname, other_inst.last_seen))
+                other_inst.mark_offline(
+                    errors=_(
+                        "Another cluster node has determined this instance to be unresponsive"
+                    )
+                )
+                logger.error(
+                    "Host {} last checked in at {}, marked as lost.".format(
+                        other_inst.hostname, other_inst.last_seen
+                    )
+                )
 
         except DatabaseError as e:
             cause = e.__cause__
-            if cause and hasattr(cause, 'sqlstate'):
+            if cause and hasattr(cause, "sqlstate"):
                 sqlstate = cause.sqlstate
                 sqlstate_str = psycopg.errors.lookup(sqlstate)
-                logger.debug('SQL Error state: {} - {}'.format(sqlstate, sqlstate_str))
+                logger.debug("SQL Error state: {} - {}".format(sqlstate, sqlstate_str))
 
                 if sqlstate == psycopg.errors.NoData:
-                    logger.debug('Another instance has marked {} as lost'.format(other_inst.hostname))
+                    logger.debug(
+                        "Another instance has marked {} as lost".format(
+                            other_inst.hostname
+                        )
+                    )
                 else:
-                    logger.exception("Error marking {} as lost.".format(other_inst.hostname))
+                    logger.exception(
+                        "Error marking {} as lost.".format(other_inst.hostname)
+                    )
             else:
-                logger.exception('No SQL state available.  Error marking {} as lost'.format(other_inst.hostname))
+                logger.exception(
+                    "No SQL state available.  Error marking {} as lost".format(
+                        other_inst.hostname
+                    )
+                )
 
 
-@task(queue=get_task_queuename, timeout=1800, on_duplicate='queue_one')
+@task(queue=get_task_queuename, timeout=1800, on_duplicate="queue_one")
 def awx_receptor_workunit_reaper():
     """
     When an AWX job is launched via receptor, files such as status, stdin, and stdout are created
@@ -841,27 +1067,33 @@ def awx_receptor_workunit_reaper():
     try:
         receptor_ctl = get_receptor_ctl()
     except FileNotFoundError:
-        logger.info('Receptorctl sockfile not found for workunit reaper, doing nothing')
+        logger.info("Receptorctl sockfile not found for workunit reaper, doing nothing")
         return
     try:
         receptor_work_list = receptor_ctl.simple_command("work list")
     except ValueError as exc:
-        logger.info(f'Error getting work list for workunit reaper, error: {str(exc)}')
+        logger.info(f"Error getting work list for workunit reaper, error: {str(exc)}")
         return
 
     unit_ids = [id for id in receptor_work_list]
-    jobs_with_unreleased_receptor_units = UnifiedJob.objects.filter(work_unit_id__in=unit_ids).exclude(status__in=ACTIVE_STATES)
+    jobs_with_unreleased_receptor_units = UnifiedJob.objects.filter(
+        work_unit_id__in=unit_ids
+    ).exclude(status__in=ACTIVE_STATES)
     if settings.RECEPTOR_KEEP_WORK_ON_ERROR:
-        jobs_with_unreleased_receptor_units = jobs_with_unreleased_receptor_units.exclude(status__in=ERROR_STATES)
+        jobs_with_unreleased_receptor_units = (
+            jobs_with_unreleased_receptor_units.exclude(status__in=ERROR_STATES)
+        )
     for job in jobs_with_unreleased_receptor_units:
-        logger.debug(f"{job.log_format} is not active, reaping receptor work unit {job.work_unit_id}")
+        logger.debug(
+            f"{job.log_format} is not active, reaping receptor work unit {job.work_unit_id}"
+        )
         receptor_ctl.simple_command(f"work cancel {job.work_unit_id}")
         receptor_ctl.simple_command(f"work release {job.work_unit_id}")
 
     administrative_workunit_reaper(receptor_work_list)
 
 
-@task(queue=get_task_queuename, timeout=1800, on_duplicate='queue_one')
+@task(queue=get_task_queuename, timeout=1800, on_duplicate="queue_one")
 def awx_k8s_reaper():
     if not settings.RECEPTOR_RELEASE_WORK:
         return
@@ -872,22 +1104,40 @@ def awx_k8s_reaper():
         logger.debug("Checking for orphaned k8s pods for {}.".format(group))
         pods = PodManager.list_active_jobs(group)
         time_cutoff = now() - timedelta(seconds=settings.K8S_POD_REAPER_GRACE_PERIOD)
-        reap_job_candidates = UnifiedJob.objects.filter(pk__in=pods.keys(), finished__lte=time_cutoff).exclude(status__in=ACTIVE_STATES)
+        reap_job_candidates = UnifiedJob.objects.filter(
+            pk__in=pods.keys(), finished__lte=time_cutoff
+        ).exclude(status__in=ACTIVE_STATES)
         if settings.RECEPTOR_KEEP_WORK_ON_ERROR:
             reap_job_candidates = reap_job_candidates.exclude(status__in=ERROR_STATES)
         for job in reap_job_candidates:
-            logger.debug('{} is no longer active, reaping orphaned k8s pod'.format(job.log_format))
+            logger.debug(
+                "{} is no longer active, reaping orphaned k8s pod".format(
+                    job.log_format
+                )
+            )
             try:
                 pm = PodManager(job)
-                pm.kube_api.delete_namespaced_pod(name=pods[job.id], namespace=pm.namespace, _request_timeout=settings.AWX_CONTAINER_GROUP_K8S_API_TIMEOUT)
+                pm.kube_api.delete_namespaced_pod(
+                    name=pods[job.id],
+                    namespace=pm.namespace,
+                    _request_timeout=settings.AWX_CONTAINER_GROUP_K8S_API_TIMEOUT,
+                )
             except Exception:
-                logger.exception("Failed to delete orphaned pod {} from {}".format(job.log_format, group))
+                logger.exception(
+                    "Failed to delete orphaned pod {} from {}".format(
+                        job.log_format, group
+                    )
+                )
 
 
-@task(queue=get_task_queuename, timeout=3600 * 5, on_duplicate='discard')
+@task(queue=get_task_queuename, timeout=3600 * 5, on_duplicate="discard")
 def awx_periodic_scheduler():
     lock_session_timeout_milliseconds = settings.TASK_MANAGER_LOCK_TIMEOUT * 1000
-    with advisory_lock('awx_periodic_scheduler_lock', lock_session_timeout_milliseconds=lock_session_timeout_milliseconds, wait=False) as acquired:
+    with advisory_lock(
+        "awx_periodic_scheduler_lock",
+        lock_session_timeout_milliseconds=lock_session_timeout_milliseconds,
+        wait=False,
+    ) as acquired:
         if acquired is False:
             logger.debug("Not running periodic scheduler, another task holds lock")
             return
@@ -905,8 +1155,12 @@ def awx_periodic_scheduler():
             try:
                 schedule.update_computed_fields()
             except Exception:
-                logger.exception("Failed to update computed fields for schedule %s.", schedule)
-                Schedule.objects.filter(pk=schedule.pk).update(next_run=None, dtend=None)
+                logger.exception(
+                    "Failed to update computed fields for schedule %s.", schedule
+                )
+                Schedule.objects.filter(pk=schedule.pk).update(
+                    next_run=None, dtend=None
+                )
         schedules = Schedule.objects.enabled().between(last_run, run_now)
 
         invalid_license = False
@@ -920,34 +1174,51 @@ def awx_periodic_scheduler():
             try:
                 schedule.update_computed_fields()  # To update next_run timestamp.
             except Exception:
-                logger.exception("Failed to update computed fields for schedule %s.", schedule)
-                Schedule.objects.filter(pk=schedule.pk).update(next_run=None, dtend=None)
+                logger.exception(
+                    "Failed to update computed fields for schedule %s.", schedule
+                )
+                Schedule.objects.filter(pk=schedule.pk).update(
+                    next_run=None, dtend=None
+                )
                 continue
             if template.cache_timeout_blocked:
-                logger.warning("Cache timeout is in the future, bypassing schedule for template %s" % str(template.id))
+                logger.warning(
+                    "Cache timeout is in the future, bypassing schedule for template %s"
+                    % str(template.id)
+                )
                 continue
             try:
                 job_kwargs = schedule.get_job_kwargs()
-                new_unified_job = schedule.unified_job_template.create_unified_job(**job_kwargs)
-                logger.debug('Spawned {} from schedule {}-{}.'.format(new_unified_job.log_format, schedule.name, schedule.pk))
+                new_unified_job = schedule.unified_job_template.create_unified_job(
+                    **job_kwargs
+                )
+                logger.debug(
+                    "Spawned {} from schedule {}-{}.".format(
+                        new_unified_job.log_format, schedule.name, schedule.pk
+                    )
+                )
 
                 if invalid_license:
-                    new_unified_job.status = 'failed'
+                    new_unified_job.status = "failed"
                     new_unified_job.job_explanation = str(invalid_license)
-                    new_unified_job.save(update_fields=['status', 'job_explanation'])
+                    new_unified_job.save(update_fields=["status", "job_explanation"])
                     new_unified_job.websocket_emit_status("failed")
                     raise invalid_license
                 can_start = new_unified_job.signal_start()
             except Exception:
-                logger.exception('Error spawning scheduled job.')
+                logger.exception("Error spawning scheduled job.")
                 continue
             if not can_start:
-                new_unified_job.status = 'failed'
-                new_unified_job.job_explanation = gettext_noop("Scheduled job could not start because it \
-                    was not in the right state or required manual credentials")
-                new_unified_job.save(update_fields=['status', 'job_explanation'])
+                new_unified_job.status = "failed"
+                new_unified_job.job_explanation = gettext_noop(
+                    "Scheduled job could not start because it \
+                    was not in the right state or required manual credentials"
+                )
+                new_unified_job.save(update_fields=["status", "job_explanation"])
                 new_unified_job.websocket_emit_status("failed")
-            emit_channel_notification('schedules-changed', dict(id=schedule.id, group_name="schedules"))
+            emit_channel_notification(
+                "schedules-changed", dict(id=schedule.id, group_name="schedules")
+            )
 
 
 @task(queue=get_task_queuename, timeout=3600)
@@ -957,12 +1228,14 @@ def handle_failure_notifications(task_ids):
     for instance in UnifiedJob.objects.filter(id__in=task_ids):
         found_task_ids.add(instance.id)
         try:
-            instance.send_notification_templates('failed')
+            instance.send_notification_templates("failed")
         except Exception:
-            logger.exception(f'Error preparing notifications for task {instance.id}')
+            logger.exception(f"Error preparing notifications for task {instance.id}")
     deleted_tasks = set(task_ids) - found_task_ids
     if deleted_tasks:
-        logger.warning(f'Could not send notifications for {deleted_tasks} because they were not found in the database')
+        logger.warning(
+            f"Could not send notifications for {deleted_tasks} because they were not found in the database"
+        )
 
 
 @task(queue=get_task_queuename, timeout=3600 * 5)
@@ -973,7 +1246,10 @@ def update_inventory_computed_fields(inventory_id):
     """
     i = Inventory.objects.filter(id=inventory_id)
     if not i.exists():
-        logger.error("Update Inventory Computed Fields failed due to missing inventory: " + str(inventory_id))
+        logger.error(
+            "Update Inventory Computed Fields failed due to missing inventory: "
+            + str(inventory_id)
+        )
         return
     i = i[0]
     try:
@@ -984,30 +1260,43 @@ def update_inventory_computed_fields(inventory_id):
 
         # if sqlstate is set then there was a database error and otherwise will re-raise that error
         cause = e.__cause__
-        if cause and hasattr(cause, 'sqlstate'):
+        if cause and hasattr(cause, "sqlstate"):
             sqlstate = cause.sqlstate
             sqlstate_str = psycopg.errors.lookup(sqlstate)
-            logger.error('SQL Error state: {} - {}'.format(sqlstate, sqlstate_str))
+            logger.error("SQL Error state: {} - {}".format(sqlstate, sqlstate_str))
             raise
 
         # otherwise
-        logger.debug('Exiting duplicate update_inventory_computed_fields task.')
+        logger.debug("Exiting duplicate update_inventory_computed_fields task.")
 
 
 def update_smart_memberships_for_inventory(smart_inventory):
-    current = set(SmartInventoryMembership.objects.filter(inventory=smart_inventory).values_list('host_id', flat=True))
-    new = set(smart_inventory.hosts.values_list('id', flat=True))
+    current = set(
+        SmartInventoryMembership.objects.filter(inventory=smart_inventory).values_list(
+            "host_id", flat=True
+        )
+    )
+    new = set(smart_inventory.hosts.values_list("id", flat=True))
     additions = new - current
     removals = current - new
     if additions or removals:
         with transaction.atomic():
             if removals:
-                SmartInventoryMembership.objects.filter(inventory=smart_inventory, host_id__in=removals).delete()
+                SmartInventoryMembership.objects.filter(
+                    inventory=smart_inventory, host_id__in=removals
+                ).delete()
             if additions:
-                add_for_inventory = [SmartInventoryMembership(inventory_id=smart_inventory.id, host_id=host_id) for host_id in additions]
-                SmartInventoryMembership.objects.bulk_create(add_for_inventory, ignore_conflicts=True)
+                add_for_inventory = [
+                    SmartInventoryMembership(
+                        inventory_id=smart_inventory.id, host_id=host_id
+                    )
+                    for host_id in additions
+                ]
+                SmartInventoryMembership.objects.bulk_create(
+                    add_for_inventory, ignore_conflicts=True
+                )
         logger.debug(
-            'Smart host membership cached for {}, {} additions, {} removals, {} total count.'.format(
+            "Smart host membership cached for {}, {} additions, {} removals, {} total count.".format(
                 smart_inventory.pk, len(additions), len(removals), len(new)
             )
         )
@@ -1015,9 +1304,11 @@ def update_smart_memberships_for_inventory(smart_inventory):
     return False
 
 
-@task(queue=get_task_queuename, timeout=3600, on_duplicate='queue_one')
+@task(queue=get_task_queuename, timeout=3600, on_duplicate="queue_one")
 def update_host_smart_inventory_memberships():
-    smart_inventories = Inventory.objects.filter(kind='smart', host_filter__isnull=False, pending_deletion=False)
+    smart_inventories = Inventory.objects.filter(
+        kind="smart", host_filter__isnull=False, pending_deletion=False
+    )
     changed_inventories = set([])
     for smart_inventory in smart_inventories:
         try:
@@ -1025,7 +1316,11 @@ def update_host_smart_inventory_memberships():
             if changed:
                 changed_inventories.add(smart_inventory)
         except IntegrityError:
-            logger.exception('Failed to update smart inventory memberships for {}'.format(smart_inventory.pk))
+            logger.exception(
+                "Failed to update smart inventory memberships for {}".format(
+                    smart_inventory.pk
+                )
+            )
     # Update computed fields for changed inventories outside atomic action
     for smart_inventory in changed_inventories:
         smart_inventory.update_computed_fields()
@@ -1045,18 +1340,31 @@ def _batched_delete_inventory(inventory, batch_size=500):
     # first delete all hosts in batches
     total_deleted = 0
     while True:
-        pks = list(Host.objects.filter(inventory_id=inventory.id).values_list('pk', flat=True)[:batch_size])
+        pks = list(
+            Host.objects.filter(inventory_id=inventory.id).values_list("pk", flat=True)[
+                :batch_size
+            ]
+        )
         if not pks:
             break
         with transaction.atomic():
             deleted_count, _ = Host.objects.filter(pk__in=pks).delete()
             total_deleted += deleted_count
-        logger.debug('Batch-deleted %d hosts from inventory %d (%d total so far)', len(pks), inventory.id, total_deleted)
+        logger.debug(
+            "Batch-deleted %d hosts from inventory %d (%d total so far)",
+            len(pks),
+            inventory.id,
+            total_deleted,
+        )
 
     # then delete the inventory itself
     inv_id = inventory.id
     inventory.delete()
-    logger.info('Batched deletion of inventory %d complete (%d hosts removed)', inv_id, total_deleted)
+    logger.info(
+        "Batched deletion of inventory %d complete (%d hosts removed)",
+        inv_id,
+        total_deleted,
+    )
 
 
 @task(queue=get_task_queuename, timeout=3600 * 5)
@@ -1069,17 +1377,36 @@ def delete_inventory(inventory_id, user_id, retries=5):
             user = User.objects.get(id=user_id)
         except Exception:
             user = None
-    with ignore_inventory_computed_fields(), ignore_inventory_group_removal(), impersonate(user):
+    with (
+        ignore_inventory_computed_fields(),
+        ignore_inventory_group_removal(),
+        impersonate(user),
+    ):
         try:
             inv = Inventory.objects.get(id=inventory_id)
             _batched_delete_inventory(inv)
-            emit_channel_notification('inventories-status_changed', {'group_name': 'inventories', 'inventory_id': inventory_id, 'status': 'deleted'})
-            logger.debug('Deleted inventory {} as user {}.'.format(inventory_id, user_id))
+            emit_channel_notification(
+                "inventories-status_changed",
+                {
+                    "group_name": "inventories",
+                    "inventory_id": inventory_id,
+                    "status": "deleted",
+                },
+            )
+            logger.debug(
+                "Deleted inventory {} as user {}.".format(inventory_id, user_id)
+            )
         except Inventory.DoesNotExist:
-            logger.warning("Delete Inventory failed due to missing inventory: " + str(inventory_id))
+            logger.warning(
+                "Delete Inventory failed due to missing inventory: " + str(inventory_id)
+            )
             return
         except DatabaseError:
-            logger.exception('Database error deleting inventory {}, but will retry.'.format(inventory_id))
+            logger.exception(
+                "Database error deleting inventory {}, but will retry.".format(
+                    inventory_id
+                )
+            )
             if retries > 0:
                 time.sleep(10)
                 delete_inventory(inventory_id, user_id, retries=retries - 1)
@@ -1107,7 +1434,7 @@ def with_path_cleanup(f):
 def _reconstruct_relationships(copy_mapping):
     for old_obj, new_obj in copy_mapping.items():
         model = type(old_obj)
-        for field_name in getattr(model, 'FIELDS_TO_PRESERVE_AT_COPY', []):
+        for field_name in getattr(model, "FIELDS_TO_PRESERVE_AT_COPY", []):
             field = model._meta.get_field(field_name)
             if isinstance(field, ForeignKey):
                 if getattr(new_obj, field_name, None):
@@ -1117,14 +1444,22 @@ def _reconstruct_relationships(copy_mapping):
                 setattr(new_obj, field_name, related_obj)
             elif field.many_to_many:
                 for related_obj in getattr(old_obj, field_name).all():
-                    logger.debug('Deep copy: Adding {} to {}({}).{} relationship'.format(related_obj, new_obj, model, field_name))
-                    getattr(new_obj, field_name).add(copy_mapping.get(related_obj, related_obj))
+                    logger.debug(
+                        "Deep copy: Adding {} to {}({}).{} relationship".format(
+                            related_obj, new_obj, model, field_name
+                        )
+                    )
+                    getattr(new_obj, field_name).add(
+                        copy_mapping.get(related_obj, related_obj)
+                    )
         new_obj.save()
 
 
 @task(queue=get_task_queuename, timeout=600)
-def deep_copy_model_obj(model_module, model_name, obj_pk, new_obj_pk, user_pk, permission_check_func=None):
-    logger.debug('Deep copy {} from {} to {}.'.format(model_name, obj_pk, new_obj_pk))
+def deep_copy_model_obj(
+    model_module, model_name, obj_pk, new_obj_pk, user_pk, permission_check_func=None
+):
+    logger.debug("Deep copy {} from {} to {}.".format(model_name, obj_pk, new_obj_pk))
 
     model = getattr(importlib.import_module(model_module), model_name, None)
     if model is None:
@@ -1138,7 +1473,7 @@ def deep_copy_model_obj(model_module, model_name, obj_pk, new_obj_pk, user_pk, p
         return
 
     o2m_to_preserve = {}
-    fields_to_preserve = set(getattr(model, 'FIELDS_TO_PRESERVE_AT_COPY', []))
+    fields_to_preserve = set(getattr(model, "FIELDS_TO_PRESERVE_AT_COPY", []))
 
     for field in model._meta.get_fields():
         if field.name in fields_to_preserve:
@@ -1158,32 +1493,46 @@ def deep_copy_model_obj(model_module, model_name, obj_pk, new_obj_pk, user_pk, p
     from awx.api.generics import CopyAPIView
     from awx.main.signals import disable_activity_stream
 
-    with transaction.atomic(), ignore_inventory_computed_fields(), disable_activity_stream():
+    with (
+        transaction.atomic(),
+        ignore_inventory_computed_fields(),
+        disable_activity_stream(),
+    ):
         copy_mapping = {}
         for sub_obj_setup in sub_obj_list:
-            sub_model = getattr(importlib.import_module(sub_obj_setup[0]), sub_obj_setup[1], None)
+            sub_model = getattr(
+                importlib.import_module(sub_obj_setup[0]), sub_obj_setup[1], None
+            )
             if sub_model is None:
                 continue
             try:
                 sub_obj = sub_model.objects.get(pk=sub_obj_setup[2])
             except ObjectDoesNotExist:
                 continue
-            copy_mapping.update(CopyAPIView.copy_model_obj(obj, new_obj, sub_model, sub_obj, creater))
+            copy_mapping.update(
+                CopyAPIView.copy_model_obj(obj, new_obj, sub_model, sub_obj, creater)
+            )
         _reconstruct_relationships(copy_mapping)
         if permission_check_func:
-            permission_check_func = getattr(getattr(importlib.import_module(permission_check_func[0]), permission_check_func[1]), permission_check_func[2])
+            permission_check_func = getattr(
+                getattr(
+                    importlib.import_module(permission_check_func[0]),
+                    permission_check_func[1],
+                ),
+                permission_check_func[2],
+            )
             permission_check_func(creater, copy_mapping.values())
     if isinstance(new_obj, Inventory):
         update_inventory_computed_fields.delay(new_obj.id)
 
 
-@task(queue=get_task_queuename, timeout=3600, on_duplicate='discard')
+@task(queue=get_task_queuename, timeout=3600, on_duplicate="discard")
 def periodic_resource_sync():
-    if not getattr(settings, 'RESOURCE_SERVER', None):
+    if not getattr(settings, "RESOURCE_SERVER", None):
         logger.debug("Skipping periodic resource_sync, RESOURCE_SERVER not configured")
         return
 
-    with advisory_lock('periodic_resource_sync', wait=False) as acquired:
+    with advisory_lock("periodic_resource_sync", wait=False) as acquired:
         if acquired is False:
             logger.debug("Not running periodic_resource_sync, another task holds lock")
             return
@@ -1192,10 +1541,12 @@ def periodic_resource_sync():
         executor = SyncExecutor()
         executor.run()
         for key, item_list in executor.results.items():
-            if not item_list or key == 'noop':
+            if not item_list or key == "noop":
                 continue
             # Log creations and conflicts
-            if len(item_list) > 10 and settings.LOG_AGGREGATOR_LEVEL != 'DEBUG':
-                logger.info(f'Periodic resource sync {key}, first 10 items:\n{item_list[:10]}')
+            if len(item_list) > 10 and settings.LOG_AGGREGATOR_LEVEL != "DEBUG":
+                logger.info(
+                    f"Periodic resource sync {key}, first 10 items:\n{item_list[:10]}"
+                )
             else:
-                logger.info(f'Periodic resource sync {key}:\n{item_list}')
+                logger.info(f"Periodic resource sync {key}:\n{item_list}")

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -902,7 +902,10 @@ def awx_periodic_scheduler():
 
         old_schedules = Schedule.objects.enabled().before(last_run)
         for schedule in old_schedules:
-            schedule.update_computed_fields()
+            try:
+                schedule.update_computed_fields()
+            except Exception:
+                logger.exception("Failed to update computed fields for schedule %s.", schedule)
         schedules = Schedule.objects.enabled().between(last_run, run_now)
 
         invalid_license = False
@@ -913,7 +916,11 @@ def awx_periodic_scheduler():
 
         for schedule in schedules:
             template = schedule.unified_job_template
-            schedule.update_computed_fields()  # To update next_run timestamp.
+            try:
+                schedule.update_computed_fields()  # To update next_run timestamp.
+            except Exception:
+                logger.exception("Failed to update computed fields for schedule %s.", schedule)
+                continue
             if template.cache_timeout_blocked:
                 logger.warning("Cache timeout is in the future, bypassing schedule for template %s" % str(template.id))
                 continue

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -906,6 +906,7 @@ def awx_periodic_scheduler():
                 schedule.update_computed_fields()
             except Exception:
                 logger.exception("Failed to update computed fields for schedule %s.", schedule)
+                Schedule.objects.filter(pk=schedule.pk).update(next_run=None, dtend=None)
         schedules = Schedule.objects.enabled().between(last_run, run_now)
 
         invalid_license = False
@@ -920,6 +921,7 @@ def awx_periodic_scheduler():
                 schedule.update_computed_fields()  # To update next_run timestamp.
             except Exception:
                 logger.exception("Failed to update computed fields for schedule %s.", schedule)
+                Schedule.objects.filter(pk=schedule.pk).update(next_run=None, dtend=None)
                 continue
             if template.cache_timeout_blocked:
                 logger.warning("Cache timeout is in the future, bypassing schedule for template %s" % str(template.id))

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -1,5 +1,6 @@
 import datetime
 import pytest
+from unittest import mock
 
 from django.utils.encoding import smart_str
 from django.utils.timezone import now
@@ -9,6 +10,22 @@ from awx.main.models import JobTemplate, Schedule
 from awx.main.utils.encryption import decrypt_value, get_encryption_key
 
 RRULE_EXAMPLE = 'DTSTART:20151117T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1'
+
+# This rrule triggers ValueError in _fast_forward_rrule when the dtstart is in
+# the past and the fast-forwarded dtstart conflicts with the BYxxx constraints.
+# The DTSTART hour (13 = 1 mod 4) aligns with all BYHOUR values (1,5,9,13,17,21
+# are all 1 mod 4) during EST (UTC-5). But during EDT (UTC-4), the 1-hour shift
+# causes the fast-forwarded local hour to be 0 mod 4 (e.g., 10), which has no
+# overlap with BYHOUR, so dateutil raises "Invalid rrule byxxx generates an
+# empty set."
+RRULE_INVALID_BYXXX = 'DTSTART;TZID=America/New_York:20251211T130000 RRULE:FREQ=HOURLY;INTERVAL=4;WKST=MO;BYDAY=MO,TU,WE,TH,FR;BYHOUR=1,5,9,13,17,21;BYMINUTE=0'
+
+# Same constraints but with a future dtstart, used to test the pathway where
+# a schedule is created when dtstart is in the future (fast-forward skipped)
+# and only breaks later when time passes and fast-forward kicks in during EDT.
+RRULE_INVALID_BYXXX_FUTURE = (
+    'DTSTART;TZID=America/New_York:20351211T130000 RRULE:FREQ=HOURLY;INTERVAL=4;WKST=MO;BYDAY=MO,TU,WE,TH,FR;BYHOUR=1,5,9,13,17,21;BYMINUTE=0'
+)
 
 
 def get_rrule(tz=None):
@@ -595,3 +612,68 @@ def test_normal_user_can_create_inventory_update_schedule(options, post, invento
     inventory_source.inventory.update_role.members.add(alice)
     assert 'POST' in options(url, user=alice).data['actions'].keys()
     post(url, params, alice, expect=201)
+
+
+@pytest.mark.django_db
+def test_patch_invalid_byxxx_accepted_during_est_crashes_during_edt(post, patch, get, admin_user, project, inventory):
+    """PATCH with the problematic rrule succeeds during EST (when fast-forward
+    hour alignment holds) but a subsequent GET during EDT crashes because
+    the DST offset shifts the fast-forwarded hour out of the BYHOUR constraint.
+
+    This demonstrates that PATCH does go through serializer validation, but
+    the validation is time-dependent: during EST the fast-forward preserves
+    BYHOUR alignment, so the rrule passes. During EDT the 1-hour DST shift
+    breaks alignment, causing ValueError on any code path that calls
+    Schedule.rrulestr() (GET serialization, periodic scheduler, etc.).
+    """
+    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+
+    # Create a valid schedule first
+    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
+    r = post(url, {'name': 'test-schedule', 'rrule': RRULE_EXAMPLE}, admin_user, expect=201)
+    schedule_id = r.data['id']
+    detail_url = reverse('api:schedule_detail', kwargs={'pk': schedule_id})
+
+    # PATCH with the problematic rrule during EST (Jan 15, 2026, 18:00 UTC = 1 PM EST)
+    # Fast-forward lands on 1 PM EST (hour 13, which is 1 mod 4), matching BYHOUR.
+    est_now = datetime.datetime(2026, 1, 15, 18, 0, 0, tzinfo=datetime.timezone.utc)
+    with mock.patch('awx.main.models.schedules.now', return_value=est_now):
+        patch(detail_url, {'rrule': RRULE_INVALID_BYXXX}, admin_user, expect=200)
+
+    # Verify the problematic rrule is now in the database
+    schedule = Schedule.objects.get(pk=schedule_id)
+    assert 'BYHOUR' in schedule.rrule
+
+    # GET during EDT (Jul 1, 2026, 14:00 UTC = 10 AM EDT)
+    # Fast-forward lands on hour 10 (0 mod 4), no overlap with BYHOUR → ValueError
+    edt_now = datetime.datetime(2026, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
+    with mock.patch('awx.main.models.schedules.now', return_value=edt_now):
+        r = get(detail_url, admin_user, expect=200)
+        assert r.data['id'] == schedule_id
+
+
+@pytest.mark.django_db
+def test_future_dtstart_created_successfully_crashes_on_get_during_edt(post, get, admin_user, project, inventory):
+    """A schedule with conflicting BYxxx + BYHOUR constraints passes API
+    validation when dtstart is in the future (fast-forward is skipped entirely).
+    After dtstart passes, GET during EDT crashes because the DST hour shift
+    breaks alignment with the BYHOUR values.
+    """
+    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
+
+    # Create with future dtstart — fast-forward is skipped, validation passes
+    r = post(url, {'name': 'future-schedule', 'rrule': RRULE_INVALID_BYXXX_FUTURE}, admin_user, expect=201)
+    schedule_id = r.data['id']
+
+    # Verify schedule was created with the problematic rrule
+    schedule = Schedule.objects.get(pk=schedule_id)
+    assert 'BYHOUR' in schedule.rrule
+
+    # GET during EDT when dtstart is now in the past — fast-forward kicks in
+    # and the DST shift breaks the BYHOUR alignment
+    edt_now = datetime.datetime(2036, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
+    detail_url = reverse('api:schedule_detail', kwargs={'pk': schedule_id})
+    with mock.patch('awx.main.models.schedules.now', return_value=edt_now):
+        r = get(detail_url, admin_user, expect=200)
+        assert r.data['id'] == schedule_id

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -615,49 +615,59 @@ def test_normal_user_can_create_inventory_update_schedule(options, post, invento
 
 
 @pytest.mark.django_db
-def test_patch_invalid_byxxx_accepted_during_est_crashes_during_edt(post, patch, get, admin_user, project, inventory):
-    """PATCH with the problematic rrule succeeds during EST (when fast-forward
-    hour alignment holds) but a subsequent GET during EDT crashes because
-    the DST offset shifts the fast-forwarded hour out of the BYHOUR constraint.
-
-    This demonstrates that PATCH does go through serializer validation, but
-    the validation is time-dependent: during EST the fast-forward preserves
-    BYHOUR alignment, so the rrule passes. During EDT the 1-hour DST shift
-    breaks alignment, causing ValueError on any code path that calls
-    Schedule.rrulestr() (GET serialization, periodic scheduler, etc.).
+def test_patch_invalid_byxxx_rejected_during_edt(post, patch, admin_user, project, inventory):
+    """PATCH with the problematic rrule during EDT is rejected by validation.
+    The fast-forward shifts the hour out of BYHOUR alignment, causing
+    ValueError which validate_rrule catches and returns as a 400.
     """
     job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
-
-    # Create a valid schedule first
     url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
     r = post(url, {'name': 'test-schedule', 'rrule': RRULE_EXAMPLE}, admin_user, expect=201)
-    schedule_id = r.data['id']
-    detail_url = reverse('api:schedule_detail', kwargs={'pk': schedule_id})
+    detail_url = reverse('api:schedule_detail', kwargs={'pk': r.data['id']})
 
-    # PATCH with the problematic rrule during EST (Jan 15, 2026, 18:00 UTC = 1 PM EST)
-    # Fast-forward lands on 1 PM EST (hour 13, which is 1 mod 4), matching BYHOUR.
-    est_now = datetime.datetime(2026, 1, 15, 18, 0, 0, tzinfo=datetime.timezone.utc)
-    with mock.patch('awx.main.models.schedules.now', return_value=est_now):
-        patch(detail_url, {'rrule': RRULE_INVALID_BYXXX}, admin_user, expect=200)
-
-    # Verify the problematic rrule is now in the database
-    schedule = Schedule.objects.get(pk=schedule_id)
-    assert 'BYHOUR' in schedule.rrule
-
-    # GET during EDT (Jul 1, 2026, 14:00 UTC = 10 AM EDT)
-    # Fast-forward lands on hour 10 (0 mod 4), no overlap with BYHOUR → ValueError
+    # During EDT (Jul 1, 2026), fast-forward lands on hour 10 (0 mod 4),
+    # no overlap with BYHOUR=1,5,9,13,17,21 → ValueError → 400
     edt_now = datetime.datetime(2026, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
     with mock.patch('awx.main.models.schedules.now', return_value=edt_now):
-        r = get(detail_url, admin_user, expect=200)
-        assert r.data['id'] == schedule_id
+        r = patch(detail_url, {'rrule': RRULE_INVALID_BYXXX}, admin_user, expect=400)
+        assert 'rrule' in r.data
 
 
 @pytest.mark.django_db
-def test_future_dtstart_created_successfully_crashes_on_get_during_edt(post, get, admin_user, project, inventory):
+def test_get_survives_invalid_byxxx_already_in_db(get, admin_user, project, inventory):
+    """GET on a schedule whose rrule was accepted during EST but now fails
+    fast-forward during EDT should not 500. The timezone and until properties
+    catch the ValueError and return fallback values.
+    """
+    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+
+    # Create a valid schedule, then inject the bad rrule at the DB level
+    # (simulates data accepted during EST that breaks during EDT)
+    schedule = Schedule.objects.create(
+        name='bad-byxxx-schedule',
+        rrule='DTSTART:20251211T130000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1',
+        unified_job_template=job_template,
+    )
+    Schedule.objects.filter(pk=schedule.pk).update(rrule=RRULE_INVALID_BYXXX)
+
+    # GET during EDT — timezone/until properties catch ValueError gracefully
+    edt_now = datetime.datetime(2026, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
+    with mock.patch('awx.main.models.schedules.now', return_value=edt_now):
+        url = reverse('api:schedule_list')
+        r = get(url, admin_user, expect=200)
+        assert r.data['count'] >= 1
+
+        detail_url = reverse('api:schedule_detail', kwargs={'pk': schedule.pk})
+        r = get(detail_url, admin_user, expect=200)
+        assert r.data['id'] == schedule.pk
+
+
+@pytest.mark.django_db
+def test_future_dtstart_created_and_get_survives_edt(post, get, admin_user, project, inventory):
     """A schedule with conflicting BYxxx + BYHOUR constraints passes API
     validation when dtstart is in the future (fast-forward is skipped entirely).
-    After dtstart passes, GET during EDT crashes because the DST hour shift
-    breaks alignment with the BYHOUR values.
+    After dtstart passes, GET during EDT should not crash — the timezone and
+    until properties catch the ValueError from the DST hour shift.
     """
     job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
     url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
@@ -666,12 +676,9 @@ def test_future_dtstart_created_successfully_crashes_on_get_during_edt(post, get
     r = post(url, {'name': 'future-schedule', 'rrule': RRULE_INVALID_BYXXX_FUTURE}, admin_user, expect=201)
     schedule_id = r.data['id']
 
-    # Verify schedule was created with the problematic rrule
-    schedule = Schedule.objects.get(pk=schedule_id)
-    assert 'BYHOUR' in schedule.rrule
-
     # GET during EDT when dtstart is now in the past — fast-forward kicks in
-    # and the DST shift breaks the BYHOUR alignment
+    # and the DST shift breaks the BYHOUR alignment, but timezone/until
+    # properties catch it gracefully
     edt_now = datetime.datetime(2036, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
     detail_url = reverse('api:schedule_detail', kwargs={'pk': schedule_id})
     with mock.patch('awx.main.models.schedules.now', return_value=edt_now):

--- a/awx/main/tests/functional/api/test_schedules.py
+++ b/awx/main/tests/functional/api/test_schedules.py
@@ -9,7 +9,7 @@ from awx.api.versioning import reverse
 from awx.main.models import JobTemplate, Schedule
 from awx.main.utils.encryption import decrypt_value, get_encryption_key
 
-RRULE_EXAMPLE = 'DTSTART:20151117T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1'
+RRULE_EXAMPLE = "DTSTART:20151117T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1"
 
 # This rrule triggers ValueError in _fast_forward_rrule when the dtstart is in
 # the past and the fast-forwarded dtstart conflicts with the BYxxx constraints.
@@ -18,154 +18,261 @@ RRULE_EXAMPLE = 'DTSTART:20151117T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1'
 # causes the fast-forwarded local hour to be 0 mod 4 (e.g., 10), which has no
 # overlap with BYHOUR, so dateutil raises "Invalid rrule byxxx generates an
 # empty set."
-RRULE_INVALID_BYXXX = 'DTSTART;TZID=America/New_York:20251211T130000 RRULE:FREQ=HOURLY;INTERVAL=4;WKST=MO;BYDAY=MO,TU,WE,TH,FR;BYHOUR=1,5,9,13,17,21;BYMINUTE=0'
+RRULE_INVALID_BYXXX = "DTSTART;TZID=America/New_York:20251211T130000 RRULE:FREQ=HOURLY;INTERVAL=4;WKST=MO;BYDAY=MO,TU,WE,TH,FR;BYHOUR=1,5,9,13,17,21;BYMINUTE=0"
 
 # Same constraints but with a future dtstart, used to test the pathway where
 # a schedule is created when dtstart is in the future (fast-forward skipped)
 # and only breaks later when time passes and fast-forward kicks in during EDT.
-RRULE_INVALID_BYXXX_FUTURE = (
-    'DTSTART;TZID=America/New_York:20351211T130000 RRULE:FREQ=HOURLY;INTERVAL=4;WKST=MO;BYDAY=MO,TU,WE,TH,FR;BYHOUR=1,5,9,13,17,21;BYMINUTE=0'
-)
+RRULE_INVALID_BYXXX_FUTURE = "DTSTART;TZID=America/New_York:20351211T130000 RRULE:FREQ=HOURLY;INTERVAL=4;WKST=MO;BYDAY=MO,TU,WE,TH,FR;BYHOUR=1,5,9,13,17,21;BYMINUTE=0"
 
 
 def get_rrule(tz=None):
-    parts = ['DTSTART']
+    parts = ["DTSTART"]
     if tz:
-        parts.append(';TZID={}'.format(tz))
-    parts.append(':20300308T050000')
+        parts.append(";TZID={}".format(tz))
+    parts.append(":20300308T050000")
     if tz is None:
-        parts.append('Z')
-    parts.append(' RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5')
-    return ''.join(parts)
+        parts.append("Z")
+    parts.append(" RRULE:FREQ=DAILY;INTERVAL=1;COUNT=5")
+    return "".join(parts)
 
 
 @pytest.mark.django_db
 def test_non_job_extra_vars_prohibited(post, project, admin_user):
-    url = reverse('api:project_schedules_list', kwargs={'pk': project.id})
-    r = post(url, {'name': 'test sch', 'rrule': RRULE_EXAMPLE, 'extra_data': '{"a": 5}'}, admin_user, expect=400)
-    assert 'not allowed on launch' in str(r.data['extra_data'][0])
+    url = reverse("api:project_schedules_list", kwargs={"pk": project.id})
+    r = post(
+        url,
+        {"name": "test sch", "rrule": RRULE_EXAMPLE, "extra_data": '{"a": 5}'},
+        admin_user,
+        expect=400,
+    )
+    assert "not allowed on launch" in str(r.data["extra_data"][0])
 
 
 @pytest.mark.django_db
 def test_wfjt_schedule_accepted(post, workflow_job_template, admin_user):
-    url = reverse('api:workflow_job_template_schedules_list', kwargs={'pk': workflow_job_template.id})
-    post(url, {'name': 'test sch', 'rrule': RRULE_EXAMPLE}, admin_user, expect=201)
+    url = reverse(
+        "api:workflow_job_template_schedules_list",
+        kwargs={"pk": workflow_job_template.id},
+    )
+    post(url, {"name": "test sch", "rrule": RRULE_EXAMPLE}, admin_user, expect=201)
 
 
 @pytest.mark.django_db
-def test_wfjt_unprompted_inventory_rejected(post, workflow_job_template, inventory, admin_user):
+def test_wfjt_unprompted_inventory_rejected(
+    post, workflow_job_template, inventory, admin_user
+):
     r = post(
-        url=reverse('api:workflow_job_template_schedules_list', kwargs={'pk': workflow_job_template.id}),
-        data={'name': 'test sch', 'rrule': RRULE_EXAMPLE, 'inventory': inventory.pk},
+        url=reverse(
+            "api:workflow_job_template_schedules_list",
+            kwargs={"pk": workflow_job_template.id},
+        ),
+        data={"name": "test sch", "rrule": RRULE_EXAMPLE, "inventory": inventory.pk},
         user=admin_user,
         expect=400,
     )
-    assert r.data['inventory'] == ['Field is not configured to prompt on launch.']
+    assert r.data["inventory"] == ["Field is not configured to prompt on launch."]
 
 
 @pytest.mark.django_db
-def test_wfjt_unprompted_inventory_accepted(post, workflow_job_template, inventory, admin_user):
+def test_wfjt_unprompted_inventory_accepted(
+    post, workflow_job_template, inventory, admin_user
+):
     workflow_job_template.ask_inventory_on_launch = True
     workflow_job_template.save()
     r = post(
-        url=reverse('api:workflow_job_template_schedules_list', kwargs={'pk': workflow_job_template.id}),
-        data={'name': 'test sch', 'rrule': RRULE_EXAMPLE, 'inventory': inventory.pk},
+        url=reverse(
+            "api:workflow_job_template_schedules_list",
+            kwargs={"pk": workflow_job_template.id},
+        ),
+        data={"name": "test sch", "rrule": RRULE_EXAMPLE, "inventory": inventory.pk},
         user=admin_user,
         expect=201,
     )
-    assert Schedule.objects.get(pk=r.data['id']).inventory == inventory
+    assert Schedule.objects.get(pk=r.data["id"]).inventory == inventory
 
 
 @pytest.mark.django_db
 def test_valid_survey_answer(post, admin_user, project, inventory, survey_spec_factory):
-    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+    job_template = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
     job_template.ask_variables_on_launch = False
     job_template.survey_enabled = True
-    job_template.survey_spec = survey_spec_factory('var1')
-    assert job_template.survey_spec['spec'][0]['type'] == 'integer'
+    job_template.survey_spec = survey_spec_factory("var1")
+    assert job_template.survey_spec["spec"][0]["type"] == "integer"
     job_template.save()
-    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
-    post(url, {'name': 'test sch', 'rrule': RRULE_EXAMPLE, 'extra_data': '{"var1": 54}'}, admin_user, expect=201)
+    url = reverse("api:job_template_schedules_list", kwargs={"pk": job_template.id})
+    post(
+        url,
+        {"name": "test sch", "rrule": RRULE_EXAMPLE, "extra_data": '{"var1": 54}'},
+        admin_user,
+        expect=201,
+    )
 
 
 @pytest.mark.django_db
-def test_encrypted_survey_answer(post, patch, admin_user, project, inventory, survey_spec_factory):
+def test_encrypted_survey_answer(
+    post, patch, admin_user, project, inventory, survey_spec_factory
+):
     job_template = JobTemplate.objects.create(
-        name='test-jt',
+        name="test-jt",
         project=project,
-        playbook='helloworld.yml',
+        playbook="helloworld.yml",
         inventory=inventory,
         ask_variables_on_launch=False,
         survey_enabled=True,
-        survey_spec=survey_spec_factory([{'variable': 'var1', 'type': 'password'}]),
+        survey_spec=survey_spec_factory([{"variable": "var1", "type": "password"}]),
     )
 
     # test encrypted-on-create
-    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
-    r = post(url, {'name': 'test sch', 'rrule': RRULE_EXAMPLE, 'extra_data': '{"var1": "foo"}'}, admin_user, expect=201)
-    assert r.data['extra_data']['var1'] == "$encrypted$"
-    schedule = Schedule.objects.get(pk=r.data['id'])
-    assert schedule.extra_data['var1'].startswith('$encrypted$')
-    assert decrypt_value(get_encryption_key('value', pk=None), schedule.extra_data['var1']) == 'foo'
+    url = reverse("api:job_template_schedules_list", kwargs={"pk": job_template.id})
+    r = post(
+        url,
+        {"name": "test sch", "rrule": RRULE_EXAMPLE, "extra_data": '{"var1": "foo"}'},
+        admin_user,
+        expect=201,
+    )
+    assert r.data["extra_data"]["var1"] == "$encrypted$"
+    schedule = Schedule.objects.get(pk=r.data["id"])
+    assert schedule.extra_data["var1"].startswith("$encrypted$")
+    assert (
+        decrypt_value(get_encryption_key("value", pk=None), schedule.extra_data["var1"])
+        == "foo"
+    )
 
     # test a no-op change
-    r = patch(schedule.get_absolute_url(), data={'extra_data': {'var1': '$encrypted$'}}, user=admin_user, expect=200)
-    assert r.data['extra_data']['var1'] == '$encrypted$'
+    r = patch(
+        schedule.get_absolute_url(),
+        data={"extra_data": {"var1": "$encrypted$"}},
+        user=admin_user,
+        expect=200,
+    )
+    assert r.data["extra_data"]["var1"] == "$encrypted$"
     schedule.refresh_from_db()
-    assert decrypt_value(get_encryption_key('value', pk=None), schedule.extra_data['var1']) == 'foo'
+    assert (
+        decrypt_value(get_encryption_key("value", pk=None), schedule.extra_data["var1"])
+        == "foo"
+    )
 
     # change to a different value
-    r = patch(schedule.get_absolute_url(), data={'extra_data': {'var1': 'bar'}}, user=admin_user, expect=200)
-    assert r.data['extra_data']['var1'] == '$encrypted$'
+    r = patch(
+        schedule.get_absolute_url(),
+        data={"extra_data": {"var1": "bar"}},
+        user=admin_user,
+        expect=200,
+    )
+    assert r.data["extra_data"]["var1"] == "$encrypted$"
     schedule.refresh_from_db()
-    assert decrypt_value(get_encryption_key('value', pk=None), schedule.extra_data['var1']) == 'bar'
+    assert (
+        decrypt_value(get_encryption_key("value", pk=None), schedule.extra_data["var1"])
+        == "bar"
+    )
 
 
 @pytest.mark.django_db
-def test_survey_password_default(post, patch, admin_user, project, inventory, survey_spec_factory):
+def test_survey_password_default(
+    post, patch, admin_user, project, inventory, survey_spec_factory
+):
     job_template = JobTemplate.objects.create(
-        name='test-jt',
+        name="test-jt",
         project=project,
-        playbook='helloworld.yml',
+        playbook="helloworld.yml",
         inventory=inventory,
         ask_variables_on_launch=False,
         survey_enabled=True,
-        survey_spec=survey_spec_factory([{'variable': 'var1', 'question_name': 'Q1', 'type': 'password', 'required': True, 'default': 'foobar'}]),
+        survey_spec=survey_spec_factory(
+            [
+                {
+                    "variable": "var1",
+                    "question_name": "Q1",
+                    "type": "password",
+                    "required": True,
+                    "default": "foobar",
+                }
+            ]
+        ),
     )
 
     # test removal of $encrypted$
-    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
-    r = post(url, {'name': 'test sch', 'rrule': RRULE_EXAMPLE, 'extra_data': '{"var1": "$encrypted$"}'}, admin_user, expect=201)
-    schedule = Schedule.objects.get(pk=r.data['id'])
+    url = reverse("api:job_template_schedules_list", kwargs={"pk": job_template.id})
+    r = post(
+        url,
+        {
+            "name": "test sch",
+            "rrule": RRULE_EXAMPLE,
+            "extra_data": '{"var1": "$encrypted$"}',
+        },
+        admin_user,
+        expect=201,
+    )
+    schedule = Schedule.objects.get(pk=r.data["id"])
     assert schedule.extra_data == {}
     assert schedule.enabled is True
 
     # test an unrelated change
-    patch(schedule.get_absolute_url(), data={'enabled': False}, user=admin_user, expect=200)
-    patch(schedule.get_absolute_url(), data={'enabled': True}, user=admin_user, expect=200)
+    patch(
+        schedule.get_absolute_url(),
+        data={"enabled": False},
+        user=admin_user,
+        expect=200,
+    )
+    patch(
+        schedule.get_absolute_url(), data={"enabled": True}, user=admin_user, expect=200
+    )
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    'rrule, error',
+    "rrule, error",
     [
         ("", "This field may not be blank"),
         ("DTSTART:NONSENSE", "Valid DTSTART required in rrule"),
-        ("DTSTART:20300308T050000 RRULE:FREQ=DAILY;INTERVAL=1", "DTSTART cannot be a naive datetime"),
-        ("DTSTART:20300308T050000Z DTSTART:20310308T050000", "Multiple DTSTART is not supported"),
+        (
+            "DTSTART:20300308T050000 RRULE:FREQ=DAILY;INTERVAL=1",
+            "DTSTART cannot be a naive datetime",
+        ),
+        (
+            "DTSTART:20300308T050000Z DTSTART:20310308T050000",
+            "Multiple DTSTART is not supported",
+        ),
         ("DTSTART:20300308T050000Z", "One or more rule required in rrule"),
-        ("DTSTART:20300308T050000Z RRULE:FREQ=MONTHLY;INTERVAL=1; EXDATE:20220401", "EXDATE not allowed in rrule"),
-        ("DTSTART:20300308T050000Z RRULE:FREQ=MONTHLY;INTERVAL=1; RDATE:20220401", "RDATE not allowed in rrule"),
-        ("DTSTART:20300308T050000Z RRULE:FREQ=YEARLY;INTERVAL=0;BYDAY=MO", "INTERVAL must be a positive integer"),
-        ("DTSTART:20300308T050000Z RRULE:FREQ=SECONDLY;INTERVAL=5;COUNT=6", "SECONDLY is not supported"),
+        (
+            "DTSTART:20300308T050000Z RRULE:FREQ=MONTHLY;INTERVAL=1; EXDATE:20220401",
+            "EXDATE not allowed in rrule",
+        ),
+        (
+            "DTSTART:20300308T050000Z RRULE:FREQ=MONTHLY;INTERVAL=1; RDATE:20220401",
+            "RDATE not allowed in rrule",
+        ),
+        (
+            "DTSTART:20300308T050000Z RRULE:FREQ=YEARLY;INTERVAL=0;BYDAY=MO",
+            "INTERVAL must be a positive integer",
+        ),
+        (
+            "DTSTART:20300308T050000Z RRULE:FREQ=SECONDLY;INTERVAL=5;COUNT=6",
+            "SECONDLY is not supported",
+        ),
         # Individual rule test
         ("DTSTART:20300308T050000Z RRULE:NONSENSE", "INTERVAL required in rrule"),
-        ("DTSTART:20300308T050000Z RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=5MO", "BYDAY with numeric prefix not supported"),  # noqa
-        ("DTSTART:20030925T104941Z RRULE:FREQ=DAILY;INTERVAL=10;COUNT=500;UNTIL=20040925T104941Z", "RRULE may not contain both COUNT and UNTIL"),  # noqa
-        ("DTSTART:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=2000", "COUNT > 999 is unsupported"),  # noqa
+        (
+            "DTSTART:20300308T050000Z RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=5MO",
+            "BYDAY with numeric prefix not supported",
+        ),  # noqa
+        (
+            "DTSTART:20030925T104941Z RRULE:FREQ=DAILY;INTERVAL=10;COUNT=500;UNTIL=20040925T104941Z",
+            "RRULE may not contain both COUNT and UNTIL",
+        ),  # noqa
+        (
+            "DTSTART:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=2000",
+            "COUNT > 999 is unsupported",
+        ),  # noqa
         # Individual rule test with multiple rules
         # Bad Rule:  RRULE:NONSENSE
-        ("DTSTART:20300308T050000Z RRULE:NONSENSE RRULE:INTERVAL=1;FREQ=DAILY EXRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU", "INTERVAL required in rrule"),
+        (
+            "DTSTART:20300308T050000Z RRULE:NONSENSE RRULE:INTERVAL=1;FREQ=DAILY EXRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU",
+            "INTERVAL required in rrule",
+        ),
         # Bad Rule:  RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=5MO
         (
             "DTSTART:20300308T050000Z RRULE:INTERVAL=1;FREQ=DAILY EXRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=5MO",
@@ -182,21 +289,35 @@ def test_survey_password_default(post, patch, admin_user, project, inventory, su
             "COUNT > 999 is unsupported",
         ),  # noqa
         # Multiple errors, first condition should be returned
-        ("DTSTART:NONSENSE RRULE:NONSENSE RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=3,4", "Valid DTSTART required in rrule"),
+        (
+            "DTSTART:NONSENSE RRULE:NONSENSE RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=3,4",
+            "Valid DTSTART required in rrule",
+        ),
         # Parsing Tests
-        ("DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5", "A valid TZID must be provided"),  # noqa
-        ("DTSTART:20300308T050000Z RRULE:FREQ=REGULARLY;INTERVAL=1", "rrule parsing failed validation: invalid 'FREQ': REGULARLY"),  # noqa
-        ("DTSTART;TZID=America/New_York:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1", "rrule parsing failed validation"),
+        (
+            "DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5",
+            "A valid TZID must be provided",
+        ),  # noqa
+        (
+            "DTSTART:20300308T050000Z RRULE:FREQ=REGULARLY;INTERVAL=1",
+            "rrule parsing failed validation: invalid 'FREQ': REGULARLY",
+        ),  # noqa
+        (
+            "DTSTART;TZID=America/New_York:20300308T050000Z RRULE:FREQ=DAILY;INTERVAL=1",
+            "rrule parsing failed validation",
+        ),
     ],
 )
 def test_invalid_rrules(post, admin_user, project, inventory, rrule, error):
-    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
-    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
+    job_template = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
+    url = reverse("api:job_template_schedules_list", kwargs={"pk": job_template.id})
     resp = post(
         url,
         {
-            'name': 'Some Schedule',
-            'rrule': rrule,
+            "name": "Some Schedule",
+            "rrule": rrule,
         },
         admin_user,
         expect=400,
@@ -205,13 +326,15 @@ def test_invalid_rrules(post, admin_user, project, inventory, rrule, error):
 
 
 def test_multiple_invalid_rrules(post, admin_user, project, inventory):
-    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
-    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
+    job_template = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
+    url = reverse("api:job_template_schedules_list", kwargs={"pk": job_template.id})
     resp = post(
         url,
         {
-            'name': 'Some Schedule',
-            'rrule': "EXRULE:FREQ=SECONDLY DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5;UNTIL=20220101 DTSTART;TZID=US-Eastern:19961105T090000",
+            "name": "Some Schedule",
+            "rrule": "EXRULE:FREQ=SECONDLY DTSTART;TZID=US-Eastern:19961105T090000 RRULE:FREQ=MINUTELY;INTERVAL=10;COUNT=5;UNTIL=20220101 DTSTART;TZID=US-Eastern:19961105T090000",
         },
         admin_user,
         expect=400,
@@ -230,43 +353,43 @@ def test_multiple_invalid_rrules(post, admin_user, project, inventory):
 
 @pytest.mark.django_db
 def test_normal_users_can_preview_schedules(post, alice):
-    url = reverse('api:schedule_rrule')
-    post(url, {'rrule': get_rrule()}, alice, expect=200)
+    url = reverse("api:schedule_rrule")
+    post(url, {"rrule": get_rrule()}, alice, expect=200)
 
 
 @pytest.mark.django_db
 def test_utc_preview(post, admin_user):
-    url = reverse('api:schedule_rrule')
-    r = post(url, {'rrule': get_rrule()}, admin_user, expect=200)
-    assert r.data['utc'] == r.data['local']
-    assert list(map(str, r.data['utc'])) == [
-        '2030-03-08 05:00:00+00:00',
-        '2030-03-09 05:00:00+00:00',
-        '2030-03-10 05:00:00+00:00',
-        '2030-03-11 05:00:00+00:00',
-        '2030-03-12 05:00:00+00:00',
+    url = reverse("api:schedule_rrule")
+    r = post(url, {"rrule": get_rrule()}, admin_user, expect=200)
+    assert r.data["utc"] == r.data["local"]
+    assert list(map(str, r.data["utc"])) == [
+        "2030-03-08 05:00:00+00:00",
+        "2030-03-09 05:00:00+00:00",
+        "2030-03-10 05:00:00+00:00",
+        "2030-03-11 05:00:00+00:00",
+        "2030-03-12 05:00:00+00:00",
     ]
 
 
 @pytest.mark.django_db
 def test_nyc_with_dst(post, admin_user):
-    url = reverse('api:schedule_rrule')
-    r = post(url, {'rrule': get_rrule('America/New_York')}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    r = post(url, {"rrule": get_rrule("America/New_York")}, admin_user, expect=200)
 
     # March 10, 2030 is when DST takes effect in NYC
-    assert list(map(str, r.data['local'])) == [
-        '2030-03-08 05:00:00-05:00',
-        '2030-03-09 05:00:00-05:00',
-        '2030-03-10 05:00:00-04:00',
-        '2030-03-11 05:00:00-04:00',
-        '2030-03-12 05:00:00-04:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-03-08 05:00:00-05:00",
+        "2030-03-09 05:00:00-05:00",
+        "2030-03-10 05:00:00-04:00",
+        "2030-03-11 05:00:00-04:00",
+        "2030-03-12 05:00:00-04:00",
     ]
-    assert list(map(str, r.data['utc'])) == [
-        '2030-03-08 10:00:00+00:00',
-        '2030-03-09 10:00:00+00:00',
-        '2030-03-10 09:00:00+00:00',
-        '2030-03-11 09:00:00+00:00',
-        '2030-03-12 09:00:00+00:00',
+    assert list(map(str, r.data["utc"])) == [
+        "2030-03-08 10:00:00+00:00",
+        "2030-03-09 10:00:00+00:00",
+        "2030-03-10 09:00:00+00:00",
+        "2030-03-11 09:00:00+00:00",
+        "2030-03-12 09:00:00+00:00",
     ]
 
 
@@ -274,102 +397,102 @@ def test_nyc_with_dst(post, admin_user):
 def test_phoenix_without_dst(post, admin_user):
     # The state of Arizona (aside from a few Native American territories) does
     # not observe DST
-    url = reverse('api:schedule_rrule')
-    r = post(url, {'rrule': get_rrule('America/Phoenix')}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    r = post(url, {"rrule": get_rrule("America/Phoenix")}, admin_user, expect=200)
 
     # March 10, 2030 is when DST takes effect in NYC
-    assert list(map(str, r.data['local'])) == [
-        '2030-03-08 05:00:00-07:00',
-        '2030-03-09 05:00:00-07:00',
-        '2030-03-10 05:00:00-07:00',
-        '2030-03-11 05:00:00-07:00',
-        '2030-03-12 05:00:00-07:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-03-08 05:00:00-07:00",
+        "2030-03-09 05:00:00-07:00",
+        "2030-03-10 05:00:00-07:00",
+        "2030-03-11 05:00:00-07:00",
+        "2030-03-12 05:00:00-07:00",
     ]
-    assert list(map(str, r.data['utc'])) == [
-        '2030-03-08 12:00:00+00:00',
-        '2030-03-09 12:00:00+00:00',
-        '2030-03-10 12:00:00+00:00',
-        '2030-03-11 12:00:00+00:00',
-        '2030-03-12 12:00:00+00:00',
+    assert list(map(str, r.data["utc"])) == [
+        "2030-03-08 12:00:00+00:00",
+        "2030-03-09 12:00:00+00:00",
+        "2030-03-10 12:00:00+00:00",
+        "2030-03-11 12:00:00+00:00",
+        "2030-03-12 12:00:00+00:00",
     ]
 
 
 @pytest.mark.django_db
 def test_interval_by_local_day(post, admin_user):
-    url = reverse('api:schedule_rrule')
-    rrule = 'DTSTART;TZID=America/New_York:20300112T210000 RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=SA;BYSETPOS=1;COUNT=4'
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    rrule = "DTSTART;TZID=America/New_York:20300112T210000 RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=SA;BYSETPOS=1;COUNT=4"
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
     # March 10, 2030 is when DST takes effect in NYC
-    assert list(map(str, r.data['local'])) == [
-        '2030-02-02 21:00:00-05:00',
-        '2030-03-02 21:00:00-05:00',
-        '2030-04-06 21:00:00-04:00',
-        '2030-05-04 21:00:00-04:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-02-02 21:00:00-05:00",
+        "2030-03-02 21:00:00-05:00",
+        "2030-04-06 21:00:00-04:00",
+        "2030-05-04 21:00:00-04:00",
     ]
 
-    assert list(map(str, r.data['utc'])) == [
-        '2030-02-03 02:00:00+00:00',
-        '2030-03-03 02:00:00+00:00',
-        '2030-04-07 01:00:00+00:00',
-        '2030-05-05 01:00:00+00:00',
+    assert list(map(str, r.data["utc"])) == [
+        "2030-02-03 02:00:00+00:00",
+        "2030-03-03 02:00:00+00:00",
+        "2030-04-07 01:00:00+00:00",
+        "2030-05-05 01:00:00+00:00",
     ]
 
 
 @pytest.mark.django_db
 def test_weekday_timezone_boundary(post, admin_user):
-    url = reverse('api:schedule_rrule')
-    rrule = 'DTSTART;TZID=America/New_York:20300101T210000 RRULE:FREQ=WEEKLY;BYDAY=TU;INTERVAL=1;COUNT=3'
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    rrule = "DTSTART;TZID=America/New_York:20300101T210000 RRULE:FREQ=WEEKLY;BYDAY=TU;INTERVAL=1;COUNT=3"
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
-    assert list(map(str, r.data['local'])) == [
-        '2030-01-01 21:00:00-05:00',
-        '2030-01-08 21:00:00-05:00',
-        '2030-01-15 21:00:00-05:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-01-01 21:00:00-05:00",
+        "2030-01-08 21:00:00-05:00",
+        "2030-01-15 21:00:00-05:00",
     ]
 
-    assert list(map(str, r.data['utc'])) == [
-        '2030-01-02 02:00:00+00:00',
-        '2030-01-09 02:00:00+00:00',
-        '2030-01-16 02:00:00+00:00',
+    assert list(map(str, r.data["utc"])) == [
+        "2030-01-02 02:00:00+00:00",
+        "2030-01-09 02:00:00+00:00",
+        "2030-01-16 02:00:00+00:00",
     ]
 
 
 @pytest.mark.django_db
 def test_first_monthly_weekday_timezone_boundary(post, admin_user):
-    url = reverse('api:schedule_rrule')
-    rrule = 'DTSTART;TZID=America/New_York:20300101T210000 RRULE:FREQ=MONTHLY;BYDAY=SU;BYSETPOS=1;INTERVAL=1;COUNT=3'
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    rrule = "DTSTART;TZID=America/New_York:20300101T210000 RRULE:FREQ=MONTHLY;BYDAY=SU;BYSETPOS=1;INTERVAL=1;COUNT=3"
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
-    assert list(map(str, r.data['local'])) == [
-        '2030-01-06 21:00:00-05:00',
-        '2030-02-03 21:00:00-05:00',
-        '2030-03-03 21:00:00-05:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-01-06 21:00:00-05:00",
+        "2030-02-03 21:00:00-05:00",
+        "2030-03-03 21:00:00-05:00",
     ]
 
-    assert list(map(str, r.data['utc'])) == [
-        '2030-01-07 02:00:00+00:00',
-        '2030-02-04 02:00:00+00:00',
-        '2030-03-04 02:00:00+00:00',
+    assert list(map(str, r.data["utc"])) == [
+        "2030-01-07 02:00:00+00:00",
+        "2030-02-04 02:00:00+00:00",
+        "2030-03-04 02:00:00+00:00",
     ]
 
 
 @pytest.mark.django_db
 def test_annual_timezone_boundary(post, admin_user):
-    url = reverse('api:schedule_rrule')
-    rrule = 'DTSTART;TZID=America/New_York:20301231T230000 RRULE:FREQ=YEARLY;INTERVAL=1;COUNT=3'
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    rrule = "DTSTART;TZID=America/New_York:20301231T230000 RRULE:FREQ=YEARLY;INTERVAL=1;COUNT=3"
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
-    assert list(map(str, r.data['local'])) == [
-        '2030-12-31 23:00:00-05:00',
-        '2031-12-31 23:00:00-05:00',
-        '2032-12-31 23:00:00-05:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-12-31 23:00:00-05:00",
+        "2031-12-31 23:00:00-05:00",
+        "2032-12-31 23:00:00-05:00",
     ]
 
-    assert list(map(str, r.data['utc'])) == [
-        '2031-01-01 04:00:00+00:00',
-        '2032-01-01 04:00:00+00:00',
-        '2033-01-01 04:00:00+00:00',
+    assert list(map(str, r.data["utc"])) == [
+        "2031-01-01 04:00:00+00:00",
+        "2032-01-01 04:00:00+00:00",
+        "2033-01-01 04:00:00+00:00",
     ]
 
 
@@ -380,56 +503,56 @@ def test_dst_phantom_hour(post, admin_user):
 
     # Three Sundays, starting 2:30AM America/New_York, starting Mar 3, 2030,
     # should _not_ include Mar 10, 2030 @ 2:30AM (because it doesn't exist)
-    url = reverse('api:schedule_rrule')
-    rrule = 'DTSTART;TZID=America/New_York:20300303T023000 RRULE:FREQ=WEEKLY;BYDAY=SU;INTERVAL=1;COUNT=3'
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    rrule = "DTSTART;TZID=America/New_York:20300303T023000 RRULE:FREQ=WEEKLY;BYDAY=SU;INTERVAL=1;COUNT=3"
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
-    assert list(map(str, r.data['local'])) == [
-        '2030-03-03 02:30:00-05:00',
-        '2030-03-17 02:30:00-04:00',  # Skip 3/10 because 3/10 @ 2:30AM isn't a real date
+    assert list(map(str, r.data["local"])) == [
+        "2030-03-03 02:30:00-05:00",
+        "2030-03-17 02:30:00-04:00",  # Skip 3/10 because 3/10 @ 2:30AM isn't a real date
     ]
 
-    assert list(map(str, r.data['utc'])) == [
-        '2030-03-03 07:30:00+00:00',
-        '2030-03-17 06:30:00+00:00',  # Skip 3/10 because 3/10 @ 2:30AM isn't a real date
+    assert list(map(str, r.data["utc"])) == [
+        "2030-03-03 07:30:00+00:00",
+        "2030-03-17 06:30:00+00:00",  # Skip 3/10 because 3/10 @ 2:30AM isn't a real date
     ]
 
 
 @pytest.mark.django_db
 def test_months_with_31_days(post, admin_user):
-    url = reverse('api:schedule_rrule')
-    rrule = 'DTSTART;TZID=America/New_York:20300101T000000 RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=31;COUNT=7'
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    rrule = "DTSTART;TZID=America/New_York:20300101T000000 RRULE:FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=31;COUNT=7"
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
     # 30 days have September, April, June, and November...
-    assert list(map(str, r.data['local'])) == [
-        '2030-01-31 00:00:00-05:00',
-        '2030-03-31 00:00:00-04:00',
-        '2030-05-31 00:00:00-04:00',
-        '2030-07-31 00:00:00-04:00',
-        '2030-08-31 00:00:00-04:00',
-        '2030-10-31 00:00:00-04:00',
-        '2030-12-31 00:00:00-05:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-01-31 00:00:00-05:00",
+        "2030-03-31 00:00:00-04:00",
+        "2030-05-31 00:00:00-04:00",
+        "2030-07-31 00:00:00-04:00",
+        "2030-08-31 00:00:00-04:00",
+        "2030-10-31 00:00:00-04:00",
+        "2030-12-31 00:00:00-05:00",
     ]
 
 
 @pytest.mark.django_db
 @pytest.mark.timeout(3)
 @pytest.mark.parametrize(
-    'freq, delta, total_seconds',
+    "freq, delta, total_seconds",
     (
-        ('MINUTELY', 1, 60),
-        ('MINUTELY', 15, 15 * 60),
-        ('HOURLY', 1, 3600),
-        ('HOURLY', 2, 3600 * 2),
+        ("MINUTELY", 1, 60),
+        ("MINUTELY", 15, 15 * 60),
+        ("HOURLY", 1, 3600),
+        ("HOURLY", 2, 3600 * 2),
     ),
 )
 def test_really_old_dtstart(post, admin_user, freq, delta, total_seconds):
-    url = reverse('api:schedule_rrule')
+    url = reverse("api:schedule_rrule")
     # every <interval>, at the :30 second mark
-    rrule = f'DTSTART;TZID=America/New_York:20051231T000030 RRULE:FREQ={freq};INTERVAL={delta}'
+    rrule = f"DTSTART;TZID=America/New_York:20051231T000030 RRULE:FREQ={freq};INTERVAL={delta}"
     start = now()
-    next_ten = post(url, {'rrule': rrule}, admin_user, expect=200).data['utc']
+    next_ten = post(url, {"rrule": rrule}, admin_user, expect=200).data["utc"]
 
     assert len(next_ten) == 10
 
@@ -437,7 +560,9 @@ def test_really_old_dtstart(post, admin_user, freq, delta, total_seconds):
     assert next_ten[0] >= start
 
     # ...but *no more than* <interval> into the future
-    assert now() + datetime.timedelta(**{'minutes' if freq == 'MINUTELY' else 'hours': delta})
+    assert now() + datetime.timedelta(
+        **{"minutes" if freq == "MINUTELY" else "hours": delta}
+    )
 
     # every date in the list is <interval> greater than the last
     for i, x in enumerate(next_ten):
@@ -453,77 +578,81 @@ def test_dst_rollback_duplicates(post, admin_user):
     # Make sure we don't "double count" duplicate times in the "rolled back"
     # hour.
 
-    url = reverse('api:schedule_rrule')
-    rrule = 'DTSTART;TZID=America/New_York:20301102T233000 RRULE:FREQ=HOURLY;INTERVAL=1;COUNT=5'
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    rrule = "DTSTART;TZID=America/New_York:20301102T233000 RRULE:FREQ=HOURLY;INTERVAL=1;COUNT=5"
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
-    assert list(map(str, r.data['local'])) == [
-        '2030-11-02 23:30:00-04:00',
-        '2030-11-03 00:30:00-04:00',
-        '2030-11-03 01:30:00-04:00',
-        '2030-11-03 02:30:00-05:00',
-        '2030-11-03 03:30:00-05:00',
+    assert list(map(str, r.data["local"])) == [
+        "2030-11-02 23:30:00-04:00",
+        "2030-11-03 00:30:00-04:00",
+        "2030-11-03 01:30:00-04:00",
+        "2030-11-03 02:30:00-05:00",
+        "2030-11-03 03:30:00-05:00",
     ]
 
 
 @pytest.mark.parametrize(
-    'rrule, expected_result',
+    "rrule, expected_result",
     (
         pytest.param(
-            'DTSTART;TZID=America/New_York:20300302T150000 RRULE:INTERVAL=1;FREQ=DAILY;UNTIL=20300304T1500 EXRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU',
-            ['2030-03-02 15:00:00-05:00', '2030-03-04 15:00:00-05:00'],
+            "DTSTART;TZID=America/New_York:20300302T150000 RRULE:INTERVAL=1;FREQ=DAILY;UNTIL=20300304T1500 EXRULE:FREQ=WEEKLY;INTERVAL=1;BYDAY=SU",
+            ["2030-03-02 15:00:00-05:00", "2030-03-04 15:00:00-05:00"],
             id="Every day except sundays",
         ),
         pytest.param(
-            'DTSTART;TZID=US/Eastern:20300428T170000 RRULE:INTERVAL=1;FREQ=DAILY;COUNT=4 EXRULE:INTERVAL=1;FREQ=DAILY;BYMONTH=4;BYMONTHDAY=30',
-            ['2030-04-28 17:00:00-04:00', '2030-04-29 17:00:00-04:00', '2030-05-01 17:00:00-04:00'],
+            "DTSTART;TZID=US/Eastern:20300428T170000 RRULE:INTERVAL=1;FREQ=DAILY;COUNT=4 EXRULE:INTERVAL=1;FREQ=DAILY;BYMONTH=4;BYMONTHDAY=30",
+            [
+                "2030-04-28 17:00:00-04:00",
+                "2030-04-29 17:00:00-04:00",
+                "2030-05-01 17:00:00-04:00",
+            ],
             id="Every day except April 30th",
         ),
         pytest.param(
-            'DTSTART;TZID=America/New_York:20300313T164500 RRULE:INTERVAL=5;FREQ=MINUTELY EXRULE:FREQ=MINUTELY;INTERVAL=5;BYDAY=WE;BYHOUR=17,18',
+            "DTSTART;TZID=America/New_York:20300313T164500 RRULE:INTERVAL=5;FREQ=MINUTELY EXRULE:FREQ=MINUTELY;INTERVAL=5;BYDAY=WE;BYHOUR=17,18",
             [
-                '2030-03-13 16:45:00-04:00',
-                '2030-03-13 16:50:00-04:00',
-                '2030-03-13 16:55:00-04:00',
-                '2030-03-13 19:00:00-04:00',
-                '2030-03-13 19:05:00-04:00',
-                '2030-03-13 19:10:00-04:00',
-                '2030-03-13 19:15:00-04:00',
-                '2030-03-13 19:20:00-04:00',
-                '2030-03-13 19:25:00-04:00',
-                '2030-03-13 19:30:00-04:00',
+                "2030-03-13 16:45:00-04:00",
+                "2030-03-13 16:50:00-04:00",
+                "2030-03-13 16:55:00-04:00",
+                "2030-03-13 19:00:00-04:00",
+                "2030-03-13 19:05:00-04:00",
+                "2030-03-13 19:10:00-04:00",
+                "2030-03-13 19:15:00-04:00",
+                "2030-03-13 19:20:00-04:00",
+                "2030-03-13 19:25:00-04:00",
+                "2030-03-13 19:30:00-04:00",
             ],
             id="Every 5 minutes but not Wednesdays from 5-7pm",
         ),
         pytest.param(
-            'DTSTART;TZID=America/New_York:20300426T100100 RRULE:INTERVAL=15;FREQ=MINUTELY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=10,11 EXRULE:INTERVAL=15;FREQ=MINUTELY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=11;BYMINUTE=3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,34,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59',
+            "DTSTART;TZID=America/New_York:20300426T100100 RRULE:INTERVAL=15;FREQ=MINUTELY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=10,11 EXRULE:INTERVAL=15;FREQ=MINUTELY;BYDAY=MO,TU,WE,TH,FR;BYHOUR=11;BYMINUTE=3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,34,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59",
             [
-                '2030-04-26 10:01:00-04:00',
-                '2030-04-26 10:16:00-04:00',
-                '2030-04-26 10:31:00-04:00',
-                '2030-04-26 10:46:00-04:00',
-                '2030-04-26 11:01:00-04:00',
-                '2030-04-29 10:01:00-04:00',
-                '2030-04-29 10:16:00-04:00',
-                '2030-04-29 10:31:00-04:00',
-                '2030-04-29 10:46:00-04:00',
-                '2030-04-29 11:01:00-04:00',
+                "2030-04-26 10:01:00-04:00",
+                "2030-04-26 10:16:00-04:00",
+                "2030-04-26 10:31:00-04:00",
+                "2030-04-26 10:46:00-04:00",
+                "2030-04-26 11:01:00-04:00",
+                "2030-04-29 10:01:00-04:00",
+                "2030-04-29 10:16:00-04:00",
+                "2030-04-29 10:31:00-04:00",
+                "2030-04-29 10:46:00-04:00",
+                "2030-04-29 11:01:00-04:00",
             ],
             id="Every 15 minutes Monday - Friday from 10:01am to 11:02pm (inclusive)",
         ),
         pytest.param(
-            'DTSTART:20301219T130551Z RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=12,13,14,15,16,17,18',
+            "DTSTART:20301219T130551Z RRULE:FREQ=MONTHLY;INTERVAL=1;BYDAY=SA;BYMONTHDAY=12,13,14,15,16,17,18",
             [
-                '2031-01-18 13:05:51+00:00',
-                '2031-02-15 13:05:51+00:00',
-                '2031-03-15 13:05:51+00:00',
-                '2031-04-12 13:05:51+00:00',
-                '2031-05-17 13:05:51+00:00',
-                '2031-06-14 13:05:51+00:00',
-                '2031-07-12 13:05:51+00:00',
-                '2031-08-16 13:05:51+00:00',
-                '2031-09-13 13:05:51+00:00',
-                '2031-10-18 13:05:51+00:00',
+                "2031-01-18 13:05:51+00:00",
+                "2031-02-15 13:05:51+00:00",
+                "2031-03-15 13:05:51+00:00",
+                "2031-04-12 13:05:51+00:00",
+                "2031-05-17 13:05:51+00:00",
+                "2031-06-14 13:05:51+00:00",
+                "2031-07-12 13:05:51+00:00",
+                "2031-08-16 13:05:51+00:00",
+                "2031-09-13 13:05:51+00:00",
+                "2031-10-18 13:05:51+00:00",
             ],
             id="Any Saturday whose month day is between 12 and 18",
         ),
@@ -532,105 +661,115 @@ def test_dst_rollback_duplicates(post, admin_user):
 def test_complex_schedule(post, admin_user, rrule, expected_result):
     # Every day except Sunday, 2022-05-01 is a Sunday
 
-    url = reverse('api:schedule_rrule')
-    r = post(url, {'rrule': rrule}, admin_user, expect=200)
+    url = reverse("api:schedule_rrule")
+    r = post(url, {"rrule": rrule}, admin_user, expect=200)
 
-    assert list(map(str, r.data['local'])) == expected_result
+    assert list(map(str, r.data["local"])) == expected_result
 
 
 @pytest.mark.django_db
 def test_zoneinfo(get, admin_user):
-    url = reverse('api:schedule_zoneinfo')
+    url = reverse("api:schedule_zoneinfo")
     r = get(url, admin_user, expect=200)
-    assert 'America/New_York' in r.data['zones']
+    assert "America/New_York" in r.data["zones"]
 
 
 @pytest.mark.django_db
 def test_normal_user_can_create_jt_schedule(options, post, project, inventory, alice):
-    jt = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+    jt = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
     jt.save()
-    url = reverse('api:schedule_list')
+    url = reverse("api:schedule_list")
 
     # can't create a schedule on the JT because we don't have execute rights
     params = {
-        'name': 'My Example Schedule',
-        'rrule': RRULE_EXAMPLE,
-        'unified_job_template': jt.id,
+        "name": "My Example Schedule",
+        "rrule": RRULE_EXAMPLE,
+        "unified_job_template": jt.id,
     }
-    assert 'POST' not in options(url, user=alice).data['actions'].keys()
+    assert "POST" not in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=403)
 
     # now we can, because we're allowed to execute the JT
     jt.execute_role.members.add(alice)
-    assert 'POST' in options(url, user=alice).data['actions'].keys()
+    assert "POST" in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=201)
 
 
 @pytest.mark.django_db
 def test_normal_user_can_create_project_schedule(options, post, project, alice):
-    url = reverse('api:schedule_list')
+    url = reverse("api:schedule_list")
 
     # can't create a schedule on the project because we don't have update rights
     params = {
-        'name': 'My Example Schedule',
-        'rrule': RRULE_EXAMPLE,
-        'unified_job_template': project.id,
+        "name": "My Example Schedule",
+        "rrule": RRULE_EXAMPLE,
+        "unified_job_template": project.id,
     }
-    assert 'POST' not in options(url, user=alice).data['actions'].keys()
+    assert "POST" not in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=403)
 
     # use role does *not* grant the ability to schedule
     project.use_role.members.add(alice)
-    assert 'POST' not in options(url, user=alice).data['actions'].keys()
+    assert "POST" not in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=403)
 
     # now we can, because we're allowed to update project
     project.update_role.members.add(alice)
-    assert 'POST' in options(url, user=alice).data['actions'].keys()
+    assert "POST" in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=201)
 
 
 @pytest.mark.django_db
-def test_normal_user_can_create_inventory_update_schedule(options, post, inventory_source, alice):
-    url = reverse('api:schedule_list')
+def test_normal_user_can_create_inventory_update_schedule(
+    options, post, inventory_source, alice
+):
+    url = reverse("api:schedule_list")
 
     # can't create a schedule on the project because we don't have update rights
     params = {
-        'name': 'My Example Schedule',
-        'rrule': RRULE_EXAMPLE,
-        'unified_job_template': inventory_source.id,
+        "name": "My Example Schedule",
+        "rrule": RRULE_EXAMPLE,
+        "unified_job_template": inventory_source.id,
     }
-    assert 'POST' not in options(url, user=alice).data['actions'].keys()
+    assert "POST" not in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=403)
 
     # use role does *not* grant the ability to schedule
     inventory_source.inventory.use_role.members.add(alice)
-    assert 'POST' not in options(url, user=alice).data['actions'].keys()
+    assert "POST" not in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=403)
 
     # now we can, because we're allowed to update project
     inventory_source.inventory.update_role.members.add(alice)
-    assert 'POST' in options(url, user=alice).data['actions'].keys()
+    assert "POST" in options(url, user=alice).data["actions"].keys()
     post(url, params, alice, expect=201)
 
 
 @pytest.mark.django_db
-def test_patch_invalid_byxxx_rejected_during_edt(post, patch, admin_user, project, inventory):
+def test_patch_invalid_byxxx_rejected_during_edt(
+    post, patch, admin_user, project, inventory
+):
     """PATCH with the problematic rrule during EDT is rejected by validation.
     The fast-forward shifts the hour out of BYHOUR alignment, causing
     ValueError which validate_rrule catches and returns as a 400.
     """
-    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
-    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
-    r = post(url, {'name': 'test-schedule', 'rrule': RRULE_EXAMPLE}, admin_user, expect=201)
-    detail_url = reverse('api:schedule_detail', kwargs={'pk': r.data['id']})
+    job_template = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
+    url = reverse("api:job_template_schedules_list", kwargs={"pk": job_template.id})
+    r = post(
+        url, {"name": "test-schedule", "rrule": RRULE_EXAMPLE}, admin_user, expect=201
+    )
+    detail_url = reverse("api:schedule_detail", kwargs={"pk": r.data["id"]})
 
     # During EDT (Jul 1, 2026), fast-forward lands on hour 10 (0 mod 4),
     # no overlap with BYHOUR=1,5,9,13,17,21 → ValueError → 400
     edt_now = datetime.datetime(2026, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
-    with mock.patch('awx.main.models.schedules.now', return_value=edt_now):
-        r = patch(detail_url, {'rrule': RRULE_INVALID_BYXXX}, admin_user, expect=400)
-        assert 'rrule' in r.data
+    with mock.patch("awx.main.models.schedules.now", return_value=edt_now):
+        r = patch(detail_url, {"rrule": RRULE_INVALID_BYXXX}, admin_user, expect=400)
+        assert "rrule" in r.data
 
 
 @pytest.mark.django_db
@@ -639,48 +778,59 @@ def test_get_survives_invalid_byxxx_already_in_db(get, admin_user, project, inve
     fast-forward during EDT should not 500. The timezone and until properties
     catch the ValueError and return fallback values.
     """
-    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+    job_template = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
 
     # Create a valid schedule, then inject the bad rrule at the DB level
     # (simulates data accepted during EST that breaks during EDT)
     schedule = Schedule.objects.create(
-        name='bad-byxxx-schedule',
-        rrule='DTSTART:20251211T130000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1',
+        name="bad-byxxx-schedule",
+        rrule="DTSTART:20251211T130000Z RRULE:FREQ=DAILY;INTERVAL=1;COUNT=1",
         unified_job_template=job_template,
     )
     Schedule.objects.filter(pk=schedule.pk).update(rrule=RRULE_INVALID_BYXXX)
 
     # GET during EDT — timezone/until properties catch ValueError gracefully
     edt_now = datetime.datetime(2026, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
-    with mock.patch('awx.main.models.schedules.now', return_value=edt_now):
-        url = reverse('api:schedule_list')
+    with mock.patch("awx.main.models.schedules.now", return_value=edt_now):
+        url = reverse("api:schedule_list")
         r = get(url, admin_user, expect=200)
-        assert r.data['count'] >= 1
+        assert r.data["count"] >= 1
 
-        detail_url = reverse('api:schedule_detail', kwargs={'pk': schedule.pk})
+        detail_url = reverse("api:schedule_detail", kwargs={"pk": schedule.pk})
         r = get(detail_url, admin_user, expect=200)
-        assert r.data['id'] == schedule.pk
+        assert r.data["id"] == schedule.pk
 
 
 @pytest.mark.django_db
-def test_future_dtstart_created_and_get_survives_edt(post, get, admin_user, project, inventory):
+def test_future_dtstart_created_and_get_survives_edt(
+    post, get, admin_user, project, inventory
+):
     """A schedule with conflicting BYxxx + BYHOUR constraints passes API
     validation when dtstart is in the future (fast-forward is skipped entirely).
     After dtstart passes, GET during EDT should not crash — the timezone and
     until properties catch the ValueError from the DST hour shift.
     """
-    job_template = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
-    url = reverse('api:job_template_schedules_list', kwargs={'pk': job_template.id})
+    job_template = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
+    url = reverse("api:job_template_schedules_list", kwargs={"pk": job_template.id})
 
     # Create with future dtstart — fast-forward is skipped, validation passes
-    r = post(url, {'name': 'future-schedule', 'rrule': RRULE_INVALID_BYXXX_FUTURE}, admin_user, expect=201)
-    schedule_id = r.data['id']
+    r = post(
+        url,
+        {"name": "future-schedule", "rrule": RRULE_INVALID_BYXXX_FUTURE},
+        admin_user,
+        expect=201,
+    )
+    schedule_id = r.data["id"]
 
     # GET during EDT when dtstart is now in the past — fast-forward kicks in
     # and the DST shift breaks the BYHOUR alignment, but timezone/until
     # properties catch it gracefully
     edt_now = datetime.datetime(2036, 7, 1, 14, 0, 0, tzinfo=datetime.timezone.utc)
-    detail_url = reverse('api:schedule_detail', kwargs={'pk': schedule_id})
-    with mock.patch('awx.main.models.schedules.now', return_value=edt_now):
+    detail_url = reverse("api:schedule_detail", kwargs={"pk": schedule_id})
+    with mock.patch("awx.main.models.schedules.now", return_value=edt_now):
         r = get(detail_url, admin_user, expect=200)
-        assert r.data['id'] == schedule_id
+        assert r.data["id"] == schedule_id

--- a/awx/main/tests/functional/tasks/test_tasks_system.py
+++ b/awx/main/tests/functional/tasks/test_tasks_system.py
@@ -19,7 +19,17 @@ from awx.main.tasks.system import (
 from awx.main.management.commands.dispatcherd import Command
 from django.db import DatabaseError
 
-from awx.main.models import Instance, Inventory, Job, JobTemplate, Organization, ReceptorAddress, InstanceLink, Schedule, TowerScheduleState
+from awx.main.models import (
+    Instance,
+    Inventory,
+    Job,
+    JobTemplate,
+    Organization,
+    ReceptorAddress,
+    InstanceLink,
+    Schedule,
+    TowerScheduleState,
+)
 from awx.main.models.inventory import Group, Host
 
 
@@ -30,29 +40,39 @@ class TestLinkState:
         settings.IS_K8S = True
 
     def test_inspect_established_receptor_connections(self):
-        '''
+        """
         Change link state from ADDING to ESTABLISHED
         if the receptor status KnownConnectionCosts field
         has an entry for the source and target node.
-        '''
-        hop1 = Instance.objects.create(hostname='hop1')
-        hop2 = Instance.objects.create(hostname='hop2')
-        hop2addr = ReceptorAddress.objects.create(instance=hop2, address='hop2', port=5678)
-        InstanceLink.objects.create(source=hop1, target=hop2addr, link_state=InstanceLink.States.ADDING)
+        """
+        hop1 = Instance.objects.create(hostname="hop1")
+        hop2 = Instance.objects.create(hostname="hop2")
+        hop2addr = ReceptorAddress.objects.create(
+            instance=hop2, address="hop2", port=5678
+        )
+        InstanceLink.objects.create(
+            source=hop1, target=hop2addr, link_state=InstanceLink.States.ADDING
+        )
 
         # calling with empty KnownConnectionCosts should not change the link state
         inspect_established_receptor_connections({"KnownConnectionCosts": {}})
-        assert InstanceLink.objects.get(source=hop1, target=hop2addr).link_state == InstanceLink.States.ADDING
+        assert (
+            InstanceLink.objects.get(source=hop1, target=hop2addr).link_state
+            == InstanceLink.States.ADDING
+        )
 
         mesh_state = {"KnownConnectionCosts": {"hop1": {"hop2": 1}}}
         inspect_established_receptor_connections(mesh_state)
-        assert InstanceLink.objects.get(source=hop1, target=hop2addr).link_state == InstanceLink.States.ESTABLISHED
+        assert (
+            InstanceLink.objects.get(source=hop1, target=hop2addr).link_state
+            == InstanceLink.States.ESTABLISHED
+        )
 
 
 @pytest.fixture
 def job_folder_factory(request):
-    def _rf(job_id='1234'):
-        pdd_path = tempfile.mkdtemp(prefix=f'awx_{job_id}_')
+    def _rf(job_id="1234"):
+        pdd_path = tempfile.mkdtemp(prefix=f"awx_{job_id}_")
 
         def test_folder_cleanup():
             if os.path.exists(pdd_path):
@@ -71,9 +91,9 @@ def mock_job_folder(job_folder_factory):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('node_type', ('control. hybrid'))
+@pytest.mark.parametrize("node_type", ("control. hybrid"))
 def test_no_worker_info_on_AWX_nodes(node_type):
-    hostname = 'us-south-3-compute.invalid'
+    hostname = "us-south-3-compute.invalid"
     Instance.objects.create(hostname=hostname, node_type=node_type)
     assert execution_node_health_check(hostname) is None
 
@@ -81,7 +101,9 @@ def test_no_worker_info_on_AWX_nodes(node_type):
 @pytest.mark.django_db
 def test_folder_cleanup_stale_file(mock_job_folder, mock_me):
     CleanupImagesAndFiles.run()
-    assert os.path.exists(mock_job_folder)  # grace period should protect folder from deletion
+    assert os.path.exists(
+        mock_job_folder
+    )  # grace period should protect folder from deletion
 
     CleanupImagesAndFiles.run(grace_period=0)
     assert not os.path.exists(mock_job_folder)  # should be deleted
@@ -89,14 +111,20 @@ def test_folder_cleanup_stale_file(mock_job_folder, mock_me):
 
 @pytest.mark.django_db
 def test_folder_cleanup_running_job(mock_job_folder, me_inst):
-    job = Job.objects.create(id=1234, controller_node=me_inst.hostname, status='running')
+    job = Job.objects.create(
+        id=1234, controller_node=me_inst.hostname, status="running"
+    )
     CleanupImagesAndFiles.run(grace_period=0)
-    assert os.path.exists(mock_job_folder)  # running job should prevent folder from getting deleted
+    assert os.path.exists(
+        mock_job_folder
+    )  # running job should prevent folder from getting deleted
 
-    job.status = 'failed'
-    job.save(update_fields=['status'])
+    job.status = "failed"
+    job.save(update_fields=["status"])
     CleanupImagesAndFiles.run(grace_period=0)
-    assert not os.path.exists(mock_job_folder)  # job is finished and no grace period, should delete
+    assert not os.path.exists(
+        mock_job_folder
+    )  # job is finished and no grace period, should delete
 
 
 @pytest.mark.django_db
@@ -106,7 +134,7 @@ def test_folder_cleanup_multiple_running_jobs(job_folder_factory, me_inst):
     num_jobs = 3
 
     for i in range(num_jobs):
-        job = Job.objects.create(controller_node=me_inst.hostname, status='running')
+        job = Job.objects.create(controller_node=me_inst.hostname, status="running")
         dirs.append(job_folder_factory(job.id))
         jobs.append(job)
 
@@ -121,10 +149,13 @@ class TestBatchedDeleteInventory:
         from django.utils import timezone
 
         now = timezone.now()
-        org = Organization.objects.create(name='test-org')
-        inv = Inventory.objects.create(name='test-inv', organization=org)
-        group = Group.objects.create(name='test-group', inventory=inv)
-        hosts = [Host(name=f'host-{i}', inventory=inv, created=now, modified=now) for i in range(count)]
+        org = Organization.objects.create(name="test-org")
+        inv = Inventory.objects.create(name="test-inv", organization=org)
+        group = Group.objects.create(name="test-group", inventory=inv)
+        hosts = [
+            Host(name=f"host-{i}", inventory=inv, created=now, modified=now)
+            for i in range(count)
+        ]
         Host.objects.bulk_create(hosts)
         group.hosts.set(Host.objects.filter(inventory=inv))
         return inv
@@ -157,7 +188,9 @@ class TestBatchedDeleteInventory:
         inv_id = inv.id
 
         # Simulate a partial deletion (as if the task crashed after 4 hosts)
-        partial_pks = list(Host.objects.filter(inventory=inv).values_list('pk', flat=True)[:4])
+        partial_pks = list(
+            Host.objects.filter(inventory=inv).values_list("pk", flat=True)[:4]
+        )
         Host.objects.filter(pk__in=partial_pks).delete()
         assert Host.objects.filter(inventory_id=inv_id).count() == 6
 
@@ -174,28 +207,34 @@ class TestBatchedDeleteInventory:
         inv = self._make_inventory_with_hosts(3)
         inv_id = inv.id
 
-        call_count = {'n': 0}
-        original = _batched_delete_inventory.__wrapped__ if hasattr(_batched_delete_inventory, '__wrapped__') else _batched_delete_inventory
+        call_count = {"n": 0}
+        original = (
+            _batched_delete_inventory.__wrapped__
+            if hasattr(_batched_delete_inventory, "__wrapped__")
+            else _batched_delete_inventory
+        )
 
         def flaky_delete(inventory, batch_size=500):
-            call_count['n'] += 1
-            if call_count['n'] == 1:
-                raise DatabaseError('connection reset')
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise DatabaseError("connection reset")
             return original(inventory, batch_size=batch_size)
 
-        with mock.patch('awx.main.tasks.system._batched_delete_inventory', side_effect=flaky_delete):
-            with mock.patch('awx.main.tasks.system.emit_channel_notification'):
-                with mock.patch('awx.main.tasks.system.time.sleep'):
+        with mock.patch(
+            "awx.main.tasks.system._batched_delete_inventory", side_effect=flaky_delete
+        ):
+            with mock.patch("awx.main.tasks.system.emit_channel_notification"):
+                with mock.patch("awx.main.tasks.system.time.sleep"):
                     delete_inventory(inv_id, None, retries=2)
 
-        assert call_count['n'] == 2
+        assert call_count["n"] == 2
         assert not Inventory.objects.filter(id=inv_id).exists()
 
 
 @pytest.mark.django_db
 def test_clear_setting_cache_log_level_branch(settings):
-    settings.LOG_AGGREGATOR_LEVEL = 'DEBUG'
-    settings.CLUSTER_HOST_ID = 'control-node'
+    settings.LOG_AGGREGATOR_LEVEL = "DEBUG"
+    settings.CLUSTER_HOST_ID = "control-node"
     published_messages = []
 
     class DummyBroker:
@@ -207,49 +246,51 @@ def test_clear_setting_cache_log_level_branch(settings):
 
     dummy_broker = DummyBroker()
 
-    with mock.patch('dispatcherd.control.get_broker', return_value=dummy_broker) as mock_get_broker:
-        clear_setting_cache(['LOG_AGGREGATOR_LEVEL'])
+    with mock.patch(
+        "dispatcherd.control.get_broker", return_value=dummy_broker
+    ) as mock_get_broker:
+        clear_setting_cache(["LOG_AGGREGATOR_LEVEL"])
 
     mock_get_broker.assert_called_once()
-    assert published_messages, 'control command was not sent through the broker'
+    assert published_messages, "control command was not sent through the broker"
     queue, payload = published_messages[-1]
-    assert queue == 'control-node'
+    assert queue == "control-node"
     body = json.loads(payload)
-    assert body['control'] == 'set_log_level'
-    assert body['control_data'] == {'level': 'DEBUG'}
+    assert body["control"] == "set_log_level"
+    assert body["control_data"] == {"level": "DEBUG"}
 
 
 @pytest.mark.django_db
 def test_configure_dispatcher_logging_updates_level(settings):
     original_logging_settings = copy.deepcopy(settings.LOGGING)
     settings.LOGGING = {
-        'version': 1,
-        'disable_existing_loggers': False,
-        'filters': {
-            'dynamic_level_filter': {
-                '()': 'logging.Filter',
+        "version": 1,
+        "disable_existing_loggers": False,
+        "filters": {
+            "dynamic_level_filter": {
+                "()": "logging.Filter",
             }
         },
-        'handlers': {
-            'console': {
-                'class': 'logging.StreamHandler',
-                'filters': ['dynamic_level_filter'],
-                'stream': 'ext://sys.stdout',
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "filters": ["dynamic_level_filter"],
+                "stream": "ext://sys.stdout",
             }
         },
-        'loggers': {
-            'dispatcherd': {
-                'handlers': ['console'],
-                'level': 'INFO',
-                'propagate': False,
+        "loggers": {
+            "dispatcherd": {
+                "handlers": ["console"],
+                "level": "INFO",
+                "propagate": False,
             }
         },
     }
-    settings.LOG_AGGREGATOR_LEVEL = 'WARNING'
+    settings.LOG_AGGREGATOR_LEVEL = "WARNING"
 
     Command().configure_dispatcher_logging()
 
-    assert logging.getLogger('dispatcherd').level == logging.WARNING
+    assert logging.getLogger("dispatcherd").level == logging.WARNING
     settings.LOGGING = original_logging_settings
 
 
@@ -265,25 +306,31 @@ def test_periodic_scheduler_survives_invalid_schedule(inventory, project):
     """
     from datetime import datetime, timedelta, timezone as dt_tz
 
-    jt = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+    jt = JobTemplate.objects.create(
+        name="test-jt", project=project, playbook="helloworld.yml", inventory=inventory
+    )
 
     run_now = datetime(2026, 7, 1, 14, 0, 0, tzinfo=dt_tz.utc)
     last_run = run_now - timedelta(seconds=30)
 
     healthy_schedule = Schedule.objects.create(
-        name='healthy-schedule',
-        rrule='DTSTART:20260101T120000Z RRULE:FREQ=DAILY;INTERVAL=1',
+        name="healthy-schedule",
+        rrule="DTSTART:20260101T120000Z RRULE:FREQ=DAILY;INTERVAL=1",
         unified_job_template=jt,
     )
-    Schedule.objects.filter(pk=healthy_schedule.pk).update(next_run=last_run + timedelta(seconds=10))
+    Schedule.objects.filter(pk=healthy_schedule.pk).update(
+        next_run=last_run + timedelta(seconds=10)
+    )
 
     bad_schedule = Schedule.objects.create(
-        name='bad-schedule',
-        rrule='DTSTART:20260101T120000Z RRULE:FREQ=DAILY;INTERVAL=1',
+        name="bad-schedule",
+        rrule="DTSTART:20260101T120000Z RRULE:FREQ=DAILY;INTERVAL=1",
         unified_job_template=jt,
     )
     bad_schedule_id = bad_schedule.pk
-    Schedule.objects.filter(pk=bad_schedule_id).update(next_run=last_run + timedelta(seconds=10))
+    Schedule.objects.filter(pk=bad_schedule_id).update(
+        next_run=last_run + timedelta(seconds=10)
+    )
 
     state = TowerScheduleState.get_solo()
     state.schedule_last_run = last_run
@@ -302,18 +349,22 @@ def test_periodic_scheduler_survives_invalid_schedule(inventory, project):
         return original_ucf(self)
 
     with (
-        mock.patch('awx.main.tasks.system.now', return_value=run_now),
-        mock.patch('awx.main.models.schedules.now', return_value=run_now),
-        mock.patch('awx.main.models.schedules.emit_channel_notification'),
-        mock.patch('awx.main.tasks.system.emit_channel_notification'),
-        mock.patch.object(Schedule, 'update_computed_fields', update_or_raise),
+        mock.patch("awx.main.tasks.system.now", return_value=run_now),
+        mock.patch("awx.main.models.schedules.now", return_value=run_now),
+        mock.patch("awx.main.models.schedules.emit_channel_notification"),
+        mock.patch("awx.main.tasks.system.emit_channel_notification"),
+        mock.patch.object(Schedule, "update_computed_fields", update_or_raise),
     ):
         awx_periodic_scheduler()
 
-    assert bad_schedule_raised, "The bad schedule's update_computed_fields should have been called and raised"
+    assert bad_schedule_raised, (
+        "The bad schedule's update_computed_fields should have been called and raised"
+    )
 
     healthy_jobs = Job.objects.filter(schedule=healthy_schedule)
-    assert healthy_jobs.count() == 1, "Healthy schedule should have created exactly one job"
+    assert healthy_jobs.count() == 1, (
+        "Healthy schedule should have created exactly one job"
+    )
 
     bad_jobs = Job.objects.filter(schedule=bad_schedule)
     assert bad_jobs.count() == 0, "Bad schedule should not have created a job"

--- a/awx/main/tests/functional/tasks/test_tasks_system.py
+++ b/awx/main/tests/functional/tasks/test_tasks_system.py
@@ -10,6 +10,7 @@ import pytest
 
 from awx.main.tasks.system import (
     CleanupImagesAndFiles,
+    awx_periodic_scheduler,
     execution_node_health_check,
     inspect_established_receptor_connections,
     clear_setting_cache,
@@ -18,7 +19,7 @@ from awx.main.tasks.system import (
 from awx.main.management.commands.dispatcherd import Command
 from django.db import DatabaseError
 
-from awx.main.models import Instance, Inventory, Job, Organization, ReceptorAddress, InstanceLink
+from awx.main.models import Instance, Inventory, Job, JobTemplate, Organization, ReceptorAddress, InstanceLink, Schedule, TowerScheduleState
 from awx.main.models.inventory import Group, Host
 
 
@@ -250,3 +251,69 @@ def test_configure_dispatcher_logging_updates_level(settings):
 
     assert logging.getLogger('dispatcherd').level == logging.WARNING
     settings.LOGGING = original_logging_settings
+
+
+@pytest.mark.django_db
+def test_periodic_scheduler_survives_invalid_schedule(inventory, project):
+    """A schedule whose update_computed_fields raises should not prevent the
+    periodic scheduler from processing other healthy schedules.
+
+    Simulates the scenario where a corrupt rrule causes update_computed_fields
+    to raise ValueError (the exact error from the BYHOUR/DST bug). Verifies
+    the scheduler completes, creates a job for the healthy schedule, and skips
+    the broken one.
+    """
+    from datetime import datetime, timedelta, timezone as dt_tz
+
+    jt = JobTemplate.objects.create(name='test-jt', project=project, playbook='helloworld.yml', inventory=inventory)
+
+    run_now = datetime(2026, 7, 1, 14, 0, 0, tzinfo=dt_tz.utc)
+    last_run = run_now - timedelta(seconds=30)
+
+    healthy_schedule = Schedule.objects.create(
+        name='healthy-schedule',
+        rrule='DTSTART:20260101T120000Z RRULE:FREQ=DAILY;INTERVAL=1',
+        unified_job_template=jt,
+    )
+    Schedule.objects.filter(pk=healthy_schedule.pk).update(next_run=last_run + timedelta(seconds=10))
+
+    bad_schedule = Schedule.objects.create(
+        name='bad-schedule',
+        rrule='DTSTART:20260101T120000Z RRULE:FREQ=DAILY;INTERVAL=1',
+        unified_job_template=jt,
+    )
+    bad_schedule_id = bad_schedule.pk
+    Schedule.objects.filter(pk=bad_schedule_id).update(next_run=last_run + timedelta(seconds=10))
+
+    state = TowerScheduleState.get_solo()
+    state.schedule_last_run = last_run
+    state.save()
+
+    # Make update_computed_fields raise for the bad schedule, simulating the
+    # ValueError that occurs when _fast_forward_rrule hits a corrupt rrule.
+    original_ucf = Schedule.update_computed_fields
+    bad_schedule_raised = False
+
+    def update_or_raise(self):
+        nonlocal bad_schedule_raised
+        if self.pk == bad_schedule_id:
+            bad_schedule_raised = True
+            raise ValueError("Invalid rrule byxxx generates an empty set.")
+        return original_ucf(self)
+
+    with (
+        mock.patch('awx.main.tasks.system.now', return_value=run_now),
+        mock.patch('awx.main.models.schedules.now', return_value=run_now),
+        mock.patch('awx.main.models.schedules.emit_channel_notification'),
+        mock.patch('awx.main.tasks.system.emit_channel_notification'),
+        mock.patch.object(Schedule, 'update_computed_fields', update_or_raise),
+    ):
+        awx_periodic_scheduler()
+
+    assert bad_schedule_raised, "The bad schedule's update_computed_fields should have been called and raised"
+
+    healthy_jobs = Job.objects.filter(schedule=healthy_schedule)
+    assert healthy_jobs.count() == 1, "Healthy schedule should have created exactly one job"
+
+    bad_jobs = Job.objects.filter(schedule=bad_schedule)
+    assert bad_jobs.count() == 0, "Bad schedule should not have created a job"


### PR DESCRIPTION
##### SUMMARY

DST - daylight savings time

- Fix unhandled `ValueError` in `_fast_forward_rrule` that causes HTTP 500 on the schedules page when an HOURLY rrule with BYHOUR constraints is fast-forwarded across a DST boundary
- Harden `awx_periodic_scheduler` so one bad schedule cannot crash the task and block all other schedules from running

The `_fast_forward_rrule` optimization advances the dtstart of HOURLY/MINUTELY rrules close to the current time, computing in UTC then converting back to local timezone. With rrules whose BYHOUR values are aligned to a specific residue mod INTERVAL (e.g., BYHOUR=1,5,9,13,17,21 with INTERVAL=4 — all 1 mod 4), this alignment holds during EST (UTC-5) but breaks during EDT (UTC-4). The 1-hour DST shift changes the residue, dateutil finds no valid hours, and raises `ValueError: Invalid rrule byxxx generates an empty set.` This propagates uncaught through the `timezone`/`until` serializer properties on GET and through `update_computed_fields` in the periodic scheduler — crashing the schedules page and preventing all scheduled jobs from launching.

Bad rrules enter the database through two confirmed pathways: PATCH during EST (validation passes because fast-forward alignment holds in standard time, then breaks when EDT starts) and POST with a future dtstart (fast-forward is skipped entirely, then fails once dtstart passes and the clock is in EDT). Both are covered by new functional tests with deterministic mocked time.

The fix catches `ValueError` in `_fast_forward_rrule` and falls back to the original rrule (safe, since fast-forwarding is purely a performance optimization), adds defense-in-depth in `update_computed_fields_no_save` to set `next_run = None` for any unparseable rrule, and wraps both unprotected `update_computed_fields()` calls in `awx_periodic_scheduler` with try/except — matching the safe pattern already used in `_run_dispatch_startup_common`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches schedule recomputation and the periodic scheduler loop; while mostly defensive error handling, it can change how invalid schedules are persisted/ignored and could impact job launch timing if parsing behavior regresses.
> 
> **Overview**
> Prevents schedule reads and the periodic scheduler from crashing when an `rrule` becomes unparsable (notably DST-triggered `BYxxx` empty-set errors).
> 
> `Schedule.timezone`/`Schedule.until` now catch `ValueError` from `Schedule.rrulestr` and return empty fallbacks, and `awx_periodic_scheduler` now wraps `update_computed_fields()` so a single bad schedule is logged, has `next_run`/`dtend` nulled, and is skipped without blocking other schedules.
> 
> Adds functional tests covering DST/`BYHOUR` failure scenarios (PATCH rejected with 400; GET stays 200 even if bad data exists in DB) and a task-level test ensuring the scheduler continues processing healthy schedules when one schedule recompute raises.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 719aeff7b563d234fd3eaeb607084de25a146244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduler now logs and skips invalid or DST-sensitive recurrence rules instead of failing; affected schedules have their upcoming run cleared. PATCHing an invalid rule returns 400, while reads remain available (no server error).
* **Tests**
  * Added functional tests ensuring the scheduler continues running healthy schedules across invalid recurrence rules and timezone transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->