### PR TITLE
Fix: Increase awx-operator molecule timeout to 20m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
         continue-on-error: true
         run: |
           set +e
-          timeout 15m bash -elc '
+          timeout 20m bash -elc '
             python -m pip install -r molecule/requirements.txt
             python -m pip install PyYAML # for awx/tools/scripts/rewrite-awx-operator-requirements.py
             $(realpath ../awx/tools/scripts/rewrite-awx-operator-requirements.py) molecule/requirements.yml $(realpath ../awx)


### PR DESCRIPTION
## Summary
- The awx-operator molecule kind test intermittently times out after 15 minutes on GitHub Actions runners, causing flaky CI failures on `devel`
- Same root cause as ansible/tower#7567 (stable-2.7): the bash-level `timeout 15m` is too tight when kind cluster teardown is slow
- Bumps the bash-level timeout from 15m to 20m (step-level `timeout-minutes: 60` is unchanged)

Closes: AAP-81583

Replaces: ansible/tower#7569 (closed — wrong repo, required 6 approvals for a CI tweak)

## Test plan
- [ ] CI passes on this PR
- [ ] Monitor next 5+ scheduled CI runs on `devel` after merge
- [ ] Confirm awx-operator job no longer times out intermittently

Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the allowed runtime for a CI deployment check, reducing the chance of false timeouts during longer runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->