### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/api_schema_check.yml
+++ b/.github/workflows/api_schema_check.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
           fetch-depth: 0  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
             coverage-upload-name: "awx-collection"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 
@@ -113,7 +113,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.cov-report-files != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           fail_ci_if_error: >-
             ${{
@@ -132,7 +132,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.test-result-files != ''
-        uses: codecov/test-results-action@v1
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1
         with:
           fail_ci_if_error: >-
             ${{
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload test artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.tests.name }}-artifacts
           path: |
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 
@@ -214,7 +214,7 @@ jobs:
       DEBUG_OUTPUT_DIR: /tmp/awx_operator_molecule_test
     steps:
       - name: Checkout awx
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
           path: awx
@@ -224,7 +224,7 @@ jobs:
           ssh-private-key: ${{ secrets.PRIVATE_GITHUB_KEY }}
 
       - name: Checkout awx-operator
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false\
           repository: ansible/awx-operator
@@ -299,7 +299,7 @@ jobs:
 
       - name: Upload debug output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: awx-operator-debug-output
           path: ${{ env.DEBUG_OUTPUT_DIR }}
@@ -368,7 +368,7 @@ jobs:
           - name: r-z0-9
             regex: ^[r-z0-9]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 
@@ -412,7 +412,7 @@ jobs:
         if: >-
           !cancelled()
           && steps.make-run.outputs.cov-report-files != ''
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           fail_ci_if_error: >-
             ${{
@@ -430,7 +430,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       # Upload coverage report as artifact
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: coverage-${{ matrix.target-regex.name }}
@@ -451,7 +451,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           show-progress: false
@@ -468,7 +468,7 @@ jobs:
         run: python -m pip install --upgrade ansible-core
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           merge-multiple: true
           path: coverage
@@ -492,7 +492,7 @@ jobs:
           echo 'Download the HTML artifacts to view the coverage report.' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage report as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: awx-collection-integration-coverage-html
           path: ~/.ansible/collections/ansible_collections/awx/awx/tests/output/reports/coverage

--- a/.github/workflows/dab-release.yml
+++ b/.github/workflows/dab-release.yml
@@ -21,7 +21,7 @@ jobs:
           excludes: prerelease, draft
 
       - name: Check out respository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - id: dab-pinned
         name: Get current django-ansible-base pinned version

--- a/.github/workflows/devel_images.yml
+++ b/.github/workflows/devel_images.yml
@@ -34,15 +34,15 @@ jobs:
             make-target: awx-kube-buildx
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set GITHUB_ENV variables
         run: |
@@ -58,7 +58,7 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Setup node and npm for the new UI build
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: '18'
         if: matrix.build-targets.image-name == 'awx'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 

--- a/.github/workflows/label_issue.yml
+++ b/.github/workflows/label_issue.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Label Issue
-        uses: github/issue-labeler@v3.1
+        uses: github/issue-labeler@e24a3eb6b2e28c8904d086302a2b760647f5f45c # v3.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           not-before: 2021-12-07T07:00:00Z
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 20
     name: Label Issue - Community
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 
@@ -40,7 +40,7 @@ jobs:
         run: pip install requests
 
       - name: Check if user is a member of Ansible org
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@9d8e2e0878d575fb6073277f38ce3f10ebf4f059 # v1
         id: check_user
         with:
           script: |

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Label PR
-        uses: actions/labeler@v3
+        uses: actions/labeler@26546f6c4d63b6c0623e8e39bde7869e3c2b1d7b # v3
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/pr_labeler.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 20
     name: Label PR - Community
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 
@@ -40,7 +40,7 @@ jobs:
       - name: Install python requests
         run: pip install requests
       - name: Check if user is a member of Ansible org
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@9d8e2e0878d575fb6073277f38ce3f10ebf4f059 # v1
         id: check_user
         with:
           script: |

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -32,7 +32,7 @@ jobs:
           echo "TAG_NAME=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
 
       - name: Checkout awx
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 

--- a/.github/workflows/sonarcloud_pr.yml
+++ b/.github/workflows/sonarcloud_pr.yml
@@ -44,7 +44,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.repository == 'ansible/awx'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Download all individual coverage artifacts from CI workflow
       - name: Download coverage artifacts
@@ -207,7 +207,7 @@ jobs:
       github.event.workflow_run.event == 'push' &&
       github.repository == 'ansible/awx'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # Download all individual coverage artifacts from CI workflow (optional for branch pushes)
       - name: Download coverage artifacts

--- a/.github/workflows/spec-sync-on-merge.yml
+++ b/.github/workflows/spec-sync-on-merge.yml
@@ -32,7 +32,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout Controller repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout spec repo
         id: checkout_spec_repo
         continue-on-error: true
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ansible-automation-platform/aap-openapi-specs
           ref: ${{ github.ref_name }}

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -45,20 +45,20 @@ jobs:
           exit 0
 
       - name: Checkout awx
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
           path: awx
 
       - name: Checkout awx-operator
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
           repository: ${{ github.repository_owner }}/awx-operator
           path: awx-operator
 
       - name: Checkout awx-logos
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
           repository: ansible/awx-logos
@@ -73,7 +73,7 @@ jobs:
           python3 -m pip install docker
 
       - name: Log into registry ghcr.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -85,7 +85,7 @@ jobs:
           cp ../awx-logos/awx/ui/client/assets/* awx/ui/public/static/media/
 
       - name: Setup node and npm for new UI build
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '18'
           cache: 'npm'

--- a/.github/workflows/update_dependabot_prs.yml
+++ b/.github/workflows/update_dependabot_prs.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 

--- a/.github/workflows/upload_schema.yml
+++ b/.github/workflows/upload_schema.yml
@@ -24,7 +24,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           show-progress: false
 


### PR DESCRIPTION
Pin unpinned GitHub Actions to immutable commit SHAs. Defense against supply-chain attacks via mutable tags. Version tags retained as inline comments. See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned multiple GitHub Actions to fixed versions across build, CI, docs, release, and automation workflows.
  * Improved consistency and reproducibility of automated jobs by reducing reliance on floating version tags.
  * No workflow behavior, triggers, or step logic was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->