### PR TITLE
fix: as_user() gateway session cookie fallback

### DIFF
--- a/awxkit/awxkit/awx/utils.py
+++ b/awxkit/awxkit/awx/utils.py
@@ -85,15 +85,23 @@ def as_user(v, username, password=None):
         if config.use_sessions:
             session_id = None
             domain = None
+            cookie_name = connection.session_cookie_name
             # requests doesn't provide interface for retrieving
             # domain segregated cookies other than iterating.
             for cookie in connection.session.cookies:
-                if cookie.name == connection.session_cookie_name:
+                if cookie.name == cookie_name:
                     session_id = cookie.value
                     domain = cookie.domain
                     break
+            if session_id is None and cookie_name != 'gateway_sessionid':
+                for cookie in connection.session.cookies:
+                    if cookie.name == 'gateway_sessionid':
+                        session_id = cookie.value
+                        domain = cookie.domain
+                        cookie_name = 'gateway_sessionid'
+                        break
             if session_id:
-                del connection.session.cookies[connection.session_cookie_name]
+                del connection.session.cookies[cookie_name]
             kwargs = connection.get_session_requirements()
         else:
             previous_auth = connection.session.auth
@@ -102,9 +110,11 @@ def as_user(v, username, password=None):
         yield
     finally:
         if config.use_sessions:
-            del connection.session.cookies[connection.session_cookie_name]
+            for name in {connection.session_cookie_name, cookie_name}:
+                with suppress(KeyError):
+                    del connection.session.cookies[name]
             if session_id:
-                connection.session.cookies.set(connection.session_cookie_name, session_id, domain=domain)
+                connection.session.cookies.set(cookie_name, session_id, domain=domain)
         else:
             connection.session.auth = previous_auth
 

--- a/awxkit/test/test_as_user.py
+++ b/awxkit/test/test_as_user.py
@@ -1,0 +1,151 @@
+from http.cookiejar import Cookie
+from unittest import mock
+
+import pytest
+
+from awxkit.api.client import Connection
+from awxkit.awx.utils import as_user
+from awxkit.config import config
+
+
+def _make_cookie(name, value, domain='.example.com'):
+    return Cookie(
+        version=0,
+        name=name,
+        value=value,
+        port=None,
+        port_specified=False,
+        domain=domain,
+        domain_specified=True,
+        domain_initial_dot=True,
+        path='/',
+        path_specified=True,
+        secure=False,
+        expires=None,
+        discard=True,
+        comment=None,
+        comment_url=None,
+        rest={},
+        rfc2109=False,
+    )
+
+
+class FakeCookieJar:
+    def __init__(self):
+        self._cookies = {}
+
+    def __iter__(self):
+        return iter(self._cookies.values())
+
+    def get(self, name, default=None):
+        c = self._cookies.get(name)
+        return c.value if c else default
+
+    def set(self, name, value, domain='.example.com'):
+        self._cookies[name] = _make_cookie(name, value, domain)
+
+    def __delitem__(self, name):
+        del self._cookies[name]
+
+
+@pytest.fixture
+def connection():
+    conn = mock.MagicMock(spec=Connection)
+    conn.session = mock.MagicMock()
+    conn.session.cookies = FakeCookieJar()
+    conn.session_cookie_name = 'sessionid'
+    conn.get_session_requirements.return_value = {'next': '/api/controller/'}
+    yield conn
+
+
+class TestAsUserSessionAuth:
+    """Tests for as_user() with session-based authentication."""
+
+    def setup_method(self):
+        self._orig = config.use_sessions
+        config.use_sessions = True
+
+    def teardown_method(self):
+        config.use_sessions = self._orig
+
+    def test_swaps_sessionid_cookie(self, connection):
+        connection.session.cookies.set('sessionid', 'admin_session')
+
+        with as_user(connection, 'testuser', 'testpass'):
+            connection.login.assert_called_once_with('testuser', 'testpass', next='/api/controller/')
+
+        assert connection.session.cookies.get('sessionid') == 'admin_session'
+
+    def test_gateway_sessionid_fallback(self, connection):
+        """When session_cookie_name is 'sessionid' but actual cookie is 'gateway_sessionid',
+        as_user() should find and swap the gateway cookie."""
+        connection.session.cookies.set('gateway_sessionid', 'admin_gw_session')
+
+        with as_user(connection, 'testuser', 'testpass'):
+            connection.login.assert_called_once_with('testuser', 'testpass', next='/api/controller/')
+            assert connection.session.cookies.get('gateway_sessionid') is None
+
+        assert connection.session.cookies.get('gateway_sessionid') == 'admin_gw_session'
+
+    def test_gateway_fallback_not_triggered_when_sessionid_exists(self, connection):
+        """When sessionid cookie exists, gateway_sessionid fallback should not trigger."""
+        connection.session.cookies.set('sessionid', 'admin_session')
+        connection.session.cookies.set('gateway_sessionid', 'admin_gw_session')
+
+        with as_user(connection, 'testuser', 'testpass'):
+            pass
+
+        assert connection.session.cookies.get('sessionid') == 'admin_session'
+        assert connection.session.cookies.get('gateway_sessionid') == 'admin_gw_session'
+
+    def test_accepts_user_object(self, connection):
+        from awxkit.api import User
+
+        user = mock.MagicMock(spec=User)
+        user.username = 'bob'
+        user.password = 'secret'
+        connection.session.cookies.set('sessionid', 'admin_session')
+
+        with as_user(connection, user):
+            connection.login.assert_called_once_with('bob', 'secret', next='/api/controller/')
+
+    def test_restores_gateway_cookie_after_exception(self, connection):
+        connection.session.cookies.set('gateway_sessionid', 'admin_gw_session')
+
+        with pytest.raises(RuntimeError):
+            with as_user(connection, 'testuser', 'testpass'):
+                raise RuntimeError('boom')
+
+        assert connection.session.cookies.get('gateway_sessionid') == 'admin_gw_session'
+
+    def test_no_session_cookie_at_all(self, connection):
+        with as_user(connection, 'testuser', 'testpass'):
+            connection.login.assert_called_once()
+
+
+class TestAsUserBasicAuth:
+    """Tests for as_user() with basic authentication."""
+
+    def setup_method(self):
+        self._orig = config.use_sessions
+        config.use_sessions = False
+
+    def teardown_method(self):
+        config.use_sessions = self._orig
+
+    def test_swaps_basic_auth(self, connection):
+        connection.session.auth = ('admin', 'adminpass')
+
+        with as_user(connection, 'testuser', 'testpass'):
+            connection.login.assert_called_once_with('testuser', 'testpass')
+
+        assert connection.session.auth == ('admin', 'adminpass')
+
+    def test_restores_basic_auth_after_exception(self, connection):
+        connection.session.auth = ('admin', 'adminpass')
+
+        with pytest.raises(RuntimeError):
+            with as_user(connection, 'testuser', 'testpass'):
+                raise RuntimeError('boom')
+
+        assert connection.session.auth == ('admin', 'adminpass')


### PR DESCRIPTION
##### SUMMARY

`as_user()` fails to switch the authenticated user when requests go through the AAP gateway. `connection.session_cookie_name` is `sessionid`, but the gateway uses `gateway_sessionid`. The cookie is never found, never deleted, and all requests inside the context continue as admin.

Adds a `gateway_sessionid` fallback — if no cookie matches `session_cookie_name`, check `gateway_sessionid` before proceeding. This mirrors the existing fallback in `Connection.login()` (client.py:52-55). The `finally` block cleans up whichever cookie name was actually used.

Non-gateway environments are unaffected: when `sessionid` is found on the first pass, the fallback is never reached.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - awxkit

##### STEPS TO REPRODUCE AND EXTRA INFO

1. Deploy AAP 2.7 containerized (gateway enabled, `bypass-gateway=no`)
2. Run any tower-qa RBAC test that uses `self.current_user()` / `as_user()`:
   ```
   AWXKIT_API_BASE_PATH=/api/controller/ pytest tests/api/rbac/test_copy_rbac.py::Test_Copy_RBAC
   ```
3. All negative permission tests pass incorrectly — the user context never switches, so requests continue as admin

**Before fix:** 37 of 52 tests fail (false RBAC results)
**After fix:** 0 failures (52 passed, 10 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to test helper cookie handling plus new unit tests; low blast radius with clear regression coverage.
> 
> **Overview**
> Fixes `as_user()` session swapping when requests are routed through the AAP gateway by **falling back to `gateway_sessionid`** if no cookie matches `connection.session_cookie_name`, and by cleaning up/restoring whichever cookie name was actually used.
> 
> Adds a focused test suite (`test_as_user.py`) covering session-cookie swapping (including gateway fallback), exception-safe restoration, and basic-auth behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c81aada4369a05ec679460807f6d37b95defd99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session handling and fallback logic during temporary credential swaps, ensuring cookies and authentication state are correctly cleaned up and restored even on errors.

* **Tests**
  * Added comprehensive tests covering session-based and basic-auth scenarios to validate credential swapping, fallback behavior, and state restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->