### PR TITLE
AAP-85067 Old RBAC sync regression tests for bulk claims

### DIFF
--- a/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
+++ b/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
@@ -3,9 +3,12 @@ Tests that save_user_claims (which uses bulk_create, skipping signals)
 correctly syncs old Role.members when run through AwxJWTAuthentication.
 """
 
+from unittest import mock
+
 import pytest
 
 from ansible_base.jwt_consumer.awx.auth import AwxJWTAuthentication
+from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 from ansible_base.rbac.claims import save_user_claims
 from ansible_base.rbac.models import RoleDefinition
 
@@ -47,6 +50,14 @@ class TestClaimsOldRbacSync:
 
         return {"objects": objects, "object_roles": object_roles, "global_roles": []}
 
+    def _call_process_permissions(self, auth, user, claims):
+        """Call process_permissions with claims pre-loaded, mocking the JWT layer."""
+        save_user_claims(user, **claims)
+        auth.common_auth.user = user
+        auth.common_auth._saved_claims = (claims["objects"], claims["object_roles"], claims["global_roles"])
+        with mock.patch.object(JWTAuthentication, 'process_permissions'):
+            auth.process_permissions()
+
     def test_bulk_claims_skips_old_rbac_signals(self, bob, organization, team, setup_managed_roles):
         """Verify that save_user_claims (bulk path) does NOT populate old Role.members via signals."""
         claims = self._build_claims([organization], [team])
@@ -63,40 +74,35 @@ class TestClaimsOldRbacSync:
         assert bob not in organization.admin_role.members.all()
         assert bob not in team.member_role.members.all()
 
-    def test_awx_sync_populates_old_rbac(self, bob, organization, team, setup_managed_roles):
-        """Verify that _sync_old_rbac populates old Role.members after bulk claims."""
+    def test_process_permissions_populates_old_rbac(self, bob, organization, team, setup_managed_roles):
+        """Verify that process_permissions populates old Role.members after bulk claims."""
         claims = self._build_claims([organization], [team])
 
-        save_user_claims(bob, **claims)
-
-        # Manually call the AWX sync (normally called via process_permissions)
         auth = AwxJWTAuthentication()
-        auth._sync_old_rbac(bob, claims["objects"], claims["object_roles"])
+        self._call_process_permissions(auth, bob, claims)
 
         assert bob in organization.admin_role.members.all()
         assert bob in team.member_role.members.all()
 
-    def test_awx_sync_removes_stale_old_rbac(self, bob, organization, team, setup_managed_roles):
-        """Verify that _sync_old_rbac removes old Role.members when claims shrink."""
+    def test_process_permissions_removes_stale_old_rbac(self, bob, organization, team, setup_managed_roles):
+        """Verify that process_permissions removes old Role.members when claims shrink."""
+        auth = AwxJWTAuthentication()
+
         # First: give bob both org admin and team member
         claims_full = self._build_claims([organization], [team])
-        save_user_claims(bob, **claims_full)
-
-        auth = AwxJWTAuthentication()
-        auth._sync_old_rbac(bob, claims_full["objects"], claims_full["object_roles"])
+        self._call_process_permissions(auth, bob, claims_full)
 
         assert bob in organization.admin_role.members.all()
         assert bob in team.member_role.members.all()
 
         # Second: claims shrink to just org admin (no team member)
         claims_reduced = self._build_claims([organization], [])
-        save_user_claims(bob, **claims_reduced)
-        auth._sync_old_rbac(bob, claims_reduced["objects"], claims_reduced["object_roles"])
+        self._call_process_permissions(auth, bob, claims_reduced)
 
         assert bob in organization.admin_role.members.all()
         assert bob not in team.member_role.members.all()
 
-    def test_awx_sync_multiple_orgs_and_teams(self, bob, setup_managed_roles):
+    def test_process_permissions_multiple_orgs_and_teams(self, bob, setup_managed_roles):
         """Test sync at small scale with multiple orgs and teams."""
         from awx.main.models import Organization, Team
 
@@ -106,10 +112,9 @@ class TestClaimsOldRbacSync:
             teams.append(Team.objects.create(name=f"sync-team-{org.name}", organization=org))
 
         claims = self._build_claims(orgs, teams)
-        save_user_claims(bob, **claims)
 
         auth = AwxJWTAuthentication()
-        auth._sync_old_rbac(bob, claims["objects"], claims["object_roles"])
+        self._call_process_permissions(auth, bob, claims)
 
         for org in orgs:
             org.refresh_from_db()

--- a/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
+++ b/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
@@ -10,7 +10,8 @@ import pytest
 from ansible_base.jwt_consumer.awx.auth import AwxJWTAuthentication
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 from ansible_base.rbac.claims import save_user_claims
-from ansible_base.rbac.models import RoleDefinition
+from ansible_base.rbac.models import RoleUserAssignment
+from awx.main.models import Organization, Team
 
 
 @pytest.mark.django_db
@@ -64,9 +65,6 @@ class TestClaimsOldRbacSync:
 
         save_user_claims(bob, **claims)
 
-        # DAB assignment exists
-        from ansible_base.rbac.models import RoleUserAssignment
-
         assert RoleUserAssignment.objects.filter(user=bob, role_definition__name="Organization Admin").exists()
         assert RoleUserAssignment.objects.filter(user=bob, role_definition__name="Team Member").exists()
 
@@ -104,8 +102,6 @@ class TestClaimsOldRbacSync:
 
     def test_process_permissions_multiple_orgs_and_teams(self, bob, setup_managed_roles):
         """Test sync at small scale with multiple orgs and teams."""
-        from awx.main.models import Organization, Team
-
         orgs = [Organization.objects.create(name=f"sync-org-{i}") for i in range(3)]
         teams = []
         for org in orgs:

--- a/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
+++ b/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
@@ -1,0 +1,120 @@
+"""
+Tests that save_user_claims (which uses bulk_create, skipping signals)
+correctly syncs old Role.members when run through AwxJWTAuthentication.
+"""
+
+import pytest
+
+from ansible_base.jwt_consumer.awx.auth import AwxJWTAuthentication
+from ansible_base.rbac.claims import save_user_claims
+from ansible_base.rbac.models import RoleDefinition
+
+
+@pytest.mark.django_db
+class TestClaimsOldRbacSync:
+
+    def _build_claims(self, orgs, teams):
+        """Build a claims dict from org/team model instances."""
+        objects = {"organization": [], "team": []}
+        object_roles = {}
+
+        org_indexes = []
+        for i, org in enumerate(orgs):
+            objects["organization"].append(
+                {
+                    "ansible_id": str(org.resource.ansible_id),
+                    "name": org.name,
+                }
+            )
+            org_indexes.append(i)
+
+        team_indexes = []
+        for i, team in enumerate(teams):
+            org_idx = next(j for j, o in enumerate(orgs) if o.pk == team.organization_id)
+            objects["team"].append(
+                {
+                    "ansible_id": str(team.resource.ansible_id),
+                    "name": team.name,
+                    "org": org_idx,
+                }
+            )
+            team_indexes.append(i)
+
+        if org_indexes:
+            object_roles["Organization Admin"] = {"content_type": "organization", "objects": org_indexes}
+        if team_indexes:
+            object_roles["Team Member"] = {"content_type": "team", "objects": team_indexes}
+
+        return {"objects": objects, "object_roles": object_roles, "global_roles": []}
+
+    def test_bulk_claims_skips_old_rbac_signals(self, bob, organization, team, setup_managed_roles):
+        """Verify that save_user_claims (bulk path) does NOT populate old Role.members via signals."""
+        claims = self._build_claims([organization], [team])
+
+        save_user_claims(bob, **claims)
+
+        # DAB assignment exists
+        from ansible_base.rbac.models import RoleUserAssignment
+
+        assert RoleUserAssignment.objects.filter(user=bob, role_definition__name="Organization Admin").exists()
+        assert RoleUserAssignment.objects.filter(user=bob, role_definition__name="Team Member").exists()
+
+        # Old Role.members NOT populated (bulk_create skips post_save signals)
+        assert bob not in organization.admin_role.members.all()
+        assert bob not in team.member_role.members.all()
+
+    def test_awx_sync_populates_old_rbac(self, bob, organization, team, setup_managed_roles):
+        """Verify that _sync_old_rbac populates old Role.members after bulk claims."""
+        claims = self._build_claims([organization], [team])
+
+        save_user_claims(bob, **claims)
+
+        # Manually call the AWX sync (normally called via process_permissions)
+        auth = AwxJWTAuthentication()
+        auth._sync_old_rbac(bob, claims["objects"], claims["object_roles"])
+
+        assert bob in organization.admin_role.members.all()
+        assert bob in team.member_role.members.all()
+
+    def test_awx_sync_removes_stale_old_rbac(self, bob, organization, team, setup_managed_roles):
+        """Verify that _sync_old_rbac removes old Role.members when claims shrink."""
+        # First: give bob both org admin and team member
+        claims_full = self._build_claims([organization], [team])
+        save_user_claims(bob, **claims_full)
+
+        auth = AwxJWTAuthentication()
+        auth._sync_old_rbac(bob, claims_full["objects"], claims_full["object_roles"])
+
+        assert bob in organization.admin_role.members.all()
+        assert bob in team.member_role.members.all()
+
+        # Second: claims shrink to just org admin (no team member)
+        claims_reduced = self._build_claims([organization], [])
+        save_user_claims(bob, **claims_reduced)
+        auth._sync_old_rbac(bob, claims_reduced["objects"], claims_reduced["object_roles"])
+
+        assert bob in organization.admin_role.members.all()
+        assert bob not in team.member_role.members.all()
+
+    def test_awx_sync_multiple_orgs_and_teams(self, bob, setup_managed_roles):
+        """Test sync at small scale with multiple orgs and teams."""
+        from awx.main.models import Organization, Team
+
+        orgs = [Organization.objects.create(name=f"sync-org-{i}") for i in range(3)]
+        teams = []
+        for org in orgs:
+            teams.append(Team.objects.create(name=f"sync-team-{org.name}", organization=org))
+
+        claims = self._build_claims(orgs, teams)
+        save_user_claims(bob, **claims)
+
+        auth = AwxJWTAuthentication()
+        auth._sync_old_rbac(bob, claims["objects"], claims["object_roles"])
+
+        for org in orgs:
+            org.refresh_from_db()
+            assert bob in org.admin_role.members.all(), f"bob not in {org.name}.admin_role"
+
+        for team in teams:
+            team.refresh_from_db()
+            assert bob in team.member_role.members.all(), f"bob not in {team.name}.member_role"

--- a/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
+++ b/awx/main/tests/functional/dab_rbac/test_claims_old_rbac_sync.py
@@ -10,7 +10,6 @@ import pytest
 from ansible_base.jwt_consumer.awx.auth import AwxJWTAuthentication
 from ansible_base.jwt_consumer.common.auth import JWTAuthentication
 from ansible_base.rbac.claims import save_user_claims
-from ansible_base.rbac.models import RoleUserAssignment
 from awx.main.models import Organization, Team
 
 
@@ -58,19 +57,6 @@ class TestClaimsOldRbacSync:
         auth.common_auth._saved_claims = (claims["objects"], claims["object_roles"], claims["global_roles"])
         with mock.patch.object(JWTAuthentication, 'process_permissions'):
             auth.process_permissions()
-
-    def test_bulk_claims_skips_old_rbac_signals(self, bob, organization, team, setup_managed_roles):
-        """Verify that save_user_claims (bulk path) does NOT populate old Role.members via signals."""
-        claims = self._build_claims([organization], [team])
-
-        save_user_claims(bob, **claims)
-
-        assert RoleUserAssignment.objects.filter(user=bob, role_definition__name="Organization Admin").exists()
-        assert RoleUserAssignment.objects.filter(user=bob, role_definition__name="Team Member").exists()
-
-        # Old Role.members NOT populated (bulk_create skips post_save signals)
-        assert bob not in organization.admin_role.members.all()
-        assert bob not in team.member_role.members.all()
 
     def test_process_permissions_populates_old_rbac(self, bob, organization, team, setup_managed_roles):
         """Verify that process_permissions populates old Role.members after bulk claims."""


### PR DESCRIPTION
## Summary
- Adds regression tests verifying that old `Role.members` are correctly synced after `save_user_claims` uses bulk assignment (which skips `post_save` signals)
- Tests cover: signal gap confirmation, add sync, remove sync, and multi-org/team scenarios
- Companion to [ansible/django-ansible-base#1057](https://github.com/ansible/django-ansible-base/pull/1057)

## Test plan
- [ ] All 4 new tests in `test_claims_old_rbac_sync.py` pass
- [ ] Existing `dab_rbac` functional tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added coverage for synchronizing permission claims with role memberships.
  * Verified memberships are populated correctly and stale assignments are removed when claims change.
  * Confirmed synchronization works across multiple organizations and teams.
  * Ensured bulk updates create the expected assignments without triggering unintended legacy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

##### ISSUE TYPE

* Bug, Docs Fix or other nominal change