### PR TITLE
Restore oauth_token backward compatibility for collection token auth

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth.py
+++ b/awx_collection/plugins/doc_fragments/auth.py
@@ -42,7 +42,7 @@ options:
     - If value not set, will try environment variable C(CONTROLLER_OAUTH_TOKEN) and then config files
     type: raw
     version_added: "3.7.0"
-    aliases: [ controller_oauthtoken, tower_oauthtoken ]
+    aliases: [ oauth_token, controller_oauthtoken, tower_oauthtoken ]
   validate_certs:
     description:
     - Whether to allow insecure connections to AWX.

--- a/awx_collection/plugins/doc_fragments/auth_plugin.py
+++ b/awx_collection/plugins/doc_fragments/auth_plugin.py
@@ -58,7 +58,7 @@ options:
         why: Collection name change
         alternatives: 'AAP_TOKEN'
     - name: AAP_TOKEN
-    aliases: [ controller_oauthtoken, tower_oauthtoken ]
+    aliases: [ oauth_token, controller_oauthtoken, tower_oauthtoken ]
   verify_ssl:
     description:
     - Specify whether Ansible should verify the SSL certificate of the controller host.

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -311,8 +311,8 @@ class ControllerModule(AnsibleModule):
         except Exception as e:
             raise_from(ConfigFileException("An unknown exception occured trying to load config file: {0}".format(e)), e)
 
-        # Backward compatibility: config files written for older collection versions
-        # (4.6.0 and earlier) used the oauth_token key; map it to aap_token.
+        # Backward compatibility: config files written for older collection
+        # releases used the oauth_token key; map it to aap_token.
         # If both keys are present, the new aap_token key wins.
         if 'oauth_token' in config_data and 'aap_token' not in config_data:
             config_data['aap_token'] = config_data['oauth_token']

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -99,7 +99,7 @@ class ControllerModule(AnsibleModule):
         aap_token=dict(
             type='raw',
             no_log=True,
-            aliases=['controller_oauthtoken', 'tower_oauthtoken'],
+            aliases=['oauth_token', 'controller_oauthtoken', 'tower_oauthtoken'],
             required=False,
             fallback=(env_fallback, ['CONTROLLER_OAUTH_TOKEN', 'TOWER_OAUTH_TOKEN', 'AAP_TOKEN'])
         ),
@@ -298,7 +298,8 @@ class ControllerModule(AnsibleModule):
 
                     # If we made it here then we have values from reading the ini file, so let's pull them out into a dict
                     config_data = {}
-                    for honorred_setting in self.short_params:
+                    # 'oauth_token' is the legacy (pre-aap_token) config file key, kept for backward compatibility
+                    for honorred_setting in list(self.short_params) + ['oauth_token']:
                         try:
                             config_data[honorred_setting] = config.get('general', honorred_setting)
                         except NoOptionError:
@@ -309,6 +310,12 @@ class ControllerModule(AnsibleModule):
 
         except Exception as e:
             raise_from(ConfigFileException("An unknown exception occured trying to load config file: {0}".format(e)), e)
+
+        # Backward compatibility: config files written for older collection versions
+        # (4.6.0 and earlier) used the oauth_token key; map it to aap_token.
+        # If both keys are present, the new aap_token key wins.
+        if 'oauth_token' in config_data and 'aap_token' not in config_data:
+            config_data['aap_token'] = config_data['oauth_token']
 
         # If we made it here, we have a dict which has values in it from our config, any final settings logic can be performed here
         for honorred_setting in self.short_params:

--- a/awx_collection/test/awx/test_token_auth.py
+++ b/awx_collection/test/awx/test_token_auth.py
@@ -45,6 +45,10 @@ def make_module(collection_import, module_args, **kwargs):
     # patch the cached args directly: AnsibleModule caches sys.argv parsing in
     # basic._ANSIBLE_ARGS, so patching sys.argv would leak args between tests
     with mock.patch.object(basic, '_ANSIBLE_ARGS', to_bytes(json.dumps(cli_data))):
+        # ansible-core 2.21+ also requires a serialization profile alongside the args
+        if hasattr(basic, '_ANSIBLE_PROFILE'):
+            with mock.patch.object(basic, '_ANSIBLE_PROFILE', 'legacy'):
+                return ControllerAPIModule(argument_spec=dict(), **kwargs)
         return ControllerAPIModule(argument_spec=dict(), **kwargs)
 
 
@@ -70,10 +74,41 @@ def test_aap_token_sends_bearer_header(collection_import, token_value):
     assert module.authenticated is False
 
 
-@pytest.mark.parametrize('param', ['controller_oauthtoken', 'tower_oauthtoken'])
+@pytest.mark.parametrize('param', ['oauth_token', 'controller_oauthtoken', 'tower_oauthtoken'])
 def test_aap_token_legacy_aliases(collection_import, param):
     module = make_module(collection_import, {param: 'legacy-token'})
     assert module.aap_token == 'legacy-token'
+
+
+def test_lookup_oauth_token_option_maps_to_aap_token(collection_import):
+    # The 4.6.0-era lookup/inventory plugins pass options through as direct
+    # params keyed by the plugin option name; oauth_token must resolve to
+    # aap_token via the argspec alias.
+    module = make_module(collection_import, {'oauth_token': 'plugin-token'})
+    assert module.aap_token == 'plugin-token'
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.get_endpoint('ping')
+
+    assert calls[0]['headers']['Authorization'] == 'Bearer plugin-token'
+
+
+def test_config_file_legacy_oauth_token_key(collection_import, tmp_path):
+    # tower_cli.cfg-style config files from 4.6.0 used the oauth_token key
+    config_file = tmp_path / 'tower_cli.cfg'
+    config_file.write_text('[general]\nhost = https://127.0.0.1\noauth_token = ini-legacy-token\n')
+
+    module = make_module(collection_import, {'controller_config_file': str(config_file)})
+    assert module.aap_token == 'ini-legacy-token'
+
+
+def test_config_file_aap_token_wins_over_legacy_key(collection_import, tmp_path):
+    config_file = tmp_path / 'tower_cli.cfg'
+    config_file.write_text('[general]\nhost = https://127.0.0.1\noauth_token = ini-legacy-token\naap_token = ini-new-token\n')
+
+    module = make_module(collection_import, {'controller_config_file': str(config_file)})
+    assert module.aap_token == 'ini-new-token'
 
 
 def test_aap_token_dict_without_token_entry_fails(collection_import):

--- a/awx_collection/test/awx/test_token_auth.py
+++ b/awx_collection/test/awx/test_token_auth.py
@@ -81,7 +81,7 @@ def test_aap_token_legacy_aliases(collection_import, param):
 
 
 def test_lookup_oauth_token_option_maps_to_aap_token(collection_import):
-    # The 4.6.0-era lookup/inventory plugins pass options through as direct
+    # Older lookup/inventory plugin releases pass options through as direct
     # params keyed by the plugin option name; oauth_token must resolve to
     # aap_token via the argspec alias.
     module = make_module(collection_import, {'oauth_token': 'plugin-token'})
@@ -95,7 +95,7 @@ def test_lookup_oauth_token_option_maps_to_aap_token(collection_import):
 
 
 def test_config_file_legacy_oauth_token_key(collection_import, tmp_path):
-    # tower_cli.cfg-style config files from 4.6.0 used the oauth_token key
+    # tower_cli.cfg-style config files from older releases used the oauth_token key
     config_file = tmp_path / 'tower_cli.cfg'
     config_file.write_text('[general]\nhost = https://127.0.0.1\noauth_token = ini-legacy-token\n')
 


### PR DESCRIPTION
##### SUMMARY
Follow-up to #16498. The `aap_token` rename restored module-level token auth, but two interfaces from earlier collection releases remained broken:

1. **Lookup/inventory plugin option `oauth_token`** — earlier collection releases declared an option literally named `oauth_token` (its only spelling) in the `auth_plugin` doc fragment, used by the `controller_api` lookup (`query(..., oauth_token=...)`) and the `controller` inventory plugin (`oauth_token:` key in inventory YAML). The renamed option only carried the `controller_oauthtoken`/`tower_oauthtoken` aliases, so existing lookup/inventory usage failed with an invalid-option error. `oauth_token` is now an alias of `aap_token` in the doc fragment.

2. **Legacy `oauth_token` key in tower_cli.cfg-style config files** — `short_params` previously mapped the `oauth_token` ini key under `[general]`; after the rename it was silently ignored, quietly degrading auth (the same failure mode #16498 fixed). `load_config()` now also reads the legacy `oauth_token` key and maps it to `aap_token`, with the new `aap_token` key winning when both are present. `aap_token` remains the canonical attribute consumed by `_parse_aap_token()` and the Bearer-header logic.

Note on scope: `oauth_token` is also added to the `aap_token` aliases in `AUTH_ARGSPEC` (and documented in the module `auth` doc fragment). Unlike the two items above this is *not* a restoration — modules historically used `controller_oauthtoken`/`tower_oauthtoken` (both already aliased) — it just keeps the module and plugin option surfaces consistent. Happy to drop that hunk if reviewers prefer the strictly-compat scope.

Also makes the test helper compatible with ansible-core 2.21+, which requires a serialization profile alongside `_ANSIBLE_ARGS` — without this, the tests added in #16498 fail on 2.21.

No changelog fragment: `awx_collection/changelogs/` does not exist on devel.

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- Collection

##### AWX VERSION
devel

##### ADDITIONAL INFORMATION
Behavior verified against the pre-rename collection sources (`awx_collection/plugins/doc_fragments/auth_plugin.py` declared `oauth_token`; `module_utils/controller_api.py` had `'oauth_token': 'controller_oauthtoken'` in `short_params` with `config_name = 'tower_cli.cfg'`).

Tested with `pytest awx_collection/test/awx/test_token_auth.py` in the awx_devel image (ansible-core 2.21.0): 10 passed — the 6 pre-existing canonical `aap_token` cases (string and dict inputs) plus 4 new/extended compat cases (`oauth_token` alias on modules and lookup, legacy config-file key, `aap_token` precedence over the legacy key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes the legacy token name "oauth_token" as an alias for the current authentication token and maps legacy entries to the current parameter for backward compatibility.

* **Documentation**
  * Updated docs to list "oauth_token" alongside existing token aliases.

* **Tests**
  * Expanded tests covering legacy alias handling, config-file compatibility, and precedence when both legacy and current tokens are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->