### PR TITLE
Remove 'setuptools' from install_requires in awxkit setup.py

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -90,7 +90,6 @@ setup(
     install_requires=[
         'PyYAML',
         'requests',
-        'setuptools',
     ],
     python_requires=">=3.11",
     extras_require={'formatting': ['jq'], 'websockets': ['websocket-client==0.57.0'], 'crypto': ['cryptography']},


### PR DESCRIPTION
## Summary

- Removes `setuptools` from the `install_requires` list in `awxkit/setup.py`
- `setuptools` is a build/packaging tool, not a runtime dependency, so it should not be listed under `install_requires`

## Test plan

- [ ] Verify `pip install awxkit` succeeds without `setuptools` being explicitly installed
- [ ] Confirm awxkit functionality is unaffected (no runtime import of `setuptools`)

Fixes #16378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unnecessary dependency from package installation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->