### PR TITLE
Add integration test to verify custom files actually injected

### DIFF
--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Check that CUSTOM_FILE_PATH env var is set
+      debug:
+        msg: "File path from env: {{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: env_path
+
+    - name: Assert env var is not empty
+      assert:
+        that:
+          - lookup('env', 'CUSTOM_FILE_PATH') | length > 0
+        fail_msg: "CUSTOM_FILE_PATH environment variable is not set"
+
+    - name: Read the injected file
+      slurp:
+        src: "{{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: file_content
+
+    - name: Assert file contains expected content
+      assert:
+        that:
+          - "'Hello from custom credential type!' in file_content['content'] | b64decode"
+        fail_msg: "File does not contain expected content"
+
+    - name: Display file content
+      debug:
+        msg: "File content: {{ file_content['content'] | b64decode }}"

--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -7,55 +7,42 @@
       set_fact:
         config_file_path: "{{ lookup('env', 'CONFIG_FILE_PATH') }}"
 
-    - name: Assert CONFIG_FILE_PATH is set (not empty)
+    - name: Assert CONFIG_FILE_PATH is set and not blank
       assert:
         that:
           - config_file_path != ''
-        fail_msg: "CONFIG_FILE_PATH environment variable must be set"
+        fail_msg: "FAIL: CONFIG_FILE_PATH environment variable is blank or not set"
 
     - name: Read the config file
       slurp:
         src: "{{ config_file_path }}"
       register: config_content
 
-    - name: Display config file content
-      debug:
-        msg: "Config file content:\n{{ config_content['content'] | b64decode }}"
-
     - name: Assert config file has expected content
       assert:
         that:
           - "'localhost' in config_content['content'] | b64decode"
           - "'port=8080' in config_content['content'] | b64decode"
-        fail_msg: |
-          Config file at {{ config_file_path }} does not contain expected content.
-          Expected 'localhost' and 'port=8080', but got: {{ config_content['content'] | b64decode }}
+        fail_msg: "FAIL: Config file does not contain expected content (localhost, port=8080)"
 
     - name: Get EXTRA_FILE_PATH environment variable
       set_fact:
         extra_file_path: "{{ lookup('env', 'EXTRA_FILE_PATH') }}"
 
-    - name: Check if EXTRA_FILE_PATH is defined (for multi-file test)
-      debug:
-        msg: "EXTRA_FILE_PATH is {% if extra_file_path %}set to: {{ extra_file_path }}{% else %}not set{% endif %}"
+    - name: Assert EXTRA_FILE_PATH is set and not blank
+      assert:
+        that:
+          - extra_file_path != ''
+        fail_msg: "FAIL: EXTRA_FILE_PATH environment variable is blank or not set"
 
-    - name: Read the extra file (if EXTRA_FILE_PATH is set)
+    - name: Read the extra file
       slurp:
         src: "{{ extra_file_path }}"
       register: extra_content
-      when: extra_file_path != ''
 
-    - name: Display extra file content (if exists)
-      debug:
-        msg: "Extra file content:\n{{ extra_content['content'] | b64decode }}"
-      when: extra_file_path != ''
-
-    - name: Assert extra file has expected content (if EXTRA_FILE_PATH is set)
+    - name: Assert extra file has expected content
       assert:
         that:
           - "'Additional settings' in extra_content['content'] | b64decode"
           - "'Created by custom credential injection' in extra_content['content'] | b64decode"
-        fail_msg: |
-          Extra file at {{ extra_file_path }} does not contain expected content.
-          Expected 'Additional settings' and 'Created by custom credential injection', but got: {{ extra_content['content'] | b64decode }}
-      when: extra_file_path != ''
+        fail_msg: "FAIL: Extra file does not contain expected content (Additional settings, Created by custom credential injection)"

--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -3,54 +3,59 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: Check CONFIG_FILE_PATH env var is set
-      debug:
-        msg: "Config file path from env: {{ lookup('env', 'CONFIG_FILE_PATH') }}"
+    - name: Get CONFIG_FILE_PATH environment variable
+      set_fact:
+        config_file_path: "{{ lookup('env', 'CONFIG_FILE_PATH') }}"
 
-    - name: Check EXTRA_FILE_PATH env var is set
-      debug:
-        msg: "Extra file path from env: {{ lookup('env', 'EXTRA_FILE_PATH') }}"
-
-    - name: Assert CONFIG_FILE_PATH is not empty
+    - name: Assert CONFIG_FILE_PATH is set (not empty)
       assert:
         that:
-          - lookup('env', 'CONFIG_FILE_PATH') | length > 0
-        fail_msg: "CONFIG_FILE_PATH environment variable is not set"
-
-    - name: Assert EXTRA_FILE_PATH is not empty
-      assert:
-        that:
-          - lookup('env', 'EXTRA_FILE_PATH') | length > 0
-        fail_msg: "EXTRA_FILE_PATH environment variable is not set"
+          - config_file_path != ''
+        fail_msg: "CONFIG_FILE_PATH environment variable must be set"
 
     - name: Read the config file
       slurp:
-        src: "{{ lookup('env', 'CONFIG_FILE_PATH') }}"
+        src: "{{ config_file_path }}"
       register: config_content
-
-    - name: Read the extra file
-      slurp:
-        src: "{{ lookup('env', 'EXTRA_FILE_PATH') }}"
-      register: extra_content
 
     - name: Display config file content
       debug:
-        msg: "Config file:\n{{ config_content['content'] | b64decode }}"
+        msg: "Config file content:\n{{ config_content['content'] | b64decode }}"
 
-    - name: Display extra file content
-      debug:
-        msg: "Extra file:\n{{ extra_content['content'] | b64decode }}"
-
-    - name: Assert config file contains expected content
+    - name: Assert config file has expected content
       assert:
         that:
           - "'localhost' in config_content['content'] | b64decode"
           - "'port=8080' in config_content['content'] | b64decode"
-        fail_msg: "Config file does not contain expected content"
+        fail_msg: |
+          Config file at {{ config_file_path }} does not contain expected content.
+          Expected 'localhost' and 'port=8080', but got: {{ config_content['content'] | b64decode }}
 
-    - name: Assert extra file contains expected content
+    - name: Get EXTRA_FILE_PATH environment variable
+      set_fact:
+        extra_file_path: "{{ lookup('env', 'EXTRA_FILE_PATH') }}"
+
+    - name: Check if EXTRA_FILE_PATH is defined (for multi-file test)
+      debug:
+        msg: "EXTRA_FILE_PATH is {% if extra_file_path %}set to: {{ extra_file_path }}{% else %}not set{% endif %}"
+
+    - name: Read the extra file (if EXTRA_FILE_PATH is set)
+      slurp:
+        src: "{{ extra_file_path }}"
+      register: extra_content
+      when: extra_file_path != ''
+
+    - name: Display extra file content (if exists)
+      debug:
+        msg: "Extra file content:\n{{ extra_content['content'] | b64decode }}"
+      when: extra_file_path != ''
+
+    - name: Assert extra file has expected content (if EXTRA_FILE_PATH is set)
       assert:
         that:
           - "'Additional settings' in extra_content['content'] | b64decode"
           - "'Created by custom credential injection' in extra_content['content'] | b64decode"
-        fail_msg: "Extra file does not contain expected content"
+        fail_msg: |
+          Extra file at {{ extra_file_path }} does not contain expected content.
+          Expected 'Additional settings' and 'Created by custom credential injection', but got: {{ extra_content['content'] | b64decode }}
+      when: extra_file_path != ''

--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -3,28 +3,54 @@
   gather_facts: false
   connection: local
   tasks:
-    - name: Check that CUSTOM_FILE_PATH env var is set
+    - name: Check CONFIG_FILE_PATH env var is set
       debug:
-        msg: "File path from env: {{ lookup('env', 'CUSTOM_FILE_PATH') }}"
-      register: env_path
+        msg: "Config file path from env: {{ lookup('env', 'CONFIG_FILE_PATH') }}"
 
-    - name: Assert env var is not empty
+    - name: Check EXTRA_FILE_PATH env var is set
+      debug:
+        msg: "Extra file path from env: {{ lookup('env', 'EXTRA_FILE_PATH') }}"
+
+    - name: Assert CONFIG_FILE_PATH is not empty
       assert:
         that:
-          - lookup('env', 'CUSTOM_FILE_PATH') | length > 0
-        fail_msg: "CUSTOM_FILE_PATH environment variable is not set"
+          - lookup('env', 'CONFIG_FILE_PATH') | length > 0
+        fail_msg: "CONFIG_FILE_PATH environment variable is not set"
 
-    - name: Read the injected file
+    - name: Assert EXTRA_FILE_PATH is not empty
+      assert:
+        that:
+          - lookup('env', 'EXTRA_FILE_PATH') | length > 0
+        fail_msg: "EXTRA_FILE_PATH environment variable is not set"
+
+    - name: Read the config file
       slurp:
-        src: "{{ lookup('env', 'CUSTOM_FILE_PATH') }}"
-      register: file_content
+        src: "{{ lookup('env', 'CONFIG_FILE_PATH') }}"
+      register: config_content
 
-    - name: Assert file contains expected content
+    - name: Read the extra file
+      slurp:
+        src: "{{ lookup('env', 'EXTRA_FILE_PATH') }}"
+      register: extra_content
+
+    - name: Display config file content
+      debug:
+        msg: "Config file:\n{{ config_content['content'] | b64decode }}"
+
+    - name: Display extra file content
+      debug:
+        msg: "Extra file:\n{{ extra_content['content'] | b64decode }}"
+
+    - name: Assert config file contains expected content
       assert:
         that:
-          - "'Hello from custom credential type!' in file_content['content'] | b64decode"
-        fail_msg: "File does not contain expected content"
+          - "'localhost' in config_content['content'] | b64decode"
+          - "'port=8080' in config_content['content'] | b64decode"
+        fail_msg: "Config file does not contain expected content"
 
-    - name: Display file content
-      debug:
-        msg: "File content: {{ file_content['content'] | b64decode }}"
+    - name: Assert extra file contains expected content
+      assert:
+        that:
+          - "'Additional settings' in extra_content['content'] | b64decode"
+          - "'Created by custom credential injection' in extra_content['content'] | b64decode"
+        fail_msg: "Extra file does not contain expected content"

--- a/awx/main/tests/data/projects/custom_cred_project/test_multi_file.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_multi_file.yml
@@ -51,12 +51,12 @@
       set_fact:
         extra_decoded: "{{ extra_content['content'] | b64decode }}"
 
-    - name: Assert extra file has expected content
+    - name: Verify config file path is referenced in extra file
       assert:
         that:
-          - "'Additional settings' in extra_decoded"
-          - "'Created by custom credential injection' in extra_decoded"
+          - "config_file_path.startswith('/')"
+          - "config_file_path in extra_decoded"
         fail_msg: |
-          FAIL: Extra file does not contain expected content.
-          Expected to find 'Additional settings' and 'Created by custom credential injection'
-          Actual content: {{ extra_decoded }}
+          FAIL: Extra file does not contain the path to the config file.
+          Config file path from CONFIG_FILE_PATH env var: {{ config_file_path }}
+          Extra file actual content: {{ extra_decoded }}

--- a/awx/main/tests/data/projects/custom_cred_project/test_multi_file.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_multi_file.yml
@@ -41,18 +41,15 @@
         that:
           - extra_file_path != ''
         fail_msg: "FAIL: EXTRA_FILE_PATH environment variable is blank or not set"
-      when: "'template.extra' in ansible_facts.get('run_job_cred_injectors', '')"
 
     - name: Read the extra file
       slurp:
         src: "{{ extra_file_path }}"
       register: extra_content
-      when: extra_file_path != ''
 
     - name: Decode extra file content
       set_fact:
         extra_decoded: "{{ extra_content['content'] | b64decode }}"
-      when: extra_file_path != ''
 
     - name: Assert extra file has expected content
       assert:
@@ -63,4 +60,3 @@
           FAIL: Extra file does not contain expected content.
           Expected to find 'Additional settings' and 'Created by custom credential injection'
           Actual content: {{ extra_decoded }}
-      when: extra_file_path != ''

--- a/awx/main/tests/data/projects/custom_cred_project/test_single_file.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_single_file.yml
@@ -1,0 +1,33 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Get CONFIG_FILE_PATH environment variable
+      set_fact:
+        config_file_path: "{{ lookup('env', 'CONFIG_FILE_PATH') }}"
+
+    - name: Assert CONFIG_FILE_PATH is set and not blank
+      assert:
+        that:
+          - config_file_path != ''
+        fail_msg: "FAIL: CONFIG_FILE_PATH environment variable is blank or not set"
+
+    - name: Read the config file
+      slurp:
+        src: "{{ config_file_path }}"
+      register: config_content
+
+    - name: Decode config file content
+      set_fact:
+        config_decoded: "{{ config_content['content'] | b64decode }}"
+
+    - name: Assert config file has expected content
+      assert:
+        that:
+          - "'localhost' in config_decoded"
+          - "'port=8080' in config_decoded"
+        fail_msg: |
+          FAIL: Config file does not contain expected content.
+          Expected to find 'localhost' and 'port=8080'
+          Actual content: {{ config_decoded }}

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -207,7 +207,7 @@ def project_factory(post, default_org, admin):
 
 @pytest.fixture
 def run_job_from_playbook(demo_inv, post, admin, project_factory):
-    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True):
+    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True, credentials=None):
         jt_name = f'{test_name} JT: {playbook}'
 
         if not proj:
@@ -235,6 +235,8 @@ def run_job_from_playbook(demo_inv, post, admin, project_factory):
             expect=201,
         )
         jt = JobTemplate.objects.get(id=result.data['id'])
+        if credentials:
+            jt.credentials.add(*credentials)
         job = jt.create_unified_job()
         job.signal_start()
 

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -1,0 +1,67 @@
+import pytest
+
+from awx.main.models import CredentialType, Credential
+from awx.main.tests.live.tests.conftest import unified_job_stdout
+
+
+@pytest.fixture
+def custom_cred_type(default_org):
+    """Create a custom credential type that creates a file and sets an env var."""
+    CredentialType.objects.filter(name='Custom File Type', kind='cloud').delete()
+
+    cred_type = CredentialType(
+        kind='cloud',
+        name='Custom File Type',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'test_file_content',
+                    'label': 'File Content',
+                    'type': 'string',
+                    'required': True,
+                }
+            ]
+        },
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename | quote }}'}},
+    )
+    cred_type.save()
+    return cred_type
+
+
+@pytest.fixture
+def custom_credential(custom_cred_type, default_org):
+    """Create a credential using the custom type."""
+    Credential.objects.filter(name='Custom File Credential').delete()
+
+    cred = Credential(
+        credential_type=custom_cred_type,
+        name='Custom File Credential',
+        organization=default_org,
+        inputs={'test_file_content': 'Hello from custom credential type!'},
+    )
+    cred.save()
+    return cred
+
+
+def test_custom_credential_type_file_injection(
+    run_job_from_playbook,
+    live_tmp_folder,
+    custom_credential,
+):
+    """
+    Test that a custom credential type can inject files and environment variables.
+    The playbook verifies that the injected file exists and contains the expected content,
+    and that the environment variable points to the correct path.
+    """
+    result = run_job_from_playbook(
+        test_name='custom_credential_type',
+        playbook='test_cred.yml',
+        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
+        jt_params={'credentials': [custom_credential.id]},
+    )
+
+    job = result['job']
+    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
+    output = unified_job_stdout(job)
+    assert 'Hello from custom credential type!' in output

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -124,11 +124,8 @@ def test_custom_credential_type_single_file_injection(
     )
 
     job = result['job']
-    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
     output = unified_job_stdout(job)
-    # Verify file was created and accessible with multiline content
-    assert 'localhost' in output
-    assert 'port=8080' in output
+    assert job.status == 'successful', f'Job failed with status {job.status}. Output:\n{output}'
 
 
 def test_custom_credential_type_cross_file_references(
@@ -149,9 +146,5 @@ def test_custom_credential_type_cross_file_references(
     )
 
     job = result['job']
-    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
     output = unified_job_stdout(job)
-    # Verify both files were created and accessible
-    assert 'localhost' in output  # From config file
-    assert 'Additional settings' in output  # From extra file
-    assert 'Created by custom credential injection' in output
+    assert job.status == 'successful', f'Job failed with status {job.status}. Output:\n{output}'

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -23,7 +23,7 @@ def custom_cred_type(default_org):
                 }
             ]
         },
-        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename | quote }}'}},
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file | quote }}'}},
     )
     cred_type.save()
     return cred_type
@@ -58,7 +58,7 @@ def test_custom_credential_type_file_injection(
         test_name='custom_credential_type',
         playbook='test_cred.yml',
         scm_url=f'file://{live_tmp_folder}/custom_cred_project',
-        jt_params={'credentials': [custom_credential.id]},
+        credentials=[custom_credential],
     )
 
     job = result['job']

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -118,7 +118,7 @@ def test_custom_credential_type_single_file_injection(
     """
     result = run_job_from_playbook(
         test_name='simple_file_injection',
-        playbook='test_cred.yml',
+        playbook='test_single_file.yml',
         scm_url=f'file://{live_tmp_folder}/custom_cred_project',
         credentials=[simple_file_credential],
     )
@@ -143,7 +143,7 @@ def test_custom_credential_type_cross_file_references(
     """
     result = run_job_from_playbook(
         test_name='cross_ref_injection',
-        playbook='test_cred.yml',
+        playbook='test_multi_file.yml',
         scm_url=f'file://{live_tmp_folder}/custom_cred_project',
         credentials=[cross_ref_credential],
     )

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -5,63 +5,153 @@ from awx.main.tests.live.tests.conftest import unified_job_stdout
 
 
 @pytest.fixture
-def custom_cred_type(default_org):
-    """Create a custom credential type that creates a file and sets an env var."""
-    CredentialType.objects.filter(name='Custom File Type', kind='cloud').delete()
+def simple_file_cred_type(default_org):
+    """Create a custom credential type that creates a single file with multiline content."""
+    CredentialType.objects.filter(name='Simple File Type', kind='cloud').delete()
 
     cred_type = CredentialType(
         kind='cloud',
-        name='Custom File Type',
+        name='Simple File Type',
         managed=False,
         inputs={
             'fields': [
                 {
-                    'id': 'test_file_content',
+                    'id': 'file_content',
                     'label': 'File Content',
                     'type': 'string',
                     'required': True,
                 }
             ]
         },
-        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file | quote }}'}},
+        injectors={'file': {'template.config': '{{ file_content }}'}, 'env': {'CONFIG_FILE_PATH': '{{ tower.filename.config }}'}},
     )
     cred_type.save()
     return cred_type
 
 
 @pytest.fixture
-def custom_credential(custom_cred_type, default_org):
-    """Create a credential using the custom type."""
-    Credential.objects.filter(name='Custom File Credential').delete()
+def simple_file_credential(simple_file_cred_type, default_org):
+    """Create a credential using the simple file type."""
+    Credential.objects.filter(name='Simple File Credential').delete()
+
+    file_content = '''[main]
+host=localhost
+port=8080
+debug=true'''
 
     cred = Credential(
-        credential_type=custom_cred_type,
-        name='Custom File Credential',
+        credential_type=simple_file_cred_type,
+        name='Simple File Credential',
         organization=default_org,
-        inputs={'test_file_content': 'Hello from custom credential type!'},
+        inputs={'file_content': file_content},
     )
     cred.save()
     return cred
 
 
-def test_custom_credential_type_file_injection(
+@pytest.fixture
+def cross_ref_cred_type(default_org):
+    """Create a custom credential type with two files where one references the other."""
+    CredentialType.objects.filter(name='Cross Ref File Type', kind='cloud').delete()
+
+    cred_type = CredentialType(
+        kind='cloud',
+        name='Cross Ref File Type',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'config_content',
+                    'label': 'Config Content',
+                    'type': 'string',
+                    'required': True,
+                },
+                {
+                    'id': 'extra_content',
+                    'label': 'Extra Content',
+                    'type': 'string',
+                    'required': True,
+                },
+            ]
+        },
+        injectors={
+            'file': {'template.config': '{{ config_content }}', 'template.extra': '{{ extra_content }}'},
+            'env': {'CONFIG_FILE_PATH': '{{ tower.filename.config }}', 'EXTRA_FILE_PATH': '{{ tower.filename.extra }}'},
+        },
+    )
+    cred_type.save()
+    return cred_type
+
+
+@pytest.fixture
+def cross_ref_credential(cross_ref_cred_type, default_org):
+    """Create a credential using the cross-reference type with two files."""
+    Credential.objects.filter(name='Cross Ref Credential').delete()
+
+    config_content = '''[main]
+host=localhost
+port=8080
+debug=true'''
+
+    extra_content = '''Config file location: {{ tower.filename.config }}
+Additional settings for the configuration.
+Created by custom credential injection.'''
+
+    cred = Credential(
+        credential_type=cross_ref_cred_type,
+        name='Cross Ref Credential',
+        organization=default_org,
+        inputs={'config_content': config_content, 'extra_content': extra_content},
+    )
+    cred.save()
+    return cred
+
+
+def test_custom_credential_type_single_file_injection(
     run_job_from_playbook,
     live_tmp_folder,
-    custom_credential,
+    simple_file_credential,
 ):
     """
-    Test that a custom credential type can inject files and environment variables.
-    The playbook verifies that the injected file exists and contains the expected content,
-    and that the environment variable points to the correct path.
+    Test that a custom credential type can inject a single file with multiline content
+    and set an environment variable pointing to it.
     """
     result = run_job_from_playbook(
-        test_name='custom_credential_type',
+        test_name='simple_file_injection',
         playbook='test_cred.yml',
         scm_url=f'file://{live_tmp_folder}/custom_cred_project',
-        credentials=[custom_credential],
+        credentials=[simple_file_credential],
     )
 
     job = result['job']
     assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
     output = unified_job_stdout(job)
-    assert 'Hello from custom credential type!' in output
+    # Verify file was created and accessible with multiline content
+    assert 'localhost' in output
+    assert 'port=8080' in output
+
+
+def test_custom_credential_type_cross_file_references(
+    run_job_from_playbook,
+    live_tmp_folder,
+    cross_ref_credential,
+):
+    """
+    Test that a custom credential type can inject multiple files where one file
+    references another using tower.filename.xyz syntax, and environment variables
+    properly expose the injected file paths.
+    """
+    result = run_job_from_playbook(
+        test_name='cross_ref_injection',
+        playbook='test_cred.yml',
+        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
+        credentials=[cross_ref_credential],
+    )
+
+    job = result['job']
+    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
+    output = unified_job_stdout(job)
+    # Verify both files were created and accessible
+    assert 'localhost' in output  # From config file
+    assert 'Additional settings' in output  # From extra file
+    assert 'Created by custom credential injection' in output


### PR DESCRIPTION
##### SUMMARY
Current status:

failing

```
E         PLAY [localhost] ***************************************************************
E         
E         TASK [Check that CUSTOM_FILE_PATH env var is set] ******************************
E         
E         ok: [localhost] => {
E             "msg": "File path from env: "
E         }
E         
E         TASK [Assert env var is not empty] *********************************************
E         
E         fatal: [localhost]: FAILED! => {
E             "assertion": "lookup('env', 'CUSTOM_FILE_PATH') | length > 0",
E             "changed": false,
E             "evaluated_to": false,
E             "msg": "CUSTOM_FILE_PATH environment variable is not set"
E         }
E         
E         PLAY RECAP *********************************************************************
E         localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
E         [WARNING]: Collection community.vmware does not support Ansible version 2.18.17
E       assert 'failed' == 'successful'

```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API
