### PR TITLE
Use in-memory data for reaper waiting job logic, consolidate with heartbeat

### DIFF
--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -98,7 +98,7 @@ def reap_orphaned_jobs():
     execution nodes and reaps them. Runs independently to avoid passing
     large argument lists and to prevent saturating task manager cycle.
     """
-    valid_execution_nodes = {inst for inst in Instance.objects.filter(node_type__in=('hybrid', 'execution')).values_list('hostname', flat=True)}
+    valid_execution_nodes = set(Instance.objects.filter(node_type__in=('hybrid', 'execution')).values_list('hostname', flat=True))
 
     orphaned_running = get_orphaned_running_jobs_query(valid_execution_nodes)
 
@@ -116,7 +116,7 @@ def reset_orphaned_waiting_jobs():
     controller nodes and resets them to pending. Runs independently to
     avoid passing large argument lists and to prevent saturating task manager.
     """
-    valid_controller_nodes = {inst for inst in Instance.objects.filter(node_type__in=('hybrid', 'control')).values_list('hostname', flat=True)}
+    valid_controller_nodes = set(Instance.objects.filter(node_type__in=('hybrid', 'control')).values_list('hostname', flat=True))
 
     orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node__in=valid_controller_nodes)
 

--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -98,11 +98,11 @@ def reap_orphaned_jobs():
     execution nodes and reaps them. Runs independently to avoid passing
     large argument lists and to prevent saturating task manager cycle.
     """
-    valid_execution_nodes = set(Instance.objects.filter(node_type__in=('hybrid', 'execution')).values_list('hostname', flat=True))
+    valid_execution_nodes = {Instance.objects.filter(node_type__in=('hybrid', 'execution')).values_list('hostname', flat=True)}
 
     orphaned_running = get_orphaned_running_jobs_query(valid_execution_nodes)
 
-    logger.info(f'Reaping orphaned running jobs')
+    logger.info('Reaping orphaned running jobs')
     for job in orphaned_running:
         if not job.is_container_group_task:
             reap_job(job, 'failed', job_explanation='Task execution node is not a registered instance')
@@ -116,11 +116,11 @@ def reset_orphaned_waiting_jobs():
     controller nodes and resets them to pending. Runs independently to
     avoid passing large argument lists and to prevent saturating task manager.
     """
-    valid_controller_nodes = set(Instance.objects.filter(node_type__in=('hybrid', 'control')).values_list('hostname', flat=True))
+    valid_controller_nodes = {Instance.objects.filter(node_type__in=('hybrid', 'control')).values_list('hostname', flat=True)}
 
     orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node__in=valid_controller_nodes)
 
-    logger.info(f'Resetting orphaned waiting jobs to pending')
+    logger.info('Resetting orphaned waiting jobs to pending')
     for job in orphaned_waiting:
         job.status = 'pending'
         job.controller_node = ''

--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -2,8 +2,11 @@ import logging
 
 from django.db.models import Q
 from django.contrib.contenttypes.models import ContentType
+from dispatcherd.publish import task as dispatcher_task
 
+from awx.main.dispatch import get_task_queuename
 from awx.main.models import Instance, UnifiedJob, WorkflowJob
+from awx.main.utils import ScheduleTaskManager
 
 logger = logging.getLogger('awx.main.dispatch')
 
@@ -47,6 +50,26 @@ def reap_job(j, status, job_explanation=None):
     logger.error(f'{j.log_format} is no longer {status_before}; reaping')
 
 
+def get_orphaned_running_jobs_query(valid_execution_node_hostnames):
+    """Get queryset for running jobs on orphaned execution nodes.
+
+    Args:
+        valid_execution_node_hostnames: Iterable of valid execution node hostnames
+
+    Returns:
+        QuerySet of running jobs on invalid execution nodes, excluding workflows
+    """
+    workflow_ctype_id = ContentType.objects.get_for_model(WorkflowJob).id
+    return (
+        UnifiedJob.objects.filter(
+            status='running',
+            execution_node__isnull=False,
+        )
+        .exclude(execution_node__in=valid_execution_node_hostnames)
+        .exclude(polymorphic_ctype_id=workflow_ctype_id)
+    )
+
+
 def reap(instance=None, status='failed', job_explanation=None, excluded_uuids=None, ref_time=None):
     """
     Reap all jobs in running for this instance.
@@ -65,3 +88,44 @@ def reap(instance=None, status='failed', job_explanation=None, excluded_uuids=No
         jobs = jobs.exclude(celery_task_id__in=excluded_uuids)
     for j in jobs:
         reap_job(j, status, job_explanation=job_explanation)
+
+
+@dispatcher_task(queue=get_task_queuename, timeout=600, on_duplicate='queue_one')
+def reap_orphaned_jobs():
+    """Background task to reap running jobs on orphaned instances.
+
+    Queries for running jobs referencing non-existent or unregistered
+    execution nodes and reaps them. Runs independently to avoid passing
+    large argument lists and to prevent saturating task manager cycle.
+    """
+    valid_execution_nodes = set(Instance.objects.filter(node_type__in=('hybrid', 'execution')).values_list('hostname', flat=True))
+
+    orphaned_running = get_orphaned_running_jobs_query(valid_execution_nodes)
+
+    logger.info(f'Reaping orphaned running jobs')
+    for job in orphaned_running:
+        if not job.is_container_group_task:
+            reap_job(job, 'failed', job_explanation='Task execution node is not a registered instance')
+
+
+@dispatcher_task(queue=get_task_queuename, timeout=600, on_duplicate='queue_one')
+def reset_orphaned_waiting_jobs():
+    """Background task to reset waiting jobs on orphaned controller instances.
+
+    Queries for waiting jobs referencing non-existent or unregistered
+    controller nodes and resets them to pending. Runs independently to
+    avoid passing large argument lists and to prevent saturating task manager.
+    """
+    valid_controller_nodes = set(Instance.objects.filter(node_type__in=('hybrid', 'control')).values_list('hostname', flat=True))
+
+    orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node__in=valid_controller_nodes)
+
+    logger.info(f'Resetting orphaned waiting jobs to pending')
+    for job in orphaned_waiting:
+        job.status = 'pending'
+        job.controller_node = ''
+        job.execution_node = ''
+        job.save(update_fields=['status', 'controller_node', 'execution_node'])
+
+    # Trigger task manager to re-process these now-pending jobs
+    ScheduleTaskManager().schedule()

--- a/awx/main/dispatch/reaper.py
+++ b/awx/main/dispatch/reaper.py
@@ -98,7 +98,7 @@ def reap_orphaned_jobs():
     execution nodes and reaps them. Runs independently to avoid passing
     large argument lists and to prevent saturating task manager cycle.
     """
-    valid_execution_nodes = {Instance.objects.filter(node_type__in=('hybrid', 'execution')).values_list('hostname', flat=True)}
+    valid_execution_nodes = {inst for inst in Instance.objects.filter(node_type__in=('hybrid', 'execution')).values_list('hostname', flat=True)}
 
     orphaned_running = get_orphaned_running_jobs_query(valid_execution_nodes)
 
@@ -116,7 +116,7 @@ def reset_orphaned_waiting_jobs():
     controller nodes and resets them to pending. Runs independently to
     avoid passing large argument lists and to prevent saturating task manager.
     """
-    valid_controller_nodes = {Instance.objects.filter(node_type__in=('hybrid', 'control')).values_list('hostname', flat=True)}
+    valid_controller_nodes = {inst for inst in Instance.objects.filter(node_type__in=('hybrid', 'control')).values_list('hostname', flat=True)}
 
     orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node__in=valid_controller_nodes)
 

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -25,9 +25,8 @@ from ansible_base.lib.utils.models import get_type_for_model
 from ansible_base.lib.utils.db import advisory_lock
 
 # AWX
-from awx.main.dispatch.reaper import reap_job, get_orphaned_running_jobs_query, reap_orphaned_jobs, reset_orphaned_waiting_jobs
+from awx.main.dispatch.reaper import get_orphaned_running_jobs_query, reap_orphaned_jobs, reset_orphaned_waiting_jobs
 from awx.main.models import (
-    Instance,
     InventorySource,
     InventoryUpdate,
     Job,

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -25,7 +25,7 @@ from ansible_base.lib.utils.models import get_type_for_model
 from ansible_base.lib.utils.db import advisory_lock
 
 # AWX
-from awx.main.dispatch.reaper import reap_job
+from awx.main.dispatch.reaper import reap_job, get_orphaned_running_jobs_query, reap_orphaned_jobs, reset_orphaned_waiting_jobs
 from awx.main.models import (
     Instance,
     InventorySource,
@@ -675,28 +675,42 @@ class TaskManager(TaskBase):
                 tasks_to_update_job_explanation.append(task)
         logger.debug("{} couldn't be scheduled on graph, waiting for next cycle".format(task.log_format))
 
-    def reap_jobs_from_orphaned_instances(self):
-        # discover jobs that are in running state but aren't on an execution node
-        # that we know about; this is a fairly rare event, but it can occur if you,
-        # for example, SQL backup an awx install with running jobs and restore it
-        # elsewhere
-        for j in UnifiedJob.objects.filter(
-            status__in=['pending', 'waiting', 'running'],
-        ).exclude(execution_node__in=Instance.objects.exclude(node_type='hop').values_list('hostname', flat=True)):
-            if j.execution_node and not j.is_container_group_task:
-                logger.error(f'{j.execution_node} is not a registered instance; reaping {j.log_format}')
-                reap_job(j, 'failed')
+    def queue_orphaned_job_reaping(self):
+        """Queue background tasks to reap orphaned jobs if any are detected.
 
-        # Reset waiting jobs whose controller_node was deprovisioned (e.g. K8s pod replaced).
-        # These jobs will never be picked up because no live node is listening for them.
-        registered_control_nodes = Instance.objects.filter(node_type__in=('control', 'hybrid')).values_list('hostname', flat=True)
-        orphaned_waiting = UnifiedJob.objects.filter(status='waiting').exclude(controller_node__in=registered_control_nodes)
-        for j in orphaned_waiting:
-            logger.warning(f'{j.controller_node} is not a registered instance; resetting {j.log_format} to pending')
-            j.status = 'pending'
-            j.controller_node = ''
-            j.execution_node = ''
-            j.save(update_fields=['status', 'controller_node', 'execution_node'])
+        Detection checks:
+        1. In-memory check for waiting jobs (already loaded by get_tasks) on orphaned controllers
+        2. Existence check for running jobs on orphaned execution nodes
+
+        Queues idempotent background tasks to do the actual reaping work.
+        """
+        assert hasattr(self, 'tm_models'), "queue_orphaned_job_reaping() called before after_lock_init()"
+        assert hasattr(self, 'all_tasks'), "queue_orphaned_job_reaping() called before get_tasks()"
+
+        # Build sets of valid instance hostnames from in-memory data
+        valid_execution_nodes = set(
+            hostname for hostname, inst in self.tm_models.instances.instances_by_hostname.items() if inst.node_type in ('hybrid', 'execution')
+        )
+
+        valid_controller_nodes = set(
+            hostname for hostname, inst in self.tm_models.instances.instances_by_hostname.items() if inst.node_type in ('hybrid', 'control')
+        )
+
+        # Check waiting jobs in memory (already loaded by get_tasks)
+        orphaned_waiting_exists = any(
+            task.status == 'waiting' and task.controller_node and task.controller_node not in valid_controller_nodes for task in self.all_tasks
+        )
+
+        if orphaned_waiting_exists:
+            logger.warning('Detected orphaned waiting jobs; queueing reset task')
+            reset_orphaned_waiting_jobs.delay()
+
+        # Check if running jobs on orphaned execution nodes exist (without fetching them)
+        orphaned_running_exists = get_orphaned_running_jobs_query(valid_execution_nodes).exists()
+
+        if orphaned_running_exists:
+            logger.warning('Detected orphaned running jobs; queueing reaping task')
+            reap_orphaned_jobs.delay()
 
     def process_tasks(self):
         # maintain a list of jobs that went to an early failure state,
@@ -743,7 +757,7 @@ class TaskManager(TaskBase):
         self.get_tasks(dict(status__in=["pending", "waiting", "running"], dependencies_processed=True))
 
         self.after_lock_init()
-        self.reap_jobs_from_orphaned_instances()
+        self.queue_orphaned_job_reaping()
 
         if len(self.all_tasks) > 0:
             self.process_tasks()

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -687,13 +687,13 @@ class TaskManager(TaskBase):
         assert hasattr(self, 'all_tasks'), "queue_orphaned_job_reaping() called before get_tasks()"
 
         # Build sets of valid instance hostnames from in-memory data
-        valid_execution_nodes = set(
+        valid_execution_nodes = {
             hostname for hostname, inst in self.tm_models.instances.instances_by_hostname.items() if inst.node_type in ('hybrid', 'execution')
-        )
+        }
 
-        valid_controller_nodes = set(
+        valid_controller_nodes = {
             hostname for hostname, inst in self.tm_models.instances.instances_by_hostname.items() if inst.node_type in ('hybrid', 'control')
-        )
+        }
 
         # Check waiting jobs in memory (already loaded by get_tasks)
         orphaned_waiting_exists = any(

--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -780,24 +780,20 @@ def _heartbeat_check_versions(this_inst, instance_list):
 
 
 def _heartbeat_handle_lost_instances(lost_instances, this_inst):
-    """Handle lost instances by reaping their running jobs and marking them offline."""
+    """Handle lost instances by marking them offline, then trigger task manager to detect orphaned jobs."""
+    instances_marked_down = []
+
     for other_inst in lost_instances:
-        try:
-            # Any jobs marked as running will be marked as error
-            explanation = "Job reaped due to instance shutdown"
-            reaper.reap(other_inst, job_explanation=explanation)
-            # Any jobs that were waiting to be processed by this node will be handed back to task manager
-            UnifiedJob.objects.filter(status='waiting', controller_node=other_inst.hostname).update(status='pending', controller_node='', execution_node='')
-        except Exception:
-            logger.exception('failed to re-process jobs for lost instance {}'.format(other_inst.hostname))
         try:
             if settings.AWX_AUTO_DEPROVISION_INSTANCES and other_inst.node_type == "control":
                 deprovision_hostname = other_inst.hostname
-                other_inst.delete()  # FIXME: what about associated inbound links?
+                other_inst.delete()
                 logger.info("Host {} Automatically Deprovisioned.".format(deprovision_hostname))
+                instances_marked_down.append(deprovision_hostname)
             elif other_inst.node_state == Instance.States.READY:
                 other_inst.mark_offline(errors=_('Another cluster node has determined this instance to be unresponsive'))
                 logger.error("Host {} last checked in at {}, marked as lost.".format(other_inst.hostname, other_inst.last_seen))
+                instances_marked_down.append(other_inst.hostname)
 
         except DatabaseError as e:
             cause = e.__cause__
@@ -812,6 +808,12 @@ def _heartbeat_handle_lost_instances(lost_instances, this_inst):
                     logger.exception("Error marking {} as lost.".format(other_inst.hostname))
             else:
                 logger.exception('No SQL state available.  Error marking {} as lost'.format(other_inst.hostname))
+
+    if instances_marked_down:
+        logger.info(f"Triggering task manager to handle jobs from lost instances: {instances_marked_down}")
+        from awx.main.utils import ScheduleTaskManager
+
+        ScheduleTaskManager().schedule()
 
 
 @task(queue=get_task_queuename, timeout=1800, on_duplicate='queue_one')

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -4,7 +4,7 @@ from django.utils.timezone import now as tz_now
 import pytest
 from django.test import override_settings
 
-from awx.main.models import Job, WorkflowJob, Instance
+from awx.main.models import InstanceGroup, Job, WorkflowJob, Instance
 from awx.main.dispatch import reaper
 from awx.main.dispatch.reaper import (
     reset_orphaned_waiting_jobs,
@@ -332,6 +332,38 @@ class TestJobReaper(object):
         job.refresh_from_db()
         assert job.status == 'failed'
         assert job.start_args == original_args
+
+    def test_reap_orphaned_jobs_skips_container_group_task(self):
+        """Container group tasks on orphaned nodes should not be reaped."""
+        exec_inst = Instance(hostname='exec-live', node_type='execution')
+        exec_inst.save()
+        cg = InstanceGroup.objects.create(name='container-group', is_container_group=True)
+
+        cg_job = Job.objects.create(
+            status='running',
+            execution_node='exec-orphaned',
+            controller_node='',
+            start_args='SENSITIVE',
+        )
+        cg_job.instance_group = cg
+        cg_job.save(update_fields=['instance_group'])
+
+        normal_job = Job.objects.create(
+            status='running',
+            execution_node='exec-orphaned',
+            controller_node='',
+            start_args='SENSITIVE',
+        )
+
+        reap_orphaned_jobs()
+
+        cg_job.refresh_from_db()
+        normal_job.refresh_from_db()
+
+        assert cg_job.status == 'running', 'Container group task should not be reaped'
+        assert cg_job.start_args != ''
+        assert normal_job.status == 'failed'
+        assert 'not a registered instance' in normal_job.job_explanation
 
     def test_heartbeat_handle_lost_instances_marks_offline(self, mocker):
         """Test _heartbeat_handle_lost_instances marks lost control instances offline and triggers task manager."""

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -95,6 +95,12 @@ class TestJobReaper(object):
         job = Job.objects.create(status='waiting', controller_node=lost_inst.hostname, execution_node='lost')
 
         system._heartbeat_handle_lost_instances([lost_inst], this_inst)
+
+        # Simulate what the background task would do
+        from awx.main.dispatch.reaper import reset_orphaned_waiting_jobs
+
+        reset_orphaned_waiting_jobs()
+
         job.refresh_from_db()
 
         assert job.status == 'pending'
@@ -165,15 +171,15 @@ class TestJobReaper(object):
         """When a controller pod is replaced (e.g. K8s rollout), waiting jobs
         assigned to the now-gone controller_node should be reset to pending
         by the task manager so they can be re-dispatched."""
-        from awx.main.scheduler import TaskManager
-
         live_inst = Instance(hostname='awx-task-live', node_type='control')
         live_inst.save()
         # No instance record for 'awx-task-dead' — it was already deprovisioned
         job = Job.objects.create(status='waiting', controller_node='awx-task-dead', execution_node='')
 
-        tm = TaskManager()
-        tm.reap_jobs_from_orphaned_instances()
+        # Simulate what the background task would do
+        from awx.main.dispatch.reaper import reset_orphaned_waiting_jobs
+
+        reset_orphaned_waiting_jobs()
 
         job.refresh_from_db()
         assert job.status == 'pending'
@@ -183,14 +189,14 @@ class TestJobReaper(object):
     @pytest.mark.parametrize('node_type', ['control', 'hybrid'])
     def test_waiting_job_not_reset_when_controller_node_alive(self, node_type):
         """Waiting jobs on a live control or hybrid node should not be touched."""
-        from awx.main.scheduler import TaskManager
-
         live_inst = Instance(hostname='awx-task-live', node_type=node_type)
         live_inst.save()
         job = Job.objects.create(status='waiting', controller_node='awx-task-live', execution_node='')
 
-        tm = TaskManager()
-        tm.reap_jobs_from_orphaned_instances()
+        # Simulate what the background task would do
+        from awx.main.dispatch.reaper import reset_orphaned_waiting_jobs
+
+        reset_orphaned_waiting_jobs()
 
         job.refresh_from_db()
         assert job.status == 'waiting'

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -2,9 +2,17 @@ import datetime
 from unittest import mock
 from django.utils.timezone import now as tz_now
 import pytest
+from django.test import override_settings
 
 from awx.main.models import Job, WorkflowJob, Instance
 from awx.main.dispatch import reaper
+from awx.main.dispatch.reaper import (
+    reset_orphaned_waiting_jobs,
+    reap_orphaned_jobs,
+    get_orphaned_running_jobs_query,
+    startup_reaping,
+    reap_job,
+)
 from awx.main.tasks import system
 from dispatcherd.publish import task
 
@@ -97,8 +105,6 @@ class TestJobReaper(object):
         system._heartbeat_handle_lost_instances([lost_inst], this_inst)
 
         # Simulate what the background task would do
-        from awx.main.dispatch.reaper import reset_orphaned_waiting_jobs
-
         reset_orphaned_waiting_jobs()
 
         job.refresh_from_db()
@@ -177,8 +183,6 @@ class TestJobReaper(object):
         job = Job.objects.create(status='waiting', controller_node='awx-task-dead', execution_node='')
 
         # Simulate what the background task would do
-        from awx.main.dispatch.reaper import reset_orphaned_waiting_jobs
-
         reset_orphaned_waiting_jobs()
 
         job.refresh_from_db()
@@ -194,10 +198,167 @@ class TestJobReaper(object):
         job = Job.objects.create(status='waiting', controller_node='awx-task-live', execution_node='')
 
         # Simulate what the background task would do
-        from awx.main.dispatch.reaper import reset_orphaned_waiting_jobs
-
         reset_orphaned_waiting_jobs()
 
         job.refresh_from_db()
         assert job.status == 'waiting'
         assert job.controller_node == 'awx-task-live'
+
+    def test_reap_orphaned_jobs_background_task(self):
+        """Test the reap_orphaned_jobs background task reaps running jobs on orphaned execution nodes."""
+        exec_inst = Instance(hostname='exec-live', node_type='execution')
+        exec_inst.save()
+
+        orphaned_job = Job.objects.create(
+            status='running',
+            execution_node='exec-orphaned',
+            controller_node='',
+            start_args='SENSITIVE',
+        )
+        valid_job = Job.objects.create(
+            status='running',
+            execution_node='exec-live',
+            controller_node='',
+        )
+
+        reap_orphaned_jobs()
+
+        orphaned_job.refresh_from_db()
+        valid_job.refresh_from_db()
+
+        assert orphaned_job.status == 'failed'
+        assert 'not a registered instance' in orphaned_job.job_explanation
+        assert orphaned_job.start_args == ''
+        assert valid_job.status == 'running'
+
+    def test_get_orphaned_running_jobs_query(self):
+        """Test that get_orphaned_running_jobs_query filters correctly."""
+        exec_inst = Instance(hostname='exec-live', node_type='execution')
+        exec_inst.save()
+
+        orphaned = Job.objects.create(status='running', execution_node='exec-orphaned', controller_node='')
+        valid = Job.objects.create(status='running', execution_node='exec-live', controller_node='')
+        not_running = Job.objects.create(status='pending', execution_node='exec-orphaned', controller_node='')
+        workflow = WorkflowJob.objects.create(status='running', execution_node='exec-orphaned', controller_node='')
+
+        valid_nodes = ['exec-live']
+        qs = get_orphaned_running_jobs_query(valid_nodes)
+
+        result_ids = set(qs.values_list('id', flat=True))
+        assert orphaned.id in result_ids
+        assert valid.id not in result_ids
+        assert not_running.id not in result_ids
+        assert workflow.id not in result_ids
+
+    def test_reset_orphaned_waiting_jobs_background_task(self):
+        """Test the reset_orphaned_waiting_jobs background task resets waiting jobs on orphaned controller nodes."""
+        ctrl_inst = Instance(hostname='ctrl-live', node_type='control')
+        ctrl_inst.save()
+
+        orphaned_job = Job.objects.create(
+            status='waiting',
+            controller_node='ctrl-orphaned',
+            execution_node='',
+        )
+        valid_job = Job.objects.create(
+            status='waiting',
+            controller_node='ctrl-live',
+            execution_node='',
+        )
+        pending_job = Job.objects.create(
+            status='pending',
+            controller_node='ctrl-orphaned',
+            execution_node='',
+        )
+
+        reset_orphaned_waiting_jobs()
+
+        orphaned_job.refresh_from_db()
+        valid_job.refresh_from_db()
+        pending_job.refresh_from_db()
+
+        assert orphaned_job.status == 'pending'
+        assert orphaned_job.controller_node == ''
+        assert orphaned_job.execution_node == ''
+        assert valid_job.status == 'waiting'
+        assert pending_job.status == 'pending'
+
+    def test_startup_reaping(self, mocker):
+        """Test startup_reaping reaps running jobs on the controller node at startup."""
+        inst = Instance(hostname='awx-controller')
+        inst.save()
+
+        mocker.patch('awx.main.models.Instance.objects.my_hostname', return_value='awx-controller')
+
+        job1 = Job.objects.create(status='running', controller_node='awx-controller', start_args='SENSITIVE')
+        job2 = Job.objects.create(status='running', controller_node='other', start_args='SENSITIVE')
+        job3 = Job.objects.create(status='failed', controller_node='awx-controller')
+
+        startup_reaping()
+
+        job1.refresh_from_db()
+        job2.refresh_from_db()
+        job3.refresh_from_db()
+
+        assert job1.status == 'failed'
+        assert 'at system start up' in job1.job_explanation
+        assert job1.start_args == ''
+        assert job2.status == 'running'
+        assert job3.status == 'failed'
+
+    def test_reap_job_updates_status(self):
+        """Test reap_job marks a running job as failed and clears sensitive data."""
+        job = Job.objects.create(
+            status='running',
+            start_args='SENSITIVE_DATA',
+            job_explanation='Some prior explanation.',
+        )
+
+        reap_job(job, 'failed', job_explanation='Task was lost')
+
+        job.refresh_from_db()
+        assert job.status == 'failed'
+        assert job.start_args == ''
+        assert 'Some prior explanation' in job.job_explanation
+        assert 'Task was lost' in job.job_explanation
+
+    def test_reap_job_does_not_reap_non_running(self):
+        """Test reap_job does not modify jobs that are not running or waiting."""
+        job = Job.objects.create(status='failed', start_args='SENSITIVE')
+        original_args = job.start_args
+
+        reap_job(job, 'failed', job_explanation='Should not apply')
+
+        job.refresh_from_db()
+        assert job.status == 'failed'
+        assert job.start_args == original_args
+
+    def test_heartbeat_handle_lost_instances_marks_offline(self, mocker):
+        """Test _heartbeat_handle_lost_instances marks lost control instances offline and triggers task manager."""
+        this_inst = Instance(hostname='awx-alive', node_type='control')
+        this_inst.save()
+        lost_inst = Instance(hostname='awx-lost', node_type='control', node_state=Instance.States.READY)
+        lost_inst.save()
+
+        schedule_mock = mocker.patch('awx.main.utils.ScheduleTaskManager')
+
+        system._heartbeat_handle_lost_instances([lost_inst], this_inst)
+
+        lost_inst.refresh_from_db()
+        assert lost_inst.node_state == Instance.States.UNAVAILABLE
+        schedule_mock.return_value.schedule.assert_called_once()
+
+    @override_settings(AWX_AUTO_DEPROVISION_INSTANCES=True)
+    def test_heartbeat_handle_lost_instances_deprovisioned(self, mocker):
+        """Test _heartbeat_handle_lost_instances auto-deprovisions control nodes when enabled."""
+        this_inst = Instance(hostname='awx-alive', node_type='control')
+        this_inst.save()
+        lost_inst = Instance(hostname='awx-lost', node_type='control')
+        lost_inst.save()
+
+        schedule_mock = mocker.patch('awx.main.utils.ScheduleTaskManager')
+
+        system._heartbeat_handle_lost_instances([lost_inst], this_inst)
+
+        assert not Instance.objects.filter(hostname='awx-lost').exists()
+        schedule_mock.return_value.schedule.assert_called_once()


### PR DESCRIPTION
##### SUMMARY
Putting up a concrete implementation of my rambling review comment from @fosterseth patch

https://github.com/ansible/awx/pull/16467

The heartbeat change here is slightly architectural. When a peer instance is marked offline, the jobs from that will not _right away_ be reaped, as another tick of the task manager, _and_ another background task is necessary. However, when a node goes down we are not in a rush to reap jobs from it, and we can get in trouble for doing it too fast. Plus, all of these have immediate re-scheduling happening so if the system isn't bogged down we can expect it to happen as fast as the system resources can carry it.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background processing for jobs associated with unavailable execution or controller nodes.

* **Bug Fixes**
  * Running jobs on invalid execution nodes are marked failed with an explanation.
  * Waiting jobs on invalid controller nodes are reset to pending and reprocessed.
  * Improved handling when nodes become unavailable or are automatically deprovisioned.
  * Container-group tasks are preserved from inappropriate reaping.

* **Tests**
  * Expanded coverage for orphaned jobs, node loss, reprocessing, and reaping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->