### PR TITLE
AAP-70872 Prefer visible JT in deprecated named URL reference

### DIFF
--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -99,7 +99,7 @@ class DisableLocalAuthMiddleware(MiddlewareMixin):
 
 class URLModificationMiddleware(MiddlewareMixin):
     @staticmethod
-    def _hijack_for_old_jt_name(node, kwargs, named_url):
+    def _hijack_for_old_jt_name(node, kwargs, named_url, user=None):
         try:
             int(named_url)
             return False
@@ -107,10 +107,12 @@ class URLModificationMiddleware(MiddlewareMixin):
             pass
         JobTemplate = node.model
         name = urllib.parse.unquote(named_url)
+        if user is not None and user.is_authenticated:
+            return user.get_queryset(JobTemplate).filter(name=name).order_by('organization__created').first()
         return JobTemplate.objects.filter(name=name).order_by('organization__created').first()
 
     @classmethod
-    def _named_url_to_pk(cls, node, resource, named_url):
+    def _named_url_to_pk(cls, node, resource, named_url, user=None):
         kwargs = {}
         reset_counters()
         if node.populate_named_url_query_kwargs(kwargs, named_url):
@@ -132,13 +134,13 @@ class URLModificationMiddleware(MiddlewareMixin):
         if resource == 'job_templates' and '++' not in named_url:
             # special case for deprecated job template case
             # will not raise a 404 on its own
-            jt = cls._hijack_for_old_jt_name(node, kwargs, named_url)
+            jt = cls._hijack_for_old_jt_name(node, kwargs, named_url, user=user)
             if jt:
                 return str(jt.pk)
         return named_url
 
     @classmethod
-    def _convert_named_url(cls, url_path):
+    def _convert_named_url(cls, url_path, user=None):
         default_prefix = PurePosixPath('/api/v2/')
         optional_prefix = PurePosixPath(f'/api/{settings.OPTIONAL_API_URLPATTERN_PREFIX}/v2/')
 
@@ -163,7 +165,7 @@ class URLModificationMiddleware(MiddlewareMixin):
 
         resource = resource_path.parts[0]
         if resource in settings.NAMED_URL_MAPPINGS:
-            pk = PurePosixPath(cls._named_url_to_pk(settings.NAMED_URL_GRAPH[settings.NAMED_URL_MAPPINGS[resource]], resource, name))
+            pk = PurePosixPath(cls._named_url_to_pk(settings.NAMED_URL_GRAPH[settings.NAMED_URL_MAPPINGS[resource]], resource, name, user=user))
         else:
             return url_path_original
 
@@ -172,7 +174,7 @@ class URLModificationMiddleware(MiddlewareMixin):
 
     def process_request(self, request):
         old_path = request.path_info
-        new_path = self._convert_named_url(old_path)
+        new_path = self._convert_named_url(old_path, user=getattr(request, 'user', None))
         if request.path_info != new_path:
             request.environ['awx.named_url_rewritten'] = request.path
             request.path = request.path.replace(request.path_info, new_path)

--- a/awx/main/tests/functional/test_named_url.py
+++ b/awx/main/tests/functional/test_named_url.py
@@ -206,6 +206,115 @@ def test_403_vs_404(get):
 
 
 @pytest.mark.django_db
+class TestOldStyleJTNamedUrlPermissions:
+    """Test the deprecated old-style named URL for job templates (name only, no org).
+
+    The middleware has a special _hijack_for_old_jt_name path that resolves
+    /api/v2/job_templates/<name>/ without requiring the ++org_name suffix.
+    This does an unscoped DB query (ignoring user permissions) to find the JT.
+    """
+
+    def test_old_style_url_no_access(self, get):
+        """User with no access to any JT should not resolve an old-style named URL."""
+        org = Organization.objects.create(name='test_org')
+        JobTemplate.objects.create(name='secret_jt', organization=org)
+        rando = User.objects.create(username='rando', password='rando')
+
+        old_url = '/api/v2/job_templates/secret_jt/'
+        resolved = URLModificationMiddleware._convert_named_url(old_url, user=rando)
+        # With user-scoped filtering, the JT is not visible so the name
+        # is returned as-is (no rewrite), which results in a 404.
+        assert resolved == old_url
+
+    def test_old_style_url_resolves_to_accessible_jt(self, get):
+        """When two JTs share a name, old-style URL resolves to the one
+        the user can actually access, not an arbitrary pick by org age.
+        """
+        org_old = Organization.objects.create(name='org_old')
+        org_new = Organization.objects.create(name='org_new')
+        JobTemplate.objects.create(name='shared_jt', organization=org_old)
+        jt_new = JobTemplate.objects.create(name='shared_jt', organization=org_new)
+
+        rando = User.objects.create(username='rando', password='rando')
+
+        # Give rando read access to org_new's JT only
+        jt_new.read_role.members.add(rando)
+
+        # The old-style URL should resolve to jt_new (the one rando can see)
+        old_url = '/api/v2/job_templates/shared_jt/'
+        resolved = URLModificationMiddleware._convert_named_url(old_url, user=rando)
+        assert resolved == f'/api/v2/job_templates/{jt_new.pk}/'
+
+        response = get(resolved, user=rando, expect=200)
+        assert response.data['id'] == jt_new.pk
+        assert response.data['organization'] == org_new.pk
+
+    def test_old_style_url_each_user_sees_own_jt(self, get):
+        """Each user resolves the old-style URL to a JT they have access to."""
+        org_a = Organization.objects.create(name='alpha_org')
+        org_b = Organization.objects.create(name='beta_org')
+
+        jt_a = JobTemplate.objects.create(name='patching', organization=org_a)
+        jt_b = JobTemplate.objects.create(name='patching', organization=org_b)
+
+        user_a = User.objects.create(username='user_a', password='user_a')
+        user_b = User.objects.create(username='user_b', password='user_b')
+
+        jt_a.read_role.members.add(user_a)
+        jt_b.read_role.members.add(user_b)
+
+        old_url = '/api/v2/job_templates/patching/'
+
+        resolved_a = URLModificationMiddleware._convert_named_url(old_url, user=user_a)
+        assert resolved_a == f'/api/v2/job_templates/{jt_a.pk}/'
+        response_a = get(resolved_a, user=user_a, expect=200)
+        assert response_a.data['organization'] == org_a.pk
+
+        resolved_b = URLModificationMiddleware._convert_named_url(old_url, user=user_b)
+        assert resolved_b == f'/api/v2/job_templates/{jt_b.pk}/'
+        response_b = get(resolved_b, user=user_b, expect=200)
+        assert response_b.data['organization'] == org_b.pk
+
+    def test_old_style_url_without_user_falls_back_to_unscoped(self):
+        """Without a user (e.g. direct classmethod call), old behavior is preserved."""
+        org = Organization.objects.create(name='test_org')
+        jt = JobTemplate.objects.create(name='test_jt', organization=org)
+
+        old_url = '/api/v2/job_templates/test_jt/'
+        resolved = URLModificationMiddleware._convert_named_url(old_url)
+        assert resolved == f'/api/v2/job_templates/{jt.pk}/'
+
+    def test_org_admin_sees_jt_via_old_style_url(self, get):
+        """An org admin can view JTs in their org through implicit grant."""
+        org = Organization.objects.create(name='test_org')
+        jt = JobTemplate.objects.create(name='patching', organization=org)
+        admin_user = User.objects.create(username='org_admin', password='org_admin')
+
+        org.admin_role.members.add(admin_user)
+
+        old_url = '/api/v2/job_templates/patching/'
+        resolved = URLModificationMiddleware._convert_named_url(old_url, user=admin_user)
+        assert resolved == f'/api/v2/job_templates/{jt.pk}/'
+
+        response = get(resolved, user=admin_user, expect=200)
+        assert response.data['id'] == jt.pk
+
+    def test_org_member_cannot_see_jt_via_old_style_url(self):
+        """An org member does NOT automatically get JT view access.
+        The old-style URL should not resolve to the JT.
+        """
+        org = Organization.objects.create(name='test_org')
+        JobTemplate.objects.create(name='patching', organization=org)
+        member = User.objects.create(username='member', password='member')
+
+        org.member_role.members.add(member)
+
+        old_url = '/api/v2/job_templates/patching/'
+        resolved = URLModificationMiddleware._convert_named_url(old_url, user=member)
+        assert resolved == old_url
+
+
+@pytest.mark.django_db
 class TestConvertNamedUrl:
     @pytest.mark.parametrize(
         "url",


### PR DESCRIPTION
##### SUMMARY
For case of

GET `/api/v2/job_templates/jt_name/`

where the name of the job template is "jt_name", this will now give different behavior. Where job templates both visible and non-visible to that user exists.

Before, if a non-visible JT was returned as the `.first()` in the query, the page would attempt to render but give a 403. In this revision, it will get the first visible JT, so this will change to a 200, giving the _other_ JT that the user has access to see.

Ambiguous cases still exist, which is why that URL pattern is deprecated in favor of `/api/v2/job_templates/org_name++jt_name/`

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request URL rewriting for deprecated job template named URLs to depend on the authenticated user’s visible queryset, which can alter which resource is returned (or whether it rewrites at all). Moderate risk because it touches middleware routing and permission-sensitive resolution paths.
> 
> **Overview**
> Adjusts `URLModificationMiddleware` so deprecated `/api/v2/job_templates/<name>/` named-URL rewriting resolves job templates using the *request user’s* permitted queryset (when authenticated) instead of an unscoped DB lookup, preventing rewrites to inaccessible templates and preferring a visible template when names collide.
> 
> Adds functional tests covering no-access, duplicate-name visibility selection, per-user resolution, fallback behavior when no user is provided, and org role edge cases for this deprecated URL form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb4ba3f852fe742ff067d2c241b56da5483da88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced job template URL resolution to be permission-aware, enabling users to be correctly routed to templates they can access when multiple templates share the same name across organizations.

* **Tests**
  * Added test coverage for permission-based job template URL resolution, including multi-user and multi-organization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->