### PR TITLE
Update the copyright year and the trademark in the REST API views

### DIFF
--- a/awx/templates/rest_framework/api.html
+++ b/awx/templates/rest_framework/api.html
@@ -71,7 +71,7 @@
       <div class="col-sm-6">
       </div>
       <div class="col-sm-6 footer-copyright">
-        Copyright &copy; 2024 <a href="http://www.redhat.com" target="_blank">Red Hat</a>, Inc. All Rights Reserved.
+        Copyright &copy; 2026 <a href="http://www.redhat.com" target="_blank">Red Hat</a>, LLC. All Rights Reserved.
       </div>
     </div>
   </div>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update the copyright year and the trademark in the REST API views (e.g. https:// AAP Controller URL /api/). 

I have considered whether we should apply a dynamic approach (e.g. `new Date().getFullYear()`) on the year displayed, but given AAP is version-based, I still proceed with a static year approach (e.g. If we see 'Copyright 2035' in AAP 2.5 in 2035, we are not providing technical support for that long.)

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Other



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Red Hat trademark guidelines (regarding Red Hat, Inc -> Red Hat, LLC): https://www.redhat.com/en/about/trademark-guidelines-and-policies

<img width="1152" height="864" alt="AAP root API view" src="https://github.com/user-attachments/assets/98c80ad4-7628-41b3-843b-077bb97cf08b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright year in API page footer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->