### PR TITLE
fix: invalid renovate config to bump tekton pipeline bundles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "packageRules": [
-    {
-      "description": "Update aap-ci tekton-catalog pipeline bundles",
-      "matchPackageNames": ["/^quay\\.io\\/aap-ci\\/tekton-catalog\\/pipeline\\//"],
-      "matchManagers": ["tekton"],
-      "automerge": true
-    }
-  ]
+  "enabledManagers": ["tekton"],
+  "tekton": {
+    "schedule": ["0 * * * *"],
+    "packageRules": [
+      {
+        "description": "Update aap-ci tekton-catalog pipeline bundles",
+        "matchPackageNames": ["/^quay\\.io\\/aap-ci\\/tekton-catalog\\/pipeline\\/"],
+        "matchManagers": ["tekton"],
+        "automerge": true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR updates the renovate configuration to enable mint maker to automatically send PRs for updating the tekton pipeline bundles.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified dependency-management configuration for Tekton pipeline bundles by updating the package-matching pattern to consistently target pipeline package paths. Manager selection and automerge behavior remain unchanged.
  * No changes to public APIs or runtime behavior; only configuration adjustments to package-matching logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->