### PR TITLE
[devel backport][AAP-70902] Use _actor_role_filter() in UnifiedJobTemplate.accessible_pk_qs()

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -234,7 +234,7 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
         dab_role_cts = permission_registry.content_type_model.objects.get_for_models(*role_subclasses).values()
 
         return (
-            RoleEvaluation.objects.filter(role__in=accessor.has_roles.all(), codename__in=all_codenames, content_type_id__in=[ct.id for ct in dab_role_cts])
+            RoleEvaluation.objects.filter(**RoleEvaluation._actor_role_filter(accessor), codename__in=all_codenames, content_type_id__in=[ct.id for ct in dab_role_cts])
             .values_list('object_id')
             .distinct()
         )

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -234,7 +234,11 @@ class UnifiedJobTemplate(PolymorphicModel, CommonModelNameNotUnique, ExecutionEn
         dab_role_cts = permission_registry.content_type_model.objects.get_for_models(*role_subclasses).values()
 
         return (
-            RoleEvaluation.objects.filter(**RoleEvaluation._actor_role_filter(accessor), codename__in=all_codenames, content_type_id__in=[ct.id for ct in dab_role_cts])
+            RoleEvaluation.objects.filter(
+                **RoleEvaluation._actor_role_filter(accessor),
+                codename__in=all_codenames,
+                content_type_id__in=[ct.id for ct in dab_role_cts],
+            )
             .values_list('object_id')
             .distinct()
         )


### PR DESCRIPTION
##### SUMMARY

Backport of ansible/tower#7496 to awx/devel.

Replace `role__in=accessor.has_roles.all()` with the optimized `_actor_role_filter()` subquery pattern from django-ansible-base.

The old pattern causes a 3-table JOIN through `RoleUserAssignment` -> `ObjectRole` -> `RoleEvaluation` on every non-superuser request. `_actor_role_filter()` skips the `ObjectRole` table entirely by using a direct subquery on `RoleUserAssignment.object_role_id`, eliminating the intermediate JOIN and reducing query time for `/api/v2/unified_jobs/` requests by non-superusers.

Resolves: AAP-78351

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved permission filtering for job template accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->