### PR TITLE
fix docs for vault ssh engine, input field is ssh_public_key_data not…

### DIFF
--- a/docs/credentials/credential_plugins.md
+++ b/docs/credentials/credential_plugins.md
@@ -230,7 +230,7 @@ HTTP/1.1 201 Created
     -H "Authorization: Bearer <token>" \
     -H "Content-Type: application/json" \
     -X POST \
-    -d '{"source_credential": 2, "input_field_name": "password", "metadata": {"public_key": "UNSIGNED PUBLIC KEY", "secret_path": "/ssh/", "role": "example-role"}}'
+    -d '{"source_credential": 2, "input_field_name": "ssh_public_key_data", "metadata": {"public_key": "UNSIGNED PUBLIC KEY", "secret_path": "/ssh/", "role": "example-role"}}'
 HTTP/1.1 201 Created
 ```
 


### PR DESCRIPTION
… password

##### SUMMARY
In order to make vault ssh secret engine and awx to work together the input field needs to be set to `ssh_public_key_data` instead of `password` as the docs now state.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the HashiCorp Vault SSH Secrets Engine credential configuration example to reference the correct SSH public key field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->