### PR TITLE
feat: improve unauthorized response on aap deployments

### DIFF
--- a/awx/api/generics.py
+++ b/awx/api/generics.py
@@ -272,7 +272,10 @@ class APIView(views.APIView):
                 response = self.handle_exception(self.__init_request_error__)
             if response.status_code == 401:
                 if response.data and 'detail' in response.data:
-                    response.data['detail'] += _(' To establish a login session, visit') + ' /api/login/.'
+                    if getattr(settings, 'RESOURCE_SERVER__URL', None):
+                        response.data['detail'] += _(' Direct access is not allowed, authenticate via the platform gateway.')
+                    else:
+                        response.data['detail'] += _(' To establish a login session, visit') + ' /api/login/.'
                 logger.info(status_msg)
             else:
                 logger.warning(status_msg)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Improve the error message returned when trying to access the Controller API on an AAP deployment.
<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the human-readable `401` error `detail` string based on `RESOURCE_SERVER__URL`, with no changes to authentication/authorization decisions.
> 
> **Overview**
> Improves `401 Unauthorized` responses by **changing the appended guidance message**: when `RESOURCE_SERVER__URL` is set (AAP/gateway deployments), the API now tells clients that direct access is not allowed and to authenticate via the platform gateway; otherwise it keeps the existing hint to establish a session via `/api/login/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630b37248dc2f88f2ac66e12df570e0af16e13f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error messages for HTTP 401 responses: messages now adapt to your deployment configuration and either instruct you to authenticate via the platform gateway when direct access is restricted or direct you to the standard login endpoint when appropriate, giving clearer, context-aware guidance for re-authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->