### PR TITLE
Exclude .tox from flake8 linter scope

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
 
 [flake8]
 select = F401,F402,F821,F823,F841,F811,E265,E266,F541,W605,E722,F822,F523,W291,F405
-exclude = env,awx_collection_build
+exclude = env,awx_collection_build,.tox
 
 [testenv:pip-compile-docs]
 description = Compile docs build lockfiles


### PR DESCRIPTION
## Summary
- Add `.tox` to the flake8 `exclude` list in `tox.ini`
- `awxkit` has its own `tox.ini`; when `tox -e linters` runs, `awxkit/.tox/py3/` can get populated with a virtualenv whose site-packages (PyYAML, etc.) produce hundreds of false-positive flake8 errors (F405, E265, E266)
- Matches the existing exclusion of `env` for virtualenvs

## Test plan
- [ ] Run `tox -e linters` with an `awxkit/.tox/py3` venv present — should no longer report site-packages errors
- [ ] Verify normal flake8 coverage of `awx`, `awxkit`, and `awx_collection` is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code-quality checks to exclude the `.tox` directory from Flake8 scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->