### PR TITLE
[AAP-82221] Skip reverse sync during post-migrate role definition setup

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -79,10 +79,16 @@ class MainConfig(AppConfig):
     def _sync_managed_role_definitions(sender, **kwargs):
         from django.apps import apps as global_apps
 
+        from ansible_base.resource_registry.signals.handlers import no_reverse_sync
+
         # NOTE: setup_managed_role_definitions lives in the migrations module because
         # it is also called from migration 0192. Ideally this would be extracted to a
         # shared non-migration module, but doing so requires updating the migration
         # import, which is a broader refactor (see also models/rbac.py imports).
         from awx.main.migrations._dab_rbac import setup_managed_role_definitions
 
-        setup_managed_role_definitions(global_apps, None)
+        # During post-migrate the resource server (gateway) may not be ready
+        # (e.g. migrate_service_data still holds a 423 lock).  Disable reverse
+        # sync for this call — gateway reconciles via migrate_service_data.
+        with no_reverse_sync():
+            setup_managed_role_definitions(global_apps, None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Following AAP-16545 side effects that the dab_post_migrate signal added causes the 423 crash during fresh installs, because it runs setup_managed_role_definitions on every migrate — including when Gateway isn't ready.

The dab_post_migrate signal handler added in 64dc097914 calls setup_managed_role_definitions on every awx-manage migrate run. During fresh installs this deletes stale managed role definitions and triggers a reverse sync to the gateway, which returns 423 Locked because migrate_service_data has not finished yet. The installer retries 5 times but each attempt fires the same signal and hits the same 423, failing the controller init.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
