### PR TITLE
test: add tests for aap_token Gateway Bearer token auth

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -6,7 +6,7 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.urls import Request, SSLValidationError, ConnectionError
 from ansible.module_utils.parsing.convert_bool import boolean as strtobool
 from ansible.module_utils.six import PY2
-from ansible.module_utils.six import raise_from
+from ansible.module_utils.six import raise_from, string_types
 from ansible.module_utils.six.moves import StringIO
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
@@ -118,6 +118,7 @@ class ControllerModule(AnsibleModule):
         'request_timeout': 'request_timeout',
         'max_retries': 'max_retries',
         'retry_backoff_factor': 'retry_backoff_factor',
+        'oauth_token': 'aap_token',
     }
     host = '127.0.0.1'
     username = None
@@ -126,6 +127,7 @@ class ControllerModule(AnsibleModule):
     request_timeout = 10
     max_retries = 5
     retry_backoff_factor = 2
+    oauth_token = None
     authenticated = False
     config_name = 'tower_cli.cfg'
     version_checked = False
@@ -159,6 +161,20 @@ class ControllerModule(AnsibleModule):
             direct_value = self.params.get(long_param)
             if direct_value is not None:
                 setattr(self, short_param, direct_value)
+
+        # Perform magic depending on whether aap_token is a string or a dict
+        if self.params.get('aap_token'):
+            token_param = self.params.get('aap_token')
+            if isinstance(token_param, dict):
+                if 'token' in token_param:
+                    self.oauth_token = token_param['token']
+                else:
+                    self.fail_json(msg="The provided dict in aap_token did not properly contain the token entry")
+            elif isinstance(token_param, string_types):
+                self.oauth_token = token_param
+            else:
+                error_msg = "The provided aap_token type was not valid ({0}). Valid options are str or dict.".format(type(token_param).__name__)
+                self.fail_json(msg=error_msg)
 
         # Perform some basic validation
         if not self.host.startswith(("https://", "http://")):  # NOSONAR
@@ -572,12 +588,13 @@ class ControllerAPIModule(ControllerModule):
         # Extract the headers, this will be used in a couple of places
         headers = kwargs.get('headers', {})
 
-        # Authenticate to AWX (if not already done so)
-        if not self.authenticated:
-            # This method will set a cookie in the cookie jar for us
+        # Authenticate to AWX (if we don't have a token and if not already done so)
+        if not self.oauth_token and not self.authenticated:
+            # This method will set a cookie in the cookie jar for us and also an oauth_token
             self.authenticate(**kwargs)
-
-        headers['Authorization'] = self._get_basic_authorization_header()
+        if self.oauth_token:
+            # If we have an oauth token, we just use a bearer header
+            headers['Authorization'] = 'Bearer {0}'.format(self.oauth_token)
 
         if method in ['POST', 'PUT', 'PATCH']:
             headers.setdefault('Content-Type', 'application/json')

--- a/awx_collection/test/awx/test_aap_token_auth.py
+++ b/awx_collection/test/awx/test_aap_token_auth.py
@@ -1,0 +1,187 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import sys
+
+from unittest import mock
+
+import pytest
+from requests.models import Response
+
+
+def mock_ping_response(self, method, url, **kwargs):
+    r = Response()
+    r.getheader = lambda header_name, default: {
+        'X-API-Product-Name': 'AWX',
+        'X-API-Product-Version': '1.0.0',
+    }.get(header_name, default)
+    r.read = lambda: json.dumps({})
+    r.status = 200
+    return r
+
+
+class TestAapTokenParsing:
+    """Tests for aap_token parameter parsing in ControllerModule.__init__"""
+
+    def test_string_token(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        module = ControllerAPIModule(
+            argument_spec={},
+            direct_params={'controller_host': 'https://localhost', 'aap_token': 'my-gateway-token'},
+        )
+        assert module.oauth_token == 'my-gateway-token'
+
+    def test_dict_token_with_token_key(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        module = ControllerAPIModule(
+            argument_spec={},
+            direct_params={'controller_host': 'https://localhost', 'aap_token': {'token': 'dict-token-value', 'id': 1}},
+        )
+        assert module.oauth_token == 'dict-token-value'
+
+    def test_dict_token_missing_token_key(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        with pytest.raises(SystemExit):
+            ControllerAPIModule(
+                argument_spec={},
+                direct_params={'controller_host': 'https://localhost', 'aap_token': {'id': 1}},
+            )
+
+    def test_invalid_token_type(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        with pytest.raises(SystemExit):
+            ControllerAPIModule(
+                argument_spec={},
+                direct_params={'controller_host': 'https://localhost', 'aap_token': 12345},
+            )
+
+    def test_no_token(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        module = ControllerAPIModule(
+            argument_spec={},
+            direct_params={'controller_host': 'https://localhost'},
+        )
+        assert module.oauth_token is None
+
+    def test_env_var_fallback(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        cli_data = {'ANSIBLE_MODULE_ARGS': {}}
+        testargs = ['module_file.py', json.dumps(cli_data)]
+        with mock.patch.object(sys, 'argv', testargs):
+            with mock.patch.dict('os.environ', {'CONTROLLER_OAUTH_TOKEN': 'env-token', 'CONTROLLER_HOST': 'https://localhost'}):
+                module = ControllerAPIModule(argument_spec={})
+        assert module.oauth_token == 'env-token'
+
+
+class TestBearerAuthHeader:
+    """Tests for Bearer auth header in make_request"""
+
+    def test_bearer_header_sent_when_token_present(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        module = ControllerAPIModule(
+            argument_spec={},
+            direct_params={'controller_host': 'https://localhost', 'aap_token': 'my-gateway-token'},
+        )
+        module._COLLECTION_TYPE = 'awx'
+
+        captured_headers = {}
+
+        def mock_open(self, method, url, **kwargs):
+            captured_headers.update(kwargs.get('headers', {}))
+            r = Response()
+            r.status_code = 200
+            r._content = json.dumps({'count': 0, 'results': []}).encode()
+            r.getheader = lambda h, d: None
+            r.read = lambda: r._content
+            r.status = 200
+            return r
+
+        with mock.patch('ansible.module_utils.urls.Request.open', new=mock_open):
+            module.make_request('GET', 'job_templates')
+
+        assert 'Authorization' in captured_headers
+        assert captured_headers['Authorization'] == 'Bearer my-gateway-token'
+
+    def test_basic_auth_used_without_token(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        module = ControllerAPIModule(
+            argument_spec={},
+            direct_params={
+                'controller_host': 'https://localhost',
+                'controller_username': 'admin',
+                'controller_password': 'password',
+            },
+        )
+        module._COLLECTION_TYPE = 'awx'
+
+        captured_headers = {}
+
+        def mock_open(self, method, url, **kwargs):
+            captured_headers.update(kwargs.get('headers', {}))
+            r = Response()
+            r.status_code = 200
+            r._content = json.dumps({'count': 0, 'results': []}).encode()
+            r.getheader = lambda h, d: None
+            r.read = lambda: r._content
+            r.status = 200
+            return r
+
+        with mock.patch('ansible.module_utils.urls.Request.open', new=mock_open):
+            module.make_request('GET', 'job_templates')
+
+        assert 'Authorization' in captured_headers
+        assert captured_headers['Authorization'].startswith('Basic ')
+
+    def test_token_skips_basic_auth(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        module = ControllerAPIModule(
+            argument_spec={},
+            direct_params={'controller_host': 'https://localhost', 'aap_token': 'my-gateway-token'},
+        )
+        module._COLLECTION_TYPE = 'awx'
+
+        def mock_open(self, method, url, **kwargs):
+            r = Response()
+            r.status_code = 200
+            r._content = json.dumps({'count': 0, 'results': []}).encode()
+            r.getheader = lambda h, d: None
+            r.read = lambda: r._content
+            r.status = 200
+            return r
+
+        with mock.patch('ansible.module_utils.urls.Request.open', new=mock_open):
+            with mock.patch.object(module, '_authenticate_with_basic_auth') as mock_basic:
+                module.make_request('GET', 'job_templates')
+                mock_basic.assert_not_called()
+
+    def test_token_precedence_over_username_password(self, collection_import):
+        ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+        module = ControllerAPIModule(
+            argument_spec={},
+            direct_params={
+                'controller_host': 'https://localhost',
+                'aap_token': 'my-gateway-token',
+                'controller_username': 'admin',
+                'controller_password': 'password',
+            },
+        )
+        module._COLLECTION_TYPE = 'awx'
+
+        captured_headers = {}
+
+        def mock_open(self, method, url, **kwargs):
+            captured_headers.update(kwargs.get('headers', {}))
+            r = Response()
+            r.status_code = 200
+            r._content = json.dumps({'count': 0, 'results': []}).encode()
+            r.getheader = lambda h, d: None
+            r.read = lambda: r._content
+            r.status = 200
+            return r
+
+        with mock.patch('ansible.module_utils.urls.Request.open', new=mock_open):
+            module.make_request('GET', 'job_templates')
+
+        assert captured_headers['Authorization'] == 'Bearer my-gateway-token'


### PR DESCRIPTION
## Summary
Adds test coverage for `aap_token` Gateway Bearer token authentication restored in #16493.

## Tests Added (`awx_collection/test/awx/test_aap_token_auth.py`)

### Token Parsing (`TestAapTokenParsing`)
| Test | Verifies |
|------|----------|
| `test_string_token` | String token sets `self.oauth_token` |
| `test_dict_token_with_token_key` | Dict `{'token': '...'}` extracts correctly |
| `test_dict_token_missing_token_key` | Dict without `token` key fails |
| `test_invalid_token_type` | Non-string/dict type fails |
| `test_no_token` | No token leaves `oauth_token` as None |
| `test_env_var_fallback` | `CONTROLLER_OAUTH_TOKEN` env var populates token |

### Bearer Auth Header (`TestBearerAuthHeader`)
| Test | Verifies |
|------|----------|
| `test_bearer_header_sent_when_token_present` | `Authorization: Bearer <token>` header in requests |
| `test_basic_auth_used_without_token` | Falls back to `Basic` auth with username/password |
| `test_token_skips_basic_auth` | `_authenticate_with_basic_auth()` not called when token present |
| `test_token_precedence_over_username_password` | Token wins when both token and credentials provided |

## Dependencies
- Builds on #16493 (`fix/restore-collection-oauth-token-auth`)

## Test plan
- [ ] `pytest awx_collection/test/awx/test_aap_token_auth.py -v`

Ref: AAP-78115, AAP-38395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth token authentication support as an alternative to username/password credentials for controller connections.
  * OAuth tokens take precedence over basic authentication when both are provided.
  * Token configuration now supported via environment variables.

* **Tests**
  * Added comprehensive test coverage for token parsing and bearer authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->