### PR TITLE
Fix: Update Codecov actions to resolve GPG verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.cov-report-files != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: >-
             ${{
@@ -124,7 +124,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.test-result-files != ''
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@v1.2.1
         with:
           fail_ci_if_error: >-
             ${{
@@ -404,7 +404,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.cov-report-files != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: >-
             ${{


### PR DESCRIPTION
## Summary
- CI was failing on 3 jobs due to GPG signature verification errors in codecov-action@v4
- Updated codecov/codecov-action from v4 to v6 (latest stable release)
- Updated codecov/test-results-action from v1 to v1.2.1
- Fixes Node.js 20 deprecation warnings by using Node.js 24-compatible versions

## Test plan
- [ ] CI passes on this PR (codecov upload steps succeed)
- [ ] GPG signature verification errors are resolved
- [ ] No regressions in coverage reporting

Link to failing CI run: https://github.com/ansible/awx/actions/runs/24834908601

## Change Type
Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes third-party GitHub Action versions used for uploading coverage/results, but could affect CI reporting behavior if the new Codecov actions differ.
> 
> **Overview**
> **CI Codecov uploads are updated.** The workflow bumps `codecov/codecov-action` from `v4` to `v6` (in both unit and collection-integration jobs) and upgrades `codecov/test-results-action` from `v1` to `v1.2.1` for test result uploads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4374cad41f8201a635919f429b539d0257942ade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality and testing infrastructure tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->