### PR TITLE
AAP-75742 Make dispatcherd min_workers literally 4

### DIFF
--- a/awx/main/dispatch/config.py
+++ b/awx/main/dispatch/config.py
@@ -25,7 +25,7 @@ def get_dispatcherd_config(for_service: bool = False, mock_publish: bool = False
         "version": 2,
         "service": {
             "pool_kwargs": {
-                "min_workers": settings.JOB_EVENT_WORKERS,
+                "min_workers": settings.DISPATCHER_MIN_WORKERS,
                 "max_workers": max_workers,
                 # This must be less than max_workers to make sense, which is usually 4
                 # With reserve of 1, after a burst of tasks, load needs to down to 4-1=3

--- a/awx/main/tests/functional/management/test_dispatcherd.py
+++ b/awx/main/tests/functional/management/test_dispatcherd.py
@@ -8,7 +8,7 @@ from awx.main.management.commands.dispatcherd import _hash_config
 def test_dispatcherd_config_hash_is_stable(settings, monkeypatch):
     monkeypatch.setenv('AWX_COMPONENT', 'dispatcher')
     settings.CLUSTER_HOST_ID = 'test-node'
-    settings.JOB_EVENT_WORKERS = 1
+    settings.DISPATCHER_MIN_WORKERS = 1
     settings.DISPATCHER_SCHEDULE = {}
 
     config_one = get_dispatcherd_config(for_service=True)

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -215,6 +215,9 @@ LOCAL_STDOUT_EXPIRE_TIME = 2592000
 # events into the database
 JOB_EVENT_WORKERS = 4
 
+# Minimum number of workers for the dispatcher (dispatcherd) process pool
+DISPATCHER_MIN_WORKERS = 4
+
 # The number of seconds to buffer callback receiver bulk
 # writes in memory before flushing via JobEvent.objects.bulk_create()
 JOB_EVENT_BUFFER_SECONDS = 1


### PR DESCRIPTION
##### SUMMARY
This was from a conversation with @kdelee and there should be a Jira and all that but I am just making this from memory of the conversation.

Some time ago, @jainnikhil30 made a change to set the callback receiver workers based on the system resources (like CPUs). This had extremely major consequences for resource consumption. However, whatever your feelings on that, this wasn't intended to apply to the dispatcher and never made sense to apply to the dispatcher.

The dispatcher needs to have at least 4 workers because that is what is needs in order to process schedule jobs that run in the background. If scheduled _user_ jobs are at a certain level or higher, we don't care, the auto-scaling logic will take care of it, and anyway, the system resources doesn't have anything to do with that metric.

With dispatcherd, we made a change that the workers will have a connection open in the background so that they are able to quickly process work. The combination of that with this apparently unintended higher number of min_workers was Bad News. It exhausted the connection pool, and exhausting the connection pool has become a very very big problem.

This is a minor change, fixing something outright unintended, essentially a bug. We have more work to do with connection management but this is the "duh" level of patch to get better at that.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispatcher process-pool sizing behavior by introducing a dedicated `DISPATCHER_MIN_WORKERS` setting; deployments that previously tuned `JOB_EVENT_WORKERS` may see different dispatcher concurrency and DB connection usage.
> 
> **Overview**
> **Dispatcher pool sizing is now configured independently.** `get_dispatcherd_config()` switches `pool_kwargs.min_workers` from `JOB_EVENT_WORKERS` to a new `DISPATCHER_MIN_WORKERS` setting (default `4`).
> 
> Tests are updated to set `DISPATCHER_MIN_WORKERS` when asserting dispatcherd config hashing stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0833d34512834c8e0c92e811b88580465884a0f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new configuration setting to independently control the minimum size of the dispatcher process pool (default: 4).

* **Chores**
  * Dispatcher configuration now uses the new dedicated setting instead of the previously shared parameter, allowing clearer and safer tuning of worker concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->