### PR TITLE
Fix awxkit tox test failure caused by root pytest.ini config bleed

### DIFF
--- a/awxkit/conftest.py
+++ b/awxkit/conftest.py
@@ -1,0 +1,16 @@
+# This conftest registers pytest-django CLI options and INI keys as harmless
+# no-ops so that the awxkit tox environment (which does not install Django or
+# pytest-django) does not crash when the root pytest.ini config leaks through.
+#
+# Root pytest.ini contains settings like --reuse-db, --nomigrations, and
+# DJANGO_SETTINGS_MODULE that are only meaningful for Django tests.  Placing
+# this conftest at the awxkit/ level ensures it is loaded before argument
+# parsing regardless of which config file pytest ultimately selects.
+
+
+def pytest_addoption(parser):
+    group = parser.getgroup("awxkit-compat", "awxkit tox compatibility shims")
+    group.addoption("--reuse-db", action="store_true", default=False, help="(no-op in awxkit) pytest-django compat")
+    group.addoption("--nomigrations", action="store_true", default=False, help="(no-op in awxkit) pytest-django compat")
+    group.addoption("--create-db", action="store_true", default=False, help="(no-op in awxkit) pytest-django compat")
+    parser.addini("DJANGO_SETTINGS_MODULE", help="(no-op in awxkit) pytest-django compat", default="")

--- a/awxkit/pytest.ini
+++ b/awxkit/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+addopts = -v --tb=native
+testpaths = test
+python_files = test_*.py
+
+filterwarnings =
+  error
+
+junit_family=xunit2

--- a/awxkit/tox.ini
+++ b/awxkit/tox.ini
@@ -19,7 +19,7 @@ deps =
     pytest-mock
 
 commands =
-    coverage run --parallel --source awxkit -m pytest --doctest-glob='*.md' --junit-xml=report.xml {posargs}
+    coverage run --parallel --source awxkit -m pytest -c pytest.ini test --doctest-glob='*.md' --junit-xml=report.xml {posargs}
     coverage combine
     coverage xml
 
@@ -44,6 +44,8 @@ max-line-length = 120
 
 [pytest]
 addopts = -v --tb=native
+testpaths = test
+python_files = test_*.py
 
 filterwarnings =
   error


### PR DESCRIPTION
##### SUMMARY

Forward port of ansible/tower#7537 (merged to stable-2.7).

Fixes awxkit tox test failures caused by root `pytest.ini` settings leaking into the awxkit tox environment, which lacks Django and pytest-django. The root config's `python_files = *.py`, `--reuse-db`, `--nomigrations`, `DJANGO_SETTINGS_MODULE`, and Django-specific `filterwarnings` all bleed into the awxkit tox run, causing collection errors and crashes.

**Changes:**
- **`awxkit/pytest.ini`** (new): Config boundary that prevents pytest from walking up to the root `pytest.ini`; sets `testpaths = test` and `python_files = test_*.py`
- **`awxkit/conftest.py`** (new): Registers `--reuse-db`, `--nomigrations`, `--create-db`, and `DJANGO_SETTINGS_MODULE` as harmless no-ops for the awxkit env
- **`awxkit/tox.ini`**: Passes `test` as explicit path argument to pytest for robust test collection restriction
- **`pytest.ini`** (root): Removes `:django.core.paginator.UnorderedObjectListWarning` class qualifier from Pagination filterwarning (unresolvable when Django is not installed)

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

The awxkit tox tests fail with `collected 288 items / 603 errors` and `INTERNALERROR SystemExit: 1` because pytest discovers and tries to import non-test `.py` files (e.g. `tools/scripts/get_next_release.py`) due to root config leakage.

\`\`\`
rootdir: /awx_devel/awxkit
configfile: pytest.ini
collected 288 items / 603 errors
INTERNALERROR> ...
INTERNALERROR>   File "/awx_devel/awxkit/tools/scripts/get_next_release.py", line 21, in <module>
INTERNALERROR>     sys.exit(1)
INTERNALERROR> SystemExit: 1
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a pytest compatibility shim to safely handle Django/pytest-django-specific CLI options and settings when those extras aren’t installed.
  * Tightened default test discovery to only run tests under the `test` directory matching `test_*.py`.
  * Updated the coverage test command to explicitly target the `test` directory for consistent runs.
  * Added a new pytest configuration to enable verbose output, native tracebacks, treat warnings as errors, and standardize JUnit XML output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->