### PR TITLE
Suppress SonarQube S7498 for Ansible collection modules

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -113,10 +113,13 @@ sonar.cpd.exclusions=\
 # =============================================================================
 
 # Ignore specific rules for certain file patterns
-sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria=e1,e2
 # Ignore "should be a variable" in migrations
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S1192
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/migrations/**/*
+# Ignore "use literal instead of constructor" in collection modules — dict() is idiomatic Ansible
+sonar.issue.ignore.multicriteria.e2.ruleKey=python:S7498
+sonar.issue.ignore.multicriteria.e2.resourceKey=awx_collection/plugins/modules/**
 
 # =============================================================================
 # GITHUB INTEGRATION


### PR DESCRIPTION
## Summary
- Adds a SonarQube issue ignore rule for `python:S7498` ("use literal instead of constructor") scoped to `awx_collection/plugins/modules/**`
- `dict()` with keyword arguments is idiomatic for Ansible module `argument_spec` definitions, so this rule is noise in that context

## Test plan
- [ ] Verify SonarCloud analysis no longer flags `dict()` usage in collection modules
- [ ] Confirm existing S1192 suppression for migrations is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality scan exclusions to better match existing project patterns.
  * Kept the current suppression for migration-related files.
  * Added an additional exclusion for module-related files to reduce irrelevant issue reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->