### PR TITLE
chore: update tekton pipeline bundle digest and renovate config

### DIFF
--- a/.tekton/run-atf-tests-pull-request.yaml
+++ b/.tekton/run-atf-tests-pull-request.yaml
@@ -27,7 +27,7 @@ spec:
       - name: name
         value: aap-api-tests
       - name: bundle
-        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:50aadd6725a239ab53247deb7cf601d1163ceb1792792fd239a3f37d21a490d7
+        value: quay.io/aap-ci/tekton-catalog/pipeline/test/aap-api-tests:0.1@sha256:0c1621395487e9305fb7652feb6d65071018953a199b991dcf520bd50c0b05ef
       - name: kind
         value: pipeline
       - name: secret

--- a/renovate.json
+++ b/renovate.json
@@ -2,14 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabledManagers": ["tekton"],
   "tekton": {
-    "schedule": ["0 * * * *"],
-    "packageRules": [
-      {
-        "description": "Update aap-ci tekton-catalog pipeline bundles",
-        "matchPackageNames": ["/^quay\\.io\\/aap-ci\\/tekton-catalog\\/pipeline\\/"],
-        "matchManagers": ["tekton"],
-        "automerge": true
-      }
-    ]
+    "enabled": true,
+    "automerge": true,
+    "schedule": ["* */12 * * 1-5"]
   }
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR updates the run atf tekton pipeline bundle sha ahead of mint maker to unblock pipelines when deploying aap-dev. Also simplifies the renovate config to attempt to have mint maker open PRs to update the tekton pipeline bundle digest automatically.

Latest pipeline changes:
1. Unblock error seen in the report-test-results-to-pr task
2. No longer use AWS spot instances

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

Closes #16479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated test pipeline to use a newer test bundle, improving test execution consistency and reliability.
  * Revised dependency-update behavior: Tekton updates are now enabled with auto-merging and run on a twice-daily business-day schedule to streamline maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->