### PR TITLE
Add integration test for custom credential file injection

### DIFF
--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Check that CUSTOM_FILE_PATH env var is set
+      debug:
+        msg: "File path from env: {{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: env_path
+
+    - name: Assert env var is not empty
+      assert:
+        that:
+          - lookup('env', 'CUSTOM_FILE_PATH') | length > 0
+        fail_msg: "CUSTOM_FILE_PATH environment variable is not set"
+
+    - name: Read the injected file
+      slurp:
+        src: "{{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: file_content
+
+    - name: Assert file contains expected content
+      assert:
+        that:
+          - "'Hello from custom credential type!' in file_content['content'] | b64decode"
+        fail_msg: "File does not contain expected content"
+
+    - name: Display file content
+      debug:
+        msg: "File content: {{ file_content['content'] | b64decode }}"

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -1,0 +1,70 @@
+import pytest
+
+from awx.main.models import CredentialType, Credential
+from awx.main.tests.live.tests.conftest import unified_job_stdout
+
+
+@pytest.fixture
+def custom_cred_type(default_org):
+    """Create a custom credential type that creates a file and sets an env var."""
+    CredentialType.objects.filter(name='Custom File Type', kind='cloud').delete()
+
+    cred_type = CredentialType(
+        kind='cloud',
+        name='Custom File Type',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'test_file_content',
+                    'label': 'File Content',
+                    'type': 'string',
+                    'required': True,
+                }
+            ]
+        },
+        injectors={
+            'file': {'template.custom_file': '{{ test_file_content }}'},
+            'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file }}'},
+        },
+    )
+    cred_type.save()
+    return cred_type
+
+
+@pytest.fixture
+def custom_credential(custom_cred_type, default_org):
+    """Create a credential using the custom type."""
+    Credential.objects.filter(name='Custom File Credential').delete()
+
+    cred = Credential(
+        credential_type=custom_cred_type,
+        name='Custom File Credential',
+        organization=default_org,
+        inputs={'test_file_content': 'Hello from custom credential type!'},
+    )
+    cred.save()
+    return cred
+
+
+def test_custom_credential_type_file_injection(
+    run_job_from_playbook,
+    live_tmp_folder,
+    custom_credential,
+):
+    """
+    Test that a custom credential type can inject files and environment variables.
+    The playbook verifies that the injected file exists and contains the expected content,
+    and that the environment variable points to the correct path.
+    """
+    result = run_job_from_playbook(
+        test_name='custom_credential_type',
+        playbook='test_cred.yml',
+        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
+        jt_params={'credentials': [custom_credential.id]},
+    )
+
+    job = result['job']
+    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
+    output = unified_job_stdout(job)
+    assert 'Hello from custom credential type!' in output

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -1,7 +1,8 @@
 import pytest
 
-from awx.main.models import CredentialType, Credential
-from awx.main.tests.live.tests.conftest import unified_job_stdout
+from awx.api.versioning import reverse
+from awx.main.models import CredentialType, Credential, JobTemplate
+from awx.main.tests.live.tests.conftest import unified_job_stdout, wait_for_job
 
 
 @pytest.fixture
@@ -48,23 +49,44 @@ def custom_credential(custom_cred_type, default_org):
 
 
 def test_custom_credential_type_file_injection(
-    run_job_from_playbook,
+    project_factory,
+    demo_inv,
     live_tmp_folder,
     custom_credential,
+    post,
+    admin,
 ):
     """
     Test that a custom credential type can inject files and environment variables.
     The playbook verifies that the injected file exists and contains the expected content,
     and that the environment variable points to the correct path.
     """
-    result = run_job_from_playbook(
-        test_name='custom_credential_type',
-        playbook='test_cred.yml',
-        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
-        jt_params={'credentials': [custom_credential.id]},
-    )
+    proj = project_factory(scm_url=f'file://{live_tmp_folder}/custom_cred_project')
 
-    job = result['job']
+    if proj.current_job:
+        wait_for_job(proj.current_job)
+
+    playbook = 'test_cred.yml'
+    assert proj.get_project_path()
+    assert playbook in proj.playbooks
+
+    jt_name = 'custom_credential_type JT: test_cred.yml'
+    JobTemplate.objects.filter(name=jt_name).delete()
+
+    result = post(
+        reverse('api:job_template_list'),
+        {'name': jt_name, 'project': proj.id, 'playbook': playbook, 'inventory': demo_inv.id},
+        admin,
+        expect=201,
+    )
+    jt = JobTemplate.objects.get(id=result.data['id'])
+
+    jt.credentials.add(custom_credential)
+
+    job = jt.create_unified_job()
+    job.signal_start()
+    wait_for_job(job)
+
     assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
     output = unified_job_stdout(job)
     assert 'Hello from custom credential type!' in output


### PR DESCRIPTION
## Summary
Add a live integration test to verify custom credential types can inject files and set environment variables.

Based on @AlanCoding's test design from #16484, with two fixes:

### 1. Credential association (test fix)
The original test passed `credentials` in `jt_params`, which gets merged into the JT creation POST payload. However, `credentials` is not a writable field on the JobTemplate serializer — it's a many-to-many relationship managed via a sub-resource endpoint. The API silently ignores it, so the job ran without any credentials attached and file injection never occurred.

Fixed by using `jt.credentials.add()` to associate the credential with the JT before creating the job.

### 2. Removed `| quote` filter (test fix)
The original injector template used `{{ tower.filename.custom_file | quote }}`, but the `quote` filter is not registered in the Jinja2 sandbox used for credential injection. This would cause a template rendering error during `inject_credential()`. The test never hit this because it failed earlier on the credential association issue.

Removed `| quote` from the injector definition. The base file injection works without it.


Bug, Docs Fix or other nominal change