### PR TITLE
[devel backport] AAP-41742: Fix workflow node update failing when JT has unprompted labels

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4149,6 +4149,7 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
         requested_prompt_fields = incoming_attr_keys & ask_mapping_keys
         if 'extra_data' in incoming_attr_keys:
             requested_prompt_fields.add('extra_vars')
+            requested_prompt_fields.add('survey_passwords')
 
         # prompts_dict() pulls persisted M2M state (labels, credentials,
         # instance_groups) via the instance pk.  Only re-validate the full prompt

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4143,8 +4143,24 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
 
         # Build unsaved version of this config, use it to detect prompts errors
         mock_obj = self._build_mock_obj(attrs)
-        if set(list(ujt.get_ask_mapping().keys()) + ['extra_data']) & set(attrs.keys()):
-            accepted, rejected, errors = ujt._accept_or_ignore_job_kwargs(_exclude_errors=self.exclude_errors, **mock_obj.prompts_dict())
+        ask_mapping_keys = set(ujt.get_ask_mapping().keys())
+        requested_prompt_fields = set(attrs.keys()) & ask_mapping_keys
+        if 'extra_data' in attrs:
+            requested_prompt_fields.add('extra_vars')
+
+        # prompts_dict() pulls persisted M2M state (labels, credentials,
+        # instance_groups) via the instance pk.  Only re-validate the full prompt
+        # state when the caller is switching the underlying template; otherwise
+        # restrict validation to the fields the request explicitly provided.
+        if 'unified_job_template' in attrs:
+            prompts_to_validate = mock_obj.prompts_dict()
+        elif requested_prompt_fields:
+            prompts_to_validate = {k: v for k, v in mock_obj.prompts_dict().items() if k in requested_prompt_fields}
+        else:
+            prompts_to_validate = None
+
+        if prompts_to_validate is not None:
+            accepted, rejected, errors = ujt._accept_or_ignore_job_kwargs(_exclude_errors=self.exclude_errors, **prompts_to_validate)
         else:
             # Only perform validation of prompts if prompts fields are provided
             errors = {}

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -4142,10 +4142,12 @@ class LaunchConfigurationBaseSerializer(BaseSerializer):
                             attrs['extra_data'][key] = db_extra_data[key]
 
         # Build unsaved version of this config, use it to detect prompts errors
+        # Capture keys before _build_mock_obj pops pseudo-fields from attrs
+        incoming_attr_keys = set(attrs.keys())
         mock_obj = self._build_mock_obj(attrs)
         ask_mapping_keys = set(ujt.get_ask_mapping().keys())
-        requested_prompt_fields = set(attrs.keys()) & ask_mapping_keys
-        if 'extra_data' in attrs:
+        requested_prompt_fields = incoming_attr_keys & ask_mapping_keys
+        if 'extra_data' in incoming_attr_keys:
             requested_prompt_fields.add('extra_vars')
 
         # prompts_dict() pulls persisted M2M state (labels, credentials,

--- a/awx/main/tests/functional/api/test_workflow_node.py
+++ b/awx/main/tests/functional/api/test_workflow_node.py
@@ -13,6 +13,7 @@ from awx.main.models.workflow import (
     WorkflowJobTemplateNode,
 )
 from awx.main.models.credential import Credential
+from awx.main.models.label import Label
 from awx.main.scheduler import TaskManager, WorkflowManager, DependencyManager
 
 # Django
@@ -49,6 +50,31 @@ def test_node_accepts_prompted_fields(inventory, project, workflow_job_template,
     job_template = JobTemplate.objects.create(inventory=inventory, project=project, playbook='helloworld.yml', ask_limit_on_launch=True)
     url = reverse('api:workflow_job_template_workflow_nodes_list', kwargs={'pk': workflow_job_template.pk})
     post(url, {'unified_job_template': job_template.pk, 'limit': 'webservers'}, user=admin_user, expect=201)
+
+
+@pytest.mark.django_db
+def test_node_extra_data_patch_with_unprompted_labels(inventory, project, organization, workflow_job_template, patch, admin_user):
+    """AAP-41742: PATCH extra_data on a workflow node should succeed even when
+    the node has labels associated but the JT has ask_labels_on_launch=False."""
+    jt = JobTemplate.objects.create(
+        inventory=inventory,
+        project=project,
+        playbook='helloworld.yml',
+        ask_variables_on_launch=True,
+        ask_labels_on_launch=False,
+    )
+    label = Label.objects.create(name='repro-label', organization=organization)
+
+    node = WorkflowJobTemplateNode.objects.create(
+        workflow_job_template=workflow_job_template,
+        unified_job_template=jt,
+        extra_data={'foo': 'bar'},
+    )
+    node.labels.add(label)
+
+    url = reverse('api:workflow_job_template_node_detail', kwargs={'pk': node.pk})
+    r = patch(url, {'extra_data': {'foo': 'edited'}}, user=admin_user, expect=200)
+    assert r.data['extra_data'] == {'foo': 'edited'}
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
Backport of ansible/tower#7423 to AWX `devel`.

- Fixes a bug where updating `extra_data` on a workflow job template node via PATCH fails with `{"labels":["Field is not configured to prompt on launch."]}` when the node has labels associated but the underlying Job Template has `ask_labels_on_launch=False`
- Root cause: `LaunchConfigurationBaseSerializer.validate()` was passing all persisted M2M state (labels, credentials, instance_groups) from `prompts_dict()` to `_accept_or_ignore_job_kwargs()` on every PATCH, re-validating unchanged fields against `ask_*_on_launch` flags
- Fix scopes prompt validation to only the fields explicitly in the request payload; full re-validation still occurs when `unified_job_template` is being changed

Fixes: https://redhat.atlassian.net/browse/AAP-41742

Bug, Docs Fix or other nominal change

## Test plan
- [x] Added regression test `test_node_extra_data_patch_with_unprompted_labels`
- [x] Tests validated on tower `stable-2.6` (identical code); CI will validate on AWX `devel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Launch validation now only validates prompt fields explicitly included in API requests, preventing unnecessary validation errors when partially updating launch data.
  * Workflow job template node updates now allow PATCHing extra data even when node labels exist but label prompting is disabled, fixing failed updates in that scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launch configuration validation to only re-validate prompt fields included in the request, which may affect API error behavior for partial updates and needs careful regression coverage across promptable fields.
> 
> **Overview**
> Fixes workflow node PATCH failures caused by re-validating persisted M2M prompt state (e.g., `labels`) when updating unrelated fields like `extra_data`.
> 
> `LaunchConfigurationBaseSerializer.validate()` now tracks which prompt fields were provided in the request and only passes those to `_accept_or_ignore_job_kwargs()` for validation, while still validating the full prompt set when `unified_job_template` changes. Adds a regression test ensuring `extra_data` can be PATCHed on a node with labels even when the underlying job template has `ask_labels_on_launch=False`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979b81c8548cee6e07a399b2e6709041a8788451. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->