### PR TITLE
AAP-78420: Updating the remediation condition in system.py to check for cpu and memory values set to 0.

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -633,7 +633,7 @@ def inspect_execution_and_hop_nodes(instance_list):
                 # check
                 logger.warning(f'Execution node attempting to rejoin as instance {hostname}.')
                 execution_node_health_check.apply_async([hostname])
-            elif instance.capacity == 0 and instance.enabled:
+            elif (instance.capacity == 0 or (instance.cpu == 0 and instance.memory == 0)) and instance.enabled:
                 # nodes with proven connection but need remediation run health checks are reduced frequency
                 if not instance.last_health_check or (nowtime - instance.last_health_check).total_seconds() >= settings.EXECUTION_NODE_REMEDIATION_CHECKS:
                     # Periodically re-run the health check of errored nodes, in case someone fixed it


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The execution nodes are getting stuck at values of `capacity=1` with `cpu=0` and `memory=0` permanently if the initial health check fails. The remediation condition to re-run the health check is never triggered because the if statement only checks for if `capacity=0`. The calculations for capacity lead to a situation where the capacity value has a floor of 1, so the remediation condition is never met. 

The `max(1, ...)` floor in capacity formulas and the `capacity == 0` remediation check are contradictory:

`get_cpu_effective_capacity(0)` → `max(1, int(0 * 4))` → 1
`get_mem_effective_capacity(0)` → `max(1, (0 - 2GB) // 100MB)` → 1
`set_capacity_value()` → `min(1, 1) + (max(1, 1) - min(1, 1)) * 1.0` → 1

Since capacity is 1 (not 0), the remediation condition at line 636 never matches.

I updated the remediation condition in `awx/main/tasks/system.py:636` to also rerun the health check when `instance.cpu == 0 and instance.memory == 0)`. This would make it so that the health check would run even if capacity = 1, if the cpu and memory values are set to 0. 

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
1. Deploy a containerized AAP cluster with 2 control nodes and 2 execution nodes
2. During initial setup, if the receptor mesh is not fully established when the first execution_node_health_check runs, the health check may return partial/empty data
3. The execution nodes end up with `cpu=0`, `memory=0`, `version=ansible-runner-???`, `cpu_capacity=1`, `mem_capacity=1`, `capacity=1`, `node_state=ready`
4. Wait any amount of time - the nodes remain stuck at `capacity=1` indefinitely with no automatic remediation

Expected Result: Remediation logic should detect that the CPU and Memory values are at 0 and retrigger a health check eventually. 

Actual Result: Nodes are stuck without retriggering a health check, because the capacity value is stuck at 1. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# Before
elif instance.capacity == 0 and instance.enabled:

# After
elif (instance.capacity == 0 or (instance.cpu == 0 and instance.memory == 0)) and instance.enabled:
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded system instance health checks to trigger remediation not only when enabled instances have `capacity` set to zero, but also when both `CPU` and `memory` are set to zero—improving detection of instances that require attention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->