### PR TITLE
feat: add per-approval-node notification templates

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4011,7 +4011,10 @@ class WorkflowApprovalTemplateSerializer(UnifiedJobTemplateSerializer):
         if 'last_job' in res:
             del res['last_job']
 
-        res.update(jobs=self.reverse('api:workflow_approval_template_jobs_list', kwargs={'pk': obj.pk}))
+        res.update(
+            jobs=self.reverse('api:workflow_approval_template_jobs_list', kwargs={'pk': obj.pk}),
+            notification_templates_approvals=self.reverse('api:workflow_approval_template_notification_templates_approvals_list', kwargs={'pk': obj.pk}),
+        )
         return res
 
 

--- a/awx/api/urls/workflow_approval_template.py
+++ b/awx/api/urls/workflow_approval_template.py
@@ -3,11 +3,20 @@
 
 from django.urls import re_path
 
-from awx.api.views import WorkflowApprovalTemplateDetail, WorkflowApprovalTemplateJobsList
+from awx.api.views import (
+    WorkflowApprovalTemplateDetail,
+    WorkflowApprovalTemplateJobsList,
+    WorkflowApprovalTemplateNotificationTemplatesApprovalList,
+)
 
 urls = [
     re_path(r'^(?P<pk>[0-9]+)/$', WorkflowApprovalTemplateDetail.as_view(), name='workflow_approval_template_detail'),
     re_path(r'^(?P<pk>[0-9]+)/approvals/$', WorkflowApprovalTemplateJobsList.as_view(), name='workflow_approval_template_jobs_list'),
+    re_path(
+        r'^(?P<pk>[0-9]+)/notification_templates_approvals/$',
+        WorkflowApprovalTemplateNotificationTemplatesApprovalList.as_view(),
+        name='workflow_approval_template_notification_templates_approvals_list',
+    ),
 ]
 
 __all__ = ['urls']

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -4980,6 +4980,14 @@ class WorkflowApprovalTemplateJobsList(SubListAPIView):
     resource_purpose = 'workflow approvals of a workflow approval template'
 
 
+class WorkflowApprovalTemplateNotificationTemplatesApprovalList(SubListCreateAttachDetachAPIView):
+    model = models.NotificationTemplate
+    serializer_class = serializers.NotificationTemplateSerializer
+    parent_model = models.WorkflowApprovalTemplate
+    relationship = 'notification_templates_approvals'
+    resource_purpose = 'notification templates triggered on this specific approval node'
+
+
 class WorkflowApprovalList(ListAPIView):
     model = models.WorkflowApproval
     serializer_class = serializers.WorkflowApprovalListSerializer

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2857,7 +2857,7 @@ class WorkflowApprovalAccess(BaseAccess):
             return True
 
 
-class WorkflowApprovalTemplateAccess(BaseAccess):
+class WorkflowApprovalTemplateAccess(NotificationAttachMixin, BaseAccess):
     """
     A user can create a workflow approval if they are a superuser, an org admin
     of the org connected to the workflow, or if they are assigned as admins to

--- a/awx/main/migrations/0206_workflowapprovaltemplate_notification_templates_approvals.py
+++ b/awx/main/migrations/0206_workflowapprovaltemplate_notification_templates_approvals.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0205_add_ordering_to_instancegroup_and_workflow_nodes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='workflowapprovaltemplate',
+            name='notification_templates_approvals',
+            field=models.ManyToManyField(
+                blank=True,
+                related_name='%(class)s_notification_templates_for_approvals',
+                to='main.notificationtemplate',
+            ),
+        ),
+    ]

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -812,6 +812,7 @@ class WorkflowApprovalTemplate(UnifiedJobTemplate, RelatedJobsMixin):
     FIELDS_TO_PRESERVE_AT_COPY = [
         'description',
         'timeout',
+        'notification_templates_approvals',
     ]
 
     class Meta:
@@ -821,6 +822,11 @@ class WorkflowApprovalTemplate(UnifiedJobTemplate, RelatedJobsMixin):
         blank=True,
         default=0,
         help_text=_("The amount of time (in seconds) before the approval node expires and fails."),
+    )
+    notification_templates_approvals = models.ManyToManyField(
+        "NotificationTemplate",
+        blank=True,
+        related_name='%(class)s_notification_templates_for_approvals',
     )
 
     @classmethod
@@ -965,9 +971,13 @@ class WorkflowApproval(UnifiedJob, JobNotificationMixin):
     def send_approval_notification(self, approval_status):
         from awx.main.tasks.system import send_notifications  # avoid circular import
 
+        # Orphaned approvals (WFJT deleted) must not dispatch notifications,
+        # even when node-level templates are configured on the approval template.
         if self.workflow_job_template is None:
             return
-        for nt in self.workflow_job_template.notification_templates["approvals"]:
+        node_templates = list(self.workflow_approval_template.notification_templates_approvals.all()) if self.workflow_approval_template else []
+        notification_templates = node_templates or self.workflow_job_template.notification_templates.get("approvals", [])
+        for nt in notification_templates:
             try:
                 notification_subject, notification_body = self.build_approval_notification_message(nt, approval_status)
             except Exception:

--- a/awx/main/tests/functional/api/test_notifications.py
+++ b/awx/main/tests/functional/api/test_notifications.py
@@ -155,6 +155,33 @@ def test_post_org_approval_notification(get, post, admin, notification_template,
     assert len(response.data['results']) == 1
 
 
+@pytest.fixture
+def workflow_approval_template(workflow_job_template):
+    from awx.main.models.workflow import WorkflowApprovalTemplate, WorkflowJobTemplateNode
+
+    wat = WorkflowApprovalTemplate.objects.create(name='test-approval', timeout=0)
+    WorkflowJobTemplateNode.objects.create(workflow_job_template=workflow_job_template, unified_job_template=wat)
+    return wat
+
+
+@pytest.mark.django_db
+def test_get_approval_template_approval_notification(get, admin, workflow_approval_template):
+    url = reverse('api:workflow_approval_template_notification_templates_approvals_list', kwargs={'pk': workflow_approval_template.pk})
+    response = get(url, admin)
+    assert response.status_code == 200
+    assert len(response.data['results']) == 0
+
+
+@pytest.mark.django_db
+def test_post_approval_template_approval_notification(get, post, admin, notification_template, workflow_approval_template):
+    url = reverse('api:workflow_approval_template_notification_templates_approvals_list', kwargs={'pk': workflow_approval_template.pk})
+    response = post(url, dict(id=notification_template.id, associate=True), admin)
+    assert response.status_code == 204
+    response = get(url, admin)
+    assert response.status_code == 200
+    assert len(response.data['results']) == 1
+
+
 @pytest.mark.django_db
 def test_post_wfj_notification(get, post, admin, workflow_job, notification):
     workflow_job.notifications.add(notification)

--- a/awx/main/tests/functional/rbac/test_rbac_notifications.py
+++ b/awx/main/tests/functional/rbac/test_rbac_notifications.py
@@ -1,7 +1,7 @@
 import pytest
 
 from awx.main.models import Organization, Project
-from awx.main.access import NotificationTemplateAccess, NotificationAccess, JobTemplateAccess
+from awx.main.access import NotificationTemplateAccess, NotificationAccess, JobTemplateAccess, WorkflowApprovalTemplateAccess
 
 
 @pytest.mark.django_db
@@ -222,3 +222,33 @@ def test_notification_access_org_auditor(notification, org_auditor):
     access = NotificationAccess(org_auditor)
     assert access.can_read(notification)
     assert not access.can_delete(notification)
+
+
+@pytest.mark.django_db
+def test_approval_template_NT_attach_nt_admin(rando, notification_template, workflow_job_template):
+    from awx.main.models.workflow import WorkflowApprovalTemplate, WorkflowJobTemplateNode
+
+    wat = WorkflowApprovalTemplate.objects.create(name='test-approval', timeout=0)
+    WorkflowJobTemplateNode.objects.create(workflow_job_template=workflow_job_template, unified_job_template=wat)
+
+    notification_template.organization.notification_admin_role.members.add(rando)
+    access = WorkflowApprovalTemplateAccess(rando)
+    # NT admin alone is insufficient without target access
+    assert not access.can_attach(wat, notification_template, 'notification_templates_approvals', {'id': notification_template.id})
+
+    # Granting WFJT admin (which gates WAT can_read) allows the attach
+    workflow_job_template.admin_role.members.add(rando)
+    assert access.can_attach(wat, notification_template, 'notification_templates_approvals', {'id': notification_template.id})
+
+
+@pytest.mark.django_db
+def test_approval_template_NT_attach_denied_without_nt_admin(rando, notification_template, workflow_job_template):
+    from awx.main.models.workflow import WorkflowApprovalTemplate, WorkflowJobTemplateNode
+
+    wat = WorkflowApprovalTemplate.objects.create(name='test-approval', timeout=0)
+    WorkflowJobTemplateNode.objects.create(workflow_job_template=workflow_job_template, unified_job_template=wat)
+
+    # Target access without NT admin is insufficient
+    workflow_job_template.admin_role.members.add(rando)
+    access = WorkflowApprovalTemplateAccess(rando)
+    assert not access.can_attach(wat, notification_template, 'notification_templates_approvals', {'id': notification_template.id})

--- a/awx/main/tests/functional/test_copy.py
+++ b/awx/main/tests/functional/test_copy.py
@@ -6,7 +6,7 @@ from awx.main.utils import decrypt_field
 from awx.main.models.workflow import WorkflowJobTemplate, WorkflowJobTemplateNode, WorkflowApprovalTemplate
 from awx.main.models.jobs import JobTemplate
 from awx.main.tasks.system import deep_copy_model_obj
-from awx.main.models import Label, ExecutionEnvironment, InstanceGroup
+from awx.main.models import Label, ExecutionEnvironment, InstanceGroup, NotificationTemplate
 
 
 @pytest.mark.django_db
@@ -241,6 +241,34 @@ def test_workflow_approval_node_copy(workflow_job_template, post, get, admin, or
     # if you remove the " copy" suffix from the copied template names, they
     # should match the original templates
     assert set([x.name for x in original_templates]) == set([x.name.replace(' copy', '') for x in copied_templates])
+
+
+@pytest.mark.django_db
+def test_workflow_approval_node_copy_preserves_notification_templates(workflow_job_template, post, get, admin, organization):
+    workflow_job_template.organization = organization
+    workflow_job_template.save()
+
+    nt = NotificationTemplate.objects.create(
+        name='approval-nt',
+        organization=organization,
+        notification_type='webhook',
+        notification_configuration=dict(url='http://localhost', username='', password='', headers={}),
+    )
+    wat = WorkflowApprovalTemplate.objects.create(name='test-approval-nt', timeout=0)
+    wat.notification_templates_approvals.add(nt)
+    WorkflowJobTemplateNode.objects.create(workflow_job_template=workflow_job_template, unified_job_template=wat)
+
+    with mock.patch('awx.api.generics.trigger_delayed_deep_copy') as deep_copy_mock:
+        wfjt_copy_id = post(
+            reverse('api:workflow_job_template_copy', kwargs={'pk': workflow_job_template.pk}), {'name': 'copy-nt-wfjt'}, admin, expect=201
+        ).data['id']
+        wfjt_copy = WorkflowJobTemplate.objects.get(pk=wfjt_copy_id)
+        args, kwargs = deep_copy_mock.call_args
+        deep_copy_model_obj(*args, **kwargs)
+
+    copied_wat = wfjt_copy.workflow_job_template_nodes.first().unified_job_template
+    assert copied_wat.pk != wat.pk
+    assert list(copied_wat.notification_templates_approvals.values_list('pk', flat=True)) == [nt.pk]
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/unit/models/test_workflow_unit.py
+++ b/awx/main/tests/unit/models/test_workflow_unit.py
@@ -244,3 +244,73 @@ def test_get_ask_mapping_integrity():
         'skip_tags',
         'extra_vars',
     ]
+
+
+class TestApprovalNodeNotificationOverride:
+    """Verify that send_approval_notification prefers node-level templates
+    when they are configured, and falls back to the WFJT-level templates
+    when they are not."""
+
+    def _build_approval(self, mocker, node_templates=None, wfjt_templates=None):
+        from awx.main.models.workflow import WorkflowApproval, WorkflowApprovalTemplate
+
+        nt_node = node_templates or []
+        nt_wfjt = wfjt_templates or []
+
+        wat = mocker.MagicMock(spec=WorkflowApprovalTemplate)
+        wat.notification_templates_approvals.all.return_value = nt_node
+
+        wfjt = mocker.MagicMock()
+        wfjt.notification_templates = {"approvals": nt_wfjt}
+
+        approval = WorkflowApproval()
+        mocker.patch.object(type(approval), 'workflow_approval_template', new_callable=mocker.PropertyMock, return_value=wat)
+        mocker.patch.object(type(approval), 'workflow_job_template', new_callable=mocker.PropertyMock, return_value=wfjt)
+        mocker.patch.object(approval, 'build_approval_notification_message', return_value=('subject', 'body'))
+        mocker.patch('awx.main.tasks.system.send_notifications.delay')
+        mock_conn = mocker.patch('awx.main.models.workflow.connection')
+        mock_conn.on_commit.side_effect = lambda callback: callback()
+        return approval
+
+    def test_uses_node_templates_when_set(self, mocker):
+        from awx.main.tasks.system import send_notifications
+
+        node_nt = mocker.MagicMock()
+        node_nt.generate_notification.return_value.id = 1
+        wfjt_nt = mocker.MagicMock()
+        wfjt_nt.generate_notification.return_value.id = 2
+
+        approval = self._build_approval(mocker, node_templates=[node_nt], wfjt_templates=[wfjt_nt])
+        approval.send_approval_notification('running')
+
+        node_nt.generate_notification.assert_called_once()
+        wfjt_nt.generate_notification.assert_not_called()
+        send_notifications.delay.assert_called_once()
+
+    def test_falls_back_to_wfjt_templates(self, mocker):
+        from awx.main.tasks.system import send_notifications
+
+        wfjt_nt = mocker.MagicMock()
+        wfjt_nt.generate_notification.return_value.id = 1
+
+        approval = self._build_approval(mocker, node_templates=[], wfjt_templates=[wfjt_nt])
+        approval.send_approval_notification('approved')
+
+        wfjt_nt.generate_notification.assert_called_once()
+        send_notifications.delay.assert_called_once()
+
+    def test_no_templates_no_error(self, mocker):
+        approval = self._build_approval(mocker, node_templates=[], wfjt_templates=[])
+        approval.send_approval_notification('denied')
+        from awx.main.tasks.system import send_notifications
+
+        send_notifications.delay.assert_not_called()
+
+    def test_no_wfjt_returns_early(self, mocker):
+        from awx.main.models.workflow import WorkflowApproval
+
+        approval = WorkflowApproval()
+        mocker.patch.object(type(approval), 'workflow_job_template', new_callable=mocker.PropertyMock, return_value=None)
+        send_delay = mocker.patch('awx.main.tasks.system.send_notifications.delay')
+        approval.send_approval_notification('running')
+        send_delay.assert_not_called()


### PR DESCRIPTION
##### SUMMARY

Allow notification templates to be configured directly on individual
WorkflowApprovalTemplate instances, so that different approval nodes within
the same workflow can route notifications to different channels (Slack, Teams
webhook, email, etc.).

When node-level templates are set they take precedence over the
WFJT/Organisation-level approval notification templates. When no node-level
templates are configured the existing behaviour is preserved (fully backward
compatible).

related #16411

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

1. Create a workflow job template with two approval nodes
2. Attach a webhook notification template to one approval node via
   `/api/v2/workflow_approval_templates/{id}/notification_templates_approvals/`
3. Attach a different notification template (e.g. email) at the WFJT level
4. Launch the workflow
5. The first approval node sends to the webhook; the second falls back to
   the WFJT-level email

Changes:
- Model: `notification_templates_approvals` M2M on `WorkflowApprovalTemplate`
- Logic: `WorkflowApproval.send_approval_notification()` prefers node-level
  templates when available
- RBAC: `NotificationAttachMixin` added to `WorkflowApprovalTemplateAccess`
  for consistent permission semantics with WFJT/Organisation
- API: serialiser, view, and URL for the new sub-resource
- Migration: `0206_workflowapprovaltemplate_notification_templates_approvals`
- Tests: functional API tests, RBAC tests, and unit tests for override logic

### Follow-up work

- **Ansible collection module:** Expose per-node notification templates as a
  parameter in `workflow_nodes` items within the `workflow_job_template`
  collection module. Tracked as a separate PR to keep this change focused.
- **ansible-ui:** Add a notification template picker to the approval node
  editor in the workflow visualiser. This requires a separate PR in the
  `ansible/ansible-ui` repository.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow approval nodes now support node-specific notification templates and a new API to manage them.
  * Approval notifications prefer node-level templates when configured, otherwise fall back to job-template defaults.

* **Database**
  * Migration adds an optional many-to-many relationship to store approval-node notification templates.

* **Permissions**
  * Attach/unattach permission checks updated to include notification-attachment rules for approval templates.

* **Tests**
  * New functional and unit tests covering API behavior, RBAC, and notification resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->