### PR TITLE
[AAP-76643] Prevent uWSGI zombie workers after transient DB outage

### DIFF
--- a/awx/main/utils/migration.py
+++ b/awx/main/utils/migration.py
@@ -1,14 +1,22 @@
+import logging
+
 from django.db.migrations.executor import MigrationExecutor
 from django.db import connections, DEFAULT_DB_ALIAS
 
+logger = logging.getLogger('awx.main.utils.migration')
+
 
 def is_database_synchronized(database=DEFAULT_DB_ALIAS):
-    """_summary_
-    Ensure all migrations have ran
+    """Check if all migrations have been applied.
+    Returns False if the database is unreachable.
     https://stackoverflow.com/questions/31838882/check-for-pending-django-migrations
     """
-    connection = connections[database]
-    connection.prepare_database()
-    executor = MigrationExecutor(connection)
-    targets = executor.loader.graph.leaf_nodes()
-    return not executor.migration_plan(targets)
+    try:
+        connection = connections[database]
+        connection.prepare_database()
+        executor = MigrationExecutor(connection)
+        targets = executor.loader.graph.leaf_nodes()
+        return not executor.migration_plan(targets)
+    except Exception:
+        logger.warning("Database unavailable, assuming not synchronized.")
+        return False


### PR DESCRIPTION
## Summary

- `is_database_synchronized()` now returns `False` instead of raising when the database is unreachable during uWSGI worker startup
- Prevents the permanent `app: -1` zombie state that required manual pod restarts after transient DB outages

## Root Cause

When a uWSGI worker respawns while PostgreSQL is unavailable, `AppConfig.ready()` calls `is_database_synchronized()` which queries the DB. The resulting `OperationalError` prevents the WSGI app from loading, and uWSGI never retries — the worker permanently returns 500s even after the DB recovers.

## Steps to reproduce
1. shell into docker tools_awx_1 and set uwsgi.ini processes=1 (from default 5) and restart uwsgi
2. kill postgres with `docker-compose stop tools_postgres_1`
3. in tools_awx_1, kill the uwsgi worker with (e.g. kill -9 530). use `ps awxf | grep uwsgi` to get a list of uwsgi processes
4. start postgres with `docker-compose start tools_postgres_1`
5. `curl -k https://localhost:8043/api/v2/ping/`
   -   without patch -> 500 internal server errors
   -   with patch -> 200s

## Fix

`is_database_synchronized()` catches exceptions and returns `False` instead of propagating the error. This is semantically correct (if we can't reach the DB, we can't confirm migrations are synchronized) and allows the worker to load. The skipped `setup_tower_managed_defaults()` call is a no-op in practice since credential types are already in the DB from the initial startup.

## Test plan

- [ ] Stop postgres, kill a uWSGI worker, verify worker loads with warning log instead of entering `app: -1` state
- [ ] Start postgres, verify API returns 200
- [ ] Negative case: without fix, same sequence produces permanent 500s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for database synchronization checks. The system now gracefully handles scenarios when the database is unreachable, logging warnings and continuing operation instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->