### PR TITLE
fix: allow blank password field to fix OpenAPI schema validation

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1021,7 +1021,7 @@ class UnifiedJobStdoutSerializer(UnifiedJobSerializer):
 
 
 class UserSerializer(BaseSerializer):
-    password = serializers.CharField(required=False, default='', help_text=_('Field used to change the password.'))
+    password = serializers.CharField(required=False, default='', allow_blank=True, help_text=_('Field used to change the password.'))
     is_system_auditor = serializers.BooleanField(default=False)
     show_capabilities = ['edit', 'delete']
 


### PR DESCRIPTION
##### SUMMARY

The `UserSerializer.password` CharField had `default=''` but DRF infers `minLength: 1` for CharField, causing the OpenAPI schema validator to reject the empty default. Adding `allow_blank=True` removes the `minLength` constraint so the default is valid.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

Run OpenAPI schema validation (`make validate-openapi-schema`). Before this fix:

```
./controller.json: Validation Error: '' should be non-empty

Failed validating 'minLength' in schema:
    {'type': 'string',
     'minLength': 1,
     'default': '',
     'description': 'Field used to change the password.'}

On instance:
    ''
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field serializer validation/schema tweak with minimal behavioral impact beyond permitting blank password values in requests where the field is optional.
> 
> **Overview**
> Updates `UserSerializer.password` to set `allow_blank=True`, aligning DRF/OpenAPI schema generation with the field’s `default=''` and preventing schema validation failures due to an inferred `minLength: 1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c85f1012644c9388c100ac09611478c272709768. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Password input handling updated so empty passwords are now explicitly accepted during validation while the field remains optional and continues to default to an empty string. This prevents validation failures when a blank password is submitted and preserves existing optional behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->