### PR TITLE
fix: add packaging to awxkit install_requires

### DIFF
--- a/awxkit/setup.py
+++ b/awxkit/setup.py
@@ -88,6 +88,7 @@ setup(
     },
     include_package_data=True,
     install_requires=[
+        'packaging',
         'PyYAML',
         'requests',
         'setuptools',


### PR DESCRIPTION
##### SUMMARY
Add `packaging` as a runtime dependency in awxkit's `setup.py` `install_requires`.
The `packaging` library is used by awxkit but was not declared as an install dependency,
which could cause import failures when awxkit is installed standalone.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI

##### STEPS TO REPRODUCE AND EXTRA INFO
Install awxkit in a clean virtualenv without `packaging` pre-installed and observe the ImportError.

```
pip install awxkit
# Previously failed with: ModuleNotFoundError: No module named 'packaging'
# Now installs packaging automatically as a dependency.
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency metadata change; the main impact is that `awxkit` installs `packaging` automatically, with minimal chance of compatibility issues.
> 
> **Overview**
> Fixes standalone `awxkit` installs by adding `packaging` to `install_requires` in `awxkit/setup.py`, ensuring runtime imports like `packaging.version.Version` are available without manual pre-installation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 630f562aeed3ff23daae0ee34cf53018f2ff1673. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to ensure required packages are properly installed alongside the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->