### PR TITLE
Fix awx-collection tests for ansible-core 2.21.0

### DIFF
--- a/awx_collection/test/awx/conftest.py
+++ b/awx_collection/test/awx/conftest.py
@@ -236,6 +236,7 @@ def run_module(request, collection_import, mocker):
 
         with mock.patch.object(resource_class, '_load_params', new=mock_load_params):
             mocker.patch('ansible.module_utils.basic._ANSIBLE_PROFILE', 'legacy')
+            mocker.patch('ansible.module_utils.basic._PARSED_MODULE_ARGS', {'_ansible_inject_invocation': True}, create=True)
 
             with mock.patch('ansible.module_utils.urls.Request.open', new=new_open):
                 with _get_tower_cli_mgr(new_request):


### PR DESCRIPTION
## Summary
- ansible-core 2.21.0 introduced `_PARSED_MODULE_ARGS` in `module_utils/basic.py`, used by `_return_formatted()` to conditionally include invocation data in module output
- The awx_collection test harness bypasses normal arg parsing via `_load_params` mock, leaving `_PARSED_MODULE_ARGS` as `None`
- This causes `AttributeError: 'NoneType' object has no attribute 'get'` on every `exit_json()`/`fail_json()` call, failing 150+ tests

## Test plan
- [ ] CI passes on this PR (awx-collection tests should go from 150+ failures to 0)
- [ ] Verified fix addresses the root cause by inspecting ansible-core 2.21.0 source

Link to failing CI run: https://github.com/ansible/awx/actions/runs/26163664593

## Change Type
Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is confined to the test harness and only adjusts Ansible internal globals to match newer ansible-core behavior.
> 
> **Overview**
> Updates the `run_module` test fixture to also patch `ansible.module_utils.basic._PARSED_MODULE_ARGS` (in addition to `_ANSIBLE_PROFILE`) when mocking module execution.
> 
> This aligns the harness with ansible-core 2.21+ expectations so `exit_json()`/`fail_json()` formatting that consults parsed module args no longer crashes during tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73effba4414fdd19dd344b223ceb3f2ef2c2f6fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test harness to better simulate Ansible module execution environment during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->