### PR TITLE
Fix TOCTOU race condition in acquire_lock for PROJECTS_ROOT

### DIFF
--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -548,8 +548,7 @@ class BaseTask(object):
         self.lock_fd = None
 
     def acquire_lock(self, project, unified_job_id=None):
-        if not os.path.exists(settings.PROJECTS_ROOT):
-            os.mkdir(settings.PROJECTS_ROOT)
+        os.makedirs(settings.PROJECTS_ROOT, exist_ok=True)
 
         lock_path = project.get_lock_file()
         if lock_path is None:

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1636,6 +1636,22 @@ def test_acquire_lock_acquisition_fail_logged(fcntl_lockf, logger_mock, os_close
     )
 
 
+@mock.patch('awx.main.tasks.jobs.settings')
+def test_acquire_lock_projects_root_race_condition(settings_mock, mock_me):
+    """Regression test: acquire_lock must not fail when PROJECTS_ROOT already exists (TOCTOU race on multi-replica deployments)."""
+    settings_mock.PROJECTS_ROOT = '/some/projects'
+
+    instance = mock.Mock()
+    instance.get_lock_file.return_value = '/some/projects/my_project/.lock'
+    instance.cancel_flag = False
+
+    ProjectUpdate = jobs.RunProjectUpdate()
+
+    with mock.patch('os.makedirs') as makedirs_mock, mock.patch('os.open', return_value=3), mock.patch('fcntl.lockf'), mock.patch('os.close'):
+        ProjectUpdate.acquire_lock(instance)
+        makedirs_mock.assert_called_once_with('/some/projects', exist_ok=True)
+
+
 @pytest.mark.parametrize('injector_cls', [cls for cls in ManagedCredentialType.registry.values() if cls.injectors])
 def test_managed_injector_redaction(injector_cls):
     """See awx.main.models.inventory.PluginFileInjector._get_shared_env


### PR DESCRIPTION
##### SUMMARY

Fix a TOCTOU (time-of-check/time-of-use) race condition in `acquire_lock()` that causes `FileExistsError` on `PROJECTS_ROOT` when multiple task replicas start jobs concurrently.

The non-atomic check-then-create pattern:

```python
if not os.path.exists(settings.PROJECTS_ROOT):
    os.mkdir(settings.PROJECTS_ROOT)
```

is replaced with the atomic, idempotent:

```python
os.makedirs(settings.PROJECTS_ROOT, exist_ok=True)
```

With `exist_ok=True`, concurrent replicas that race on the directory creation will all succeed rather than all but the first raising `FileExistsError`.

##### ISSUE TYPE

* Bug Fix

##### COMPONENT NAME

* `awx/main/tasks/jobs.py`

##### ADDITIONAL INFORMATION

Fixes #16447

A regression test `test_acquire_lock_projects_root_race_condition` has been added to `awx/main/tests/unit/test_tasks.py` to confirm `os.makedirs` is called with `exist_ok=True`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project update lock handling to avoid failures when the projects directory already exists.
  * Project updates now reliably proceed when the directory is created concurrently or is already present.

* **Tests**
  * Added regression coverage for concurrent project directory creation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->