### PR TITLE
Fix PROJECTS_ROOT creation race

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -548,8 +548,7 @@ class BaseTask(object):
         self.lock_fd = None
 
     def acquire_lock(self, project, unified_job_id=None):
-        if not os.path.exists(settings.PROJECTS_ROOT):
-            os.mkdir(settings.PROJECTS_ROOT)
+        os.makedirs(settings.PROJECTS_ROOT, exist_ok=True)
 
         lock_path = project.get_lock_file()
         if lock_path is None:

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1591,6 +1591,33 @@ def test_fcntl_ioerror():
         fcntl.lockf(99999, fcntl.LOCK_EX)
 
 
+def test_acquire_lock_handles_concurrent_projects_root_creation(tmp_path, mock_me):
+    projects_root = tmp_path / 'projects'
+    projects_root.mkdir()
+    lock_path = projects_root / 'project.lock'
+    real_exists = os.path.exists
+
+    def stale_projects_root_exists(path):
+        if path == str(projects_root):
+            return False
+        return real_exists(path)
+
+    instance = mock.Mock()
+    instance.get_lock_file.return_value = str(lock_path)
+
+    task = jobs.RunProjectUpdate()
+
+    with (
+        mock.patch.object(jobs.settings, 'PROJECTS_ROOT', str(projects_root)),
+        mock.patch('awx.main.tasks.jobs.os.path.exists', side_effect=stale_projects_root_exists),
+        mock.patch('os.open', return_value=3) as os_open,
+        mock.patch('fcntl.lockf'),
+    ):
+        task.acquire_lock(instance)
+
+    os_open.assert_called_once_with(str(lock_path), os.O_RDWR | os.O_CREAT)
+
+
 @mock.patch('os.open')
 @mock.patch('awx.main.tasks.jobs.logger')
 def test_acquire_lock_open_fail_logged(logger_mock, os_open, mock_me):


### PR DESCRIPTION
##### SUMMARY

Fixes #16447.

This bug was reported by @slehlib, who identified the TOCTOU race in
`BaseTask.acquire_lock()` and proposed using idempotent directory creation.

When multiple task replicas observe a missing `PROJECTS_ROOT`, more than one
worker can attempt to create it. The first succeeds while another raises
`FileExistsError` before reaching the per-project lock.

This change:

- replaces the check-then-create sequence with
  `os.makedirs(settings.PROJECTS_ROOT, exist_ok=True)`
- adds a unit regression test that simulates a stale existence check after
  another worker has created the directory

Users running multiple task replicas with shared project storage should no
longer see jobs fail during concurrent root-directory creation.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- API

##### TESTING

- `black --check awx/main/tasks/jobs.py awx/main/tests/unit/test_tasks.py`
- `git diff --check`
- `python3 -m py_compile awx/main/tasks/jobs.py awx/main/tests/unit/test_tasks.py`
- standalone concurrent `os.makedirs(..., exist_ok=True)` check with eight threads

The full AWX unit suite was not run locally because the documented Docker
development environment is not available on this host. This PR is opened as a
draft so the repository checks can validate the focused unit test.
