### PR TITLE
fix: prefer scm_revision as the cache_id if available

### DIFF
--- a/awx/main/models/projects.py
+++ b/awx/main/models/projects.py
@@ -450,13 +450,14 @@ class Project(UnifiedJobTemplate, ProjectOptions, ResourceMixin, CustomVirtualEn
 
     @property
     def cache_id(self):
-        """This gives the folder name where collections and roles will be saved to so it does not re-download
+        # Prefer scm_revision as the cache key if available. This guarantees that project changes are tracked correctly
+        # even over multiple nodes. The scm_revision is a hex string and thus safe to be used as a directory name.
+        if self.scm_revision:
+            return self.scm_revision
 
-        Normally we want this to track with the last update, because every update should pull new content.
-        This does not count sync jobs, but sync jobs do not update last_job or current_job anyway.
-        If cleanup_jobs deletes the last jobs, then we can fallback to using any given heuristic related
-        to the last job ran.
-        """
+        # If no scm_revision is available (e.g. non-scm projects), use these. current_job_id and last_job_id are global
+        # IDs in the database. This means that when a project sync runs on one node, all other nodes become outdated,
+        # resulting in unnecessary re-syncs.
         if self.current_job_id:
             return str(self.current_job_id)
         elif self.last_job_id:
@@ -638,7 +639,7 @@ class ProjectUpdate(UnifiedJob, ProjectOptions, JobNotificationMixin, TaskManage
 
     @property
     def cache_id(self):
-        if self.branch_override or self.job_type == 'check' or (not self.project):
+        if self.branch_override or (not self.project):
             return str(self.id)  # causes it to not use the cache, basically
         return self.project.cache_id
 

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -885,7 +885,9 @@ class SourceControlMixin(BaseTask):
         # Determine whether or not this project sync needs to populate the cache for Ansible content, roles and collections
         has_cache = os.path.exists(os.path.join(project.get_cache_path(), project.cache_id))
         # Galaxy requirements are not supported for manual projects
-        if project.scm_type and ((not has_cache) or branch_override):
+        # If a source update is scheduled, always include roles/collections because
+        # the new revision may have different requirements.
+        if project.scm_type and ((not has_cache) or branch_override or source_update_tag in sync_needs):
             sync_needs.extend(['install_roles', 'install_collections'])
 
         return sync_needs


### PR DESCRIPTION
##### SUMMARY

The PR changes the way the cache_id for project updates is created - if available it prefers to use the scm_revision. The cache_id is directly used as the directory name for the project contents on disk.

**Why?**

The other fields are global database IDs and that leads to a problem in multi node environments: if one node runs a project update, the ID is incremented. But now, all other nodes think that their projects are outdated, because the cache_id no longer matches their local directory names. This results in unnecessary project updates.

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project update caching to better recognize the latest source-control revision.
  * Corrected cache handling for check operations and branch overrides.
  * Source updates now reliably install required roles and collections, even when cached content is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->