### PR TITLE
Make aap_token functional for collection token auth

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -42,6 +42,7 @@ options:
     - If value not set, will try environment variable C(CONTROLLER_OAUTH_TOKEN) and then config files
     type: raw
     version_added: "3.7.0"
+    aliases: [ controller_oauthtoken, tower_oauthtoken ]
   validate_certs:
     description:
     - Whether to allow insecure connections to AWX.

--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -34,7 +34,8 @@ options:
     aliases: [ tower_password , aap_password ]
   aap_token:
     description:
-    - The OAuth token to use.
+    - The OAuth token to use, sent as a Bearer token in the Authorization header.
+    - When connecting through the AAP gateway, use a token issued by the gateway.
     - This value can be in one of two formats.
     - A string which is the token itself. (i.e. bqV5txm97wqJqtkxlMkhQz0pKhRMMX)
     - A dictionary structure as returned by the token module.

--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -36,8 +36,11 @@ options:
     description:
     - The OAuth token to use, sent as a Bearer token in the Authorization header.
     - When connecting through the AAP gateway, use a token issued by the gateway.
+    - This value can be in one of two formats.
+    - A string which is the token itself. (i.e. bqV5txm97wqJqtkxlMkhQz0pKhRMMX)
+    - A dictionary structure as set as a fact by the M(ansible.platform.token) module.
     - If value not set, will try environment variable C(CONTROLLER_OAUTH_TOKEN) and then config files
-    type: str
+    type: raw
     version_added: "3.7.0"
     aliases: [ controller_oauthtoken, tower_oauthtoken ]
   validate_certs:

--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -36,11 +36,8 @@ options:
     description:
     - The OAuth token to use, sent as a Bearer token in the Authorization header.
     - When connecting through the AAP gateway, use a token issued by the gateway.
-    - This value can be in one of two formats.
-    - A string which is the token itself. (i.e. bqV5txm97wqJqtkxlMkhQz0pKhRMMX)
-    - A dictionary structure as returned by the token module.
     - If value not set, will try environment variable C(CONTROLLER_OAUTH_TOKEN) and then config files
-    type: raw
+    type: str
     version_added: "3.7.0"
     aliases: [ controller_oauthtoken, tower_oauthtoken ]
   validate_certs:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -45,11 +45,19 @@ options:
     - The OAuth token to use, sent as a Bearer token in the Authorization header.
     - When connecting through the AAP gateway, use a token issued by the gateway.
     env:
-    - name: AAP_TOKEN
+    - name: CONTROLLER_OAUTH_TOKEN
       deprecated:
         collection_name: 'awx.awx'
         version: '4.0.0'
         why: Collection name change
+        alternatives: 'AAP_TOKEN'
+    - name: TOWER_OAUTH_TOKEN
+      deprecated:
+        collection_name: 'awx.awx'
+        version: '4.0.0'
+        why: Collection name change
+        alternatives: 'AAP_TOKEN'
+    - name: AAP_TOKEN
     aliases: [ controller_oauthtoken, tower_oauthtoken ]
   verify_ssl:
     description:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -42,7 +42,8 @@ options:
         alternatives: 'TOWER_PASSWORD, AAP_PASSWORD'
   aap_token:
     description:
-    - The OAuth token to use.
+    - The OAuth token to use, sent as a Bearer token in the Authorization header.
+    - When connecting through the AAP gateway, use a token issued by the gateway.
     env:
     - name: AAP_TOKEN
       deprecated:

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -50,6 +50,7 @@ options:
         collection_name: 'awx.awx'
         version: '4.0.0'
         why: Collection name change
+    aliases: [ controller_oauthtoken, tower_oauthtoken ]
   verify_ssl:
     description:
     - Specify whether Ansible should verify the SSL certificate of the controller host.

--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -34,7 +34,10 @@ class ControllerAWXKitModule(ControllerModule):
 
     def authenticate(self):
         try:
-            self.connection.login(username=self.username, password=self.password)
+            if self.oauth_token:
+                self.connection.session.headers['Authorization'] = 'Bearer {0}'.format(self.oauth_token)
+            else:
+                self.connection.login(username=self.username, password=self.password)
             self.authenticated = True
         except Exception:
             self.fail_json("Failed to authenticate")

--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -34,8 +34,8 @@ class ControllerAWXKitModule(ControllerModule):
 
     def authenticate(self):
         try:
-            if self.oauth_token:
-                self.connection.session.headers['Authorization'] = 'Bearer {0}'.format(self.oauth_token)
+            if self.aap_token:
+                self.connection.session.headers['Authorization'] = 'Bearer {0}'.format(self.aap_token)
             else:
                 self.connection.login(username=self.username, password=self.password)
             self.authenticated = True

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -163,13 +163,7 @@ class ControllerModule(AnsibleModule):
             if direct_value is not None:
                 setattr(self, short_param, direct_value)
 
-        # aap_token can be the token string itself, or the dict that the
-        # ansible.platform.token module sets as the aap_token fact
-        if isinstance(self.aap_token, dict):
-            if 'token' in self.aap_token:
-                self.aap_token = self.aap_token['token']
-            else:
-                self.fail_json(msg="The provided dict in aap_token did not properly contain the token entry")
+        self._parse_aap_token()
 
         # Perform some basic validation
         if not self.host.startswith(("https://", "http://")):  # NOSONAR
@@ -196,6 +190,15 @@ class ControllerModule(AnsibleModule):
                     sockaddr[0]
         except Exception as e:
             self.fail_json(msg="Unable to resolve controller_host ({1}): {0}".format(self.url.hostname, e))
+
+    def _parse_aap_token(self):
+        # aap_token can be the token string itself, or the dict that the
+        # ansible.platform.token module sets as the aap_token fact
+        if isinstance(self.aap_token, dict):
+            if 'token' in self.aap_token:
+                self.aap_token = self.aap_token['token']
+            else:
+                self.fail_json(msg="The provided dict in aap_token did not properly contain the token entry")
 
     def build_url(self, endpoint, query_params=None, app_key=None):
         # Make sure we start with /api/vX
@@ -583,17 +586,7 @@ class ControllerAPIModule(ControllerModule):
         # Extract the headers, this will be used in a couple of places
         headers = kwargs.get('headers', {})
 
-        if self.aap_token:
-            # A token (e.g. issued by the AAP gateway) is validated by the server on
-            # every request, so no login round-trip is needed
-            headers['Authorization'] = 'Bearer {0}'.format(self.aap_token)
-        else:
-            # Authenticate to AWX (if not already done so)
-            if not self.authenticated:
-                # This method will set a cookie in the cookie jar for us
-                self.authenticate(**kwargs)
-
-            headers['Authorization'] = self._get_basic_authorization_header()
+        headers['Authorization'] = self._get_authorization_header(**kwargs)
 
         if method in ['POST', 'PUT', 'PATCH']:
             headers.setdefault('Content-Type', 'application/json')
@@ -776,6 +769,19 @@ class ControllerAPIModule(ControllerModule):
             prefix = "{0}/".format(prefix)
 
         return prefix
+
+    def _get_authorization_header(self, **kwargs):
+        if self.aap_token:
+            # A token (e.g. issued by the AAP gateway) is validated by the server on
+            # every request, so no login round-trip is needed
+            return 'Bearer {0}'.format(self.aap_token)
+
+        # Authenticate to AWX (if not already done so)
+        if not self.authenticated:
+            # This method will set a cookie in the cookie jar for us
+            self.authenticate(**kwargs)
+
+        return self._get_basic_authorization_header()
 
     def _get_basic_authorization_header(self):
         basic_credentials = b64encode("{0}:{1}".format(self.username, self.password).encode()).decode()

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -7,6 +7,7 @@ from ansible.module_utils.urls import Request, SSLValidationError, ConnectionErr
 from ansible.module_utils.parsing.convert_bool import boolean as strtobool
 from ansible.module_utils.six import PY2
 from ansible.module_utils.six import raise_from
+from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves import StringIO
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
@@ -118,10 +119,13 @@ class ControllerModule(AnsibleModule):
         'request_timeout': 'request_timeout',
         'max_retries': 'max_retries',
         'retry_backoff_factor': 'retry_backoff_factor',
+        'aap_token': 'aap_token',
     }
     host = '127.0.0.1'
     username = None
     password = None
+    aap_token = None
+    oauth_token = None
     verify_ssl = True
     request_timeout = 10
     max_retries = 5
@@ -159,6 +163,20 @@ class ControllerModule(AnsibleModule):
             direct_value = self.params.get(long_param)
             if direct_value is not None:
                 setattr(self, short_param, direct_value)
+
+        # aap_token (e.g. a token issued by the AAP gateway) can be either the token
+        # string itself or a dict as returned by a token module
+        if self.aap_token:
+            if isinstance(self.aap_token, dict):
+                if 'token' in self.aap_token:
+                    self.oauth_token = self.aap_token['token']
+                else:
+                    self.fail_json(msg="The provided dict in aap_token did not properly contain the token entry")
+            elif isinstance(self.aap_token, string_types):
+                self.oauth_token = self.aap_token
+            else:
+                error_msg = "The provided aap_token type was not valid ({0}). Valid options are str or dict.".format(type(self.aap_token).__name__)
+                self.fail_json(msg=error_msg)
 
         # Perform some basic validation
         if not self.host.startswith(("https://", "http://")):  # NOSONAR
@@ -572,12 +590,17 @@ class ControllerAPIModule(ControllerModule):
         # Extract the headers, this will be used in a couple of places
         headers = kwargs.get('headers', {})
 
-        # Authenticate to AWX (if not already done so)
-        if not self.authenticated:
-            # This method will set a cookie in the cookie jar for us
-            self.authenticate(**kwargs)
+        if self.oauth_token:
+            # A token (e.g. issued by the AAP gateway) is validated by the server on
+            # every request, so no login round-trip is needed
+            headers['Authorization'] = 'Bearer {0}'.format(self.oauth_token)
+        else:
+            # Authenticate to AWX (if not already done so)
+            if not self.authenticated:
+                # This method will set a cookie in the cookie jar for us
+                self.authenticate(**kwargs)
 
-        headers['Authorization'] = self._get_basic_authorization_header()
+            headers['Authorization'] = self._get_basic_authorization_header()
 
         if method in ['POST', 'PUT', 'PATCH']:
             headers.setdefault('Content-Type', 'application/json')

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -97,7 +97,7 @@ class ControllerModule(AnsibleModule):
             required=False,
             fallback=(env_fallback, ['AAP_RETRY_BACKOFF_FACTOR'])),
         aap_token=dict(
-            type='str',
+            type='raw',
             no_log=True,
             aliases=['controller_oauthtoken', 'tower_oauthtoken'],
             required=False,
@@ -162,6 +162,14 @@ class ControllerModule(AnsibleModule):
             direct_value = self.params.get(long_param)
             if direct_value is not None:
                 setattr(self, short_param, direct_value)
+
+        # aap_token can be the token string itself, or the dict that the
+        # ansible.platform.token module sets as the aap_token fact
+        if isinstance(self.aap_token, dict):
+            if 'token' in self.aap_token:
+                self.aap_token = self.aap_token['token']
+            else:
+                self.fail_json(msg="The provided dict in aap_token did not properly contain the token entry")
 
         # Perform some basic validation
         if not self.host.startswith(("https://", "http://")):  # NOSONAR

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -100,6 +100,7 @@ class ControllerModule(AnsibleModule):
         aap_token=dict(
             type='raw',
             no_log=True,
+            aliases=['controller_oauthtoken', 'tower_oauthtoken'],
             required=False,
             fallback=(env_fallback, ['CONTROLLER_OAUTH_TOKEN', 'TOWER_OAUTH_TOKEN', 'AAP_TOKEN'])
         ),

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -7,7 +7,6 @@ from ansible.module_utils.urls import Request, SSLValidationError, ConnectionErr
 from ansible.module_utils.parsing.convert_bool import boolean as strtobool
 from ansible.module_utils.six import PY2
 from ansible.module_utils.six import raise_from
-from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves import StringIO
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
@@ -98,7 +97,7 @@ class ControllerModule(AnsibleModule):
             required=False,
             fallback=(env_fallback, ['AAP_RETRY_BACKOFF_FACTOR'])),
         aap_token=dict(
-            type='raw',
+            type='str',
             no_log=True,
             aliases=['controller_oauthtoken', 'tower_oauthtoken'],
             required=False,
@@ -126,7 +125,6 @@ class ControllerModule(AnsibleModule):
     username = None
     password = None
     aap_token = None
-    oauth_token = None
     verify_ssl = True
     request_timeout = 10
     max_retries = 5
@@ -164,20 +162,6 @@ class ControllerModule(AnsibleModule):
             direct_value = self.params.get(long_param)
             if direct_value is not None:
                 setattr(self, short_param, direct_value)
-
-        # aap_token (e.g. a token issued by the AAP gateway) can be either the token
-        # string itself or a dict as returned by a token module
-        if self.aap_token:
-            if isinstance(self.aap_token, dict):
-                if 'token' in self.aap_token:
-                    self.oauth_token = self.aap_token['token']
-                else:
-                    self.fail_json(msg="The provided dict in aap_token did not properly contain the token entry")
-            elif isinstance(self.aap_token, string_types):
-                self.oauth_token = self.aap_token
-            else:
-                error_msg = "The provided aap_token type was not valid ({0}). Valid options are str or dict.".format(type(self.aap_token).__name__)
-                self.fail_json(msg=error_msg)
 
         # Perform some basic validation
         if not self.host.startswith(("https://", "http://")):  # NOSONAR
@@ -591,10 +575,10 @@ class ControllerAPIModule(ControllerModule):
         # Extract the headers, this will be used in a couple of places
         headers = kwargs.get('headers', {})
 
-        if self.oauth_token:
+        if self.aap_token:
             # A token (e.g. issued by the AAP gateway) is validated by the server on
             # every request, so no login round-trip is needed
-            headers['Authorization'] = 'Bearer {0}'.format(self.oauth_token)
+            headers['Authorization'] = 'Bearer {0}'.format(self.aap_token)
         else:
             # Authenticate to AWX (if not already done so)
             if not self.authenticated:

--- a/awx_collection/test/awx/test_token_auth.py
+++ b/awx_collection/test/awx/test_token_auth.py
@@ -1,0 +1,103 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+from requests.models import Response
+from unittest import mock
+
+
+def getheader(self, header_name, default):
+    return default
+
+
+def read(self):
+    return json.dumps({})
+
+
+def status(self):
+    return 200
+
+
+def make_recorder():
+    """Build a mock for Request.open that records every call made through it."""
+    calls = []
+
+    def opener(self, method, url, **kwargs):
+        calls.append({'method': method, 'url': url, 'headers': kwargs.get('headers') or {}})
+        r = Response()
+        r.getheader = getheader.__get__(r)
+        r.read = read.__get__(r)
+        r.status = status.__get__(r)
+        return r
+
+    return opener, calls
+
+
+def make_module(collection_import, module_args, **kwargs):
+    ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+    cli_data = {'ANSIBLE_MODULE_ARGS': module_args}
+    # patch the cached args directly: AnsibleModule caches sys.argv parsing in
+    # basic._ANSIBLE_ARGS, so patching sys.argv would leak args between tests
+    with mock.patch.object(basic, '_ANSIBLE_ARGS', to_bytes(json.dumps(cli_data))):
+        return ControllerAPIModule(argument_spec=dict(), **kwargs)
+
+
+@pytest.mark.parametrize(
+    'token_value',
+    [
+        'a-token-string',
+        {'token': 'a-token-string', 'id': 1},  # the aap_token fact set by ansible.platform.token
+    ],
+    ids=['string', 'dict'],
+)
+def test_aap_token_sends_bearer_header(collection_import, token_value):
+    module = make_module(collection_import, {'aap_token': token_value})
+    assert module.aap_token == 'a-token-string'
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.get_endpoint('ping')
+
+    assert len(calls) == 1, calls
+    assert calls[0]['headers']['Authorization'] == 'Bearer a-token-string'
+    # a token needs no login round-trip
+    assert module.authenticated is False
+
+
+@pytest.mark.parametrize('param', ['controller_oauthtoken', 'tower_oauthtoken'])
+def test_aap_token_legacy_aliases(collection_import, param):
+    module = make_module(collection_import, {param: 'legacy-token'})
+    assert module.aap_token == 'legacy-token'
+
+
+def test_aap_token_dict_without_token_entry_fails(collection_import):
+    errors = []
+
+    def error_callback(**kwargs):
+        errors.append(kwargs)
+        raise SystemExit(1)
+
+    with pytest.raises(SystemExit):
+        make_module(collection_import, {'aap_token': {'id': 1}}, error_callback=error_callback)
+
+    assert 'did not properly contain the token entry' in errors[0]['msg']
+
+
+def test_no_token_falls_back_to_basic_auth(collection_import):
+    module = make_module(collection_import, {'controller_username': 'admin', 'controller_password': 'secret'})
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.get_endpoint('ping')
+
+    # first call is the authentication probe, second is the actual request
+    assert len(calls) == 2, calls
+    for call in calls:
+        assert call['headers']['Authorization'].startswith('Basic '), call
+    assert module.authenticated is True


### PR DESCRIPTION
##### SUMMARY

The `aap_token` parameter was added to the collection argspec and docs in #16025, but nothing consumes it: token auth was removed from the collection in #15623, and the consuming logic never came back. Passing `aap_token` (or `AAP_TOKEN`/`CONTROLLER_OAUTH_TOKEN` env vars) today is silently ignored and the module falls back to basic auth, which breaks token-based authentication through the AAP gateway.

This wires the parameter up (mirroring the downstream stable-2.6 fix):

- `aap_token` is a plain string parameter; `make_request` sends `Authorization: Bearer <token>` when it is set and skips the basic-auth `/me` login probe (the gateway validates the token on every request); the basic-auth path is unchanged when no token is provided
- `aap_token` is added to `short_params` so the `controller_api` lookup plugin and `controller` inventory plugin forward it (it was already declared in their doc fragment)
- The awxkit-based `export`/`import` modules set the Bearer header on the awxkit session when a token is provided
- Auth doc fragments updated to document the Bearer/gateway behavior
- `controller_oauthtoken` and `tower_oauthtoken` are restored as aliases of `aap_token` for back-compat with pre-removal playbooks (matching downstream stable-2.6)

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- Collection

##### AWX VERSION
devel

##### ADDITIONAL INFORMATION

Verified that string tokens, dict tokens (`{token: ...}`), and invalid dicts behave as expected, that requests carry the Bearer header without performing the basic-auth login probe, and that the no-token basic-auth path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for authenticating with OAuth bearer tokens so operations can use token-based login instead of username/password and skip interactive login when a token is provided.
  * Accepts tokens provided directly or as a token fact, and preserves existing option aliases and environment fallback.

* **Documentation**
  * Clarified that tokens are sent as Bearer tokens in the Authorization header and, when connecting via the AAP gateway, must be issued by that gateway.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

