### PR TITLE
chore: bump ATF pipeline bundle sha

### DIFF
--- a/.tekton/run-atf-tests-pull-request.yaml
+++ b/.tekton/run-atf-tests-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
       - name: name
         value: aap-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:54d9e941748bae94b2154b3b253a985e628751dfa4508a138d9b05f74a3c1ddf
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:50aadd6725a239ab53247deb7cf601d1163ceb1792792fd239a3f37d21a490d7
       - name: kind
         value: pipeline
       - name: secret


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR updates the run atf tekton pipeline bundle sha ahead of mint maker to unblock pipelines when deploying aap-dev.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->