### PR TITLE
Close dependabot stuff early if not AWX repo

### DIFF
--- a/.github/workflows/close_dependabot_tower.yml
+++ b/.github/workflows/close_dependabot_tower.yml
@@ -1,0 +1,20 @@
+---
+name: Close Dependabot PRs on non-AWX repos
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  close-dependabot:
+    if: github.actor == 'dependabot[bot]' && github.repository != 'ansible/awx'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Close PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr close "$PR_URL" --comment "Dependabot PRs are only accepted in ansible/awx. Closing automatically."


### PR DESCRIPTION
##### SUMMARY
We are getting dependabot PRs on mirrors and we don't want that.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single GitHub Actions workflow that only triggers on PR open events from `dependabot[bot]` and closes the PR using the built-in token.
> 
> **Overview**
> Adds a GitHub Actions workflow that **automatically closes newly opened Dependabot PRs** when the repository is *not* `ansible/awx`.
> 
> On `pull_request` `opened`, it runs `gh pr close` with a short comment, using `GITHUB_TOKEN` and `pull-requests: write` permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c36db460b00ce07225465c53a86df8da81bd6a22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation to manage Dependabot pull requests across repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->