### PR TITLE
Add OpenTelemetry observability to AWX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,8 @@ VAULT_TLS ?= false
 OTEL ?= false
 # If set to true docker-compose will also start a Loki instance
 LOKI ?= false
+# If set to true docker-compose will also start a Tempo instance
+TEMPO ?= false
 # If set to true docker-compose will install editable dependencies
 EDITABLE_DEPENDENCIES ?= false
 # If set to true, use tls for postgres connection
@@ -550,6 +552,7 @@ docker-compose-sources:
 	    -e vault_tls=$(VAULT_TLS) \
 	    -e enable_otel=$(OTEL) \
 	    -e enable_loki=$(LOKI) \
+	    -e enable_tempo=$(TEMPO) \
 	    -e install_editable_dependencies=$(EDITABLE_DEPENDENCIES) \
 	    -e pg_tls=$(PG_TLS) \
 	    $(EXTRA_SOURCES_ANSIBLE_OPTS)

--- a/awx/asgi.py
+++ b/awx/asgi.py
@@ -11,6 +11,8 @@ from channels.routing import get_default_application  # noqa
 
 prepare_env()  # NOQA
 
+from ansible_base.observability import setup_observability
+
 
 """
 ASGI config for AWX project.
@@ -33,6 +35,8 @@ if MODE == 'production':
         logger.error("Missing or incorrect metadata for controller version.  Ensure controller was installed using the setup playbook.")
         raise Exception("Missing or incorrect metadata for controller version.  Ensure controller was installed using the setup playbook.") from e
 
+
+setup_observability(service_name="aap-controller-daphne")
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "awx.settings")
 django.setup()

--- a/awx/main/dispatch/worker/dispatcherd.py
+++ b/awx/main/dispatch/worker/dispatcherd.py
@@ -1,14 +1,82 @@
-from dispatcherd.worker.task import TaskWorker
+from typing import Any
 
+from dispatcherd.worker.task import TaskWorker
 from django.db import connection
+from opentelemetry.trace import get_tracer, Status, StatusCode
+from ansible_base.observability import setup_observability
+
+
+tracer = get_tracer(__name__)
 
 
 class AWXTaskWorker(TaskWorker):
 
     def on_start(self) -> None:
-        """Get worker connected so that first task it gets will be worked quickly"""
+        """
+        Initialize worker process: database connection and observability.
+        Called once per worker process after fork.
+        """
+        # Initialize OpenTelemetry in this worker process
+        setup_observability(service_name="aap-controller-dispatcher")
+
+        # Get worker connected so that first task it gets will be worked quickly
         connection.ensure_connection()
 
     def pre_task(self, message) -> None:
         """This should remedy bad connections that can not fix themselves"""
         connection.close_if_unusable_or_obsolete()
+
+    def run_callable(self, message: dict) -> Any:
+        """
+        Import and execute a task with OpenTelemetry instrumentation.
+        Wraps task execution in a span with rich attributes.
+        """
+        task = message['task']
+        uuid = self.get_uuid(message)
+        args = message.get('args', [])
+        kwargs = message.get('kwargs', {})
+
+        # Extract task name components for span naming
+        # task = "awx.main.tasks.system.apply_cluster_membership_policies"
+        # Handle edge cases like lambda tasks or tasks without module paths
+        if '.' in task:
+            task_module, task_function = task.rsplit('.', 1)
+        else:
+            task_module = ""
+            task_function = task
+
+        # Normalize lambda broker tasks to stable name
+        # task = 'lambda: "broker_a89d6bc1_506a_4f37_8ce2_475f1291cc2c"' -> "broker_task"
+        if task_function.startswith('lambda:') and 'broker_' in task_function:
+            task_function = "broker_task"
+
+        # Create span with task function name (like HTTP route)
+        with tracer.start_as_current_span(task_function) as span:
+            # Set rich span attributes
+            span.set_attribute("task.name", task)
+            span.set_attribute("task.uuid", uuid)
+            span.set_attribute("task.module", task_module)
+            span.set_attribute("task.function", task_function)
+            span.set_attribute("task.args_count", len(args))
+            span.set_attribute("task.kwargs_count", len(kwargs))
+            span.set_attribute("task.worker_id", self.worker_id)
+
+            # Add correlation ID if available (from guid in message body)
+            if 'guid' in message:
+                span.set_attribute("correlation_id", message['guid'])
+
+            try:
+                # Call parent class implementation
+                result = super().run_callable(message)
+
+                # Mark span as successful
+                span.set_status(Status(StatusCode.OK))
+                return result
+
+            except Exception as e:
+                # Record exception in span
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                span.set_attribute("task.error_type", type(e).__name__)
+                span.set_attribute("task.error_message", str(e))
+                span.record_exception(e)
+                raise

--- a/awx/main/dispatch/worker/task.py
+++ b/awx/main/dispatch/worker/task.py
@@ -3,8 +3,10 @@ import importlib
 import time
 
 from django_guid import set_guid
+from opentelemetry.trace import get_tracer, Status, StatusCode
 
 logger = logging.getLogger('awx.main.dispatch')
+tracer = get_tracer(__name__)
 
 
 def resolve_callable(task):
@@ -33,17 +35,56 @@ def run_callable(body):
     uuid = body.get('uuid', '<unknown>')
     args = body.get('args', [])
     kwargs = body.get('kwargs', {})
-    if 'guid' in body:
-        set_guid(body.pop('guid'))
-    _call = resolve_callable(task)
-    log_extra = ''
-    logger_method = logger.debug
-    if 'time_pub' in body:
-        time_publish = time.time() - body['time_pub']
-        if time_publish > 5.0:
-            # If task too a very long time to process, add this information to the log
-            log_extra = f' took {time_publish:.4f} to send message'
-            logger_method = logger.info
-    # don't print kwargs, they often contain launch-time secrets
-    logger_method(f'task {uuid} starting {task}(*{args}){log_extra}')
-    return _call(*args, **kwargs)
+
+    # Extract task name components for span naming
+    # task = "awx.main.tasks.system.apply_cluster_membership_policies"
+    task_module, task_function = task.rsplit('.', 1)
+
+    # Create span with task function name (like HTTP route)
+    with tracer.start_as_current_span(task_function) as span:
+        # Set rich span attributes
+        span.set_attribute("task.name", task)
+        span.set_attribute("task.uuid", uuid)
+        span.set_attribute("task.module", task_module)
+        span.set_attribute("task.function", task_function)
+        span.set_attribute("task.args_count", len(args))
+        span.set_attribute("task.kwargs_count", len(kwargs))
+
+        # Add correlation ID if available
+        if 'guid' in body:
+            guid = body['guid']
+            span.set_attribute("correlation_id", guid)
+            set_guid(body.pop('guid'))
+
+        # Calculate message delay if publish time available
+        log_extra = ''
+        logger_method = logger.debug
+        if 'time_pub' in body:
+            time_publish = time.time() - body['time_pub']
+            delay_ms = time_publish * 1000
+            span.set_attribute("task.message_delay_ms", delay_ms)
+
+            if time_publish > 5.0:
+                # If task took a very long time to process, add this information to the log
+                log_extra = f' took {time_publish:.4f} to send message'
+                logger_method = logger.info
+
+        try:
+            # Resolve and execute task
+            _call = resolve_callable(task)
+            # don't print kwargs, they often contain launch-time secrets
+            logger_method(f'task {uuid} starting {task}(*{args}){log_extra}')
+
+            result = _call(*args, **kwargs)
+
+            # Mark span as successful
+            span.set_status(Status(StatusCode.OK))
+            return result
+
+        except Exception as e:
+            # Record exception in span
+            span.set_status(Status(StatusCode.ERROR, str(e)))
+            span.set_attribute("task.error_type", type(e).__name__)
+            span.set_attribute("task.error_message", str(e))
+            span.record_exception(e)
+            raise

--- a/awx/main/management/commands/dispatcherd.py
+++ b/awx/main/management/commands/dispatcherd.py
@@ -14,6 +14,7 @@ from django.db import connection
 
 from dispatcherd.config import setup as dispatcher_setup
 
+from ansible_base.observability import setup_observability
 from awx.main.dispatch.config import get_dispatcherd_config
 
 logger = logging.getLogger('awx.main.dispatch')
@@ -50,6 +51,7 @@ class Command(BaseCommand):
         return
 
     def handle(self, *arg, **options):
+        setup_observability(service_name="aap-controller-dispatcher")
         ensure_no_dispatcherd_env_config()
 
         self.configure_dispatcher_logging()

--- a/awx/main/management/commands/run_cache_clear.py
+++ b/awx/main/management/commands/run_cache_clear.py
@@ -3,6 +3,7 @@ import json
 
 from django.core.management.base import BaseCommand
 
+from ansible_base.observability import setup_observability
 from awx.main.dispatch import pg_bus_conn
 from awx.main.dispatch.worker.task import run_callable
 
@@ -18,6 +19,7 @@ class Command(BaseCommand):
     help = 'Launch the cache clear daemon'
 
     def handle(self, *arg, **options):
+        setup_observability(service_name="aap-controller-cache-clear")
         try:
             with pg_bus_conn() as conn:
                 conn.listen("tower_settings_change")

--- a/awx/main/management/commands/run_callback_receiver.py
+++ b/awx/main/management/commands/run_callback_receiver.py
@@ -6,6 +6,7 @@ import redis
 from django.core.management.base import BaseCommand, CommandError
 import redis.exceptions
 
+from ansible_base.observability import setup_observability
 from awx.main.analytics.subsystem_metrics import CallbackReceiverMetricsServer
 from awx.main.dispatch.worker import AWXConsumerRedis, CallbackBrokerWorker
 from awx.main.utils.redis import get_redis_client
@@ -24,6 +25,7 @@ class Command(BaseCommand):
         parser.add_argument('--status', dest='status', action='store_true', help='print the internal state of any running dispatchers')
 
     def handle(self, *arg, **options):
+        setup_observability(service_name="aap-controller-callback-receiver")
         if options.get('status'):
             print(self.status())
             return

--- a/awx/main/management/commands/run_rsyslog_configurer.py
+++ b/awx/main/management/commands/run_rsyslog_configurer.py
@@ -4,6 +4,8 @@ import json
 from django.core.management.base import BaseCommand
 from django.conf import settings
 from django.core.cache import cache
+
+from ansible_base.observability import setup_observability
 from awx.main.dispatch import pg_bus_conn
 from awx.main.dispatch.worker.task import run_callable
 from awx.main.utils.external_logging import reconfigure_rsyslog
@@ -21,6 +23,7 @@ class Command(BaseCommand):
     help = 'Launch the rsyslog_configurer daemon'
 
     def handle(self, *arg, **options):
+        setup_observability(service_name="aap-controller-rsyslog-configurer")
         try:
             with pg_bus_conn() as conn:
                 conn.listen("rsyslog_configurer")

--- a/awx/main/management/commands/run_ws_heartbeat.py
+++ b/awx/main/management/commands/run_ws_heartbeat.py
@@ -8,6 +8,7 @@ import sys
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
+from ansible_base.observability import setup_observability
 from awx.main.dispatch import pg_bus_conn
 
 logger = logging.getLogger('awx.main.commands.run_ws_heartbeat')
@@ -37,6 +38,7 @@ class Command(BaseCommand):
             time.sleep(settings.BROADCAST_WEBSOCKET_BEACON_FROM_WEB_RATE_SECONDS)
 
     def handle(self, *arg, **options):
+        setup_observability(service_name="aap-controller-heartbeat")
         signal.signal(signal.SIGTERM, self.notify_listener_and_exit)
         signal.signal(signal.SIGINT, self.notify_listener_and_exit)
 

--- a/awx/main/management/commands/run_wsrelay.py
+++ b/awx/main/management/commands/run_wsrelay.py
@@ -12,6 +12,7 @@ from django.core.management.base import BaseCommand
 from django.db import connection
 from django.db.migrations.executor import MigrationExecutor
 
+from ansible_base.observability import setup_observability
 from awx.main.analytics.broadcast_websocket import (
     RelayWebsocketStatsManager,
     safe_name,
@@ -91,6 +92,7 @@ class Command(BaseCommand):
         return host_stats
 
     def handle(self, *arg, **options):
+        setup_observability(service_name="aap-controller-wsrelay")
         # it's necessary to delay this import in case
         # database migrations are still running
         from awx.main.models.ha import Instance

--- a/awx/wsgi.py
+++ b/awx/wsgi.py
@@ -14,6 +14,8 @@ from django.conf import settings  # NOQA
 from django.urls import resolve  # NOQA
 from django.core.wsgi import get_wsgi_application  # NOQA
 
+from ansible_base.observability import setup_observability
+
 """
 WSGI config for AWX project.
 
@@ -35,6 +37,8 @@ if MODE == 'production':
         logger.error("Missing or incorrect metadata for controller version.  Ensure controller was installed using the setup playbook.")
         raise Exception("Missing or incorrect metadata for controller version.  Ensure controller was installed using the setup playbook.") from e
 
+
+setup_observability(service_name="aap-controller-uwsgi")
 
 # Return the default Django WSGI application.
 application = get_wsgi_application()

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -38,8 +38,8 @@ msrestazure
 OPA-python-client==2.0.2 # upgrading requires urllib3 2.5.0+ which is blocked by other deps
 kubernetes>=35.0.0
 openshift
-opentelemetry-api~=1.37     # new y streams can be drastically different, in a good way
-opentelemetry-sdk~=1.37
+opentelemetry-api>=1.39.0     # django-ansible-base[observability] requires LogRecordExporter added in 1.39.0
+opentelemetry-sdk>=1.39.0
 opentelemetry-instrumentation-logging
 opentelemetry-exporter-otlp
 pexpect

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,26 +1,29 @@
 adal==1.2.7
     # via msrestazure
-aiodns==3.5.0
+aiodns==4.0.4
     # via aiohttp
 aiofiles==24.1.0
     # via opa-python-client
-aiohappyeyeballs==2.6.1
+aiohappyeyeballs==2.6.2
     # via aiohttp
-aiohttp[speedups]==3.13.0
+aiohttp[speedups]==3.13.5
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   aiohttp-retry
+    #   kubernetes
     #   opa-python-client
     #   twilio
 aiohttp-retry==2.9.1
     # via twilio
 aiosignal==1.4.0
     # via aiohttp
+annotated-doc==0.0.4
+    # via typer
 ansi2html==1.9.2
     # via -r /awx_devel/requirements/requirements.in
 # ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel  # git requirements installed separately
     # via -r /awx_devel/requirements/requirements_git.txt
-asgiref==3.11.0
+asgiref==3.11.1
     # via
     #   channels
     #   channels-redis
@@ -28,19 +31,17 @@ asgiref==3.11.0
     #   django
     #   django-ansible-base
     #   django-cors-headers
-asn1==3.1.0
+asn1==3.3.0
     # via -r /awx_devel/requirements/requirements.in
-attrs==25.4.0
+attrs==26.1.0
     # via
     #   aiohttp
     #   jsonschema
     #   referencing
     #   service-identity
     #   twisted
-autobahn==24.4.2
+autobahn==25.12.2
     # via daphne
-autocommand==2.2.2
-    # via jaraco-text
 automat==25.4.16
     # via twisted
 # awx-plugins-core[credentials-github-app] @ git+https://github.com/ansible/awx-plugins.git@devel  # git requirements installed separately
@@ -49,34 +50,40 @@ automat==25.4.16
     # via
     #   -r /awx_devel/requirements/requirements_git.txt
     #   awx-plugins-core
-azure-core==1.35.1
+azure-core==1.41.0
     # via
     #   azure-identity
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
     #   msrest
-azure-identity==1.25.1
+azure-identity==1.25.3
     # via -r /awx_devel/requirements/requirements.in
 azure-keyvault==4.2.0
     # via -r /awx_devel/requirements/requirements.in
-azure-keyvault-certificates==4.10.0
+azure-keyvault-certificates==4.11.1
     # via azure-keyvault
-azure-keyvault-keys==4.11.0
+azure-keyvault-keys==4.11.1
     # via azure-keyvault
-azure-keyvault-secrets==4.10.0
+azure-keyvault-secrets==4.11.0
     # via azure-keyvault
-boto3==1.40.46
+backports-zstd==1.5.0
+    # via
+    #   aiohttp
+    #   pyzstd
+boto3==1.43.14
     # via -r /awx_devel/requirements/requirements.in
-botocore==1.40.46
+botocore==1.43.14
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   boto3
     #   s3transfer
-brotli==1.1.0
+brotli==1.2.0
     # via aiohttp
-cachetools==6.2.0
+cachetools==7.1.4
     # via -r /awx_devel/requirements/requirements.in
+cbor2==6.1.1
+    # via autobahn
 # certifi @ git+https://github.com/ansible/system-certifi.git@devel  # git requirements installed separately
     # via
     #   -r /awx_devel/requirements/requirements_git.txt
@@ -85,22 +92,25 @@ cachetools==6.2.0
     #   requests
 cffi==2.0.0
     # via
+    #   autobahn
     #   cryptography
     #   pycares
     #   pynacl
-channels==4.3.1
+channels==4.3.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels-redis
 channels-redis==4.3.0
     # via -r /awx_devel/requirements/requirements.in
-charset-normalizer==3.4.3
+charset-normalizer==3.4.7
     # via requests
-click==8.1.8
-    # via receptorctl
+click==8.3.3
+    # via
+    #   receptorctl
+    #   typer
 constantly==23.10.4
     # via twisted
-cryptography==46.0.3
+cryptography==48.0.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   adal
@@ -112,7 +122,7 @@ cryptography==46.0.3
     #   pyjwt
     #   pyopenssl
     #   service-identity
-cython==3.1.3
+cython==3.2.4
     # via -r /awx_devel/requirements/requirements.in
 daphne==4.2.1
     # via -r /awx_devel/requirements/requirements.in
@@ -120,7 +130,7 @@ dispatcherd[pg-notify]==2026.3.25
     # via -r /awx_devel/requirements/requirements.in
 distro==1.9.0
     # via -r /awx_devel/requirements/requirements.in
-django==5.2.8
+django==5.2.14
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels
@@ -134,7 +144,7 @@ django==5.2.8
     #   django-solo
     #   djangorestframework
     #   drf-spectacular
-# django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel  # git requirements installed separately
+# django-ansible-base[feature-flags,jwt-consumer,observability,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel  # git requirements installed separately
     # via -r /awx_devel/requirements/requirements_git.txt
 django-cors-headers==4.9.0
     # via -r /awx_devel/requirements/requirements.in
@@ -144,15 +154,15 @@ django-crum==0.7.9
     #   django-ansible-base
 django-extensions==4.1
     # via -r /awx_devel/requirements/requirements.in
-django-flags==5.1.0
+django-flags==5.2.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django-ansible-base
-django-guid==3.5.2
+django-guid==3.6.1
     # via -r /awx_devel/requirements/requirements.in
-django-polymorphic==4.1.0
+django-polymorphic==4.11.3
     # via -r /awx_devel/requirements/requirements.in
-django-solo==2.4.0
+django-solo==2.5.1
     # via -r /awx_devel/requirements/requirements.in
 djangorestframework==3.15.2
     # via
@@ -165,13 +175,13 @@ drf-spectacular==0.29.0
     # via -r /awx_devel/requirements/requirements.in
 durationpy==0.10
     # via kubernetes
-dynaconf==3.2.12
+dynaconf==3.2.13
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django-ansible-base
 enum-compat==0.0.3
     # via asn1
-filelock==3.19.1
+filelock==3.29.0
     # via -r /awx_devel/requirements/requirements.in
 frozenlist==1.8.0
     # via
@@ -179,32 +189,30 @@ frozenlist==1.8.0
     #   aiosignal
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.45
+gitpython==3.1.50
     # via -r /awx_devel/requirements/requirements.in
-googleapis-common-protos==1.70.0
+googleapis-common-protos==1.75.0
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.75.1
+grpcio==1.80.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   opentelemetry-exporter-otlp-proto-grpc
-hiredis==3.2.1
+hiredis==3.3.1
     # via redis
 hyperlink==21.0.0
     # via
     #   autobahn
     #   twisted
-idna==3.10
+idna==3.16
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   hyperlink
     #   requests
     #   twisted
     #   yarl
-importlib-metadata==8.7.0
-    # via opentelemetry-api
-incremental==24.7.2
+incremental==24.11.0
     # via twisted
 inflection==0.5.1
     # via
@@ -219,10 +227,14 @@ isodate==0.7.2
     #   azure-keyvault-secrets
     #   msrest
 jaraco-collections==5.2.1
-    # via irc
-jaraco-context==6.0.1
-    # via jaraco-text
-jaraco-functools==4.3.0
+    # via
+    #   irc
+    #   tempora
+jaraco-context==6.1.2
+    # via
+    #   jaraco-text
+    #   tempora
+jaraco-functools==4.5.0
     # via
     #   irc
     #   jaraco-text
@@ -231,59 +243,65 @@ jaraco-logging==3.4.0
     # via irc
 jaraco-stream==3.0.4
     # via irc
-jaraco-text==4.0.0
+jaraco-text==4.2.0
     # via
     #   irc
     #   jaraco-collections
 jinja2==3.1.6
     # via -r /awx_devel/requirements/requirements.in
-jmespath==1.0.1
+jmespath==1.1.0
     # via
     #   boto3
     #   botocore
-jq==1.10.0
+jq==1.11.0
     # via -r /awx_devel/requirements/requirements.in
 json-log-formatter==1.1.1
     # via -r /awx_devel/requirements/requirements.in
-jsonschema==4.25.1
+jsonschema==4.26.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   drf-spectacular
 jsonschema-specifications==2025.9.1
     # via jsonschema
-kubernetes==35.0.0
+kubernetes==36.0.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   openshift
 lockfile==0.12.2
     # via python-daemon
-markdown==3.9
+markdown==3.10.2
     # via -r /awx_devel/requirements/requirements.in
+markdown-it-py==4.2.0
+    # via rich
 markupsafe==3.0.3
     # via jinja2
-maturin==1.9.6
+maturin==1.13.3
     # via -r /awx_devel/requirements/requirements.in
-more-itertools==10.8.0
+mdurl==0.1.2
+    # via markdown-it-py
+more-itertools==11.1.0
     # via
     #   irc
     #   jaraco-functools
     #   jaraco-stream
     #   jaraco-text
-msal==1.34.0
+    #   tempora
+msal==1.36.0
     # via
     #   azure-identity
     #   msal-extensions
 msal-extensions==1.3.1
     # via azure-identity
-msgpack==1.1.1
+msgpack==1.1.2
     # via
     #   -r /awx_devel/requirements/requirements.in
+    #   autobahn
     #   channels-redis
 msrest==0.7.1
     # via msrestazure
 msrestazure==0.6.4.post1
     # via -r /awx_devel/requirements/requirements.in
-multidict==6.7.0
+multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
@@ -293,102 +311,156 @@ opa-python-client==2.0.2
     # via -r /awx_devel/requirements/requirements.in
 openshift==0.13.2
     # via -r /awx_devel/requirements/requirements.in
-opentelemetry-api==1.37.0
+opentelemetry-api==1.42.1
     # via
     #   -r /awx_devel/requirements/requirements.in
+    #   django-ansible-base
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-grpc
     #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-psycopg
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
-opentelemetry-exporter-otlp==1.37.0
+opentelemetry-exporter-otlp==1.42.1
     # via -r /awx_devel/requirements/requirements.in
-opentelemetry-exporter-otlp-proto-common==1.37.0
+opentelemetry-exporter-otlp-proto-common==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-grpc==1.37.0
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
+    # via
+    #   django-ansible-base
+    #   opentelemetry-exporter-otlp
+opentelemetry-exporter-otlp-proto-http==1.42.1
     # via opentelemetry-exporter-otlp
-opentelemetry-exporter-otlp-proto-http==1.37.0
-    # via opentelemetry-exporter-otlp
-opentelemetry-instrumentation==0.58b0
-    # via opentelemetry-instrumentation-logging
-opentelemetry-instrumentation-logging==0.58b0
-    # via -r /awx_devel/requirements/requirements.in
-opentelemetry-proto==1.37.0
+opentelemetry-instrumentation==0.63b1
+    # via
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-psycopg
+    #   opentelemetry-instrumentation-psycopg2
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-dbapi==0.63b1
+    # via
+    #   opentelemetry-instrumentation-psycopg
+    #   opentelemetry-instrumentation-psycopg2
+opentelemetry-instrumentation-django==0.63b1
+    # via django-ansible-base
+opentelemetry-instrumentation-grpc==0.63b1
+    # via django-ansible-base
+opentelemetry-instrumentation-logging==0.63b1
+    # via
+    #   -r /awx_devel/requirements/requirements.in
+    #   django-ansible-base
+opentelemetry-instrumentation-psycopg==0.63b1
+    # via django-ansible-base
+opentelemetry-instrumentation-psycopg2==0.63b1
+    # via django-ansible-base
+opentelemetry-instrumentation-requests==0.63b1
+    # via django-ansible-base
+opentelemetry-instrumentation-wsgi==0.63b1
+    # via opentelemetry-instrumentation-django
+opentelemetry-proto==1.42.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.37.0
+opentelemetry-sdk==1.42.1
     # via
     #   -r /awx_devel/requirements/requirements.in
+    #   django-ansible-base
     #   opentelemetry-exporter-otlp-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-semantic-conventions==0.58b0
+opentelemetry-semantic-conventions==0.63b1
     # via
     #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-grpc
+    #   opentelemetry-instrumentation-logging
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-wsgi
     #   opentelemetry-sdk
-packaging==25.0
+opentelemetry-util-http==0.63b1
+    # via
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-requests
+    #   opentelemetry-instrumentation-wsgi
+packaging==26.2
     # via
     #   ansible-runner
     #   django-guid
+    #   incremental
     #   opentelemetry-instrumentation
     #   setuptools-scm
+    #   vcs-versioning
     #   wheel
 pexpect==4.9.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   ansible-runner
-pkgconfig==1.5.5
+pkgconfig==1.6.0
     # via -r /awx_devel/requirements/requirements.in
-prometheus-client==0.23.1
+prometheus-client==0.25.0
     # via -r /awx_devel/requirements/requirements.in
-propcache==0.4.1
+propcache==0.5.2
     # via
     #   aiohttp
     #   yarl
-protobuf==6.32.1
+protobuf==6.33.6
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   googleapis-common-protos
     #   opentelemetry-proto
-psutil==7.1.0
+psutil==7.2.2
     # via -r /awx_devel/requirements/requirements.in
-psycopg==3.2.10
+psycopg==3.3.4
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   dispatcherd
 ptyprocess==0.7.0
     # via pexpect
-pyasn1==0.6.2
+py-ubjson==0.16.1
+    # via autobahn
+pyasn1==0.6.3
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   pyasn1-modules
     #   service-identity
 pyasn1-modules==0.4.2
     # via service-identity
-pycares==4.11.0
+pycares==5.0.1
     # via aiodns
-pycparser==2.23
+pycparser==3.0
     # via cffi
 pygerduty==0.38.3
     # via -r /awx_devel/requirements/requirements.in
-pygithub==2.8.1
+pygithub==2.9.1
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   awx-plugins-core
-pyjwt[crypto]==2.10.1
+pygments==2.20.0
+    # via rich
+pyjwt[crypto]==2.13.0
     # via
     #   adal
     #   django-ansible-base
     #   msal
     #   pygithub
     #   twilio
-pynacl==1.6.0
+pynacl==1.6.2
     # via pygithub
-pyopenssl==25.3.0
+pyopenssl==26.2.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   twisted
@@ -409,9 +481,9 @@ python-dsv-sdk==1.0.4
     # via -r /awx_devel/requirements/requirements.in
 python-string-utils==1.0.0
     # via openshift
-python-tss-sdk==2.0.0
+python-tss-sdk==2.0.1
     # via -r /awx_devel/requirements/requirements.in
-pytz==2025.2
+pytz==2026.2
     # via irc
 pyyaml==6.0.3
     # via
@@ -422,19 +494,19 @@ pyyaml==6.0.3
     #   drf-spectacular
     #   kubernetes
     #   receptorctl
-pyzstd==0.18.0
+pyzstd==0.19.1
     # via -r /awx_devel/requirements/requirements.in
-receptorctl==1.6.0
+receptorctl==1.6.5
     # via -r /awx_devel/requirements/requirements.in
-redis[hiredis]==7.0.1
+redis[hiredis]==7.4.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   channels-redis
-referencing==0.36.2
+referencing==0.37.0
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.5
+requests==2.34.2
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   adal
@@ -454,49 +526,56 @@ requests-oauthlib==2.0.0
     # via
     #   kubernetes
     #   msrest
-rpds-py==0.27.1
+rich==15.0.0
+    # via typer
+rpds-py==0.30.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.14.0
+s3transfer==0.17.0
     # via boto3
 semantic-version==2.10.0
     # via setuptools-rust
 service-identity==24.2.0
     # via twisted
-setuptools-rust==1.10.2
+setuptools-rust==1.12.1
     # via -r /awx_devel/requirements/requirements.in
-setuptools-scm[toml]==9.2.2
+setuptools-scm[toml]==10.0.5
     # via -r /awx_devel/requirements/requirements.in
+shellingham==1.5.4
+    # via typer
 six==1.17.0
     # via
-    #   azure-core
     #   kubernetes
     #   msrestazure
     #   openshift
     #   pygerduty
     #   python-dateutil
-slack-sdk==3.37.0
+slack-sdk==3.42.0
     # via -r /awx_devel/requirements/requirements.in
-smmap==5.0.2
+smmap==5.0.3
     # via gitdb
-sqlparse==0.5.3
+sqlparse==0.5.5
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   django
     #   django-ansible-base
-tempora==5.8.1
+tempora==5.9.0
     # via
     #   irc
     #   jaraco-logging
-twilio==9.8.3
+twilio==9.10.9
     # via -r /awx_devel/requirements/requirements.in
-twisted[tls]==25.5.0
+twisted[tls]==26.4.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   daphne
-txaio==25.9.2
+txaio==25.12.2
     # via autobahn
+typer==0.25.1
+    # via typer-slim
+typer-slim==0.24.0
+    # via jaraco-text
 typing-extensions==4.15.0
     # via
     #   aiosignal
@@ -505,6 +584,7 @@ typing-extensions==4.15.0
     #   azure-keyvault-certificates
     #   azure-keyvault-keys
     #   azure-keyvault-secrets
+    #   django-polymorphic
     #   grpcio
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-grpc
@@ -517,9 +597,11 @@ typing-extensions==4.15.0
     #   pyzstd
     #   referencing
     #   twisted
+ujson==5.12.1
+    # via autobahn
 uritemplate==4.2.0
     # via drf-spectacular
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r /awx_devel/requirements/requirements.in
     #   botocore
@@ -527,24 +609,25 @@ urllib3==2.6.3
     #   kubernetes
     #   pygithub
     #   requests
-uwsgi==2.0.30
+uwsgi==2.0.31
     # via -r /awx_devel/requirements/requirements.in
 uwsgitop==0.12
     # via -r /awx_devel/requirements/requirements.in
-websocket-client==1.8.0
+vcs-versioning==1.1.1
+    # via setuptools-scm
+websocket-client==1.9.0
     # via kubernetes
-wheel==0.46.3
+wheel==0.47.0
     # via -r /awx_devel/requirements/requirements.in
-wrapt==1.17.3
-    # via opentelemetry-instrumentation
-yarl==1.22.0
+wrapt==2.2.1
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-dbapi
+    #   opentelemetry-instrumentation-grpc
+yarl==1.24.2
     # via aiohttp
-zipp==3.23.0
-    # via importlib-metadata
-zope-interface==8.0.1
+zope-interface==8.4
     # via twisted
-zstandard==0.25.0
-    # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.3
@@ -552,7 +635,5 @@ pip==25.3
 setuptools==80.9.0
     # via
     #   -r /awx_devel/requirements/requirements.in
-    #   autobahn
-    #   incremental
     #   setuptools-rust
     #   setuptools-scm

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -20,5 +20,5 @@
 certifi @ git+https://github.com/ansible/system-certifi.git@devel
 ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel
 awx-plugins-core[credentials-github-app] @ git+https://github.com/ansible/awx-plugins.git@devel
-django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel
+django-ansible-base[feature-flags,jwt-consumer,observability,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel
 awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git

--- a/tools/docker-compose/ansible/roles/sources/defaults/main.yml
+++ b/tools/docker-compose/ansible/roles/sources/defaults/main.yml
@@ -45,6 +45,11 @@ enable_grafana: false
 enable_prometheus: false
 scrape_interval: '5s'
 
+# Observability
+enable_otel: false
+enable_loki: false
+enable_tempo: false
+
 # pgbouncer
 enable_pgbouncer: false
 pgbouncer_port: 6432

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -180,6 +180,7 @@ services:
     volumes:
       - "../../grafana:/etc/grafana/provisioning"
       - "grafana_storage:/var/lib/grafana:rw"
+{% if enable_prometheus|bool or enable_loki|bool or enable_tempo|bool %}
     depends_on:
 {% if enable_prometheus|bool %}
       - prometheus
@@ -189,6 +190,7 @@ services:
 {% endif %}
 {% if enable_tempo|bool %}
       - tempo
+{% endif %}
 {% endif %}
 {% endif %}
   postgres:

--- a/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
+++ b/tools/docker-compose/ansible/roles/sources/templates/docker-compose.yml.j2
@@ -49,6 +49,10 @@ services:
 {% if minikube_container_group|bool %}
       MINIKUBE_CONTAINER_GROUP: "true"
 {% endif %}
+{% if enable_otel|bool %}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel:4317
+      OTEL_SERVICE_NAME: aap-controller
+{% endif %}
     networks:
       - awx
       - service-mesh
@@ -162,18 +166,30 @@ services:
 {% endif %}
 {% if enable_grafana|bool %}
   grafana:
-    image: mirror.gcr.io/grafana/grafana-enterprise:12.3.4
+    image: docker.io/grafana/grafana:latest
     container_name: tools_grafana_1
     hostname: grafana
     networks:
       - awx
+      - service-mesh
     ports:
       - "3001:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
     volumes:
       - "../../grafana:/etc/grafana/provisioning"
       - "grafana_storage:/var/lib/grafana:rw"
     depends_on:
+{% if enable_prometheus|bool %}
       - prometheus
+{% endif %}
+{% if enable_loki|bool %}
+      - loki
+{% endif %}
+{% if enable_tempo|bool %}
+      - tempo
+{% endif %}
 {% endif %}
   postgres:
     image: quay.io/sclorg/postgresql-15-c9s
@@ -224,33 +240,58 @@ services:
 {% endif %}
 {% if enable_otel|bool %}
   otel:
-    image: mirror.gcr.io/otel/opentelemetry-collector-contrib:0.88.0
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
     container_name: tools_otel_1
     hostname: otel
-    command: ["--config=/etc/otel-collector-config.yaml", ""]
+    command: ["--config=/etc/otel/otel-collector-config.yaml"]
     networks:
       - awx
+      - service-mesh
     ports:
       - "4317:4317"   # OTLP gRPC receiver
       - "4318:4318"   # OTLP http receiver
-      - "55679:55679" # zpages http://localhost:55679/debug/servicez /tracez
+      - "8889:8889"   # Prometheus metrics
     volumes:
-      - "../../otel/otel-collector-config.yaml:/etc/otel-collector-config.yaml"
-      - "../../otel/awx-logs:/awx-logs/"
+      - "../../otel/otel-collector-config.yaml:/etc/otel/otel-collector-config.yaml:ro"
+{% if enable_loki|bool or enable_tempo|bool %}
+    depends_on:
+{% if enable_loki|bool %}
+      - loki
+{% endif %}
+{% if enable_tempo|bool %}
+      - tempo
+{% endif %}
+{% endif %}
 {% endif %}
 {% if enable_loki|bool %}
   loki:
-    image: mirror.gcr.io/grafana/loki:2.9.5
+    image: docker.io/grafana/loki:latest
     container_name: tools_loki_1
     hostname: loki
     ports:
       - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yaml
+    command: ["-config.file=/etc/loki/local-config.yaml"]
     networks:
       - awx
+      - service-mesh
     volumes:
       - "loki_storage:/loki:rw"
-      - "../../loki/local-config.yaml:/etc/loki/local-config.yaml"
+      - "../../loki/local-config.yaml:/etc/loki/local-config.yaml:ro"
+{% endif %}
+{% if enable_tempo|bool %}
+  tempo:
+    image: docker.io/grafana/tempo:latest
+    container_name: tools_tempo_1
+    hostname: tempo
+    ports:
+      - "3200:3200"
+    command: ["-config.file=/etc/tempo/tempo-config.yaml"]
+    networks:
+      - awx
+      - service-mesh
+    volumes:
+      - "tempo_storage:/var/tempo:rw"
+      - "../../tempo/tempo-config.yaml:/etc/tempo/tempo-config.yaml:ro"
 {% endif %}
 
 {% if execution_node_count|int > 0 %}
@@ -338,6 +379,10 @@ volumes:
 {% if enable_loki|bool %}
   loki_storage:
     name: tools_loki_storage
+{% endif %}
+{% if enable_tempo|bool %}
+  tempo_storage:
+    name: tools_tempo_storage
 {% endif %}
 
 networks:

--- a/tools/grafana/datasources/tempo_source.yml
+++ b/tools/grafana/datasources/tempo_source.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    jsonData:
+      httpMethod: GET
+      tracesToLogs:
+        datasourceUid: 'P8E80F9AEF21F6940'
+        # Map trace attributes to Loki log labels
+        mapTagNamesEnabled: true
+        mappedTags:
+          - key: 'service.name'
+            value: 'service_name'
+          - key: 'service.instance.id'
+            value: 'service_instance_id'
+        # Include trace/span IDs in log query if available
+        filterByTraceID: true
+        filterBySpanID: true
+        # Expand time range to catch logs around span boundaries
+        spanStartTimeShift: '-5m'
+        spanEndTimeShift: '5m'
+      nodeGraph:
+        enabled: true
+      search:
+        hide: false
+      serviceMap:
+        datasourceUid: 'awx_prometheus'

--- a/tools/loki/local-config.yaml
+++ b/tools/loki/local-config.yaml
@@ -6,7 +6,7 @@ server:
   grpc_server_max_send_msg_size: 524288000 # 500 MB, might be too much, be careful
 
 frontend_worker:
-  match_max_concurrent: true
+  # match_max_concurrent: true  # Removed - not supported in newer Loki versions
   grpc_client_config:
     max_send_msg_size: 524288000 # 500 MB
 
@@ -32,23 +32,24 @@ common:
 
 schema_config:
   configs:
-    - from: 2020-10-24
-      store: boltdb-shipper
+    - from: 2024-01-01
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h
 
 storage_config:
-  boltdb_shipper:
-    active_index_directory: /loki/index
-    cache_location: /loki/boltdb-cache
+  tsdb_shipper:
+    active_index_directory: /loki/tsdb-index
+    cache_location: /loki/tsdb-cache
 
 ruler:
   alertmanager_url: http://localhost:9093
 
 limits_config:
+  allow_structured_metadata: true  # Required for schema v13 and OTLP ingestion
   retention_period: 3y
   # cmeyers: The default of 30m triggers a loop of queries that take a long time
   # to complete and the UI times out
@@ -80,7 +81,7 @@ query_scheduler:
 
 query_range:
   parallelise_shardable_queries: false
-  split_queries_by_interval: 0
+  # split_queries_by_interval: 0  # Removed - not supported in newer Loki versions
 
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
 # analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/

--- a/tools/otel/otel-collector-config.yaml
+++ b/tools/otel/otel-collector-config.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: "0.0.0.0:4317"
       http:
+        endpoint: "0.0.0.0:4318"
 
 exporters:
   debug:
@@ -18,17 +20,18 @@ exporters:
     format: json
     compression: zstd
 
-  loki:
-    endpoint: http://loki:3100/loki/api/v1/push
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
     tls:
       insecure: true
-    headers:
-      "X-Scope-OrgID": "1"
-    default_labels_enabled:
-      exporter: true
-      job: true
-      instance: true
-      level: true
+
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+  prometheus:
+    endpoint: "0.0.0.0:8889"
 
 processors:
   batch:
@@ -43,7 +46,17 @@ service:
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [file, loki]
+      exporters: [otlphttp/loki]
+
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]
+
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
 
   extensions:
     - health_check


### PR DESCRIPTION
##### SUMMARY
Adds comprehensive OpenTelemetry instrumentation to AWX for distributed tracing and observability.

**Code Instrumentation:**
- Dispatcher: Task execution spans with function names, UUIDs, correlation IDs, exception tracking
- Management commands: Observability for dispatcherd, cache_clear, callback_receiver, rsyslog_configurer, ws_heartbeat, wsrelay
- ASGI/WSGI entry points: Request tracing

**Infrastructure:**
- Add Tempo trace storage backend to docker-compose
- Configure OTEL collector to route logs→Loki, traces→Tempo, metrics→Prometheus
- Add Grafana Tempo datasource with traces-to-logs integration
- Update Loki config for OTLP ingestion and structured metadata

**Dependencies:**
- Upgrade ansible-base for observability utilities
- Add opentelemetry-* tracing packages

##### ISSUE TYPE
New or Enhanced Feature

##### COMPONENT NAME
- API
- Other (Dispatcher, Management Commands, Observability Stack)

##### STEPS TO REPRODUCE AND EXTRA INFO

**Usage:**
```bash
OTEL=1 LOKI=1 TEMPO=1 GRAFANA=1 make docker-compose
```

**Verification:**
1. Start AWX with observability enabled
2. Trigger dispatcher tasks (visit UI, wait for periodic tasks)
3. Query Tempo: `curl -s "http://localhost:3200/api/search?tags=service.name=aap-controller-dispatcher" | jq`
4. View in Grafana at http://localhost:3001
   - Explore → Tempo datasource
   - Search for service: `aap-controller-dispatcher`
   - Verify span names = task function names
   - Verify attributes: task.uuid, task.name, task.module, correlation_id
   - Click trace→logs link to see correlated logs

**Before:**
- No dispatcher tracing
- No trace correlation with logs
- Limited observability into async task execution

**After:**
- Rich dispatcher spans with function names as routes
- Full trace→log correlation via service.name and trace/span IDs
- Exception tracking in spans
- Metrics exported to Prometheus
