### PR TITLE
Fix custom credential file injectors not setting env vars (AAP-78147)

### DIFF
--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -5,6 +5,7 @@
 import copy
 import json
 import re
+import shlex
 import sys
 import urllib.parse
 
@@ -747,7 +748,9 @@ class CredentialTypeInjectorField(JSONSchemaField):
 
         def validate_template_string(type_, key, tmpl):
             try:
-                sandbox.ImmutableSandboxedEnvironment(undefined=StrictUndefined).from_string(tmpl).render(valid_namespace)
+                sandbox_env = sandbox.ImmutableSandboxedEnvironment(undefined=StrictUndefined)
+                sandbox_env.filters['quote'] = shlex.quote
+                sandbox_env.from_string(tmpl).render(valid_namespace)
             except UndefinedError as e:
                 raise django_exceptions.ValidationError(
                     _('{sub_key} uses an undefined field ({error_msg})').format(sub_key=key, error_msg=e),

--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Check that CUSTOM_FILE_PATH env var is set
+      debug:
+        msg: "File path from env: {{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: env_path
+
+    - name: Assert env var is not empty
+      assert:
+        that:
+          - lookup('env', 'CUSTOM_FILE_PATH') | length > 0
+        fail_msg: "CUSTOM_FILE_PATH environment variable is not set"
+
+    - name: Read the injected file
+      slurp:
+        src: "{{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: file_content
+
+    - name: Assert file contains expected content
+      assert:
+        that:
+          - "'Hello from custom credential type!' in file_content['content'] | b64decode"
+        fail_msg: "File does not contain expected content"
+
+    - name: Display file content
+      debug:
+        msg: "File content: {{ file_content['content'] | b64decode }}"

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -1,0 +1,70 @@
+import pytest
+
+from awx.main.models import CredentialType, Credential
+from awx.main.tests.live.tests.conftest import unified_job_stdout
+
+
+@pytest.fixture
+def custom_cred_type(default_org):
+    """Create a custom credential type that creates a file and sets an env var."""
+    CredentialType.objects.filter(name='Custom File Type', kind='cloud').delete()
+
+    cred_type = CredentialType(
+        kind='cloud',
+        name='Custom File Type',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'test_file_content',
+                    'label': 'File Content',
+                    'type': 'string',
+                    'required': True,
+                }
+            ]
+        },
+        injectors={
+            'file': {'template.custom_file': '{{ test_file_content }}'},
+            'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file }}'},
+        },
+    )
+    cred_type.save()
+    return cred_type
+
+
+@pytest.fixture
+def custom_credential(custom_cred_type, default_org):
+    """Create a credential using the custom type."""
+    Credential.objects.filter(name='Custom File Credential').delete()
+
+    cred = Credential(
+        credential_type=custom_cred_type,
+        name='Custom File Credential',
+        organization=default_org,
+        inputs={'test_file_content': 'Hello from custom credential type!'},
+    )
+    cred.save()
+    return cred
+
+
+def test_custom_credential_type_file_injection(
+    run_job_from_playbook,
+    live_tmp_folder,
+    custom_credential,
+):
+    """
+    Test that a custom credential type can inject files and environment variables.
+    The playbook verifies that the injected file exists and contains the expected content,
+    and that the environment variable points to the correct path.
+    """
+    result = run_job_from_playbook(
+        test_name='custom_credential_type',
+        playbook='test_cred.yml',
+        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
+        jt_params={'credentials': [custom_credential.id]},
+    )
+
+    job = result['job']
+    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
+    output = unified_job_stdout(job)
+    assert 'Hello from custom credential type!' in output


### PR DESCRIPTION
## Summary
- Register `shlex.quote` as the `quote` Jinja2 filter in the credential type validation sandbox (`fields.py`), so credential types using `{{ tower.filename | quote }}` pass validation
- Add integration test playbook and test for custom credential file injection (ported from PR #16484)

**Note:** The corresponding fix for the injection sandbox itself is in `awx_plugins.interfaces` (`_temporary_private_inject_api.py`) — that change registers the same `quote` filter in the `ImmutableSandboxedEnvironment` used at render time. A separate PR is needed for that repo.

## Root Cause
When a custom credential type defines file injectors with environment variable references using `{{ tower.filename | quote }}`, the job fails because `ImmutableSandboxedEnvironment` does not include a `quote` filter. The same issue exists in the validation sandbox in `fields.py`.

## Test plan
- [ ] Unit tests pass for injector validation in `test_fields.py`
- [ ] Integration test `test_custom_credential_type.py` verifies file injection end-to-end
- [ ] Custom credential types using `| quote` in injector templates now pass validation

Ref: AAP-78147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests to verify custom credential type file injection functionality.
  * Enhanced validation for custom credential templates during injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->