### PR TITLE
Allow update_cache_timeout=-1 to force inventory update on launch

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1733,9 +1733,11 @@ class ConstructedInventorySerializer(InventorySerializer):
     update_cache_timeout = ConstructedIntegerField(
         required=False,
         allow_null=True,
-        min_value=0,
+        min_value=-1,
         default=None,
-        help_text=_('The cache timeout for the related auto-created inventory source, special to constructed inventory'),
+        help_text=_(
+            'The cache timeout for the related auto-created inventory source, special to constructed inventory. Set to -1 to force update on every launch.'
+        ),
     )
     limit = ConstructedCharField(
         required=False,

--- a/awx/main/migrations/0208_allow_negative_cache_timeout.py
+++ b/awx/main/migrations/0208_allow_negative_cache_timeout.py
@@ -1,0 +1,21 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0207_alter_skip_tags_to_textfield'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='inventorysource',
+            name='update_cache_timeout',
+            field=models.IntegerField(
+                default=0,
+                help_text='Time in seconds to cache inventory sync. Set to -1 to force update on every launch.',
+                validators=[django.core.validators.MinValueValidator(-1)],
+            ),
+        ),
+    ]

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1141,8 +1141,12 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, CustomVirtualE
         default=False,
     )
 
-    update_cache_timeout = models.PositiveIntegerField(
+    from django.core.validators import MinValueValidator
+
+    update_cache_timeout = models.IntegerField(
         default=0,
+        validators=[MinValueValidator(-1)],
+        help_text=_('Time in seconds to cache inventory sync. Set to -1 to force sync on every launch.'),
     )
 
     @classmethod
@@ -1241,6 +1245,8 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, CustomVirtualE
 
     @property
     def cache_timeout_blocked(self):
+        if self.update_cache_timeout == -1:
+            return False
         if not self.last_job_run:
             return False
         if (self.last_job_run + datetime.timedelta(seconds=self.update_cache_timeout)) > now():
@@ -1250,6 +1256,8 @@ class InventorySource(UnifiedJobTemplate, InventorySourceOptions, CustomVirtualE
     @property
     def needs_update_on_launch(self):
         if self.source and self.update_on_launch:
+            if self.update_cache_timeout == -1:
+                return True
             if not self.last_job_run:
                 return True
             if (self.last_job_run + datetime.timedelta(seconds=self.update_cache_timeout)) <= now():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, `InventorySource.update_cache_timeout` only accepts non-negative integers (`>= 0`). Under certain execution timing conditions, setting this value to `0` may still skip or reuse cache during rapid sequential job triggers.

This PR introduces support for setting `update_cache_timeout = -1` as a sentinel value to explicitly force an inventory synchronization on every single launch, completely bypassing timestamp checks and cache blocking.

Key changes:
- Changed `update_cache_timeout` field validator lower bound from `0` to `-1` on the `InventorySource` model and API serializer (`awx/api/serializers.py`).
- Updated `needs_update_on_launch` property in `InventorySource` to immediately return `True` when `update_cache_timeout == -1`.
- Updated `cache_timeout_blocked` property to return `False` when `update_cache_timeout == -1`.
- Added database migration `0208_allow_negative_cache_timeout.py`.

##### ISSUE TYPE
- New or Enhanced Feature

##### COMPONENT NAME
- API

##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

1. Create an Inventory Source attached to a Job Template with `update_on_launch = True`.
2. Attempt to pass `-1` for `update_cache_timeout` via the API or model update.
3. **Before change:** Validation fails because minimum value allowed is `0`. Setting `0` still relies on timestamp comparison logic.
4. **After change:** `update_cache_timeout = -1` is accepted, and launching the Job Template forces an inventory sync on every run regardless of prior run timestamps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inventory sources can now use `-1` as the cache timeout to force synchronization on every launch.
  * Updated validation and help text explain the new setting.

* **Bug Fixes**
  * Inventory sources configured with `-1` now correctly bypass cache blocking and always request an update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->