### PR TITLE
Gate Akeyless OIDC credential types behind the OIDC workload identity feature flag

### DIFF
--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -139,4 +139,9 @@ org_role_to_permission = {
 }
 
 # OIDC credential type namespaces for feature flag filtering
-OIDC_CREDENTIAL_TYPE_NAMESPACES = ['hashivault-kv-oidc', 'hashivault-ssh-oidc']
+OIDC_CREDENTIAL_TYPE_NAMESPACES = [
+    'hashivault-kv-oidc',
+    'hashivault-ssh-oidc',
+    'akeyless-oidc',
+    'akeyless-ssh-oidc',
+]

--- a/awx/main/tests/functional/api/test_oidc_credential_feature_flag.py
+++ b/awx/main/tests/functional/api/test_oidc_credential_feature_flag.py
@@ -92,7 +92,7 @@ def test_oidc_types_in_registry_when_flag_enabled(isolated_registry):
     """Test that OIDC credential types are added to the registry when flag is enabled."""
     mock_eps = _mock_entry_points_factory(
         managed_names=['ssh', 'vault'],
-        supported_names=['hashivault-kv-oidc', 'hashivault-ssh-oidc'],
+        supported_names=list(OIDC_CREDENTIAL_TYPE_NAMESPACES),
     )
     with override_settings(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED=True):
         with mock.patch('awx.main.models.credential.detect_server_product_name', return_value='NOT_AWX'):
@@ -109,7 +109,7 @@ def test_oidc_types_not_in_registry_when_flag_disabled(isolated_registry):
     """Test that OIDC credential types are excluded from the registry when flag is disabled."""
     mock_eps = _mock_entry_points_factory(
         managed_names=['ssh', 'vault'],
-        supported_names=['hashivault-kv-oidc', 'hashivault-ssh-oidc'],
+        supported_names=list(OIDC_CREDENTIAL_TYPE_NAMESPACES),
     )
     with override_settings(FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED=False):
         with mock.patch('awx.main.models.credential.detect_server_product_name', return_value='NOT_AWX'):
@@ -127,7 +127,9 @@ def test_oidc_namespaces_constant():
     """Test that OIDC_CREDENTIAL_TYPE_NAMESPACES contains the expected namespaces."""
     assert 'hashivault-kv-oidc' in OIDC_CREDENTIAL_TYPE_NAMESPACES
     assert 'hashivault-ssh-oidc' in OIDC_CREDENTIAL_TYPE_NAMESPACES
-    assert len(OIDC_CREDENTIAL_TYPE_NAMESPACES) == 2
+    assert 'akeyless-oidc' in OIDC_CREDENTIAL_TYPE_NAMESPACES
+    assert 'akeyless-ssh-oidc' in OIDC_CREDENTIAL_TYPE_NAMESPACES
+    assert len(OIDC_CREDENTIAL_TYPE_NAMESPACES) == 4
 
 
 # --- Functional API tests ---


### PR DESCRIPTION
## Summary

Adds `akeyless-oidc` and `akeyless-ssh-oidc` to `OIDC_CREDENTIAL_TYPE_NAMESPACES`.

These are the two OIDC credential types added in ansible/awx-plugins#194. Because [`_is_oidc_namespace_disabled()`](https://github.com/ansible/awx/blob/devel/awx/main/models/credential.py#L660-L661) filters namespaces against that hardcoded list, a namespace missing from it is never hidden when the feature flag is off:

```python
def _is_oidc_namespace_disabled(ns):
    return ns in OIDC_CREDENTIAL_TYPE_NAMESPACES and not getattr(settings, 'FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED', False)
```

So today, with `FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED` disabled, the Akeyless OIDC types still load and are offered in the UI, and a job that uses one fails at launch in [`populate_workload_identity_tokens()`](https://github.com/ansible/awx/blob/devel/awx/main/tasks/jobs.py#L269-L273) with `Flag FEATURE_OIDC_WORKLOAD_IDENTITY_ENABLED is not enabled, required for credential ...`. Adding them makes them behave like the HashiCorp OIDC types, which are hidden entirely while the feature is off.

Verified on AAP 2.7.1 (controller 4.8.3): with the flag off the types no longer load, and with it on they load and complete the full workload identity flow against Akeyless.

## A note on the approach

This is the minimal fix, but it means every third-party OIDC credential plugin needs a coordinated change here before it can ship.

An alternative would be to derive the gate from the plugin definition rather than a static list. The predicate already exists in [`_has_workload_identity_token()`](https://github.com/ansible/awx/blob/devel/awx/api/views/__init__.py#L1636-L1646), which checks for a field with `internal: true` and `id: workload_identity_token` — exactly what marks a credential type as OIDC-capable. Gating on that would make the feature flag automatically correct for any current or future OIDC credential plugin.

Happy to rework this PR that way if you prefer; landing the list change first is just the faster unblock.

## Test plan

- [x] `awx/main/tests/functional/api/test_oidc_credential_feature_flag.py` updated for the new entries
- [x] The registry tests iterate the constant, so their mocked entry points now derive from it instead of restating the HashiCorp namespaces, keeping the two in step as the list grows

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Akeyless OIDC and SSH OIDC credential types.
  * Expanded recognized OIDC credential namespaces to include four supported integrations.

* **Tests**
  * Updated validation to cover the expanded OIDC credential namespace set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->