### PR TITLE
AAP-79142 fix: resolve SonarCloud security rating C

### DIFF
--- a/awxkit/awxkit/api/pages/page.py
+++ b/awxkit/awxkit/api/pages/page.py
@@ -2,7 +2,6 @@ from contextlib import suppress
 import inspect
 import logging
 import json
-import re
 
 from requests import Response
 import http.client as http
@@ -23,31 +22,31 @@ get_registered_page = _page_registry.get
 
 
 def is_license_invalid(response):
-    if re.match(r".*Invalid license.*", response.text):
+    if "Invalid license" in response.text:
         return True
-    if re.match(r".*Missing 'eula_accepted' property.*", response.text):
+    if "Missing 'eula_accepted' property" in response.text:
         return True
-    if re.match(r".*'eula_accepted' must be True.*", response.text):
+    if "'eula_accepted' must be True" in response.text:
         return True
-    if re.match(r".*Invalid license data.*", response.text):
+    if "Invalid license data" in response.text:
         return True
 
 
 def is_license_exceeded(response):
-    if re.match(r".*license range of.*instances has been exceeded.*", response.text):
+    if "license range of" in response.text and "instances has been exceeded" in response.text:
         return True
-    if re.match(r".*License count of.*instances has been reached.*", response.text):
+    if "License count of" in response.text and "instances has been reached" in response.text:
         return True
-    if re.match(r".*License count of.*instances has been exceeded.*", response.text):
+    if "License count of" in response.text and "instances has been exceeded" in response.text:
         return True
-    if re.match(r".*License has expired.*", response.text):
+    if "License has expired" in response.text:
         return True
-    if re.match(r".*License is missing.*", response.text):
+    if "License is missing" in response.text:
         return True
 
 
 def is_duplicate_error(response):
-    if re.match(r".*already exists.*", response.text):
+    if "already exists" in response.text:
         return True
 
 


### PR DESCRIPTION
##### SUMMARY

Resolve SonarCloud security rating C for the AWX project by fixing two issues:

- Replace 10 `re.match(r".*X.*")` calls with plain `in` operator in `awxkit/api/pages/page.py` to eliminate ReDoS vulnerability (python:S5852)
- Delete stray empty `awx/api/urls/Pipfile` that triggered missing lockfile warning (text:S8565), which was driving the C security rating

Additionally, 5 false-positive security hotspots were reviewed and marked SAFE on SonarCloud (candlepin HTTP proxy config, awxkit test utility /tmp paths).

related AAP-79142

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

1. Visit https://sonarcloud.io/project/overview?id=ansible_awx
2. Observe Security Rating C, with quality gate failing on `new_security_rating` (C) and `new_security_hotspots_reviewed` (55.6%)

After this change:
- The MEDIUM vulnerability (empty Pipfile) is removed
- The 3 ReDoS hotspots in page.py are eliminated (code fixed)
- The 5 remaining false-positive hotspots are marked SAFE on SonarCloud

```
Security Rating: C → A (expected after rescan)
Hotspots Reviewed: 55.6% → 100%
```

Fixes: [AAP-79142](https://redhat.atlassian.net/browse/AAP-79142)

🤖 Generated with [Claude Code](https://claude.com/claude-code)