### PR TITLE
Replace realistic looking credentials in subscriptions module examples

### DIFF
--- a/awx_collection/plugins/modules/subscriptions.py
+++ b/awx_collection/plugins/modules/subscriptions.py
@@ -62,13 +62,18 @@ subscriptions:
 EXAMPLES = '''
 - name: Get subscriptions
   subscriptions:
-    client_id: "c6bd7594-d776-46e5-8156-6d17af147479"
-    client_secret: "MO9QUvoOZ5fc5JQKXoTch1AsTLI7nFsZ"
+    client_id: "00000000-0000-0000-0000-000000000000"
+    client_secret: "your-client-secret-here"
+
+- name: Get subscriptions with username and password
+  subscriptions:
+    username: "my_username"
+    password: "my_password"
 
 - name: Get subscriptions with a filter
   subscriptions:
-    client_id: "c6bd7594-d776-46e5-8156-6d17af147479"
-    client_secret: "MO9QUvoOZ5fc5JQKXoTch1AsTLI7nFsZ"
+    client_id: "00000000-0000-0000-0000-000000000000"
+    client_secret: "your-client-secret-here"
     filters:
       product_name: "Red Hat Ansible Automation Platform"
       support_level: "Self-Support"


### PR DESCRIPTION
## Summary
- Replace client_id and client_secret values that looked like real credentials with obvious placeholders
- Add a username/password example to the EXAMPLES block

## Test plan
- [ ] Verify `ansible-doc subscriptions` renders the updated examples correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example usage to replace hard-coded credentials with placeholder values.
  * Improved sample commands for subscription-related workflows by making them safer to copy and adapt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->