### PR TITLE
fix: do not include secret values in the credentials test endpoint an…

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1720,12 +1720,10 @@ class OIDCCredentialTestMixin:
         return {'details': {'sent_jwt_payload': self._decode_jwt_payload_for_display(jwt_token)}}
 
     def _call_backend_with_error_handling(self, plugin, backend_kwargs, response_body):
-        """Call credential backend and handle errors, adding secret_value to response if OIDC details present."""
+        """Call credential backend and handle errors."""
         try:
             with set_environ(**settings.AWX_TASK_ENV):
-                secret_value = plugin.backend(**backend_kwargs)
-                if 'details' in response_body:
-                    response_body['details']['secret_value'] = secret_value
+                plugin.backend(**backend_kwargs)
                 return Response(response_body, status=status.HTTP_202_ACCEPTED)
         except requests.exceptions.HTTPError as exc:
             message = self._extract_http_error_message(exc)
@@ -1791,6 +1789,8 @@ class CredentialExternalTest(OIDCCredentialTestMixin, SubDetailAPIView):
         It does not support standard credential types such as Machine, SCM, and Cloud."""})
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
+        if obj.credential_type.kind != 'external':
+            raise ParseError(_('Credential is not testable.'))
         backend_kwargs = {}
         for field_name, value in obj.inputs.items():
             backend_kwargs[field_name] = obj.get_input(field_name)
@@ -1858,6 +1858,8 @@ class CredentialTypeExternalTest(OIDCCredentialTestMixin, SubDetailAPIView):
     @extend_schema_if_available(extensions={"x-ai-description": "Test a complete set of input values for an external credential"})
     def post(self, request, *args, **kwargs):
         obj = self.get_object()
+        if obj.kind != 'external':
+            raise ParseError(_('Credential type is not testable.'))
         backend_kwargs = request.data.get('inputs', {})
         backend_kwargs.update(request.data.get('metadata', {}))
 

--- a/awx/main/tests/functional/api/test_oidc_credential_test.py
+++ b/awx/main/tests/functional/api/test_oidc_credential_test.py
@@ -257,3 +257,12 @@ def test_credential_type_test_success_returns_jwt_payload(mock_flag, post, admin
     assert response.status_code == 202
     assert 'details' in response.data
     assert 'sent_jwt_payload' in response.data['details']
+
+
+@pytest.mark.django_db
+def test_credential_external_test_returns_400_for_non_external_credential(post, admin, credential):
+    # credential fixture creates a non-external credential (e.g. SSH/vault kind)
+    url = reverse('api:credential_external_test', kwargs={'pk': credential.pk})
+    response = post(url, {'metadata': {}}, admin)
+    assert response.status_code == 400
+    assert 'not testable' in response.data.get('detail', '').lower()


### PR DESCRIPTION
##### SUMMARY

We shouldn't include the actual value of the secret in the response when testing credentials. Also, adds guards to make sure a secret is testable before attempting to test it.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent testing of credentials or credential types that are not marked external; such requests now return a clear validation error.
  * Improve error handling for credential-test requests so responses are consistent and informative.

* **Tests**
  * Added a functional test verifying the credential-test endpoint rejects non-external credentials with a 400 and explanatory detail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->