### PR TITLE
[devel]AAP-74276: Replace setuptools with packaging in awxkit install_requires

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -90,7 +90,7 @@ setup(
     install_requires=[
         'PyYAML',
         'requests',
-        'setuptools',
+        'packaging',
     ],
     python_requires=">=3.11",
     extras_require={'formatting': ['jq'], 'websockets': ['websocket-client==0.57.0'], 'crypto': ['cryptography']},


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Replace `setuptools` with `packaging` in `awxkit/setup.py` `install_requires`
- The Python 3.12 upgrade replaced `distutils.version.LooseVersion` with `packaging.version.Version` in `awxkit/awxkit/awx/__init__.py` but did not update `install_requires`
- `setuptools` is no longer needed at runtime since `pkg_resources` was also replaced with `importlib.metadata`
- This causes `ModuleNotFoundError: No module named 'packaging'` when awxkit is installed standalone (e.g., CLI RPM on a clean machine)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other


##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 4.6.20
```
> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change; main impact is on awxkit installation behavior, ensuring `packaging` is present and dropping an unnecessary runtime `setuptools` dependency.
> 
> **Overview**
> Fixes awxkit’s runtime dependency list by replacing `setuptools` with `packaging` in `awxkit/setup.py`, aligning `install_requires` with the code’s use of `packaging.version.Version`.
> 
> This prevents standalone awxkit/CLI installs from failing with missing `packaging` while also removing an unneeded runtime `setuptools` requirement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f236752e7c92059ccf96afabd3a29b234d5166bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a packaging-related dependency used during installation. This adjusts installation requirements and improves compatibility. No functional, CLI, or public API changes; end-user behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Assisted-by: Claude
