### PR TITLE
Optimize HostList API: conditional DISTINCT + composite index on JobHostSummary

### DIFF
--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -1926,7 +1926,8 @@ class HostList(HostRelatedSearchMixin, ListCreateAPIView):
         if filter_string:
             filter_qs = SmartFilter.query_from_string(filter_string)
             qs &= filter_qs
-        return qs.distinct().with_latest_summary_id()
+            qs = qs.distinct()
+        return qs.with_latest_summary_id()
 
     def list(self, *args, **kwargs):
         try:

--- a/awx/main/migrations/0206_jobhostsummary_host_id_idx.py
+++ b/awx/main/migrations/0206_jobhostsummary_host_id_idx.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('main', '0205_add_ordering_to_instancegroup_and_workflow_nodes'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='jobhostsummary',
+            index=models.Index(
+                fields=['host', '-id'],
+                name='main_jobhostsumm_host_id_desc',
+            ),
+        ),
+    ]

--- a/awx/main/models/jobs.py
+++ b/awx/main/models/jobs.py
@@ -1092,6 +1092,9 @@ class JobHostSummary(CreatedModifiedModel):
         unique_together = [('job', 'host_name')]
         verbose_name_plural = _('job host summaries')
         ordering = ('-pk',)
+        indexes = [
+            models.Index(fields=['host', '-id'], name='main_jobhostsumm_host_id_desc'),
+        ]
 
     job = models.ForeignKey(
         'Job',


### PR DESCRIPTION
## Summary

- Make `.distinct()` conditional on `host_filter` query parameter being set — without it, the RBAC `IN` subquery on a direct FK (`inventory_id`) cannot produce duplicates, so `DISTINCT` is pure overhead forcing PostgreSQL to sort/hash-dedup the entire result set
- Add composite index `(host_id, id DESC)` on `main_jobhostsummary` so the `with_latest_summary_id()` correlated subquery can use an index-only top-1 scan instead of scanning and sorting per row

The `host_list_rbac` query pattern is the **#2 DB time consumer** in Scale Lab testing at **2,871 seconds** total, and is **worsening** (+15%). Unlike AAP-81082, the RBAC subquery itself is clean (simple `IN` on a direct FK) — the cost is dominated by the unconditional `DISTINCT` and the correlated subquery lacking a composite index.

### Why `.distinct()` is safe to make conditional

`SmartFilter.query_from_string()` can filter through M2M relationships (e.g., `groups__name=...`), which produce duplicate rows via JOINs. `.distinct()` is only needed when `host_filter` is set. Without `host_filter`, the queryset flows through `HostAccess.filtered_queryset()` which filters on `inventory_id IN (RBAC subquery)` — a direct FK that cannot produce duplicates.

### Why the composite index helps

`with_latest_summary_id()` adds a correlated subquery:
```sql
SELECT id FROM main_jobhostsummary WHERE host_id = <outer.id> ORDER BY id DESC LIMIT 1
```
This runs for every result row. The existing auto-index on `host_id` alone requires scanning all matching rows then sorting. The composite `(host_id, id DESC)` index enables a single backward index scan to fetch the top-1 result directly.

### EXPLAIN analysis (Scale Lab, Jul 2)

Ran on the aap26-next read replica (37,824 hosts, 16.7M job host summaries, 320K role evaluations).

**The correlated subquery is the smoking gun** — it scans the entire 367MB PK index backward with a filter instead of using a targeted index:

```
Index Scan Backward using main_jobhostsummary_pkey (cost=0.43..624,118)
      Filter: (host_id = $0)
```

Cost **624,118 per host row**. With ~23K summaries per host on average (max 92K), each probe is extremely expensive.

| Query variant | Estimated cost | Delta |
|---|---|---|
| RBAC subquery alone | 3,113 | — |
| Minimal (no DISTINCT, no subquery, no JOINs) | 3,131 | baseline |
| Full query WITHOUT DISTINCT | 7,376 | +4,245 |
| Full query WITH DISTINCT | 7,384 | +4,253 |

The correlated subquery adds **+4,167 cost** (56% of total). DISTINCT adds +8 in planner estimate but forces Unique + Sort on 138-byte rows.

## Test plan

- [x] All existing tests pass (210 host-related tests verified locally)
- [x] EXPLAIN on Scale Lab confirms correlated subquery uses full PK scan (cost 624,118/row)
- [x] EXPLAIN confirms no composite `(host_id, id DESC)` index exists
- [ ] Verify composite index is picked up by the correlated subquery after deployment
- [ ] Measure `host_list_rbac` mean query time improvement on Scale Lab

## Classification

New or Enhanced Feature

Fixes: https://issues.redhat.com/browse/AAP-81517

🤖 Generated with [Claude Code](https://claude.com/claude-code)