### PR TITLE
fix: do not allow exec instances to be added to the control plane

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -240,12 +240,17 @@ def apply_cluster_membership_policies():
         # Process policy instance list first, these will represent manually managed memberships
         instance_hostnames_map = {inst.hostname: inst for inst in all_instances}
         for ig in all_groups:
+            # we don't want to allow execution nodes in the control plane
+            exclude_type = 'execution' if ig.name == settings.DEFAULT_CONTROL_PLANE_QUEUE_NAME else 'control'
             group_actual = Group(obj=ig, instances=[], prior_instances=[instance.pk for instance in ig.instances.all()])  # obtained in prefetch
             for hostname in ig.policy_instance_list:
                 if hostname not in instance_hostnames_map:
                     logger.info("Unknown instance {} in {} policy list".format(hostname, ig.name))
                     continue
                 inst = instance_hostnames_map[hostname]
+                if inst.node_type == exclude_type:
+                    logger.info("Instance {} is excluded in {} policy list".format(hostname, ig.name))
+                    continue
                 group_actual.instances.append(inst.id)
                 # NOTE: arguable behavior: policy-list-group is not added to
                 # instance's group count for consideration in minimum-policy rules

--- a/awx/main/tests/functional/test_instances.py
+++ b/awx/main/tests/functional/test_instances.py
@@ -288,6 +288,20 @@ def test_control_plane_policy_exception(controlplane_instance_group):
 
 
 @pytest.mark.django_db
+def test_policy_instance_list_controlplane_excludes_execution_node(controlplane_instance_group):
+    controlplane_instance_group.policy_instance_percentage = 100
+    controlplane_instance_group.save()
+    exec_inst = Instance.objects.create(hostname='exec-1', node_type='execution')
+    control_inst = Instance.objects.create(hostname='control-1', node_type='control')
+    controlplane_instance_group.policy_instance_list = [exec_inst.hostname]
+    controlplane_instance_group.save()
+    apply_cluster_membership_policies()
+    members = list(controlplane_instance_group.instances.all())
+    assert exec_inst not in members
+    assert control_inst in members
+
+
+@pytest.mark.django_db
 def test_normal_instance_group_policy_exception():
     ig = InstanceGroup.objects.create(name='bar', policy_instance_percentage=100, policy_instance_minimum=2)
     Instance.objects.create(hostname='foo-1', node_type='control')


### PR DESCRIPTION
##### SUMMARY
Cherry-picked from https://github.com/ansible/awx/pull/16477

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed policy instance list filtering to properly exclude execution nodes from control-plane groups and control nodes from execution groups during cluster membership policy application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->