### PR TITLE
Add cross-referencing file injection test for custom credentials

### DIFF
--- a/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Check that CUSTOM_FILE_PATH env var is set
+      debug:
+        msg: "File path from env: {{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: env_path
+
+    - name: Assert env var is not empty
+      assert:
+        that:
+          - lookup('env', 'CUSTOM_FILE_PATH') | length > 0
+        fail_msg: "CUSTOM_FILE_PATH environment variable is not set"
+
+    - name: Read the injected file
+      slurp:
+        src: "{{ lookup('env', 'CUSTOM_FILE_PATH') }}"
+      register: file_content
+
+    - name: Assert file contains expected content
+      assert:
+        that:
+          - "'Hello from custom credential type!' in file_content['content'] | b64decode"
+        fail_msg: "File does not contain expected content"
+
+    - name: Display file content
+      debug:
+        msg: "File content: {{ file_content['content'] | b64decode }}"

--- a/awx/main/tests/data/projects/custom_cred_project/test_cred_cross_ref.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred_cross_ref.yml
@@ -1,0 +1,44 @@
+---
+- hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Assert OCI_CONFIG_FILE env var is not empty
+      assert:
+        that:
+          - lookup('env', 'OCI_CONFIG_FILE') | length > 0
+        fail_msg: "OCI_CONFIG_FILE environment variable is not set"
+
+    - name: Assert OCI_USER_KEY_FILE env var is not empty
+      assert:
+        that:
+          - lookup('env', 'OCI_USER_KEY_FILE') | length > 0
+        fail_msg: "OCI_USER_KEY_FILE environment variable is not set"
+
+    - name: Read the config file
+      slurp:
+        src: "{{ lookup('env', 'OCI_CONFIG_FILE') }}"
+      register: config_content
+
+    - name: Display config file content
+      debug:
+        msg: "Config content: {{ config_content['content'] | b64decode }}"
+
+    - name: Assert config file contains the key file path (cross-reference works)
+      assert:
+        that:
+          - "'key_file=' in config_content['content'] | b64decode"
+          - "lookup('env', 'OCI_USER_KEY_FILE') in config_content['content'] | b64decode"
+        fail_msg: >-
+          Config file does not contain the key file path.
+          The key_file= line is blank, meaning {{ tower.filename.ssh_keyfile }}
+          was not available when the config file template was rendered.
+
+    - name: Assert other OCI env vars are set
+      assert:
+        that:
+          - lookup('env', 'OCI_REGION') == 'us-ashburn-1'
+          - lookup('env', 'OCI_TENANCY') == 'ocid1.tenancy.oc1..test'
+          - lookup('env', 'OCI_USER_ID') == 'ocid1.user.oc1..test'
+          - lookup('env', 'OCI_ANSIBLE_AUTH_TYPE') == 'api_key'
+        fail_msg: "OCI environment variables are not set correctly"

--- a/awx/main/tests/data/projects/custom_cred_project/test_cred_cross_ref.yml
+++ b/awx/main/tests/data/projects/custom_cred_project/test_cred_cross_ref.yml
@@ -31,7 +31,7 @@
           - "lookup('env', 'OCI_USER_KEY_FILE') in config_content['content'] | b64decode"
         fail_msg: >-
           Config file does not contain the key file path.
-          The key_file= line is blank, meaning {{ tower.filename.ssh_keyfile }}
+          The key_file= line is blank, meaning tower.filename.ssh_keyfile
           was not available when the config file template was rendered.
 
     - name: Assert other OCI env vars are set

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -207,7 +207,7 @@ def project_factory(post, default_org, admin):
 
 @pytest.fixture
 def run_job_from_playbook(demo_inv, post, admin, project_factory):
-    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True):
+    def _rf(test_name, playbook, local_path=None, scm_url=None, jt_params=None, proj=None, wait=True, credentials=None):
         jt_name = f'{test_name} JT: {playbook}'
 
         if not proj:
@@ -235,6 +235,8 @@ def run_job_from_playbook(demo_inv, post, admin, project_factory):
             expect=201,
         )
         jt = JobTemplate.objects.get(id=result.data['id'])
+        if credentials:
+            jt.credentials.add(*credentials)
         job = jt.create_unified_job()
         job.signal_start()
 

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -23,7 +23,7 @@ def custom_cred_type(default_org):
                 }
             ]
         },
-        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file | quote }}'}},
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file }}'}},
     )
     cred_type.save()
     return cred_type
@@ -58,7 +58,7 @@ def test_custom_credential_type_file_injection(
         test_name='custom_credential_type',
         playbook='test_cred.yml',
         scm_url=f'file://{live_tmp_folder}/custom_cred_project',
-        jt_params={'credentials': [custom_credential.id]},
+        credentials=[custom_credential],
     )
 
     job = result['job']

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -1,0 +1,67 @@
+import pytest
+
+from awx.main.models import CredentialType, Credential
+from awx.main.tests.live.tests.conftest import unified_job_stdout
+
+
+@pytest.fixture
+def custom_cred_type(default_org):
+    """Create a custom credential type that creates a file and sets an env var."""
+    CredentialType.objects.filter(name='Custom File Type', kind='cloud').delete()
+
+    cred_type = CredentialType(
+        kind='cloud',
+        name='Custom File Type',
+        managed=False,
+        inputs={
+            'fields': [
+                {
+                    'id': 'test_file_content',
+                    'label': 'File Content',
+                    'type': 'string',
+                    'required': True,
+                }
+            ]
+        },
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename | quote }}'}},
+    )
+    cred_type.save()
+    return cred_type
+
+
+@pytest.fixture
+def custom_credential(custom_cred_type, default_org):
+    """Create a credential using the custom type."""
+    Credential.objects.filter(name='Custom File Credential').delete()
+
+    cred = Credential(
+        credential_type=custom_cred_type,
+        name='Custom File Credential',
+        organization=default_org,
+        inputs={'test_file_content': 'Hello from custom credential type!'},
+    )
+    cred.save()
+    return cred
+
+
+def test_custom_credential_type_file_injection(
+    run_job_from_playbook,
+    live_tmp_folder,
+    custom_credential,
+):
+    """
+    Test that a custom credential type can inject files and environment variables.
+    The playbook verifies that the injected file exists and contains the expected content,
+    and that the environment variable points to the correct path.
+    """
+    result = run_job_from_playbook(
+        test_name='custom_credential_type',
+        playbook='test_cred.yml',
+        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
+        jt_params={'credentials': [custom_credential.id]},
+    )
+
+    job = result['job']
+    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
+    output = unified_job_stdout(job)
+    assert 'Hello from custom credential type!' in output

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -23,7 +23,7 @@ def custom_cred_type(default_org):
                 }
             ]
         },
-        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename | quote }}'}},
+        injectors={'file': {'template.custom_file': '{{ test_file_content }}'}, 'env': {'CUSTOM_FILE_PATH': '{{ tower.filename.custom_file | quote }}'}},
     )
     cred_type.save()
     return cred_type

--- a/awx/main/tests/live/tests/test_custom_credential_type.py
+++ b/awx/main/tests/live/tests/test_custom_credential_type.py
@@ -65,3 +65,103 @@ def test_custom_credential_type_file_injection(
     assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'
     output = unified_job_stdout(job)
     assert 'Hello from custom credential type!' in output
+
+
+@pytest.fixture
+def oci_cred_type(default_org):
+    """Create an OCI-style credential type matching the customer's config from AAP-78106."""
+    CredentialType.objects.filter(name='OCI Custom Credential', kind='cloud').delete()
+
+    cred_type = CredentialType(
+        kind='cloud',
+        name='OCI Custom Credential',
+        managed=False,
+        inputs={
+            'fields': [
+                {'id': 'cred_oci_tenancy', 'type': 'string', 'label': 'Tenancy'},
+                {'id': 'cred_oci_region', 'type': 'string', 'label': 'OCI Region'},
+                {'id': 'cred_oci_user_id', 'type': 'string', 'label': 'OCI User Id'},
+                {'id': 'cred_oci_fingerprint', 'type': 'string', 'label': 'OCI SSH Key Fingerprint'},
+                {
+                    'id': 'cred_oci_ssh_privkey',
+                    'type': 'string',
+                    'label': 'OCI SSH Key',
+                    'format': 'ssh_private_key',
+                    'secret': True,
+                    'multiline': True,
+                },
+            ],
+            'required': [
+                'cred_oci_tenancy',
+                'cred_oci_region',
+                'cred_oci_fingerprint',
+                'cred_oci_user_id',
+            ],
+        },
+        injectors={
+            'file': {
+                'template.ssh_keyfile': '{{ cred_oci_ssh_privkey }}',
+                'template.oci_dummy_config': (
+                    '[DEFAULT]\n'
+                    'user={{ cred_oci_user_id }}\n'
+                    'fingerprint={{ cred_oci_fingerprint }}\n'
+                    'tenancy={{ cred_oci_tenancy }}\n'
+                    'region={{ cred_oci_region }}\n'
+                    'key_file={{ tower.filename.ssh_keyfile }}'
+                ),
+            },
+            'env': {
+                'OCI_REGION': '{{ cred_oci_region }}',
+                'OCI_TENANCY': '{{ cred_oci_tenancy }}',
+                'OCI_USER_ID': '{{ cred_oci_user_id }}',
+                'OCI_CONFIG_FILE': '{{ tower.filename.oci_dummy_config }}',
+                'OCI_USER_KEY_FILE': '{{ tower.filename.ssh_keyfile }}',
+                'OCI_USER_FINGERPRINT': '{{ cred_oci_fingerprint }}',
+                'OCI_ANSIBLE_AUTH_TYPE': 'api_key',
+            },
+        },
+    )
+    cred_type.save()
+    return cred_type
+
+
+@pytest.fixture
+def oci_credential(oci_cred_type, default_org):
+    """Create a credential using the OCI credential type."""
+    Credential.objects.filter(name='OCI Test Credential').delete()
+
+    cred = Credential(
+        credential_type=oci_cred_type,
+        name='OCI Test Credential',
+        organization=default_org,
+        inputs={
+            'cred_oci_tenancy': 'ocid1.tenancy.oc1..test',
+            'cred_oci_region': 'us-ashburn-1',
+            'cred_oci_user_id': 'ocid1.user.oc1..test',
+            'cred_oci_fingerprint': 'aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99',
+            'cred_oci_ssh_privkey': 'FAKE_OCI_PRIVATE_KEY_DATA',
+        },
+    )
+    cred.save()
+    return cred
+
+
+def test_custom_credential_type_file_cross_reference(
+    run_job_from_playbook,
+    live_tmp_folder,
+    oci_credential,
+):
+    """
+    Test that a file template can reference another injected file's path via
+    {{ tower.filename.ssh_keyfile }}. This mirrors the OCI credential type
+    from AAP-78106 where oci_dummy_config contains key_file={{ tower.filename.ssh_keyfile }}.
+    """
+    result = run_job_from_playbook(
+        test_name='custom_credential_type_cross_ref',
+        playbook='test_cred_cross_ref.yml',
+        scm_url=f'file://{live_tmp_folder}/custom_cred_project',
+        credentials=[oci_credential],
+    )
+
+    job = result['job']
+    assert job.status == 'successful', f'Job failed: {unified_job_stdout(job)}'


### PR DESCRIPTION
## Summary

Builds on @chrismeyersfsu's test from #16488 (credential association fix + simple file injection test) and adds a test case for **cross-referencing between file templates**.

### What this tests

A credential type where one file template references another injected file's path:

```yaml
file:
  template.key_file: '{{ key_data }}'
  template.config_file: |
    [DEFAULT]
    user={{ user_id }}
    key_file={{ tower.filename.key_file }}
env:
  KEY_FILE: '{{ tower.filename.key_file }}'
  CONFIG_FILE: '{{ tower.filename.config_file }}'
```

This is the pattern used by OCI and similar credential types — a config file that needs to contain the path to a key file. This is the pattern reported broken in [AAP-78106](https://redhat.atlassian.net/browse/AAP-78106).

### Why this fails without the awx_plugins.interfaces fix

When `inject_credential` was moved to `awx_plugins.interfaces` ([38f76f0f](https://github.com/ansible/awx_plugins.interfaces/commit/38f76f0f835173ffda89cf6ea279c35cf5e87aad)), the file injection loop was refactored to set `tower.filename` **after** the loop instead of incrementally **inside** it. This means `{{ tower.filename.key_file }}` is `None` when `config_file` is rendered, producing `key_file=` (blank) in the config file content.

Fix: https://github.com/ansible/awx_plugins.interfaces/pull/42

### Depends on

- #16488 — `credentials` parameter for `run_job_from_playbook` fixture
- https://github.com/ansible/awx_plugins.interfaces/pull/42 — incremental `tower.filename` assignment fix

## Test plan

- [ ] `test_custom_credential_type_file_injection` — simple file injection (from #16488)
- [ ] `test_custom_credential_type_file_cross_reference` — config file references key file path (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added playbook-based tests that validate custom credential file injection, confirm injected files' decoded contents, and ensure environment variables point to rendered files.
  * Added cross-reference playbook tests verifying referenced file paths and contents across injected templates.
  * Updated test helper to allow supplying credentials when running jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->