### PR TITLE
feat: add test to ensure credential secret values are not returned

### DIFF
--- a/awx/main/tests/functional/api/test_oidc_credential_test.py
+++ b/awx/main/tests/functional/api/test_oidc_credential_test.py
@@ -170,6 +170,27 @@ def test_credential_test_success_returns_jwt_payload(mock_flag, post, admin, oid
 
 @pytest.mark.django_db
 @mock.patch('awx.api.views.flag_enabled', return_value=True)
+def test_credential_test_response_does_not_contain_secret_value(mock_flag, post, admin, oidc_credential, job_template, mock_oidc_backend):
+    """
+    the OIDC credential test endpoint must not echo the resolved Vault secret back to the caller.
+    """
+    url = reverse('api:credential_external_test', kwargs={'pk': oidc_credential.pk})
+    data = {'metadata': {'secret_path': 'test/secret', 'job_template_id': str(job_template.id)}}
+
+    credential_secret_value = 'CREDENTIAL_SECRET'
+    mock_oidc_backend['backend'].backend.return_value = credential_secret_value
+
+    response = post(url, data, admin)
+
+    assert response.status_code == 202
+    assert 'details' in response.data
+    assert 'sent_jwt_payload' in response.data['details']
+    assert 'secret_value' not in response.data['details']
+    assert credential_secret_value not in str(response.data)
+
+
+@pytest.mark.django_db
+@mock.patch('awx.api.views.flag_enabled', return_value=True)
 def test_credential_test_backend_failure_returns_jwt_and_error(mock_flag, post, admin, oidc_credential, job_template, mock_oidc_backend):
     """Test that backend failure still returns JWT payload along with error message."""
     url = reverse('api:credential_external_test', kwargs={'pk': oidc_credential.pk})
@@ -224,6 +245,29 @@ def test_credential_test_job_template_id_not_passed_to_backend(mock_flag, post, 
 
 
 # --- Tests for CredentialTypeExternalTest endpoint ---
+
+
+@pytest.mark.django_db
+@mock.patch('awx.api.views.flag_enabled', return_value=True)
+def test_credential_type_test_response_does_not_contain_secret_value(mock_flag, post, admin, oidc_credentialtype, job_template, mock_oidc_backend):
+    """
+    the credential-type variant of the test endpoint should not return the secret value
+    """
+    url = reverse('api:credential_type_external_test', kwargs={'pk': oidc_credentialtype.pk})
+    data = {
+        'inputs': {'url': 'http://vault.example.com:8200', 'auth_path': 'jwt', 'role_id': 'test-role', 'jwt_aud': 'vault'},
+        'metadata': {'secret_path': 'test/secret', 'job_template_id': str(job_template.id)},
+    }
+
+    credential_type_seret_value = 'CREDENTIAL_TYPE_SECRET'
+    mock_oidc_backend['backend'].backend.return_value = credential_type_seret_value
+    response = post(url, data, admin)
+
+    assert response.status_code == 202
+    assert 'details' in response.data
+    assert 'sent_jwt_payload' in response.data['details']
+    assert 'secret_value' not in response.data['details']
+    assert credential_type_seret_value not in str(response.data)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
##### SUMMARY

Adds tests for https://github.com/ansible/awx/pull/16425

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added functional tests for OIDC credential endpoints to confirm secret-leakage prevention: feature flag enabled, endpoints return expected 202 responses with JWT details, and sensitive secret values are not exposed anywhere in the serialized response payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->