### PR TITLE
Fix input_inventories lookup for duplicate inventory names across organizations

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -513,8 +513,8 @@ class ControllerAPIModule(ControllerModule):
     def get_exactly_one(self, endpoint, name_or_id=None, **kwargs):
         return self.get_one(endpoint, name_or_id=name_or_id, allow_none=False, **kwargs)
 
-    def resolve_name_to_id(self, endpoint, name_or_id):
-        return self.get_exactly_one(endpoint, name_or_id)['id']
+    def resolve_name_to_id(self, endpoint, name_or_id, **kwargs):
+        return self.get_exactly_one(endpoint, name_or_id, **kwargs)['id']
 
     def is_retryable(self, status_code, method, endpoint):
         """

--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -221,7 +221,7 @@ def main():
         if input_inventory_names is not None:
             association_fields['input_inventories'] = []
             for item in input_inventory_names:
-                association_fields['input_inventories'].append(module.resolve_name_to_id('inventories', item))
+                association_fields['input_inventories'].append(module.resolve_name_to_id('inventories', item, data={'organization': org_id}))
 
     # If the state was present and we can let the module build or update the existing inventory, this will return on its own
     module.create_or_update_if_needed(

--- a/awx_collection/test/awx/test_inventory.py
+++ b/awx_collection/test/awx/test_inventory.py
@@ -4,7 +4,7 @@ __metaclass__ = type
 
 import pytest
 
-from awx.main.models import Inventory
+from awx.main.models import Inventory, Organization
 
 
 @pytest.mark.django_db
@@ -58,3 +58,30 @@ def test_valid_smart_inventory_create(run_module, admin_user, organization):
     assert inv.host_filter == 'name=my_host'
     assert inv.kind == 'smart'
     assert inv.organization_id == organization.id
+
+
+@pytest.mark.django_db
+def test_constructed_inventory_input_inventories_with_duplicate_names(run_module, admin_user, organization):
+    org_b = Organization.objects.create(name='org-b')
+
+    Inventory.objects.create(name='shared-inv-name', organization=organization)
+    Inventory.objects.create(name='shared-inv-name', organization=org_b)
+
+    result = run_module(
+        'inventory',
+        {
+            'name': 'my-constructed-inventory',
+            'organization': organization.name,
+            'kind': 'constructed',
+            'input_inventories': ['shared-inv-name'],
+            'state': 'present',
+        },
+        admin_user,
+    )
+    assert not result.get('failed', False), result.get('msg', result)
+
+    constructed = Inventory.objects.get(name='my-constructed-inventory')
+    assert constructed.kind == 'constructed'
+    assert constructed.organization_id == organization.id
+    assert list(constructed.input_inventories.values_list('name', flat=True)) == ['shared-inv-name']
+    assert constructed.input_inventories.first().organization_id == organization.id


### PR DESCRIPTION
##### SUMMARY

Fix inventory `input_inventories` resolution when inventory names are duplicated across organizations.

Previously, `input_inventories` names were resolved using an unscoped inventory lookup:

```python
module.resolve_name_to_id('inventories', item)
````

If multiple organizations contained inventories with the same name, the lookup returned multiple results and failed with an ambiguous match error.

This change scopes `input_inventories` resolution to the same organization as the constructed inventory by passing:

```python
data={'organization': org_id}
```

Additionally, `resolve_name_to_id()` now forwards optional keyword arguments to `get_exactly_one()`, allowing scoped lookups while remaining fully backward compatible with existing callers.

A regression test has been added to cover inventories with duplicate names across organizations.

related #16393

##### ISSUE TYPE

* Bug, Docs Fix or other nominal change

##### COMPONENT NAME

* Collection

##### STEPS TO REPRODUCE AND EXTRA INFO

Create two organizations (`org-a` and `org-b`) and create an inventory with the same name in both organizations.

Create a constructed inventory in `org-a` referencing the inventory by name:

```yaml
- name: Create constructed inventory
  awx.awx.inventory:
    name: my-constructed-inventory
    organization: org-a
    kind: constructed
    input_inventories:
      - my-inventory
    state: present
```

Before this change, the inventory lookup was not scoped to an organization and failed when duplicate inventory names existed:

```
Request to /api/v2/inventories/?name=my-inventory returned 2 items, expected 1
```

After this change, the lookup is scoped to the constructed inventory's organization and resolves successfully.

Regression test added:

```
test_constructed_inventory_input_inventories_with_duplicate_names
```

Validation:

```
$ python -m pytest awx_collection/test/awx/test_inventory.py -v

4 passed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved constructed inventory input resolution to correctly match inventories when the same name exists across multiple organizations by enforcing organization-scoped lookups.

* **Tests**
  * Added test to verify constructed inventories correctly resolve input inventories with duplicate names across organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->