### PR TITLE
Add comment not to expose ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES via the settings API

### DIFF
--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -53,15 +53,6 @@ register(
 )
 
 register(
-    'ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES',
-    field_class=fields.BooleanField,
-    label=_('Enable Custom Team Roles'),
-    help_text=_('Controls whether custom roles that include team-level permissions can be created.'),
-    category=_('System'),
-    category_slug='system',
-)
-
-register(
     'TOWER_URL_BASE',
     field_class=fields.URLField,
     schemes=('http', 'https'),

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -53,6 +53,15 @@ register(
 )
 
 register(
+    'ANSIBLE_BASE_ALLOW_CUSTOM_TEAM_ROLES',
+    field_class=fields.BooleanField,
+    label=_('Enable Custom Team Roles'),
+    help_text=_('Controls whether custom roles that include team-level permissions can be created.'),
+    category=_('System'),
+    category_slug='system',
+)
+
+register(
     'TOWER_URL_BASE',
     field_class=fields.URLField,
     schemes=('http', 'https'),

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -1099,6 +1099,13 @@ ANSIBLE_BASE_CREATOR_DEFAULTS = ['change', 'delete', 'execute', 'use', 'adhoc', 
 ANSIBLE_BASE_CACHE_PARENT_PERMISSIONS = True
 
 # Currently features are enabled to keep compatibility with old system, except custom roles
+#
+# DO NOT register these settings with the conf system (awx/main/conf.py) or
+# expose them via the /api/v2/settings/ API. Changing these at runtime creates
+# RBAC data (e.g. custom team role definitions) that django-ansible-base data
+# migrations may not account for, risking migration failures or cross-org
+# permission spillage. If a deployment must override a value, use a local
+# settings file (e.g. custom.py) so the change is deliberate and auditable.
 ANSIBLE_BASE_ALLOW_TEAM_ORG_ADMIN = False
 # ANSIBLE_BASE_ALLOW_CUSTOM_ROLES = True
 ANSIBLE_BASE_ALLOW_TEAM_PARENTS = False


### PR DESCRIPTION
## Summary (Updated)
- After review, it seems like the original change to expose the setting in the API would be too invasive so this just adds a comment to explain the logic behind not doing so

## Issue Type
 - Bug, Docs Fix or other nominal change

## Component Name
 - API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified constraints on certain role-based access control configuration settings to prevent potential data inconsistencies during system updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->