### PR TITLE
Fix 'occured' -> 'occurred' typos in awx/main/tasks

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1966,7 +1966,7 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
             raise
         except Exception:
             logger.exception('Exception saving {} content, rolling back changes.'.format(inventory_update.log_format))
-            raise PostRunError('Error occured while saving inventory data, see traceback or server logs', status='error', tb=traceback.format_exc())
+            raise PostRunError('Error occurred while saving inventory data, see traceback or server logs', status='error', tb=traceback.format_exc())
 
 
 @task(queue=get_task_queuename)

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -477,7 +477,7 @@ class AWXReceptorJob:
             # We do not programatically handle this case. Ideally, we would handle this with a reaper case.
             # The two distinct job lifecycle log events below allow for us to at least detect when this
             # edge case occurs. If the lifecycle event work_unit_id_received occurs without the
-            # work_unit_id_assigned event then this case may have occured.
+            # work_unit_id_assigned event then this case may have occurred.
             self.task.instance.work_unit_id = result['unitid']  # Set work_unit_id in-memory only
             self.task.instance.log_lifecycle("work_unit_id_received")
             self.task.update_model(self.task.instance.pk, work_unit_id=result['unitid'])
@@ -520,7 +520,7 @@ class AWXReceptorJob:
                 signal_state.raise_exception = False
 
             if res.status == 'error':
-                # If ansible-runner ran, but an error occured at runtime, the traceback information
+                # If ansible-runner ran, but an error occurred at runtime, the traceback information
                 # is saved via the status_handler passed in to the processor.
                 if 'result_traceback' in self.task.runner_callback.extra_update_fields:
                     return res


### PR DESCRIPTION
Three instances of `occured` across two task files:

- `awx/main/tasks/receptor.py` × 2 — inline comments in the receptor job dispatcher explaining the `work_unit_id_assigned` race and ansible-runner runtime traceback handling.
- `awx/main/tasks/jobs.py:1969` — `PostRunError` message raised when saving inventory data fails; surfaced to operators in job error output.

Python `ast.parse` stays clean for both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected spelling errors in error handling messages and system comments to improve communication clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->