### PR TITLE
[AAP-53283] Fix analytics API requests to respect proxy environment variables

### DIFF
--- a/awx/api/views/analytics.py
+++ b/awx/api/views/analytics.py
@@ -9,7 +9,7 @@ from django.utils import translation
 from awx.api.generics import APIView, Response
 from awx.api.permissions import AnalyticsPermission
 from awx.api.versioning import reverse
-from awx.main.utils import get_awx_version
+from awx.main.utils import get_awx_version, set_environ
 from awx.main.utils.analytics_proxy import OIDCClient
 from rest_framework import status
 
@@ -210,31 +210,32 @@ class AnalyticsGenericView(APIView):
                 return self._error_response(ERROR_UNSUPPORTED_METHOD, method, remote=False, status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
             url = self._get_analytics_url(request.path)
             using_subscriptions_credentials = False
-            try:
-                rh_user = getattr(settings, 'REDHAT_USERNAME', None)
-                rh_password = getattr(settings, 'REDHAT_PASSWORD', None)
-                if not (rh_user and rh_password):
-                    rh_user = self._get_setting('SUBSCRIPTIONS_CLIENT_ID', None, ERROR_MISSING_USER)
-                    rh_password = self._get_setting('SUBSCRIPTIONS_CLIENT_SECRET', None, ERROR_MISSING_PASSWORD)
-                    using_subscriptions_credentials = True
+            with set_environ(**settings.AWX_TASK_ENV):
+                try:
+                    rh_user = getattr(settings, 'REDHAT_USERNAME', None)
+                    rh_password = getattr(settings, 'REDHAT_PASSWORD', None)
+                    if not (rh_user and rh_password):
+                        rh_user = self._get_setting('SUBSCRIPTIONS_CLIENT_ID', None, ERROR_MISSING_USER)
+                        rh_password = self._get_setting('SUBSCRIPTIONS_CLIENT_SECRET', None, ERROR_MISSING_PASSWORD)
+                        using_subscriptions_credentials = True
 
-                client = OIDCClient(rh_user, rh_password)
-                response = client.make_request(
-                    method,
-                    url,
-                    headers=headers,
-                    verify=settings.INSIGHTS_CERT_PATH,
-                    params=getattr(request, 'query_params', {}),
-                    json=getattr(request, 'data', {}),
-                    timeout=(31, 31),
-                )
-            except requests.RequestException:
-                # subscriptions credentials are not valid for basic auth, so just return 401
-                if using_subscriptions_credentials:
-                    response = Response(status=status.HTTP_401_UNAUTHORIZED)
-                else:
-                    logger.error("Automation Analytics API request failed, trying base auth method")
-                    response = self._base_auth_request(request, method, url, rh_user, rh_password, headers)
+                    client = OIDCClient(rh_user, rh_password)
+                    response = client.make_request(
+                        method,
+                        url,
+                        headers=headers,
+                        verify=settings.INSIGHTS_CERT_PATH,
+                        params=getattr(request, 'query_params', {}),
+                        json=getattr(request, 'data', {}),
+                        timeout=(31, 31),
+                    )
+                except requests.RequestException:
+                    # subscriptions credentials are not valid for basic auth, so just return 401
+                    if using_subscriptions_credentials:
+                        response = Response(status=status.HTTP_401_UNAUTHORIZED)
+                    else:
+                        logger.error("Automation Analytics API request failed, trying base auth method")
+                        response = self._base_auth_request(request, method, url, rh_user, rh_password, headers)
             #
             # Missing or wrong user/pass
             #

--- a/awx/main/tests/functional/api/test_analytics.py
+++ b/awx/main/tests/functional/api/test_analytics.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import requests
 from unittest import mock
@@ -257,3 +258,92 @@ class TestAnalyticsGenericView:
                 else:
                     # assert mock_base_auth_request not called
                     mock_base_auth_request.assert_not_called()
+
+    @pytest.mark.django_db
+    def test__send_to_analytics_respects_proxy_env_oidc(self):
+        settings_map = {
+            'INSIGHTS_TRACKING_STATE': True,
+            'AUTOMATION_ANALYTICS_URL': 'https://example.com',
+            'REDHAT_USERNAME': 'redhat_user',
+            'REDHAT_PASSWORD': 'redhat_pass',
+            'SUBSCRIPTIONS_CLIENT_ID': '',
+            'SUBSCRIPTIONS_CLIENT_SECRET': '',
+            'AWX_TASK_ENV': {'HTTPS_PROXY': '192.168.50.100:1234', 'HTTP_PROXY': '192.168.50.100:5678'},
+        }
+        with override_settings(**settings_map):
+            request = RequestFactory().post('/some/path')
+            view = AnalyticsGenericView()
+
+            with mock.patch('awx.api.views.analytics.OIDCClient') as mock_oidc_client:
+                mock_client_instance = mock.Mock()
+                mock_oidc_client.return_value = mock_client_instance
+
+                def _check_env_and_respond(*args, **kwargs):
+                    assert os.environ.get('HTTPS_PROXY') == '192.168.50.100:1234'
+                    assert os.environ.get('HTTP_PROXY') == '192.168.50.100:5678'
+                    return mock.Mock(status_code=200)
+
+                mock_client_instance.make_request.side_effect = _check_env_and_respond
+                response = view._send_to_analytics(request, 'POST')
+                assert response.status_code == 200
+                mock_client_instance.make_request.assert_called_once()
+
+    @pytest.mark.django_db
+    def test__send_to_analytics_respects_proxy_env_basic_auth(self):
+        settings_map = {
+            'INSIGHTS_TRACKING_STATE': True,
+            'AUTOMATION_ANALYTICS_URL': 'https://example.com',
+            'REDHAT_USERNAME': 'redhat_user',
+            'REDHAT_PASSWORD': 'redhat_pass',
+            'SUBSCRIPTIONS_CLIENT_ID': '',
+            'SUBSCRIPTIONS_CLIENT_SECRET': '',
+            'AWX_TASK_ENV': {'HTTPS_PROXY': '192.168.50.100:1234'},
+        }
+        with override_settings(**settings_map):
+            request = RequestFactory().post('/some/path')
+            view = AnalyticsGenericView()
+
+            with mock.patch('awx.api.views.analytics.OIDCClient') as mock_oidc_client, mock.patch(
+                'awx.api.views.analytics.AnalyticsGenericView._base_auth_request'
+            ) as mock_base_auth:
+                mock_client_instance = mock.Mock()
+                mock_oidc_client.return_value = mock_client_instance
+                mock_client_instance.make_request.side_effect = requests.RequestException("OIDC failed")
+
+                def _check_env_and_respond(*args, **kwargs):
+                    assert os.environ.get('HTTPS_PROXY') == '192.168.50.100:1234'
+                    return mock.Mock(status_code=200)
+
+                mock_base_auth.side_effect = _check_env_and_respond
+                response = view._send_to_analytics(request, 'POST')
+                assert response.status_code == 200
+                mock_base_auth.assert_called_once()
+
+    @pytest.mark.django_db
+    def test__send_to_analytics_restores_env_after_request(self):
+        original_value = os.environ.pop('HTTPS_PROXY', None)
+        settings_map = {
+            'INSIGHTS_TRACKING_STATE': True,
+            'AUTOMATION_ANALYTICS_URL': 'https://example.com',
+            'REDHAT_USERNAME': 'redhat_user',
+            'REDHAT_PASSWORD': 'redhat_pass',
+            'SUBSCRIPTIONS_CLIENT_ID': '',
+            'SUBSCRIPTIONS_CLIENT_SECRET': '',
+            'AWX_TASK_ENV': {'HTTPS_PROXY': '192.168.50.100:1234'},
+        }
+        try:
+            with override_settings(**settings_map):
+                request = RequestFactory().post('/some/path')
+                view = AnalyticsGenericView()
+
+                with mock.patch('awx.api.views.analytics.OIDCClient') as mock_oidc_client:
+                    mock_client_instance = mock.Mock()
+                    mock_oidc_client.return_value = mock_client_instance
+                    mock_client_instance.make_request.return_value = mock.Mock(status_code=200)
+
+                    view._send_to_analytics(request, 'POST')
+
+                assert 'HTTPS_PROXY' not in os.environ
+        finally:
+            if original_value is not None:
+                os.environ['HTTPS_PROXY'] = original_value


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix analytics API requests to respect proxy environment variables (AAP-53283)

  The automation calculator API views did not wrap outbound HTTP requests
  with set_environ(**settings.AWX_TASK_ENV), causing DNS resolution failures
  in proxy environments. This aligns analytics.py with the established
  pattern used in core.py, notifications, and other outbound request paths.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
awx: 4.6.20
```
Assisted-by: Claude
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk bug fix that scopes environment-variable changes to a `set_environ` context and adds tests; main risk is unexpected interaction if outbound analytics requests relied on the previous process environment.
> 
> **Overview**
> Ensures outbound Automation Analytics proxy calls respect proxy-related environment variables by wrapping the OIDC request (and basic-auth fallback) in `with set_environ(**settings.AWX_TASK_ENV)` inside `AnalyticsGenericView._send_to_analytics`.
> 
> Adds functional tests verifying `AWX_TASK_ENV` proxy vars are present during OIDC and basic-auth request paths and that the original process environment is restored after the request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ad2c2747ec5313326cbc3783b34876348af071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics requests now properly respect proxy environment variables (HTTPS_PROXY and HTTP_PROXY) during transmission.

* **Tests**
  * Added test coverage validating proxy environment handling for both OIDC and basic authentication credentials in analytics requests.
  * Added tests ensuring environment variables are properly restored after analytics operations complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->