### PR TITLE
Fix: add awxkit/pytest.ini to prevent root config inheritance

### DIFF
--- a/awxkit/pytest.ini
+++ b/awxkit/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = -v --tb=native
+
+filterwarnings =
+  error
+
+junit_family=xunit2

--- a/awxkit/tox.ini
+++ b/awxkit/tox.ini
@@ -41,11 +41,3 @@ commands=
 
 [flake8]
 max-line-length = 120
-
-[pytest]
-addopts = -v --tb=native
-
-filterwarnings =
-  error
-
-junit_family=xunit2


### PR DESCRIPTION
## Summary
- The awxkit tox tests (`make test` → `cd awxkit && tox -re py3`) were failing across all branches because pytest discovered the root `pytest.ini` instead of the `[pytest]` section in `awxkit/tox.ini`
- The root `pytest.ini` contains Django-specific flags (`--reuse-db`, `--nomigrations`) and warning filters that are invalid for the awxkit tox environment (which has no Django installed)
- This adds a standalone `pytest.ini` in `awxkit/` — the highest-priority pytest config format — ensuring pytest always uses the correct config regardless of parent directory contents

## Test plan
- [ ] CI passes on this PR (awxkit tox tests should now pass)
- [ ] Verified that the `[pytest]` config in the new `awxkit/pytest.ini` matches what was previously in `awxkit/tox.ini`

Link to failing CI runs:
- tower devel: https://github.com/ansible/tower/actions/runs/27974532152
- tower release_4.6: https://github.com/ansible/tower/actions/runs/27974538257
- tower stable-2.6: https://github.com/ansible/tower/actions/runs/27974540113
- awx devel: https://github.com/ansible/awx/actions/runs/27974714505

## Change Type
Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test configuration for verbose output, enhanced error handling, and standardized JUnit XML reporting format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->