### PR TITLE
fix: bump python-tss-sdk to 2.0.0+ for Delinea Cloud Platform support

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -53,7 +53,7 @@ pyopenssl
 pyparsing==2.4.7 # Upgrading to v3 of pyparsing introduce errors on smart host filtering: Expected 'or' term, found 'or'  (at char 15), (line:1, col:16)
 python-daemon
 python-dsv-sdk>=1.0.4
-python-tss-sdk>=1.2.1
+python-tss-sdk>=2.0.0
 pyyaml>=6.0.2  # require packing fix for cython 3 or higher
 pyzstd  # otel collector log file compression library
 receptorctl


### PR DESCRIPTION
## Summary
- Bumps `python-tss-sdk` minimum from `>=1.2.1` to `>=2.0.0` in `requirements.in`
- The old SDK only supports the legacy `/oauth2/token` endpoint with `grant_type=password`, which does not exist on Delinea Cloud Platform tenants (`*.delinea.app`)
- SDK 2.0.0+ adds automatic server-type detection and platform authentication via `/identity/api/oauth2/token/xpmplatform` with `grant_type=client_credentials`
- The pinned version in `requirements.txt` already resolves to 2.0.0

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

## Test plan
- [ ] Verify credential test succeeds against a `*.delinea.app` tenant
- [ ] Verify credential test still works against legacy Secret Server instances
- [ ] Verify job launch with Delinea Cloud external credential resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency constraint change confined to `requirements/requirements.in`; main risk is unexpected behavior changes from the newer `python-tss-sdk` major version in environments that previously installed 1.x.
> 
> **Overview**
> Updates the Python dependency floor for `python-tss-sdk` from `>=1.2.1` to `>=2.0.0` in `requirements/requirements.in`, ensuring installs use the newer SDK baseline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e419b34978d072280c9853816e19fdf8155237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised the minimum required python-tss-sdk version from 1.2.1 to 2.0.0. This update may require upgrading your environment or reinstalling dependencies to maintain compatibility with the latest package changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->