### PR TITLE
Add per-resource proxy field for inventory sources and projects

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1313,8 +1313,7 @@ class ProjectOptionsSerializer(BaseSerializer):
                 if _mask_proxy_password(db_proxy) == value:
                     return db_proxy
             raise serializers.ValidationError(_('Proxy password must be provided in plain text, not as $encrypted$.'))
-        if not (value.startswith('http://') or value.startswith('https://') or value.startswith('socks')):
-            raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
+        _validate_proxy_url(value)
         return value
 
     def to_representation(self, obj):
@@ -2292,23 +2291,36 @@ class GroupVariableDataSerializer(BaseVariableDataSerializer):
         model = Group
 
 
+_VALID_PROXY_SCHEMES = ('http', 'https', 'socks', 'socks4', 'socks4a', 'socks5', 'socks5h')
+
+
+def _validate_proxy_url(value):
+    """Validate that *value* is a well-formed proxy URL (scheme + hostname)."""
+    parsed = urllib.parse.urlsplit(value)
+    if parsed.scheme.lower() not in _VALID_PROXY_SCHEMES or parsed.hostname is None:
+        raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
+    try:
+        parsed.port
+    except ValueError:
+        raise serializers.ValidationError(_('Proxy URL has an invalid port.'))
+
+
 def _mask_proxy_password(proxy_url):
     """Mask credentials embedded in a proxy URL for safe API display."""
     if not proxy_url:
         return ''
-    if not (proxy_url.startswith('http://') or proxy_url.startswith('https://')):
-        return proxy_url
     parsed = urllib.parse.urlsplit(proxy_url)
+    if parsed.scheme.lower() not in _VALID_PROXY_SCHEMES:
+        return proxy_url
     if not parsed.username and not parsed.password:
         return proxy_url
+    host = parsed.netloc.rsplit('@', 1)[-1]
     if parsed.username and parsed.password:
-        masked_netloc = '{}:{}@{}'.format(parsed.username, REPLACE_STR, parsed.hostname)
+        masked_netloc = '{}:{}@{}'.format(parsed.username, REPLACE_STR, host)
     elif parsed.password:
-        masked_netloc = '{}@{}'.format(REPLACE_STR, parsed.hostname)
+        masked_netloc = '{}@{}'.format(REPLACE_STR, host)
     else:
-        masked_netloc = '{}@{}'.format(parsed.username, parsed.hostname)
-    if parsed.port:
-        masked_netloc += ':{}'.format(parsed.port)
+        masked_netloc = '{}@{}'.format(parsed.username, host)
     return urllib.parse.urlunsplit((parsed.scheme, masked_netloc, parsed.path, parsed.query, parsed.fragment))
 
 
@@ -2367,8 +2379,7 @@ class InventorySourceOptionsSerializer(BaseSerializer):
                 if _mask_proxy_password(db_proxy) == value:
                     return db_proxy
             raise serializers.ValidationError(_('Proxy password must be provided in plain text, not as $encrypted$.'))
-        if not (value.startswith('http://') or value.startswith('https://') or value.startswith('socks')):
-            raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
+        _validate_proxy_url(value)
         return value
 
     def to_representation(self, obj):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2303,7 +2303,7 @@ def _validate_proxy_url(value):
     if parsed.scheme.lower() not in _VALID_PROXY_SCHEMES or parsed.hostname is None:
         raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
     try:
-        _ = parsed.port
+        _port = parsed.port
     except ValueError:
         raise serializers.ValidationError(_('Proxy URL has an invalid port.')) from None
 
@@ -2315,15 +2315,17 @@ def _mask_proxy_password(proxy_url):
     parsed = urllib.parse.urlsplit(proxy_url)
     if parsed.scheme.lower() not in _VALID_PROXY_SCHEMES:
         return proxy_url
-    if not parsed.username and not parsed.password:
+    if '@' not in parsed.netloc:
         return proxy_url
-    host = parsed.netloc.rsplit('@', 1)[-1]
-    if parsed.username and parsed.password:
-        masked_netloc = '{}:{}@{}'.format(parsed.username, REPLACE_STR, host)
-    elif parsed.password:
-        masked_netloc = '{}@{}'.format(REPLACE_STR, host)
+    userinfo, host = parsed.netloc.rsplit('@', 1)
+    if not userinfo:
+        return proxy_url
+    if ':' in userinfo:
+        username = userinfo.split(':', 1)[0]
+        masked_userinfo = '{}:{}'.format(username, REPLACE_STR) if username else ':{}'.format(REPLACE_STR)
     else:
-        masked_netloc = '{}@{}'.format(parsed.username, host)
+        masked_userinfo = REPLACE_STR
+    masked_netloc = '{}@{}'.format(masked_userinfo, host)
     return urllib.parse.urlunsplit((parsed.scheme, masked_netloc, parsed.path, parsed.query, parsed.fragment))
 
 

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2296,13 +2296,16 @@ _VALID_PROXY_SCHEMES = ('http', 'https', 'socks', 'socks4', 'socks4a', 'socks5',
 
 def _validate_proxy_url(value):
     """Validate that *value* is a well-formed proxy URL (scheme + hostname)."""
-    parsed = urllib.parse.urlsplit(value)
+    try:
+        parsed = urllib.parse.urlsplit(value)
+    except ValueError:
+        raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.')) from None
     if parsed.scheme.lower() not in _VALID_PROXY_SCHEMES or parsed.hostname is None:
         raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
     try:
-        parsed.port
+        _ = parsed.port
     except ValueError:
-        raise serializers.ValidationError(_('Proxy URL has an invalid port.'))
+        raise serializers.ValidationError(_('Proxy URL has an invalid port.')) from None
 
 
 def _mask_proxy_password(proxy_url):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2303,7 +2303,7 @@ def _validate_proxy_url(value):
     if parsed.scheme.lower() not in _VALID_PROXY_SCHEMES or parsed.hostname is None:
         raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
     try:
-        _port = parsed.port
+        _port = parsed.port  # noqa: F841 – access triggers ValueError for invalid ports
     except ValueError:
         raise serializers.ValidationError(_('Proxy URL has an invalid port.')) from None
 

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -114,6 +114,7 @@ from awx.main.utils import (
     get_licenser,
 )
 
+from awx.main.utils.encryption import decrypt_field
 from awx.main.utils.filters import SmartFilter
 from awx.main.utils.plugins import load_combined_inventory_source_options
 from awx.main.utils.named_url_graph import reset_counters
@@ -1264,6 +1265,7 @@ class ProjectOptionsSerializer(BaseSerializer):
             'credential',
             'timeout',
             'scm_revision',
+            'proxy',
         )
 
     def get_related(self, obj):
@@ -1301,6 +1303,26 @@ class ProjectOptionsSerializer(BaseSerializer):
             raise serializers.ValidationError(errors)
 
         return super(ProjectOptionsSerializer, self).validate(attrs)
+
+    def validate_proxy(self, value):
+        if not value:
+            return value
+        if REPLACE_STR in value:
+            if self.instance:
+                db_proxy = decrypt_field(self.instance, 'proxy')
+                if _mask_proxy_password(db_proxy) == value:
+                    return db_proxy
+            raise serializers.ValidationError(_('Proxy password must be provided in plain text, not as $encrypted$.'))
+        if not (value.startswith('http://') or value.startswith('https://') or value.startswith('socks')):
+            raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
+        return value
+
+    def to_representation(self, obj):
+        ret = super().to_representation(obj)
+        if ret.get('proxy'):
+            decrypted = decrypt_field(obj, 'proxy')
+            ret['proxy'] = _mask_proxy_password(decrypted)
+        return ret
 
 
 class ExecutionEnvironmentSerializer(BaseSerializer):
@@ -2270,6 +2292,26 @@ class GroupVariableDataSerializer(BaseVariableDataSerializer):
         model = Group
 
 
+def _mask_proxy_password(proxy_url):
+    """Mask credentials embedded in a proxy URL for safe API display."""
+    if not proxy_url:
+        return ''
+    if not (proxy_url.startswith('http://') or proxy_url.startswith('https://')):
+        return proxy_url
+    parsed = urllib.parse.urlsplit(proxy_url)
+    if not parsed.username and not parsed.password:
+        return proxy_url
+    if parsed.username and parsed.password:
+        masked_netloc = '{}:{}@{}'.format(parsed.username, REPLACE_STR, parsed.hostname)
+    elif parsed.password:
+        masked_netloc = '{}@{}'.format(REPLACE_STR, parsed.hostname)
+    else:
+        masked_netloc = '{}@{}'.format(parsed.username, parsed.hostname)
+    if parsed.port:
+        masked_netloc += ':{}'.format(parsed.port)
+    return urllib.parse.urlunsplit((parsed.scheme, masked_netloc, parsed.path, parsed.query, parsed.fragment))
+
+
 class InventorySourceOptionsSerializer(BaseSerializer):
     credential = DeprecatedCredentialField(help_text=_('Cloud credential to use for inventory updates.'))
     source = serializers.ChoiceField(choices=[])
@@ -2291,6 +2333,7 @@ class InventorySourceOptionsSerializer(BaseSerializer):
             'timeout',
             'verbosity',
             'limit',
+            'proxy',
         )
         read_only_fields = ('*', 'custom_virtualenv')
 
@@ -2313,6 +2356,26 @@ class InventorySourceOptionsSerializer(BaseSerializer):
         for env_k in parse_yaml_or_json(value):
             if env_k in settings.INV_ENV_VARIABLE_BLOCKED:
                 raise serializers.ValidationError(_("`{}` is a prohibited environment variable".format(env_k)))
+        return ret
+
+    def validate_proxy(self, value):
+        if not value:
+            return value
+        if REPLACE_STR in value:
+            if self.instance:
+                db_proxy = decrypt_field(self.instance, 'proxy')
+                if _mask_proxy_password(db_proxy) == value:
+                    return db_proxy
+            raise serializers.ValidationError(_('Proxy password must be provided in plain text, not as $encrypted$.'))
+        if not (value.startswith('http://') or value.startswith('https://') or value.startswith('socks')):
+            raise serializers.ValidationError(_('Proxy must be an HTTP, HTTPS, or SOCKS URL.'))
+        return value
+
+    def to_representation(self, obj):
+        ret = super().to_representation(obj)
+        if ret.get('proxy'):
+            decrypted = decrypt_field(obj, 'proxy')
+            ret['proxy'] = _mask_proxy_password(decrypted)
         return ret
 
     # TODO: remove when old 'credential' fields are removed

--- a/awx/main/management/commands/regenerate_secret_key.py
+++ b/awx/main/management/commands/regenerate_secret_key.py
@@ -10,7 +10,7 @@ from django.db.models.signals import post_save
 from awx.conf import settings_registry
 from awx.conf.models import Setting
 from awx.conf.signals import on_post_save_setting
-from awx.main.models import UnifiedJob, Credential, NotificationTemplate, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate
+from awx.main.models import UnifiedJob, Credential, NotificationTemplate, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate, InventorySource, Project
 from awx.main.utils.encryption import encrypt_field, decrypt_field, encrypt_value, decrypt_value, get_encryption_key
 
 
@@ -47,6 +47,7 @@ class Command(BaseCommand):
         self._unified_jobs()
         self._settings()
         self._survey_passwords()
+        self._proxy_fields()
         return self.new_key
 
     def _notification_templates(self):
@@ -81,6 +82,13 @@ class Command(BaseCommand):
                 setting.value = decrypt_field(setting, 'value', secret_key=self.old_key)
                 setting.value = encrypt_field(setting, 'value', secret_key=self.new_key)
                 setting.save()
+
+    def _proxy_fields(self):
+        for model in (InventorySource, Project):
+            for obj in model.objects.exclude(proxy='').iterator():
+                obj.proxy = decrypt_field(obj, 'proxy', secret_key=self.old_key)
+                obj.proxy = encrypt_field(obj, 'proxy', secret_key=self.new_key)
+                obj.save(update_fields=['proxy'])
 
     def _survey_passwords(self):
         for _type in (JobTemplate, WorkflowJobTemplate):

--- a/awx/main/management/commands/regenerate_secret_key.py
+++ b/awx/main/management/commands/regenerate_secret_key.py
@@ -10,7 +10,19 @@ from django.db.models.signals import post_save
 from awx.conf import settings_registry
 from awx.conf.models import Setting
 from awx.conf.signals import on_post_save_setting
-from awx.main.models import UnifiedJob, Credential, NotificationTemplate, Job, JobTemplate, WorkflowJob, WorkflowJobTemplate, InventorySource, Project
+from awx.main.models import (
+    UnifiedJob,
+    Credential,
+    NotificationTemplate,
+    Job,
+    JobTemplate,
+    WorkflowJob,
+    WorkflowJobTemplate,
+    InventorySource,
+    InventoryUpdate,
+    Project,
+    ProjectUpdate,
+)
 from awx.main.utils.encryption import encrypt_field, decrypt_field, encrypt_value, decrypt_value, get_encryption_key
 
 
@@ -84,7 +96,7 @@ class Command(BaseCommand):
                 setting.save()
 
     def _proxy_fields(self):
-        for model in (InventorySource, Project):
+        for model in (InventorySource, InventoryUpdate, Project, ProjectUpdate):
             for obj in model.objects.exclude(proxy='').iterator():
                 obj.proxy = decrypt_field(obj, 'proxy', secret_key=self.old_key)
                 obj.proxy = encrypt_field(obj, 'proxy', secret_key=self.new_key)

--- a/awx/main/migrations/0206_add_proxy_to_inventory_source_and_project.py
+++ b/awx/main/migrations/0206_add_proxy_to_inventory_source_and_project.py
@@ -1,0 +1,66 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('main', '0205_add_ordering_to_instancegroup_and_workflow_nodes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='inventorysource',
+            name='proxy',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text=(
+                    'Proxy URL to use when running inventory updates '
+                    '(sets http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY). '
+                    'Overrides the global proxy set in Extra Environment Variables.'
+                ),
+                max_length=1024,
+            ),
+        ),
+        migrations.AddField(
+            model_name='inventoryupdate',
+            name='proxy',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text=(
+                    'Proxy URL to use when running inventory updates '
+                    '(sets http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY). '
+                    'Overrides the global proxy set in Extra Environment Variables.'
+                ),
+                max_length=1024,
+            ),
+        ),
+        migrations.AddField(
+            model_name='project',
+            name='proxy',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text=(
+                    'Proxy URL to use when running project updates '
+                    '(sets http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY). '
+                    'Overrides the global proxy set in Extra Environment Variables.'
+                ),
+                max_length=1024,
+            ),
+        ),
+        migrations.AddField(
+            model_name='projectupdate',
+            name='proxy',
+            field=models.CharField(
+                blank=True,
+                default='',
+                help_text=(
+                    'Proxy URL to use when running project updates '
+                    '(sets http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY). '
+                    'Overrides the global proxy set in Extra Environment Variables.'
+                ),
+                max_length=1024,
+            ),
+        ),
+    ]

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -50,6 +50,7 @@ from awx.main.models.notifications import (
     JobNotificationMixin,
 )
 from awx.main.utils import _inventory_updates
+from awx.main.utils.encryption import encrypt_field
 from awx.main.utils.safe_yaml import sanitize_jinja
 from awx.main.utils.execution_environments import get_control_plane_execution_environment
 
@@ -938,6 +939,16 @@ class InventorySourceOptions(BaseModel):
         default='',
         help_text=_('Inventory source variables in YAML or JSON format.'),
     )
+    proxy = models.CharField(
+        max_length=1024,
+        blank=True,
+        default='',
+        help_text=_(
+            'Proxy URL to use when running inventory updates '
+            '(sets http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY). '
+            'Overrides the global proxy set in Extra Environment Variables.'
+        ),
+    )
     scm_branch = models.CharField(
         max_length=1024,
         default='',
@@ -1148,6 +1159,12 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, CustomVirtualE
             if 'name' not in update_fields:
                 update_fields.append('name')
 
+        # Encrypt the proxy field before saving.
+        if self.proxy:
+            self.proxy = encrypt_field(self, 'proxy')
+            if 'proxy' not in update_fields and update_fields:
+                update_fields.append('proxy')
+
         # Do the actual save.
         super(InventorySource, self).save(*args, **kwargs)
 
@@ -1261,6 +1278,8 @@ class InventoryUpdate(UnifiedJob, InventorySourceOptions, JobNotificationMixin, 
     """
     Internal job for tracking inventory updates from external sources.
     """
+
+    PASSWORD_FIELDS = ('start_args', 'proxy')
 
     class Meta:
         app_label = 'main'

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1159,14 +1159,24 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, CustomVirtualE
             if 'name' not in update_fields:
                 update_fields.append('name')
 
-        # Encrypt the proxy field before saving.
-        if self.proxy:
+        # Defer proxy encryption for new instances (pk is None, which
+        # would produce a different encryption key than decrypt expects).
+        pending_proxy = None
+        if is_new_instance and self.proxy:
+            pending_proxy = self.proxy
+            self.proxy = ''
+        elif self.proxy:
             self.proxy = encrypt_field(self, 'proxy')
             if 'proxy' not in update_fields and update_fields:
                 update_fields.append('proxy')
 
         # Do the actual save.
         super(InventorySource, self).save(*args, **kwargs)
+
+        if pending_proxy:
+            self.proxy = pending_proxy
+            self.proxy = encrypt_field(self, 'proxy')
+            super(InventorySource, self).save(update_fields=['proxy'])
 
         # Add the PK to the name.
         if replace_text in self.name:

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -50,7 +50,7 @@ from awx.main.models.notifications import (
     JobNotificationMixin,
 )
 from awx.main.utils import _inventory_updates
-from awx.main.utils.encryption import encrypt_field
+from awx.main.utils.encryption import decrypt_field, encrypt_field
 from awx.main.utils.safe_yaml import sanitize_jinja
 from awx.main.utils.execution_environments import get_control_plane_execution_environment
 
@@ -1221,6 +1221,12 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, CustomVirtualE
         return self.create_unified_job(**kwargs)
 
     def create_unified_job(self, **kwargs):
+        # Proxy is stored encrypted under the source's pk; pass the
+        # plaintext so PasswordFieldsModel.save() re-encrypts it with
+        # the update's own pk.
+        if self.proxy and 'proxy' not in kwargs:
+            kwargs['proxy'] = decrypt_field(self, 'proxy')
+
         # Use special name, if name not already specified
         if self.inventory:
             if '_eager_fields' not in kwargs:

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -32,7 +32,7 @@ from awx.main.models.unified_jobs import (
 from awx.main.models.jobs import Job
 from awx.main.models.mixins import ResourceMixin, TaskManagerProjectUpdateMixin, CustomVirtualEnvMixin, RelatedJobsMixin
 from awx.main.utils import update_scm_url, polymorphic
-from awx.main.utils.encryption import encrypt_field
+from awx.main.utils.encryption import decrypt_field, encrypt_field
 from awx.main.utils.ansible import skip_directory, could_be_inventory, could_be_playbook
 from awx.main.utils.execution_environments import get_control_plane_execution_environment
 from awx.main.fields import ImplicitRoleField
@@ -456,6 +456,14 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
 
     def create_project_update(self, **kwargs):
         return self.create_unified_job(**kwargs)
+
+    def create_unified_job(self, **kwargs):
+        # Proxy is stored encrypted under the project's pk; pass the
+        # plaintext so PasswordFieldsModel.save() re-encrypts it with
+        # the update's own pk.
+        if self.proxy and 'proxy' not in kwargs:
+            kwargs['proxy'] = decrypt_field(self, 'proxy')
+        return super().create_unified_job(**kwargs)
 
     @property
     def cache_timeout_blocked(self):

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -386,8 +386,13 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
             self.local_path = u'_%d__%s' % (int(self.pk), slug_name)
             if 'local_path' not in update_fields:
                 update_fields.append('local_path')
-        # Encrypt the proxy field before saving.
-        if self.proxy:
+        # Defer proxy encryption for new instances (pk is None, which
+        # would produce a different encryption key than decrypt expects).
+        pending_proxy = None
+        if new_instance and self.proxy:
+            pending_proxy = self.proxy
+            self.proxy = ''
+        elif self.proxy:
             self.proxy = encrypt_field(self, 'proxy')
             if 'proxy' not in update_fields and update_fields:
                 update_fields.append('proxy')
@@ -396,6 +401,10 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
         super(Project, self).save(*args, **kwargs)
         if new_instance:
             update_fields = []
+            if pending_proxy:
+                self.proxy = pending_proxy
+                self.proxy = encrypt_field(self, 'proxy')
+                update_fields.append('proxy')
             # Generate local_path for SCM after initial save (so we have a PK).
             if self.scm_type and not self.local_path.startswith('_'):
                 update_fields.append('local_path')

--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -32,6 +32,7 @@ from awx.main.models.unified_jobs import (
 from awx.main.models.jobs import Job
 from awx.main.models.mixins import ResourceMixin, TaskManagerProjectUpdateMixin, CustomVirtualEnvMixin, RelatedJobsMixin
 from awx.main.utils import update_scm_url, polymorphic
+from awx.main.utils.encryption import encrypt_field
 from awx.main.utils.ansible import skip_directory, could_be_inventory, could_be_playbook
 from awx.main.utils.execution_environments import get_control_plane_execution_environment
 from awx.main.fields import ImplicitRoleField
@@ -133,6 +134,16 @@ class ProjectOptions(models.Model):
         blank=True,
         default=0,
         help_text=_("The amount of time (in seconds) to run before the task is canceled."),
+    )
+    proxy = models.CharField(
+        max_length=1024,
+        blank=True,
+        default='',
+        help_text=_(
+            'Proxy URL to use when running project updates '
+            '(sets http_proxy/https_proxy/HTTP_PROXY/HTTPS_PROXY). '
+            'Overrides the global proxy set in Extra Environment Variables.'
+        ),
     )
 
     def clean_scm_type(self):
@@ -375,6 +386,12 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
             self.local_path = u'_%d__%s' % (int(self.pk), slug_name)
             if 'local_path' not in update_fields:
                 update_fields.append('local_path')
+        # Encrypt the proxy field before saving.
+        if self.proxy:
+            self.proxy = encrypt_field(self, 'proxy')
+            if 'proxy' not in update_fields and update_fields:
+                update_fields.append('proxy')
+
         # Do the actual save.
         super(Project, self).save(*args, **kwargs)
         if new_instance:
@@ -537,6 +554,8 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
     """
     Internal job for tracking project updates from SCM.
     """
+
+    PASSWORD_FIELDS = ('start_args', 'proxy')
 
     class Meta:
         app_label = 'main'

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -75,6 +75,7 @@ from awx.main.tasks.facts import start_fact_cache, finish_fact_cache
 from awx.main.tasks.system import update_smart_memberships_for_inventory, update_inventory_computed_fields, events_processed_hook
 from awx.main.exceptions import AwxTaskError, PolicyEvaluationError, PostRunError, ReceptorNodeNotFound
 from awx.main.utils.ansible import read_ansible_config
+from awx.main.utils.encryption import decrypt_field
 from awx.main.utils.safe_yaml import safe_dump, sanitize_jinja
 from awx.main.utils.common import (
     update_scm_url,
@@ -1424,6 +1425,11 @@ class RunProjectUpdate(BaseTask):
         if galaxy_server_list:
             env['ANSIBLE_GALAXY_SERVER_LIST'] = ','.join(galaxy_server_list)
 
+        if project_update.proxy:
+            proxy_value = decrypt_field(project_update, 'proxy')
+            for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+                env[var] = proxy_value
+
         return env
 
     def _build_scm_url_extra_vars(self, project_update):
@@ -1768,6 +1774,11 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
             paths = ['~/.ansible/collections', '/usr/share/ansible/collections']
         paths.append('/usr/share/automation-controller/collections')
         env['ANSIBLE_COLLECTIONS_PATH'] = os.pathsep.join(paths)
+
+        if inventory_update.proxy:
+            proxy_value = decrypt_field(inventory_update, 'proxy')
+            for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+                env[var] = proxy_value
 
         return env
 

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1762,6 +1762,13 @@ class TestMaskProxyPassword:
 
         assert _mask_proxy_password('socks5://proxy.example.com:1080') == 'socks5://proxy.example.com:1080'
 
+    def test_socks_proxy_with_credentials(self):
+        from awx.api.serializers import _mask_proxy_password
+
+        result = _mask_proxy_password('socks5://user:s3cret@proxy.example.com:1080')
+        assert result == 'socks5://user:$encrypted$@proxy.example.com:1080'
+        assert 's3cret' not in result
+
 
 @pytest.mark.usefixtures("patch_Organization")
 class TestInventoryUpdateProxy(TestJobExecution):
@@ -1782,7 +1789,7 @@ class TestInventoryUpdateProxy(TestJobExecution):
         inventory_update.get_cloud_credential = mocker.Mock(return_value=None)
         inventory_update.get_extra_credentials = mocker.Mock(return_value=[])
 
-        private_data_files, ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
+        private_data_files, _ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
         env = task.build_env(inventory_update, private_data_dir, private_data_files)
 
         for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
@@ -1796,7 +1803,7 @@ class TestInventoryUpdateProxy(TestJobExecution):
         inventory_update.get_cloud_credential = mocker.Mock(return_value=None)
         inventory_update.get_extra_credentials = mocker.Mock(return_value=[])
 
-        private_data_files, ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
+        private_data_files, _ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
         env = task.build_env(inventory_update, private_data_dir, private_data_files)
 
         for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
@@ -1810,7 +1817,7 @@ class TestInventoryUpdateProxy(TestJobExecution):
         inventory_update.get_cloud_credential = mocker.Mock(return_value=None)
         inventory_update.get_extra_credentials = mocker.Mock(return_value=[])
 
-        private_data_files, ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
+        private_data_files, _ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
         env = task.build_env(inventory_update, private_data_dir, private_data_files)
 
         for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1731,3 +1731,126 @@ def test_administrative_workunit_reaper(work_unit_data, expected_function_call):
         simple_command.assert_called()
     else:
         simple_command.assert_not_called()
+
+
+class TestMaskProxyPassword:
+    def test_no_credentials(self):
+        from awx.api.serializers import _mask_proxy_password
+
+        assert _mask_proxy_password('http://proxy.example.com:3128') == 'http://proxy.example.com:3128'
+
+    def test_user_and_password(self):
+        from awx.api.serializers import _mask_proxy_password
+
+        result = _mask_proxy_password('http://user:s3cret@proxy.example.com:3128')
+        assert result == 'http://user:$encrypted$@proxy.example.com:3128'
+        assert 's3cret' not in result
+
+    def test_token_only(self):
+        from awx.api.serializers import _mask_proxy_password
+
+        result = _mask_proxy_password('http://:token123@proxy.example.com:3128')
+        assert 'token123' not in result
+
+    def test_empty_string(self):
+        from awx.api.serializers import _mask_proxy_password
+
+        assert _mask_proxy_password('') == ''
+
+    def test_socks_proxy(self):
+        from awx.api.serializers import _mask_proxy_password
+
+        assert _mask_proxy_password('socks5://proxy.example.com:1080') == 'socks5://proxy.example.com:1080'
+
+
+@pytest.mark.usefixtures("patch_Organization")
+class TestInventoryUpdateProxy(TestJobExecution):
+    @pytest.fixture(autouse=True)
+    def mock_flag_enabled(self):
+        with mock.patch('awx.main.tasks.jobs.flag_enabled', return_value=False):
+            yield
+
+    @pytest.fixture
+    def inventory_update(self, execution_environment):
+        return InventoryUpdate(pk=1, execution_environment=execution_environment, inventory_source=InventorySource(pk=1, inventory=Inventory(pk=1)))
+
+    def test_proxy_sets_env_vars(self, mocker, inventory_update, private_data_dir, mock_me):
+        task = jobs.RunInventoryUpdate()
+        task.instance = inventory_update
+        inventory_update.source = 'ec2'
+        inventory_update.proxy = 'http://squid.example.com:3128'
+        inventory_update.get_cloud_credential = mocker.Mock(return_value=None)
+        inventory_update.get_extra_credentials = mocker.Mock(return_value=[])
+
+        private_data_files, ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
+        env = task.build_env(inventory_update, private_data_dir, private_data_files)
+
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            assert env[var] == 'http://squid.example.com:3128'
+
+    def test_proxy_with_credentials(self, mocker, inventory_update, private_data_dir, mock_me):
+        task = jobs.RunInventoryUpdate()
+        task.instance = inventory_update
+        inventory_update.source = 'ec2'
+        inventory_update.proxy = 'http://user:s3cret@squid.example.com:3128'
+        inventory_update.get_cloud_credential = mocker.Mock(return_value=None)
+        inventory_update.get_extra_credentials = mocker.Mock(return_value=[])
+
+        private_data_files, ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
+        env = task.build_env(inventory_update, private_data_dir, private_data_files)
+
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            assert env[var] == 'http://user:s3cret@squid.example.com:3128'
+
+    def test_empty_proxy_leaves_env_unchanged(self, mocker, inventory_update, private_data_dir, mock_me):
+        task = jobs.RunInventoryUpdate()
+        task.instance = inventory_update
+        inventory_update.source = 'ec2'
+        inventory_update.proxy = ''
+        inventory_update.get_cloud_credential = mocker.Mock(return_value=None)
+        inventory_update.get_extra_credentials = mocker.Mock(return_value=[])
+
+        private_data_files, ssh_key_data = task.build_private_data_files(inventory_update, private_data_dir)
+        env = task.build_env(inventory_update, private_data_dir, private_data_files)
+
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            assert var not in env
+
+
+@pytest.mark.usefixtures("patch_Organization")
+class TestProjectUpdateProxy(TestJobExecution):
+    @pytest.fixture
+    def project_update(self, execution_environment):
+        org = Organization(pk=1)
+        proj = Project(pk=1, organization=org)
+        project_update = ProjectUpdate(pk=1, project=proj, scm_type='git')
+        project_update.websocket_emit_status = mock.Mock()
+        project_update.execution_environment = execution_environment
+        return project_update
+
+    def test_proxy_sets_env_vars(self, private_data_dir, project_update, mock_me):
+        project_update.proxy = 'https://proxy.example.com:8080'
+        task = jobs.RunProjectUpdate()
+        task.instance = project_update
+        env = task.build_env(project_update, private_data_dir)
+
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            assert env[var] == 'https://proxy.example.com:8080'
+
+    def test_proxy_with_credentials(self, private_data_dir, project_update, mock_me):
+        project_update.proxy = 'http://admin:p4ss@proxy.example.com:8080'
+        task = jobs.RunProjectUpdate()
+        task.instance = project_update
+        env = task.build_env(project_update, private_data_dir)
+
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            assert env[var] == 'http://admin:p4ss@proxy.example.com:8080'
+
+    def test_empty_proxy_leaves_env_unchanged(self, private_data_dir, project_update, mock_me):
+        project_update.proxy = ''
+        task = jobs.RunProjectUpdate()
+        task.instance = project_update
+        env = task.build_env(project_update, private_data_dir)
+
+        for var in ('http_proxy', 'https_proxy', 'HTTP_PROXY', 'HTTPS_PROXY'):
+            assert var not in env

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1769,6 +1769,13 @@ class TestMaskProxyPassword:
         assert result == 'socks5://user:$encrypted$@proxy.example.com:1080'
         assert 's3cret' not in result
 
+    def test_token_as_username(self):
+        from awx.api.serializers import _mask_proxy_password
+
+        result = _mask_proxy_password('http://mytoken@proxy.example.com:3128')
+        assert 'mytoken' not in result
+        assert '$encrypted$@proxy.example.com:3128' in result
+
 
 @pytest.mark.usefixtures("patch_Organization")
 class TestInventoryUpdateProxy(TestJobExecution):

--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -94,6 +94,12 @@ options:
     timeout:
       description: The amount of time (in seconds) to run before the task is canceled.
       type: int
+    proxy:
+      description:
+        - HTTP, HTTPS, or SOCKS proxy URL used for inventory sync requests.
+        - When set, the proxy is injected as http_proxy / https_proxy environment variables for the sync task.
+        - The value is encrypted at rest. To clear, pass an empty string.
+      type: str
     verbosity:
       description: The verbosity level to run this inventory source under.
       type: int
@@ -200,6 +206,7 @@ def main():
         overwrite=dict(type='bool'),
         overwrite_vars=dict(type='bool'),
         timeout=dict(type='int'),
+        proxy=dict(type='str'),
         verbosity=dict(type='int', choices=[0, 1, 2]),
         update_on_launch=dict(type='bool'),
         update_cache_timeout=dict(type='int'),

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -104,6 +104,12 @@ options:
       type: int
       aliases:
         - job_timeout
+    proxy:
+      description:
+        - HTTP, HTTPS, or SOCKS proxy URL used for SCM sync requests.
+        - When set, the proxy is injected as http_proxy / https_proxy environment variables for the sync task.
+        - The value is encrypted at rest. To clear, pass an empty string.
+      type: str
     default_environment:
       description:
         - Default Execution Environment name, ID, or named URL to use for jobs relating to the project.
@@ -266,6 +272,7 @@ def main():
         scm_update_cache_timeout=dict(type='int'),
         allow_override=dict(type='bool', aliases=['scm_allow_override']),
         timeout=dict(type='int', aliases=['job_timeout']),
+        proxy=dict(type='str'),
         default_environment=dict(),
         custom_virtualenv=dict(),
         organization=dict(),


### PR DESCRIPTION
## Summary

- Adds a dedicated `proxy` field to Inventory Source and Project models, allowing operators to route SCM and inventory sync traffic through per-resource HTTP/HTTPS/SOCKS proxies
- The proxy value is encrypted at rest (Fernet256), masked in API responses, and integrated with `regenerate_secret_key` for key rotation
- Follows the same security model as EDA's `Project.proxy` field

Closes #16409

## Changes

**Models** (`inventory.py`, `projects.py`):
- `proxy` CharField on `InventorySourceOptions` and `ProjectOptions`
- Encryption via `encrypt_field()` in `save()` with deferred encryption for new instances
- `PASSWORD_FIELDS` on `InventoryUpdate` and `ProjectUpdate` for automatic handling
- `create_unified_job()` overrides to decrypt proxy before copying to update instances

**Migration** (`0206_add_proxy_to_inventory_source_and_project.py`):
- Adds `proxy` column to `inventorysource`, `inventoryupdate`, `project`, and `projectupdate` tables

**Serialisers** (`serializers.py`):
- `_validate_proxy_url()` helper using `urlsplit()` for robust scheme/hostname/port validation
- `_mask_proxy_password()` helper to replace credentials with `$encrypted$` in API responses (supports HTTP, HTTPS, and SOCKS schemes)
- `validate_proxy()` enforces URL format and handles `$encrypted$` round-trip
- `to_representation()` decrypts and masks before display

**Task runner** (`jobs.py`):
- `RunInventoryUpdate.build_env()` and `RunProjectUpdate.build_env()` decrypt the proxy and inject `http_proxy`, `https_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`

**Key rotation** (`regenerate_secret_key.py`):
- `_proxy_fields()` re-encrypts proxy values for `InventorySource`, `InventoryUpdate`, `Project`, and `ProjectUpdate` during secret key rotation

**Collection** (`awx_collection/plugins/modules/`):
- Added `proxy` parameter to `inventory_source` and `project` modules

**Tests** (`test_tasks.py`):
- `TestMaskProxyPassword` (7 tests): no credentials, user/pass, token-only, token-as-username, empty, SOCKS, SOCKS with credentials
- `TestInventoryUpdateProxy` (3 tests): proxy injection, credentialed proxy, empty proxy
- `TestProjectUpdateProxy` (3 tests): proxy injection, credentialed proxy, empty proxy

## Test plan

- [x] All 13 new unit tests pass in `awx_devel:devel` container
- [x] Existing test suite shows zero regressions (pre-existing errors identical on clean `devel`)
- [ ] CI pipeline

[New or Enhanced Feature]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proxy field configuration to inventory sources and projects, enabling custom HTTP(S) proxy settings for inventory and project sync and update operations
  * Proxy credentials are automatically encrypted and securely masked when displayed to protect sensitive authentication information
  * Project and inventory source-level proxy settings take precedence over globally configured proxies for greater flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->