### PR TITLE
AAPRFE-3031: Truncate large event_data strings in job event serializers

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -111,6 +111,7 @@ from awx.main.utils import (
     encrypt_dict,
     prefetch_page_capabilities,
     truncate_stdout,
+    truncate_event_data,
     get_licenser,
 )
 
@@ -4467,6 +4468,8 @@ class JobEventSerializer(BaseSerializer):
         max_bytes = settings.EVENT_STDOUT_MAX_BYTES_DISPLAY
         if 'stdout' in data:
             data['stdout'] = truncate_stdout(data['stdout'], max_bytes)
+        if 'event_data' in data:
+            data['event_data'] = truncate_event_data(data['event_data'], max_bytes)
         return data
 
 
@@ -4542,6 +4545,8 @@ class AdHocCommandEventSerializer(BaseSerializer):
         max_bytes = settings.EVENT_STDOUT_MAX_BYTES_DISPLAY
         if 'stdout' in data:
             data['stdout'] = truncate_stdout(data['stdout'], max_bytes)
+        if 'event_data' in data:
+            data['event_data'] = truncate_event_data(data['event_data'], max_bytes)
         return data
 
 

--- a/awx/main/tests/functional/api/test_events.py
+++ b/awx/main/tests/functional/api/test_events.py
@@ -79,7 +79,7 @@ def test_job_events_event_data_truncation(get, organization_factory, job_templat
     result_msg = response.data['results'][0]['event_data']['res']['msg']
     assert (len(result_msg) == 2000) == expected
     if truncate:
-        assert result_msg.endswith(u'\u2026')
+        assert result_msg.endswith('\u2026')
     assert response.data['results'][0]['event_data']['res']['rc'] == 0
 
 

--- a/awx/main/tests/functional/api/test_events.py
+++ b/awx/main/tests/functional/api/test_events.py
@@ -49,6 +49,41 @@ def test_ad_hoc_events_sublist_truncation(get, organization_factory, job_templat
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    'truncate, expected',
+    [
+        (True, False),
+        (False, True),
+    ],
+)
+def test_job_events_event_data_truncation(get, organization_factory, job_template_factory, truncate, expected):
+    objs = organization_factory("org", superusers=['admin'])
+    jt = job_template_factory("jt", organization=objs.organization, inventory='test_inv', project='test_proj').job_template
+    job = jt.create_unified_job()
+    large_msg = 'a' * 2000
+    event_data = {'res': {'msg': large_msg, 'rc': 0}}
+    JobEvent.create_from_data(
+        job_id=job.pk,
+        uuid='abc456',
+        event='runner_on_ok',
+        stdout='ok',
+        event_data=event_data,
+        job_created=job.created,
+    ).save()
+
+    url = reverse('api:job_job_events_list', kwargs={'pk': job.pk})
+    if not truncate:
+        url += '?no_truncate=1'
+
+    response = get(url, user=objs.superusers.admin, expect=200)
+    result_msg = response.data['results'][0]['event_data']['res']['msg']
+    assert (len(result_msg) == 2000) == expected
+    if truncate:
+        assert result_msg.endswith(u'\u2026')
+    assert response.data['results'][0]['event_data']['res']['rc'] == 0
+
+
+@pytest.mark.django_db
 def test_job_job_events_children_summary(get, organization_factory, job_template_factory):
     objs = organization_factory("org", superusers=['admin'])
     jt = job_template_factory("jt", organization=objs.organization, inventory='test_inv', project='test_proj').job_template

--- a/awx/main/tests/unit/utils/test_common.py
+++ b/awx/main/tests/unit/utils/test_common.py
@@ -341,3 +341,47 @@ class TestHostnameRegexValidator:
     def test_bad_call_with_inverse(self, regex_expr, re_flags, inverse_match=True):
         h = HostnameRegexValidator(regex=regex_expr, flags=re_flags, inverse_match=inverse_match)
         assert h("@#$%)$#(TUFAS_DG") is None
+
+
+class TestTruncateEventData:
+    def test_noop_when_under_limit(self):
+        data = {'res': {'msg': 'short'}}
+        result = common.truncate_event_data(data, 1024)
+        assert result == data
+
+    def test_truncates_long_string(self):
+        data = {'res': {'msg': 'x' * 2000}}
+        result = common.truncate_event_data(data, 1024)
+        assert len(result['res']['msg']) == 1024
+        assert result['res']['msg'].endswith(u'\u2026')
+
+    def test_preserves_short_siblings(self):
+        data = {'res': {'msg': 'x' * 2000, 'rc': 0, 'cmd': 'echo hello'}}
+        result = common.truncate_event_data(data, 1024)
+        assert result['res']['rc'] == 0
+        assert result['res']['cmd'] == 'echo hello'
+
+    def test_truncates_inside_lists(self):
+        data = {'results': [{'msg': 'y' * 2000}, {'msg': 'ok'}]}
+        result = common.truncate_event_data(data, 1024)
+        assert len(result['results'][0]['msg']) == 1024
+        assert result['results'][1]['msg'] == 'ok'
+
+    def test_noop_for_zero_limit(self):
+        data = {'res': {'msg': 'x' * 2000}}
+        result = common.truncate_event_data(data, 0)
+        assert result == data
+
+    def test_does_not_mutate_original(self):
+        original_msg = 'x' * 2000
+        data = {'res': {'msg': original_msg}}
+        common.truncate_event_data(data, 1024)
+        assert data['res']['msg'] == original_msg
+
+    def test_handles_empty_dict(self):
+        assert common.truncate_event_data({}, 1024) == {}
+
+    def test_handles_nested_depth(self):
+        data = {'a': {'b': {'c': {'d': 'z' * 2000}}}}
+        result = common.truncate_event_data(data, 100)
+        assert len(result['a']['b']['c']['d']) == 100

--- a/awx/main/tests/unit/utils/test_common.py
+++ b/awx/main/tests/unit/utils/test_common.py
@@ -353,7 +353,7 @@ class TestTruncateEventData:
         data = {'res': {'msg': 'x' * 2000}}
         result = common.truncate_event_data(data, 1024)
         assert len(result['res']['msg']) == 1024
-        assert result['res']['msg'].endswith(u'\u2026')
+        assert result['res']['msg'].endswith('\u2026')
 
     def test_preserves_short_siblings(self):
         data = {'res': {'msg': 'x' * 2000, 'rc': 0, 'cmd': 'echo hello'}}

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -1157,7 +1157,7 @@ def truncate_event_data(event_data, max_bytes):
         if isinstance(obj, list):
             return [_truncate(v) for v in obj]
         if isinstance(obj, str) and len(obj) > max_bytes:
-            return obj[: (max_bytes - 1)] + u'\u2026'
+            return obj[: (max_bytes - 1)] + '\u2026'
         return obj
 
     return _truncate(event_data)

--- a/awx/main/utils/common.py
+++ b/awx/main/utils/common.py
@@ -89,6 +89,7 @@ __all__ = [
     'classproperty',
     'create_temporary_fifo',
     'truncate_stdout',
+    'truncate_event_data',
     'deepmerge',
     'get_event_partition_epoch',
     'cleanup_new_process',
@@ -1135,6 +1136,31 @@ def truncate_stdout(stdout, size):
             set_count += 1
 
     return stdout + '\u001b[0m' * (set_count - reset_count)
+
+
+def truncate_event_data(event_data, max_bytes):
+    """Truncate large string values inside event_data to prevent memory
+    exhaustion when serialising job event API responses.
+
+    Walks the structure recursively and truncates any string longer than
+    ``max_bytes``, appending a Unicode ellipsis (same convention used by
+    ``truncate_stdout``).  Non-string / non-container values are left
+    untouched.  Returns a shallow-copied structure so the original DB
+    cache is not mutated.
+    """
+    if max_bytes <= 0:
+        return event_data
+
+    def _truncate(obj):
+        if isinstance(obj, dict):
+            return {k: _truncate(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [_truncate(v) for v in obj]
+        if isinstance(obj, str) and len(obj) > max_bytes:
+            return obj[: (max_bytes - 1)] + u'\u2026'
+        return obj
+
+    return _truncate(event_data)
 
 
 def deepmerge(a, b):


### PR DESCRIPTION
## Summary
- `JobEventSerializer` and `AdHocCommandEventSerializer` truncate the per-event `stdout` field using `EVENT_STDOUT_MAX_BYTES_DISPLAY`, but `event_data` (particularly `event_data.res.stdout`, `event_data.res.stdout_lines`, and `event_data.res.msg`) passes through without any size limit.
- When Ansible modules produce very large output (e.g. `command`, `shell`, `uri`, or `slurp` returning multi-MB results), the GUI fetches `/job_events/?page_size=200`, and each page can contain hundreds of MB of untruncated `event_data`. This causes controller-web uWSGI workers to exhaust their memory limit, leading to OOMKills (exit code 137).
- This adds a `truncate_event_data()` utility that recursively walks `event_data` and truncates any string value exceeding `EVENT_STDOUT_MAX_BYTES_DISPLAY`, reusing the existing setting and respecting the `no_truncate` query parameter.

**Changes:**
- `awx/main/utils/common.py`: Add `truncate_event_data()` function
- `awx/api/serializers.py`: Call `truncate_event_data()` in `JobEventSerializer.to_representation()` and `AdHocCommandEventSerializer.to_representation()`
- `awx/main/tests/unit/utils/test_common.py`: 8 unit tests for the new utility
- `awx/main/tests/functional/api/test_events.py`: Functional test verifying event_data truncation in the job events list API (with and without `no_truncate`)

## Test plan
- [x] Unit tests: `truncate_event_data` handles dicts, lists, nested structures, empty input, max_bytes=0, and respects the byte limit
- [x] Functional test: job events list API truncates event_data strings, `?no_truncate=1` returns full data
- [ ] Manual: run a job with large per-task output, verify job_events API response size is bounded
- [ ] Manual: confirm `?no_truncate=1` still returns full untruncated event_data

Related: AAPRFE-3031

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

1. Run a job whose modules produce large output (e.g. `shell: python3 -c "print('A' * 200000)"` in a loop)
2. Fetch `/api/v2/jobs/<id>/job_events/?page_size=200`
3. Observe that `event_data.res.stdout` and `event_data.res.stdout_lines` are returned at full size (200 KB+ each), while the top-level `stdout` field is correctly truncated to `EVENT_STDOUT_MAX_BYTES_DISPLAY` (1024 bytes)
4. With enough large events on a single page, the serialisation causes controller-web pods to OOMKill

After this fix, string values in `event_data` exceeding `EVENT_STDOUT_MAX_BYTES_DISPLAY` are truncated with a Unicode ellipsis, consistent with the existing `stdout` truncation. Appending `?no_truncate=1` still returns the full untruncated data for API consumers that need it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job and ad hoc command event responses now consistently truncate oversized nested event details.
  * Nested content is truncated while preserving other fields and values.
  * Truncated text ends with an ellipsis for clarity.
* **Reliability**
  * Event data remains unchanged when within limits or when truncation is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->