### PR TITLE
Fix SonarCloud security rating: remove user-controlled data from sqlite filepath

### DIFF
--- a/awx/main/db/profiled_pg/base.py
+++ b/awx/main/db/profiled_pg/base.py
@@ -68,7 +68,7 @@ class RecordedQueryLog(object):
                     progname = match
                     break
             else:
-                progname = os.path.basename(sys.argv[0])
+                progname = 'unknown'
             filepath = os.path.join(self.dest, '{}.sqlite'.format(progname))
             version = _get_version('awx')
             log = sqlite3.connect(filepath, timeout=3)

--- a/awx/main/tests/unit/test_db.py
+++ b/awx/main/tests/unit/test_db.py
@@ -1,7 +1,6 @@
 import collections
 import os
 import sqlite3
-import sys
 import unittest
 
 import pytest

--- a/awx/main/tests/unit/test_db.py
+++ b/awx/main/tests/unit/test_db.py
@@ -125,7 +125,7 @@ def test_sql_above_threshold(tmpdir):
         args, kw = _call
         assert args == ('EXPLAIN VERBOSE {}'.format(QUERY['sql']),)
 
-    path = os.path.join(tmpdir, '{}.sqlite'.format(os.path.basename(sys.argv[0])))
+    path = os.path.join(tmpdir, 'unknown.sqlite')
     assert os.path.exists(path)
 
     # verify the results


### PR DESCRIPTION
##### SUMMARY

Replace `os.path.basename(sys.argv[0])` with a hardcoded `'unknown'` fallback in `RecordedQueryLog.write()` to eliminate path injection via CLI arguments. Resolves SonarCloud rule `pythonsecurity:S8706` (connection string injection).

The `write()` method in `RecordedQueryLog` uses `sys.argv` to construct a sqlite filepath. When the process name doesn't match the known allowlist (`uwsgi`, `dispatcher`, `callback_receiver`, `wsrelay`), the raw `os.path.basename(sys.argv[0])` is used — allowing user-controlled data to reach `os.path.join()` and `sqlite3.connect()`.

The fix uses a hardcoded `'unknown'` fallback, which is safe and appropriate since this is already the edge-case path for unrecognized process names.

Related AAP-80006

**SonarCloud:** https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&impactSoftwareQualities=SECURITY&id=ansible_awx

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

##### STEPS TO REPRODUCE AND EXTRA INFO

1. View the AWX SonarCloud security issues: https://sonarcloud.io/project/issues?issueStatuses=OPEN%2CCONFIRMED&impactSoftwareQualities=SECURITY&id=ansible_awx
2. The finding on `awx/main/db/profiled_pg/base.py` (line 74) flags unsanitized `sys.argv` reaching `sqlite3.connect()` via `os.path.join()`
3. This contributes to the project's Security Rating of C and Failed Quality Gate

```
Before: progname = os.path.basename(sys.argv[0])  # user-controlled
After:  progname = 'unknown'                       # hardcoded fallback
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Standardized the fallback naming used by diagnostic query profiling output when the process name can’t be determined, resulting in consistent SQLite filenames (e.g., `unknown.sqlite`).
* **Tests**
  * Updated unit tests to align with the new diagnostic output filename behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->