### PR TITLE
Pass setting to dispatcherd so it can be configured

### DIFF
--- a/awx/main/dispatch/config.py
+++ b/awx/main/dispatch/config.py
@@ -31,6 +31,7 @@ def get_dispatcherd_config(for_service: bool = False, mock_publish: bool = False
                 # With reserve of 1, after a burst of tasks, load needs to down to 4-1=3
                 # before we return to min_workers
                 "scaledown_reserve": 1,
+                "worker_max_lifetime_seconds": settings.WORKER_MAX_LIFETIME_SECONDS,
             },
             "main_kwargs": {"node_id": settings.CLUSTER_HOST_ID},
             "process_manager_cls": "ForkServerManager",


### PR DESCRIPTION
##### SUMMARY
This is the most minor of all bugs, and it was found when trying to troubleshoot something more scary.

We already had this setting, and the setting was extremely clearly intended for this use, but it was never passed-through. The consequence is that if a user did modify the setting in their local files, that change wouldn't take effect. This is extremely low-consequence, but we should merge this for completeness.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small config passthrough change that only affects worker recycling behavior when `WORKER_MAX_LIFETIME_SECONDS` is set.
> 
> **Overview**
> Ensures `dispatcherd` receives the `WORKER_MAX_LIFETIME_SECONDS` setting by adding `worker_max_lifetime_seconds` to the dispatcher service `pool_kwargs`, so configured worker max lifetimes actually take effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd14d88070c24cec590dc1f29b5f1536e7cdd0b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added worker maximum lifetime configuration parameter to enable improved resource lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->