### PR TITLE
AAP-81860 — Eliminate LEFT OUTER JOINs in ActivityStream RBAC query

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2719,17 +2719,23 @@ class ActivityStreamAccess(BaseAccess):
         q = Q(pk__in=AS.user.through.objects.filter(user=self.user).values('activitystream_id'))
 
         inventory_set = Inventory.access_ids_qs(self.user, 'view')
-        q |= (
-            Q(pk__in=AS.ad_hoc_command.through.objects.filter(adhoccommand__inventory__in=inventory_set).values('activitystream_id'))
-            | Q(pk__in=AS.inventory.through.objects.filter(inventory__in=inventory_set).values('activitystream_id'))
-            | Q(pk__in=AS.host.through.objects.filter(host__inventory__in=inventory_set).values('activitystream_id'))
-            | Q(pk__in=AS.group.through.objects.filter(group__inventory__in=inventory_set).values('activitystream_id'))
-            | Q(pk__in=AS.inventory_source.through.objects.filter(inventorysource__inventory__in=inventory_set).values('activitystream_id'))
-            | Q(pk__in=AS.inventory_update.through.objects.filter(inventoryupdate__inventory_source__inventory__in=inventory_set).values('activitystream_id'))
-        )
+        if inventory_set.exists():
+            q |= (
+                Q(pk__in=AS.ad_hoc_command.through.objects.filter(adhoccommand__inventory__in=inventory_set).values('activitystream_id'))
+                | Q(pk__in=AS.inventory.through.objects.filter(inventory__in=inventory_set).values('activitystream_id'))
+                | Q(pk__in=AS.host.through.objects.filter(host__inventory__in=inventory_set).values('activitystream_id'))
+                | Q(pk__in=AS.group.through.objects.filter(group__inventory__in=inventory_set).values('activitystream_id'))
+                | Q(pk__in=AS.inventory_source.through.objects.filter(inventorysource__inventory__in=inventory_set).values('activitystream_id'))
+                | Q(
+                    pk__in=AS.inventory_update.through.objects.filter(inventoryupdate__inventory_source__inventory__in=inventory_set).values(
+                        'activitystream_id'
+                    )
+                )
+            )
 
         credential_set = Credential.access_ids_qs(self.user, 'view')
-        q |= Q(pk__in=AS.credential.through.objects.filter(credential__in=credential_set).values('activitystream_id'))
+        if credential_set.exists():
+            q |= Q(pk__in=AS.credential.through.objects.filter(credential__in=credential_set).values('activitystream_id'))
 
         auditing_orgs = (Organization.access_qs(self.user, 'change') | Organization.access_qs(self.user, 'audit')).distinct().values_list('id', flat=True)
         if auditing_orgs.exists():
@@ -2747,28 +2753,32 @@ class ActivityStreamAccess(BaseAccess):
             )
 
         project_set = Project.access_ids_qs(self.user, 'view')
-        q |= Q(pk__in=AS.project.through.objects.filter(project__in=project_set).values('activitystream_id')) | Q(
-            pk__in=AS.project_update.through.objects.filter(projectupdate__project__in=project_set).values('activitystream_id')
-        )
+        if project_set.exists():
+            q |= Q(pk__in=AS.project.through.objects.filter(project__in=project_set).values('activitystream_id')) | Q(
+                pk__in=AS.project_update.through.objects.filter(projectupdate__project__in=project_set).values('activitystream_id')
+            )
 
         jt_set = JobTemplate.access_ids_qs(self.user, 'view')
-        q |= Q(pk__in=AS.job_template.through.objects.filter(jobtemplate__in=jt_set).values('activitystream_id')) | Q(
-            pk__in=AS.job.through.objects.filter(job__job_template__in=jt_set).values('activitystream_id')
-        )
+        if jt_set.exists():
+            q |= Q(pk__in=AS.job_template.through.objects.filter(jobtemplate__in=jt_set).values('activitystream_id')) | Q(
+                pk__in=AS.job.through.objects.filter(job__job_template__in=jt_set).values('activitystream_id')
+            )
 
         wfjt_set = WorkflowJobTemplate.access_ids_qs(self.user, 'view')
-        q |= (
-            Q(pk__in=AS.workflow_job_template.through.objects.filter(workflowjobtemplate__in=wfjt_set).values('activitystream_id'))
-            | Q(
-                pk__in=AS.workflow_job_template_node.through.objects.filter(workflowjobtemplatenode__workflow_job_template__in=wfjt_set).values(
-                    'activitystream_id'
+        if wfjt_set.exists():
+            q |= (
+                Q(pk__in=AS.workflow_job_template.through.objects.filter(workflowjobtemplate__in=wfjt_set).values('activitystream_id'))
+                | Q(
+                    pk__in=AS.workflow_job_template_node.through.objects.filter(workflowjobtemplatenode__workflow_job_template__in=wfjt_set).values(
+                        'activitystream_id'
+                    )
                 )
+                | Q(pk__in=AS.workflow_job.through.objects.filter(workflowjob__workflow_job_template__in=wfjt_set).values('activitystream_id'))
             )
-            | Q(pk__in=AS.workflow_job.through.objects.filter(workflowjob__workflow_job_template__in=wfjt_set).values('activitystream_id'))
-        )
 
         team_set = Team.access_ids_qs(self.user, 'view')
-        q |= Q(pk__in=AS.team.through.objects.filter(team__in=team_set).values('activitystream_id'))
+        if team_set.exists():
+            q |= Q(pk__in=AS.team.through.objects.filter(team__in=team_set).values('activitystream_id'))
 
         return qs.filter(q)
 

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2732,7 +2732,7 @@ class ActivityStreamAccess(BaseAccess):
         q |= Q(pk__in=AS.credential.through.objects.filter(credential__in=credential_set).values('activitystream_id'))
 
         auditing_orgs = (Organization.access_qs(self.user, 'change') | Organization.access_qs(self.user, 'audit')).distinct().values_list('id', flat=True)
-        if auditing_orgs:
+        if auditing_orgs.exists():
             q |= (
                 Q(pk__in=AS.user.through.objects.filter(user__in=auditing_orgs.values('member_role__members')).values('activitystream_id'))
                 | Q(pk__in=AS.organization.through.objects.filter(organization__in=auditing_orgs).values('activitystream_id'))

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -2714,54 +2714,63 @@ class ActivityStreamAccess(BaseAccess):
         # 'job_template', 'job', 'project', 'project_update', 'workflow_job',
         # 'inventory_source', 'workflow_job_template'
 
-        q = Q(user=self.user)
-        inventory_set = Inventory.accessible_pk_qs(self.user, 'read_role')
-        if inventory_set:
-            q |= (
-                Q(ad_hoc_command__inventory__in=inventory_set)
-                | Q(inventory__in=inventory_set)
-                | Q(host__inventory__in=inventory_set)
-                | Q(group__inventory__in=inventory_set)
-                | Q(inventory_source__inventory__in=inventory_set)
-                | Q(inventory_update__inventory_source__inventory__in=inventory_set)
-            )
+        AS = ActivityStream
 
-        credential_set = Credential.accessible_pk_qs(self.user, 'read_role')
-        if credential_set:
-            q |= Q(credential__in=credential_set)
+        q = Q(pk__in=AS.user.through.objects.filter(user=self.user).values('activitystream_id'))
+
+        inventory_set = Inventory.access_ids_qs(self.user, 'view')
+        q |= (
+            Q(pk__in=AS.ad_hoc_command.through.objects.filter(adhoccommand__inventory__in=inventory_set).values('activitystream_id'))
+            | Q(pk__in=AS.inventory.through.objects.filter(inventory__in=inventory_set).values('activitystream_id'))
+            | Q(pk__in=AS.host.through.objects.filter(host__inventory__in=inventory_set).values('activitystream_id'))
+            | Q(pk__in=AS.group.through.objects.filter(group__inventory__in=inventory_set).values('activitystream_id'))
+            | Q(pk__in=AS.inventory_source.through.objects.filter(inventorysource__inventory__in=inventory_set).values('activitystream_id'))
+            | Q(pk__in=AS.inventory_update.through.objects.filter(inventoryupdate__inventory_source__inventory__in=inventory_set).values('activitystream_id'))
+        )
+
+        credential_set = Credential.access_ids_qs(self.user, 'view')
+        q |= Q(pk__in=AS.credential.through.objects.filter(credential__in=credential_set).values('activitystream_id'))
 
         auditing_orgs = (Organization.access_qs(self.user, 'change') | Organization.access_qs(self.user, 'audit')).distinct().values_list('id', flat=True)
         if auditing_orgs:
             q |= (
-                Q(user__in=auditing_orgs.values('member_role__members'))
-                | Q(organization__in=auditing_orgs)
-                | Q(notification_template__organization__in=auditing_orgs)
-                | Q(notification__notification_template__organization__in=auditing_orgs)
-                | Q(label__organization__in=auditing_orgs)
-                | Q(role__in=Role.visible_roles(self.user) if auditing_orgs else [])
+                Q(pk__in=AS.user.through.objects.filter(user__in=auditing_orgs.values('member_role__members')).values('activitystream_id'))
+                | Q(pk__in=AS.organization.through.objects.filter(organization__in=auditing_orgs).values('activitystream_id'))
+                | Q(pk__in=AS.notification_template.through.objects.filter(notificationtemplate__organization__in=auditing_orgs).values('activitystream_id'))
+                | Q(
+                    pk__in=AS.notification.through.objects.filter(notification__notification_template__organization__in=auditing_orgs).values(
+                        'activitystream_id'
+                    )
+                )
+                | Q(pk__in=AS.label.through.objects.filter(label__organization__in=auditing_orgs).values('activitystream_id'))
+                | Q(pk__in=AS.role.through.objects.filter(role__in=Role.visible_roles(self.user)).values('activitystream_id'))
             )
 
-        project_set = Project.accessible_pk_qs(self.user, 'read_role')
-        if project_set:
-            q |= Q(project__in=project_set) | Q(project_update__project__in=project_set)
+        project_set = Project.access_ids_qs(self.user, 'view')
+        q |= Q(pk__in=AS.project.through.objects.filter(project__in=project_set).values('activitystream_id')) | Q(
+            pk__in=AS.project_update.through.objects.filter(projectupdate__project__in=project_set).values('activitystream_id')
+        )
 
-        jt_set = JobTemplate.accessible_pk_qs(self.user, 'read_role')
-        if jt_set:
-            q |= Q(job_template__in=jt_set) | Q(job__job_template__in=jt_set)
+        jt_set = JobTemplate.access_ids_qs(self.user, 'view')
+        q |= Q(pk__in=AS.job_template.through.objects.filter(jobtemplate__in=jt_set).values('activitystream_id')) | Q(
+            pk__in=AS.job.through.objects.filter(job__job_template__in=jt_set).values('activitystream_id')
+        )
 
-        wfjt_set = WorkflowJobTemplate.accessible_pk_qs(self.user, 'read_role')
-        if wfjt_set:
-            q |= (
-                Q(workflow_job_template__in=wfjt_set)
-                | Q(workflow_job_template_node__workflow_job_template__in=wfjt_set)
-                | Q(workflow_job__workflow_job_template__in=wfjt_set)
+        wfjt_set = WorkflowJobTemplate.access_ids_qs(self.user, 'view')
+        q |= (
+            Q(pk__in=AS.workflow_job_template.through.objects.filter(workflowjobtemplate__in=wfjt_set).values('activitystream_id'))
+            | Q(
+                pk__in=AS.workflow_job_template_node.through.objects.filter(workflowjobtemplatenode__workflow_job_template__in=wfjt_set).values(
+                    'activitystream_id'
+                )
             )
+            | Q(pk__in=AS.workflow_job.through.objects.filter(workflowjob__workflow_job_template__in=wfjt_set).values('activitystream_id'))
+        )
 
-        team_set = Team.accessible_pk_qs(self.user, 'read_role')
-        if team_set:
-            q |= Q(team__in=team_set)
+        team_set = Team.access_ids_qs(self.user, 'view')
+        q |= Q(pk__in=AS.team.through.objects.filter(team__in=team_set).values('activitystream_id'))
 
-        return qs.filter(q).distinct()
+        return qs.filter(q)
 
     def can_add(self, data):
         return False


### PR DESCRIPTION
## Summary

- Replace all 18 M2M field-traversal Q objects in `ActivityStreamAccess.filtered_queryset()` with `pk__in` subqueries using `.through` intermediary tables — same pattern proven in AAP-81082 (28% improvement for unified job RBAC)
- Remove `.distinct()` (no longer needed without M2M JOINs producing duplicate rows)
- Remove 5 unnecessary `if <queryset>:` truthy checks that evaluated subqueries as booleans before including them (5 extra DB roundtrips per request)
- Migrate `accessible_pk_qs(user, 'read_role')` to `access_ids_qs(user, 'view')` for direct DAB RBAC API usage

### Why

`activity_stream_list` is the #2 DB time consumer at 483s in a 10-minute Scale Lab window. The root cause is that Django translates M2M field traversals like `Q(host__inventory__in=...)` into LEFT OUTER JOINs, forcing PostgreSQL to join all 18 intermediary tables before filtering. Converting to `pk__in` subqueries changes the SQL to `IN (SELECT ...)` semi-joins, allowing PostgreSQL to skip unconditional joins.

### Expected impact

30-50% reduction in `activity_stream_list` DB time, based on the 28% improvement seen with the same pattern in AAP-81082 (which had fewer M2M branches).

## Test plan

- [x] All 8 activity stream tests pass (`test_activity_streams.py`), including `test_stream_queryset_hides_shows_items` which validates both deny (no-access user sees nothing) and allow (org admin sees all resource types) paths
- [x] All 306 traditional RBAC tests pass (`functional/rbac/`)
- [x] All 132 DAB RBAC tests pass (`functional/dab_rbac/`)
- [ ] Scale Lab validation after merge and deploy to 2.6-next

## Classification

New or Enhanced Feature

Issue: https://issues.redhat.com/browse/AAP-81860

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity stream visibility so users only see records they’re permitted to access, with more consistent filtering across related object types.
  * Refined access checks for inventory, credentials, projects, job templates, workflow job templates, teams, and organization-related activity, reducing missing items and duplicate entries in the feed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->