### PR TITLE
fix: add oauth_token option to lookup plugin auth doc fragment

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -40,15 +40,14 @@ options:
         version: '4.0.0'
         why: Collection name change
         alternatives: 'TOWER_PASSWORD, AAP_PASSWORD'
-  aap_token:
+  oauth_token:
     description:
     - The OAuth token to use.
+    - This value can be a string which is the token itself, or a dictionary as returned by the token module.
     env:
+    - name: CONTROLLER_OAUTH_TOKEN
     - name: AAP_TOKEN
-      deprecated:
-        collection_name: 'awx.awx'
-        version: '4.0.0'
-        why: Collection name change
+    aliases: [ aap_token ]
   verify_ssl:
     description:
     - Specify whether Ansible should verify the SSL certificate of the controller host.

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -6,7 +6,7 @@ from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.urls import Request, SSLValidationError, ConnectionError
 from ansible.module_utils.parsing.convert_bool import boolean as strtobool
 from ansible.module_utils.six import PY2
-from ansible.module_utils.six import raise_from
+from ansible.module_utils.six import raise_from, string_types
 from ansible.module_utils.six.moves import StringIO
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
@@ -118,6 +118,7 @@ class ControllerModule(AnsibleModule):
         'request_timeout': 'request_timeout',
         'max_retries': 'max_retries',
         'retry_backoff_factor': 'retry_backoff_factor',
+        'oauth_token': 'aap_token',
     }
     host = '127.0.0.1'
     username = None
@@ -126,6 +127,7 @@ class ControllerModule(AnsibleModule):
     request_timeout = 10
     max_retries = 5
     retry_backoff_factor = 2
+    oauth_token = None
     authenticated = False
     config_name = 'tower_cli.cfg'
     version_checked = False
@@ -159,6 +161,20 @@ class ControllerModule(AnsibleModule):
             direct_value = self.params.get(long_param)
             if direct_value is not None:
                 setattr(self, short_param, direct_value)
+
+        # Perform magic depending on whether aap_token is a string or a dict
+        if self.params.get('aap_token'):
+            token_param = self.params.get('aap_token')
+            if isinstance(token_param, dict):
+                if 'token' in token_param:
+                    self.oauth_token = token_param['token']
+                else:
+                    self.fail_json(msg="The provided dict in aap_token did not properly contain the token entry")
+            elif isinstance(token_param, string_types):
+                self.oauth_token = token_param
+            else:
+                error_msg = "The provided aap_token type was not valid ({0}). Valid options are str or dict.".format(type(token_param).__name__)
+                self.fail_json(msg=error_msg)
 
         # Perform some basic validation
         if not self.host.startswith(("https://", "http://")):  # NOSONAR
@@ -572,12 +588,13 @@ class ControllerAPIModule(ControllerModule):
         # Extract the headers, this will be used in a couple of places
         headers = kwargs.get('headers', {})
 
-        # Authenticate to AWX (if not already done so)
-        if not self.authenticated:
-            # This method will set a cookie in the cookie jar for us
+        # Authenticate to AWX (if we don't have a token and if not already done so)
+        if not self.oauth_token and not self.authenticated:
+            # This method will set a cookie in the cookie jar for us and also an oauth_token
             self.authenticate(**kwargs)
-
-        headers['Authorization'] = self._get_basic_authorization_header()
+        if self.oauth_token:
+            # If we have an oauth token, we just use a bearer header
+            headers['Authorization'] = 'Bearer {0}'.format(self.oauth_token)
 
         if method in ['POST', 'PUT', 'PATCH']:
             headers.setdefault('Content-Type', 'application/json')


### PR DESCRIPTION
## Summary
Adds the `oauth_token` option to the `auth_plugin` doc fragment so the `controller_api` lookup plugin can resolve the Bearer token from `CONTROLLER_OAUTH_TOKEN`.

## Problem
After #16493 added `'oauth_token': 'aap_token'` to `short_params`, the `controller_api` lookup plugin breaks at the "Gather Job Info" task:

```
"Requested entry (setting: oauth_token) was not defined in configuration."
```

The lookup plugin iterates `short_params` and calls `self.get_option(key)` for each entry. The `auth_plugin.py` doc fragment defined the option as `aap_token`, but the `short_params` key is `oauth_token`. Since `oauth_token` is not a registered plugin option, `get_option()` raises a `KeyError`.

## Impact Without This Fix
The AnsibleJob runner:
1. Launches the job template successfully (Bearer auth works)
2. **Fails** at "Gather Job Info" — cannot read back the job result
3. The AnsibleJob CR `status.ansibleJobResult` is never populated with `elapsed`, `started`, `finished`, or final `status`
4. Callers waiting on job completion see no result data
5. The runner exits `failed=1` despite the actual controller job succeeding

## Fix
Rename the option in `auth_plugin.py` from `aap_token` to `oauth_token` (matching the `short_params` key), keep `aap_token` as an alias, and add `CONTROLLER_OAUTH_TOKEN` as the primary env var.

## Dependencies
Builds on #16493 (`fix: add back aap_token support as Gateway Bearer token`)

## Test plan
- [ ] Verify `controller_api` lookup plugin resolves `oauth_token` from `CONTROLLER_OAUTH_TOKEN` env var
- [ ] Verify AnsibleJob "Gather Job Info" task completes without error
- [ ] Verify `ansibleJobResult` status is populated in the AnsibleJob CR

Ref: AAP-78115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth token authentication support for enhanced security.
  * OAuth tokens now accept both string and dictionary formats from token modules.
  * Updated environment variable support for `CONTROLLER_OAUTH_TOKEN` and `AAP_TOKEN`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->