### PR TITLE
Add integration test for custom credential file injection

### DIFF
--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Check that CUSTOM_FILE_PATH env var is set
+      debug:
+        msg: "File path from env: {{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: env_path
+
+    - name: Assert env var is not empty
+      assert:
+        that:
+          - lookup('env', 'CUSTOM_FILE_PATH') | length > 0
+        fail_msg: "CUSTOM_FILE_PATH environment variable is not set"
+
+    - name: Read the injected file
+      slurp:
+        src: "{{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: file_content
+
+    - name: Assert file contains expected content
+      assert:
+        that:
+          - "'Hello from custom credential type!' in file_content['content'] | b64decode"
+        fail_msg: "File does not contain expected content"
+
+    - name: Display file content
+      debug:
+        msg: "File content: {{ file_content['content'] | b64decode }}"

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -207,7 +207,7 @@ def project_factory(post, default_org, admin):
 
 @pytest.fixture
 def run_job_from_playbook(demo_inv, post, admin, project_factory):
-    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True):
+    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True, credentials=None):
         jt_name = f'{test_name} JT: {playbook}'
 
         if not proj:
@@ -235,6 +235,8 @@ def run_job_from_playbook(demo_inv, post, admin, project_factory):
             expect=201,
         )
         jt = JobTemplate.objects.get(id=result.data['id'])
+        if credentials:
+            jt.credentials.add(*credentials)
         job = jt.create_unified_job()
         job.signal_start()
 

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -23,7 +23,7 @@ def custom_cred_type(default_org):
                 }
             ]
         },
-        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file | quote }}'}},
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file }}'}},
     )
     cred_type.save()
     return cred_type
@@ -58,7 +58,7 @@ def test_custom_credential_type_file_injection(
         test_name='custom_credential_type',
         playbook='test_cred.yml',
         scm_url=f'file://{live_tmp_folder}/custom_cred_project',
-        jt_params={'credentials': [custom_credential.id]},
+        credentials=[custom_credential],
     )
 
     job = result['job']

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -1,0 +1,67 @@
+import pytest
+
+from awx.main.models import CredentialType, Credential
+from awx.main.tests.live.tests.conftest import unified_job_stdout
+
+
+@pytest.fixture
+def custom_cred_type(default_org):
+    """Create a custom credential type that creates a file and sets an env var."""
+    CredentialType.objects.filter(name='Custom File Type', kind='cloud').delete()
+
+    cred_type = CredentialType(
+        kind='cloud',
+        name='Custom File Type',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'test_file_content',
+                    'label': 'File Content',
+                    'type': 'string',
+                    'required': True,
+                }
+            ]
+        },
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename | quote }}'}},
+    )
+    cred_type.save()
+    return cred_type
+
+
+@pytest.fixture
+def custom_credential(custom_cred_type, default_org):
+    """Create a credential using the custom type."""
+    Credential.objects.filter(name='Custom File Credential').delete()
+
+    cred = Credential(
+        credential_type=custom_cred_type,
+        name='Custom File Credential',
+        organization=default_org,
+        inputs={'test_file_content': 'Hello from custom credential type!'},
+    )
+    cred.save()
+    return cred
+
+
+def test_custom_credential_type_file_injection(
+    run_job_from_playbook,
+    live_tmp_folder,
+    custom_credential,
+):
+    """
+    Test that a custom credential type can inject files and environment variables.
+    The playbook verifies that the injected file exists and contains the expected content,
+    and that the environment variable points to the correct path.
+    """
+    result = run_job_from_playbook(
+        test_name='custom_credential_type',
+        playbook='test_cred.yml',
+        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
+        jt_params={'credentials': [custom_credential.id]},
+    )
+
+    job = result['job']
+    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
+    output = unified_job_stdout(job)
+    assert 'Hello from custom credential type!' in output

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -23,7 +23,7 @@ def custom_cred_type(default_org):
                 }
             ]
         },
-        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename | quote }}'}},
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file | quote }}'}},
     )
     cred_type.save()
     return cred_type


### PR DESCRIPTION
## Summary
Add a live integration test to verify custom credential types can inject files and set environment variables.

Based on @AlanCoding's test design from #16484, with two fixes:

### 1. Credential association
`jt_params={'credentials': [...]}` is silently ignored by the JT creation API — `credentials` is not a writable field on the JobTemplate serializer. Added a `credentials` parameter to `run_job_from_playbook` that uses `jt.credentials.add()` after JT creation, before job launch.

### 2. Removed `| quote` filter
The Jinja2 sandbox used for credential injection does not have the `quote` filter registered. `{{ tower.filename.custom_file | quote }}` would fail with a template error. Removed it — base file injection works without it.

### Diff from Alan's PR
[Changes on top of #16484](https://github.com/AlanCoding/awx/compare/live_folder_check...chrismeyersfsu:awx:cmeyers/fix-custom-cred-test) — only the two fixes, clearly isolated.

Bug, Docs Fix or other nominal change