### PR TITLE
Fix 'occured' -> 'occurred' typos in AWX tasks and controller_api

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1966,7 +1966,7 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
             raise
         except Exception:
             logger.exception('Exception saving {} content, rolling back changes.'.format(inventory_update.log_format))
-            raise PostRunError('Error occured while saving inventory data, see traceback or server logs', status='error', tb=traceback.format_exc())
+            raise PostRunError('Error occurred while saving inventory data, see traceback or server logs', status='error', tb=traceback.format_exc())
 
 
 @task(queue=get_task_queuename)

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -477,7 +477,7 @@ class AWXReceptorJob:
             # We do not programatically handle this case. Ideally, we would handle this with a reaper case.
             # The two distinct job lifecycle log events below allow for us to at least detect when this
             # edge case occurs. If the lifecycle event work_unit_id_received occurs without the
-            # work_unit_id_assigned event then this case may have occured.
+            # work_unit_id_assigned event then this case may have occurred.
             self.task.instance.work_unit_id = result['unitid']  # Set work_unit_id in-memory only
             self.task.instance.log_lifecycle("work_unit_id_received")
             self.task.update_model(self.task.instance.pk, work_unit_id=result['unitid'])
@@ -520,7 +520,7 @@ class AWXReceptorJob:
                 signal_state.raise_exception = False
 
             if res.status == 'error':
-                # If ansible-runner ran, but an error occured at runtime, the traceback information
+                # If ansible-runner ran, but an error occurred at runtime, the traceback information
                 # is saved via the status_handler passed in to the processor.
                 if 'result_traceback' in self.task.runner_callback.extra_update_fields:
                     return res

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -263,10 +263,10 @@ class ControllerModule(AnsibleModule):
                             pass
 
                 except Exception as e:
-                    raise_from(ConfigFileException("An unknown exception occured trying to ini load config file: {0}".format(e)), e)
+                    raise_from(ConfigFileException("An unknown exception occurred trying to ini load config file: {0}".format(e)), e)
 
         except Exception as e:
-            raise_from(ConfigFileException("An unknown exception occured trying to load config file: {0}".format(e)), e)
+            raise_from(ConfigFileException("An unknown exception occurred trying to load config file: {0}".format(e)), e)
 
         # If we made it here, we have a dict which has values in it from our config, any final settings logic can be performed here
         for honorred_setting in self.short_params:


### PR DESCRIPTION
Fix 5 instances of `occured` → `occurred`:

- `awx/main/tasks/receptor.py` (×2): Comments
- `awx/main/tasks/jobs.py`: PostRunError message (user-visible in job output)
- `awx_collection/plugins/module_utils/controller_api.py` (×2): ConfigFileException messages

String/comment-only change.

Signed-off-by DCO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in error messages related to inventory data operations and configuration file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->