### PR TITLE
Do not mark node READY when health check reports zero cpu or memory

### DIFF
--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -374,6 +374,11 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             self.memory = new_memory
             update_fields.append('memory')
 
+        # Do not mark nodes READY if cpu or memory is zero
+        if not errors and self.node_type != Instance.Types.HOP and (not new_cpu or not new_memory):
+            errors = _('Health check for {} reported invalid values: cpu={}, memory={}').format(self.hostname, new_cpu, new_memory)
+            logger.warning(errors)
+
         if not errors:
             self.refresh_capacity_fields()
             self.errors = ''


### PR DESCRIPTION
## Summary
- Instances reporting cpu=0 or memory=0 with no errors were being transitioned to READY state with a non-zero capacity (due to `max(1, ...)` floors in capacity calculations), making them appear healthy and schedulable
- Treat zero cpu/memory as an error condition so the node is marked offline via `mark_offline()` until a valid health check is received
- Hop nodes are excluded from this check since they do not report cpu/memory

## Test plan
- [ ] Verify that an execution node reporting cpu=0 or memory=0 is not transitioned to READY
- [ ] Verify that hop nodes still transition to READY normally
- [ ] Verify that a node marked offline due to this check recovers on the next successful health check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health check validation to prevent nodes (non-HOP) from being marked as ready when CPU or memory reports are invalid or empty (including zero/falsy values). A clearer error is recorded and the node follows the existing offline/error handling flow instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->