### PR TITLE
Fix: Update Codecov actions to resolve GPG verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.cov-report-files != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: >-
             ${{
@@ -124,7 +124,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.test-result-files != ''
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@v1.2.1
         with:
           fail_ci_if_error: >-
             ${{
@@ -404,7 +404,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.cov-report-files != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           fail_ci_if_error: >-
             ${{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,9 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.test-result-files != ''
-        uses: codecov/test-results-action@v1.2.1
+        uses: codecov/codecov-action@v6
         with:
+          report-type: test_results
           fail_ci_if_error: >-
             ${{
               toJSON(env.UPSTREAM_REPOSITORY_ID == github.repository_id)


### PR DESCRIPTION
## Summary
- CI was failing on 3 jobs due to GPG signature verification errors in codecov-action@v4
- Updated codecov/codecov-action from v4 to v6 (latest stable release)
- Updated codecov/test-results-action from v1 to v1.2.1
- Fixes Node.js 20 deprecation warnings by using Node.js 24-compatible versions

## Test plan
- [ ] CI passes on this PR (codecov upload steps succeed)
- [ ] GPG signature verification errors are resolved
- [ ] No regressions in coverage reporting

Link to failing CI run: https://github.com/ansible/awx/actions/runs/24834908601

## Change Type
Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates GitHub Actions used to upload coverage and test results in CI, with no production code or data-handling changes. Main risk is CI reporting behavior changes if the new Codecov action inputs differ.
> 
> **Overview**
> Updates the CI workflow to use `codecov/codecov-action@v6` for both coverage uploads and test-results uploads (replacing the older `codecov/codecov-action@v4` and `codecov/test-results-action`).
> 
> The test-results upload now goes through the same Codecov action with `report-type: test_results`, aiming to avoid the prior signature verification failures in Codecov steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdad481d630cc8b1d6341fa289b46147f10b68cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to use a unified coverage and test-results uploader for code coverage and test reporting.
  * Improved CI/CD compatibility and reliability of coverage and test-result uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->