### PR TITLE
AAP-83163 — Eliminate LEFT JOIN fan-out in user list RBAC query

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -20,6 +20,7 @@ from rest_framework.exceptions import ParseError, PermissionDenied
 # django-ansible-base
 from ansible_base.lib.utils.validation import to_python_boolean
 from ansible_base.rbac.models import RoleEvaluation
+from ansible_base.rbac.policies import visible_users
 from ansible_base.rbac import permission_registry
 
 # AWX
@@ -643,6 +644,8 @@ class UserAccess(BaseAccess):
             Organization.access_qs(self.user, 'change').exists() or Organization.access_qs(self.user, 'audit').exists()
         ):
             qs = User.objects.all()
+        elif settings.ANSIBLE_BASE_ROLE_SYSTEM_ACTIVATED:
+            qs = visible_users(self.user)
         else:
             qs = (
                 User.objects.filter(pk__in=Organization.access_qs(self.user, 'view').values('member_role__members'))
@@ -706,12 +709,13 @@ class UserAccess(BaseAccess):
                 # in these cases only superusers can modify orphan users
                 return False
             if settings.ANSIBLE_BASE_ROLE_SYSTEM_ACTIVATED:
-                # Permission granted if the user has all permissions that the target user has
                 target_perms = set(
-                    RoleEvaluation.objects.filter(role__in=obj.has_roles.all()).values_list('object_id', 'content_type_id', 'codename').distinct()
+                    RoleEvaluation.objects.filter(**RoleEvaluation._actor_role_filter(obj)).values_list('object_id', 'content_type_id', 'codename').distinct()
                 )
                 user_perms = set(
-                    RoleEvaluation.objects.filter(role__in=self.user.has_roles.all()).values_list('object_id', 'content_type_id', 'codename').distinct()
+                    RoleEvaluation.objects.filter(**RoleEvaluation._actor_role_filter(self.user))
+                    .values_list('object_id', 'content_type_id', 'codename')
+                    .distinct()
                 )
                 return not (target_perms - user_perms)
             return not obj.roles.all().exclude(ancestors__in=self.user.roles.all()).exists()


### PR DESCRIPTION
## Summary

- Replace legacy Role M2M traversal in `UserAccess.filtered_queryset()` with DAB's `visible_users()`, which queries organizational membership through `RoleUserAssignment` subqueries instead of LEFT OUTER JOINs through the `objectrole`/`roleevaluation` tables
- Replace `role__in=actor.has_roles.all()` in `UserAccess.can_admin()` with `RoleEvaluation._actor_role_filter()` to avoid the `objectrole` JOIN in per-object permission checks

Resolves: [AAP-83163](https://redhat.atlassian.net/browse/AAP-83163)

## Context

Same anti-pattern fixed in #16527 (AAP-81082, unified jobs) and #16533 (AAP-81860, activity stream). The user list RBAC query uses Django FK-traversal through `Organization.member_role` → `Role.members` (legacy M2M), which compiles to LEFT OUTER JOINs that fan out with RBAC density. At Scale Lab scale (42K ObjectRoles, 482K RoleEvaluation rows), this query goes from 156s to 4,627s.

`visible_users()` computes the same result — users who are members of orgs the requesting user can view, plus superusers, plus self — but routes through `ObjectRole.users` via `RoleUserAssignment`, keeping all joins inside `pk__in=` subqueries. The legacy code path is preserved as a fallback when `ANSIBLE_BASE_ROLE_SYSTEM_ACTIVATED` is False.

## Classification

New or Enhanced Feature

## Test plan

- [x] `awx/main/tests/functional/rbac/test_rbac_user.py` — 17/17 passed
- [x] `awx/main/tests/functional/rbac/test_rbac_role.py` — 10/10 passed
- [x] `awx/main/tests/functional/dab_rbac/` — 132/132 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user visibility filtering when the base role system is enabled.
  * Updated administrative permission checks for orphaned users to use role-based evaluations more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->