### PR TITLE
fix: allow health check on control and hybrid nodes

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -5652,7 +5652,7 @@ class InstanceSerializer(BaseSerializer):
         if obj.node_type in [Instance.Types.EXECUTION, Instance.Types.HOP] and not obj.managed:
             res['install_bundle'] = self.reverse('api:instance_install_bundle', kwargs={'pk': obj.pk})
         if self.context['request'].user.is_superuser or self.context['request'].user.is_system_auditor:
-            if obj.node_type == 'execution':
+            if obj.node_type != 'hop':
                 res['health_check'] = self.reverse('api:instance_health_check', kwargs={'pk': obj.pk})
         return res
 

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -522,8 +522,7 @@ class InstanceHealthCheck(GenericAPIView):
     resource_purpose = 'instance health check'
 
     def get_queryset(self):
-        return super().get_queryset().filter(node_type='execution')
-        # FIXME: For now, we don't have a good way of checking the health of a hop node.
+        return super().get_queryset().exclude(node_type='hop')
 
     @extend_schema_if_available(extensions={"x-ai-description": "Get instance health check result"})
     def get(self, request, *args, **kwargs):
@@ -537,16 +536,21 @@ class InstanceHealthCheck(GenericAPIView):
         if obj.health_check_pending:
             return Response({'msg': f"Health check was already in progress for {obj.hostname}."}, status=status.HTTP_200_OK)
 
-        # Note: hop nodes are already excluded by the get_queryset method
-        obj.health_check_started = now()
-        obj.save(update_fields=['health_check_started'])
         if obj.node_type == models.Instance.Types.EXECUTION:
             from awx.main.tasks.system import execution_node_health_check
 
+            obj.health_check_started = now()
+            obj.save(update_fields=['health_check_started'])
             execution_node_health_check.apply_async([obj.hostname])
+        elif obj.node_type in (models.Instance.Types.CONTROL, models.Instance.Types.HYBRID):
+            from awx.main.tasks.system import control_node_health_check
+
+            obj.health_check_started = now()
+            obj.save(update_fields=['health_check_started'])
+            control_node_health_check.apply_async([obj.hostname], queue=obj.hostname)
         else:
             return Response(
-                {"error": f"Cannot run a health check on instances of type {obj.node_type}.  Health checks can only be run on execution nodes."},
+                {"error": f"Cannot run a health check on instances of type {obj.node_type}."},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         return Response({'msg': f"Health check is running for {obj.hostname}."}, status=status.HTTP_200_OK)

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -496,6 +496,34 @@ def cleanup_images_and_files():
     CleanupImagesAndFiles.run(image_prune=True)
 
 
+@task(queue=get_task_queuename, timeout=60, on_duplicate='queue_one')
+def control_node_health_check(node):
+    """Run local_health_check on a control or hybrid node.
+
+    Must be dispatched with queue=<target hostname> so it executes on the
+    correct pod, since local_health_check reads the local process's CPU,
+    memory, Redis connectivity, and version.
+    """
+    if not node:
+        logger.warning('Control node health check incorrectly called with blank hostname')
+        return
+    if node != settings.CLUSTER_HOST_ID:
+        logger.warning(f'control_node_health_check for {node} executed on {settings.CLUSTER_HOST_ID}; skipping to avoid recording wrong host metrics.')
+        return
+    try:
+        instance = Instance.objects.get(hostname=node)
+    except Instance.DoesNotExist:
+        logger.warning(f'Instance record for {node} missing, could not run health check.')
+        return
+    if instance.node_type not in ('control', 'hybrid'):
+        logger.warning(f'Control node health check called for {instance.node_type} node {node}')
+        return
+    if instance.node_state not in (Instance.States.READY, Instance.States.UNAVAILABLE, Instance.States.INSTALLED):
+        logger.warning(f'Control node health check ran against node {instance.hostname} in state {instance.node_state}')
+        return
+    instance.local_health_check()
+
+
 @task(queue=get_task_queuename, timeout=600, on_duplicate='queue_one')
 def execution_node_health_check(node):
     if node == '':

--- a/awx/main/tests/functional/api/test_instance.py
+++ b/awx/main/tests/functional/api/test_instance.py
@@ -62,6 +62,54 @@ def test_health_check_usage(get, post, admin_user):
     assert r.data['msg'] == f"Health check is running for {instance.hostname}."
 
 
+@pytest.mark.django_db
+def test_health_check_control_node(get, post, admin_user):
+    kwargs = dict(hostname='control-node', cpu=6, node_type='control', memory=36000000000, cpu_capacity=6, mem_capacity=42)
+    instance = Instance.objects.create(**kwargs)
+    url = reverse('api:instance_health_check', kwargs={'pk': instance.pk})
+    get(url=url, user=admin_user, expect=200)
+    r = post(url=url, user=admin_user, expect=200)
+    assert r.data['msg'] == f"Health check is running for {instance.hostname}."
+
+
+@pytest.mark.django_db
+def test_health_check_hybrid_node(get, post, admin_user):
+    kwargs = dict(hostname='hybrid-node', cpu=6, node_type='hybrid', memory=36000000000, cpu_capacity=6, mem_capacity=42)
+    instance = Instance.objects.create(**kwargs)
+    url = reverse('api:instance_health_check', kwargs={'pk': instance.pk})
+    get(url=url, user=admin_user, expect=200)
+    r = post(url=url, user=admin_user, expect=200)
+    assert r.data['msg'] == f"Health check is running for {instance.hostname}."
+
+
+@pytest.mark.django_db
+def test_health_check_hop_node_excluded(get, post, admin_user):
+    kwargs = dict(hostname='hop-node', cpu=0, node_type='hop', memory=0, cpu_capacity=0, mem_capacity=0)
+    instance = Instance.objects.create(**kwargs)
+    url = reverse('api:instance_health_check', kwargs={'pk': instance.pk})
+    get(url=url, user=admin_user, expect=404)
+    post(url=url, user=admin_user, expect=404)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('node_type', ['execution', 'control', 'hybrid'])
+def test_health_check_link_present(get, admin_user, node_type):
+    kwargs = dict(hostname=f'{node_type}-node', cpu=6, node_type=node_type, memory=36000000000, cpu_capacity=6, mem_capacity=42)
+    instance = Instance.objects.create(**kwargs)
+    url = reverse('api:instance_detail', kwargs={'pk': instance.pk})
+    r = get(url=url, user=admin_user, expect=200)
+    assert 'health_check' in r.data['related']
+
+
+@pytest.mark.django_db
+def test_health_check_link_absent_for_hop(get, admin_user):
+    kwargs = dict(hostname='hop-node', cpu=0, node_type='hop', memory=0, cpu_capacity=0, mem_capacity=0)
+    instance = Instance.objects.create(**kwargs)
+    url = reverse('api:instance_detail', kwargs={'pk': instance.pk})
+    r = get(url=url, user=admin_user, expect=200)
+    assert 'health_check' not in r.data['related']
+
+
 def test_custom_hostname_regex(post, admin_user):
     url = reverse('api:instance_list')
     with override_settings(IS_K8S=True):


### PR DESCRIPTION
## Summary

On Kubernetes/OpenShift deployments of AAP 2.6, the **Instances health check button is greyed out** and the health check API endpoint returns 404 for control nodes.

This happens because:
- `InstanceHealthCheck.get_queryset()` filtered exclusively for `node_type='execution'`, but K8s controller pods register as `control` nodes.
- `InstanceSerializer.get_related()` only included the `health_check` link for execution nodes, so the UI never rendered the button.

### Changes

- Broaden the health check queryset to exclude only hop nodes (which genuinely cannot be health-checked).
- Add a branch in the POST handler to call `local_health_check()` for control and hybrid nodes, matching the existing heartbeat behaviour.
- Update the serializer to expose the `health_check` related link for all non-hop node types.
- Add test coverage for control, hybrid, and hop node health check behaviour.

Fixes #16429
Closes: AAP-57219

## Test plan

- [x] `black --check` passes
- [ ] Existing `test_instance.py` tests pass
- [ ] New tests: `test_health_check_control_node`, `test_health_check_hybrid_node`, `test_health_check_hop_node_excluded`
- [ ] New tests: `test_health_check_link_present` (parametrised for execution/control/hybrid), `test_health_check_link_absent_for_hop`
- [ ] Manual verification on AAP 2.6 K8s deployment: health check button is no longer greyed out for control nodes

Signed-off-by: Alexey Masolov <amasolov@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health checks now run for control and hybrid instances (control-node checks are processed in background with per-instance queuing).

* **Bug Fixes**
  * Health-check endpoint and related links now include control/hybrid instances, exclude hop nodes, and return clearer status/messages for unsupported node types.

* **Tests**
  * Added functional API tests covering health-check behavior and related links for execution, control, hybrid, and hop nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->