### PR TITLE
Docs/fix spelling typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -125,7 +125,7 @@ body:
     id: expected-results
     attributes:
       label: Expected results
-      description: What did you expect to happpen when running the steps above?
+      description: What did you expect to happen when running the steps above?
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -74,7 +74,7 @@ body:
   - type: textarea
     id: sugested-results
     attributes:
-      label: Sugested feature result
+      label: Suggested feature result
       description: What is the result this new feature will bring?
     validations:
       required: true

--- a/.github/triage_replies.md
+++ b/.github/triage_replies.md
@@ -31,7 +31,7 @@ Thank you once again for this and your interest in AWX!
 ### No Progress Issue
 - Hi! \
 \
-Thank you very much for for this issue. It means a lot to us that you have taken time to contribute by opening this report. \
+Thank you very much for this issue. It means a lot to us that you have taken time to contribute by opening this report. \
 \
 On this issue, there were comments added but it has been some time since then without response. At this time we are closing this issue. If you get time to address the comments we can reopen the issue if you can contact us by using any of the communication methods listed in the page below: \
 \

--- a/.github/workflows/dab-release.yml
+++ b/.github/workflows/dab-release.yml
@@ -20,7 +20,7 @@ jobs:
           repo: django-ansible-base
           excludes: prerelease, draft
 
-      - name: Check out respository code
+      - name: Check out repository code
         uses: actions/checkout@v4
 
       - id: dab-pinned

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GIT_IS_WORKTREE := $(shell test -f .git && echo yes)
 MANAGEMENT_COMMAND ?= awx-manage
 VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py 2> /dev/null)
 
-# ansible-test requires semver compatable version, so we allow overrides to hack it
+# ansible-test requires semver compatible version, so we allow overrides to hack it
 COLLECTION_VERSION ?= $(shell $(PYTHON) tools/scripts/scm_version.py | cut -d . -f 1-3)
 # args for the ansible-test sanity command
 COLLECTION_SANITY_ARGS ?= --docker

--- a/awx/__init__.py
+++ b/awx/__init__.py
@@ -43,7 +43,7 @@ __all__ = ['__version__']
 
 
 # Check for the presence/absence of "devonly" module to determine if running
-# from a source code checkout or release packaage.
+# from a source code checkout or release package.
 try:
     import awx.devonly  # noqa
 

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -1115,7 +1115,7 @@ class UserSerializer(BaseSerializer):
             the reason for failure.
         :return: None.
         """
-        # We must do this here instead of in `validate_password` bacause some
+        # We must do this here instead of in `validate_password` because some
         # django password validators need access to other model instance fields,
         # e.g. ``username`` for the ``UserAttributeSimilarityValidator``.
         password = attrs.get("password")

--- a/awx/api/views/__init__.py
+++ b/awx/api/views/__init__.py
@@ -276,7 +276,7 @@ class DashboardJobsGraphView(APIView):
     swagger_topic = 'Jobs'
     resource_purpose = 'dashboard jobs graph data'
 
-    @extend_schema_if_available(extensions={"x-ai-description": "Get dasboard data for jobs"})
+    @extend_schema_if_available(extensions={"x-ai-description": "Get dashboard data for jobs"})
     def get(self, request, format=None):
         period = request.query_params.get('period', 'month')
         job_type = request.query_params.get('job_type', 'all')

--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -531,7 +531,7 @@ class NotificationAttachMixin(BaseAccess):
     - I have notification_admin_role to organization of the NT
     - I can read the object I am attaching it to
 
-    I can unattach when those same critiera are met
+    I can unattach when those same criteria are met
     """
 
     notification_attach_roles = None
@@ -893,7 +893,7 @@ class InventoryAccess(BaseAccess):
 class HostAccess(BaseAccess):
     """
     I can see hosts whenever I can see their inventory.
-    I can change or delete hosts whenver I can change their inventory.
+    I can change or delete hosts whenever I can change their inventory.
     """
 
     model = Host

--- a/awx/main/analytics/broadcast_websocket.py
+++ b/awx/main/analytics/broadcast_websocket.py
@@ -101,7 +101,7 @@ class RelayWebsocketStatsManager:
     @classmethod
     def get_stats_sync(cls):
         """
-        Stringified verion of all the stats
+        Stringified version of all the stats
         """
         # Reuse cached Redis client to avoid creating new connection pools on every call
         if cls._redis_client is None:

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -208,7 +208,7 @@ register(
     schemes=('http', 'https'),
     allow_plain_hostname=True,  # Allow hostname only without TLD.
     label=_('Automation Analytics upload URL'),
-    help_text=_('This setting is used to to configure the upload URL for data collection for Automation Analytics.'),
+    help_text=_('This setting is used to configure the upload URL for data collection for Automation Analytics.'),
     category=_('System'),
     category_slug='system',
 )

--- a/awx/main/conf.py
+++ b/awx/main/conf.py
@@ -763,7 +763,7 @@ register(
         'Level threshold used by log handler. Severities from lowest to highest'
         ' are DEBUG, INFO, WARNING, ERROR, CRITICAL. Messages less severe '
         'than the threshold will be ignored by log handler. (messages under category '
-        'awx.anlytics ignore this setting)'
+        'awx.analytics ignore this setting)'
     ),
     category=_('Logging'),
     category_slug='logging',

--- a/awx/main/constants.py
+++ b/awx/main/constants.py
@@ -101,7 +101,7 @@ MAX_ISOLATED_PATH_COLON_DELIMITER = 2
 SURVEY_TYPE_MAPPING = {'text': str, 'textarea': str, 'password': str, 'multiplechoice': str, 'multiselect': str, 'integer': int, 'float': (float, int)}
 
 
-# Note, the \u001b[... are ansi color codes. We don't currenly import any of the python modules which define the codes.
+# Note, the \u001b[... are ansi color codes. We don't currently import any of the python modules which define the codes.
 # Importing a library just for this message seemed like overkill
 ANSIBLE_RUNNER_NEEDS_UPDATE_MESSAGE = (
     '\u001b[31m \u001b[1m This can be caused if the version of ansible-runner in your execution environment is out of date.\u001b[0m'
@@ -133,9 +133,9 @@ org_role_to_permission = {
     'inventory_admin_role': 'add_inventory',
     'credential_admin_role': 'add_credential',
     'workflow_admin_role': 'add_workflowjobtemplate',
-    'job_template_admin_role': 'change_jobtemplate',  # TODO: this doesnt really work, solution not clear
+    'job_template_admin_role': 'change_jobtemplate',  # TODO: this doesn't really work, solution not clear
     'execution_environment_admin_role': 'add_executionenvironment',
-    'auditor_role': 'view_project',  # TODO: also doesnt really work
+    'auditor_role': 'view_project',  # TODO: also doesn't really work
 }
 
 # OIDC credential type namespaces for feature flag filtering

--- a/awx/main/dispatch/worker/callback.py
+++ b/awx/main/dispatch/worker/callback.py
@@ -224,7 +224,7 @@ class CallbackBrokerWorker:
                     # If the database is flaking, let ensure_connection throw a general exception
                     # will be caught by the outer loop, which goes into a proper sleep and retry loop
                     django_connection.ensure_connection()
-                    logger.warning(f'Error in events bulk_create, will try indiviually, error: {str(exc)}')
+                    logger.warning(f'Error in events bulk_create, will try individually, error: {str(exc)}')
                     # if an exception occurs, we should re-attempt to save the
                     # events one-by-one, because something in the list is
                     # broken/stale

--- a/awx/main/fields.py
+++ b/awx/main/fields.py
@@ -449,7 +449,7 @@ class CredentialInputField(JSONSchemaField):
         if not isinstance(value, dict):
             return super(CredentialInputField, self).validate(value, model_instance)
 
-        # Backwards compatability: in prior versions, if you submit `null` for
+        # Backwards compatibility: in prior versions, if you submit `null` for
         # a credential field value, it just considers the value an empty string
         for unset in [key for key, v in model_instance.inputs.items() if not v]:
             default_value = model_instance.credential_type.default_for_field(unset)

--- a/awx/main/management/commands/custom_venv_associations.py
+++ b/awx/main/management/commands/custom_venv_associations.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         parser.add_argument('-q', action='store_true', help='run with -q to output only the results of the query.')
 
     def handle(self, *args, **options):
-        # look organiztions and unified job templates (which include JTs, workflows, and Inventory updates)
+        # look organizations and unified job templates (which include JTs, workflows, and Inventory updates)
         super(Command, self).__init__()
         results = {}
         path = options.get('path')

--- a/awx/main/management/commands/disable_instance.py
+++ b/awx/main/management/commands/disable_instance.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
             "--retry_sleep",
             type=self.ge_1,
             default=30,
-            help="Number of seconds to sleep before consequtive retries when waiting. Default: 30",
+            help="Number of seconds to sleep before consecutive retries when waiting. Default: 30",
         )
 
     def handle(self, *args, **options):

--- a/awx/main/management/commands/enable_local_authentication.py
+++ b/awx/main/management/commands/enable_local_authentication.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
 
     def _enable_disable_auth(self, enable, disable):
         """
-        this method allows the disabling or enabling of local authenication based on the argument passed into the parser
+        this method allows the disabling or enabling of local authentication based on the argument passed into the parser
         if no arguments throw a command error, if --enable set the DISABLE_LOCAL_AUTH to False
         if --disable it's set to True. Realizing that the flag is counterintuitive to what is expected.
         """

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -43,7 +43,7 @@ LICENSE_EXPIRED_MESSAGE = '''\
 Subscription expired.
 Contact us (https://www.redhat.com/contact) for subscription extension information.'''
 
-LICENSE_NON_EXISTANT_MESSAGE = '''\
+LICENSE_NON_EXISTENT_MESSAGE = '''\
 No subscription.
 Contact us (https://www.redhat.com/contact) for subscription information.'''
 
@@ -801,7 +801,7 @@ class Command(BaseCommand):
         license_info = get_licenser().validate()
         local_license_type = license_info.get('license_type', 'UNLICENSED')
         if local_license_type == 'UNLICENSED':
-            logger.error(LICENSE_NON_EXISTANT_MESSAGE)
+            logger.error(LICENSE_NON_EXISTENT_MESSAGE)
             raise PermissionDenied('No license found!')
         elif local_license_type == 'open':
             return

--- a/awx/main/management/commands/inventory_import.py
+++ b/awx/main/management/commands/inventory_import.py
@@ -940,7 +940,7 @@ class Command(BaseCommand):
         This saves the inventory data to the database, calling load_into_database
         but also wraps that method in a host of options processing
         """
-        # outside of normal options, these are needed as part of programatic interface
+        # outside of normal options, these are needed as part of programmatic interface
         self.inventory = inventory_update.inventory
         self.inventory_source = inventory_update.inventory_source
         self.inventory_update = inventory_update

--- a/awx/main/middleware.py
+++ b/awx/main/middleware.py
@@ -203,14 +203,14 @@ class MigrationRanCheckMiddleware(MiddlewareMixin):
 class OptionalURLPrefixPath(MiddlewareMixin):
     @functools.lru_cache
     def _url_optional(self, prefix):
-        # Relavant Django code path https://github.com/django/django/blob/stable/4.2.x/django/core/handlers/base.py#L300
+        # Relevant Django code path https://github.com/django/django/blob/stable/4.2.x/django/core/handlers/base.py#L300
         #
         # resolve_request(request)
         #   get_resolver(request.urlconf)
         #     _get_cached_resolver(request.urlconf) <-- cached via @functools.cache
         #
         # Django will attempt to cache the value(s) of request.urlconf
-        # Being hashable is a prerequisit for being cachable.
+        # Being hashable is a prerequisite for being cacheable.
         # tuple() is hashable list() is not.
         # Hence the tuple(list()) wrap.
         return tuple(get_urlpatterns(prefix=prefix))

--- a/awx/main/migrations/0004_squashed_v310_release.py
+++ b/awx/main/migrations/0004_squashed_v310_release.py
@@ -741,7 +741,7 @@ class Migration(migrations.Migration):
             name='dtend',
             field=models.DateTimeField(
                 default=None,
-                help_text='The last occurrence of the schedule occurs before this time, aftewards the schedule expires.',
+                help_text='The last occurrence of the schedule occurs before this time, afterwards the schedule expires.',
                 null=True,
                 editable=False,
             ),

--- a/awx/main/migrations/0112_v370_workflow_node_identifier.py
+++ b/awx/main/migrations/0112_v370_workflow_node_identifier.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
             model_name='workflowjobnode',
             name='identifier',
             field=models.CharField(
-                blank=True, help_text='An identifier coresponding to the workflow job template node that this node was created from.', max_length=512
+                blank=True, help_text='An identifier corresponding to the workflow job template node that this node was created from.', max_length=512
             ),
         ),
         migrations.AddField(

--- a/awx/main/migrations/0113_v370_event_bigint.py
+++ b/awx/main/migrations/0113_v370_event_bigint.py
@@ -17,7 +17,7 @@ def migrate_event_data(apps, schema_editor):
             # This loop used to do roughly the following:
             #     Rename the table to _old_<tablename>
             #     Create a new table form the old table (it would have no rows)
-            #     Drop the old sequnce and create a new on tied to the new table and set the sequence to the last number from the old table
+            #     Drop the old sequence and create a new on tied to the new table and set the sequence to the last number from the old table
             # This used to work with postgres spitting out a NOTICE and DETAIL
             # With the django 4.2 upgrade that changed to an ERROR and HINT
             # By the time we hit the 4.2 upgrade, no one should be upgrading a database this old directly to this new schema

--- a/awx/main/migrations/0144_event_partitions.py
+++ b/awx/main/migrations/0144_event_partitions.py
@@ -15,7 +15,7 @@ def migrate_event_data(apps, schema_editor):
     # denormalized column, job_created, this is used as a
     # basis for partitioning job event rows
     #
-    # The initial partion will be a unique case. After
+    # The initial partition will be a unique case. After
     # the migration is completed, awx should create
     # new partitions on an hourly basis, as needed.
     # All events for a given job should be placed in
@@ -34,7 +34,7 @@ def migrate_event_data(apps, schema_editor):
             # to suffer a serious performance degradation
             cursor.execute(f'CREATE TABLE tmp_{tblname} (LIKE _unpartitioned_{tblname} INCLUDING ALL)')
 
-            # drop primary key constraint; in a partioned table
+            # drop primary key constraint; in a partitioned table
             # constraints must include the partition key itself
             # TODO: do more generic search for pkey constraints
             # instead of hardcoding this one that applies to main_jobevent
@@ -54,7 +54,7 @@ def migrate_event_data(apps, schema_editor):
 
     with connection.cursor() as cursor:
         """
-        Big int migration introduced the brin index main_jobevent_job_id_brin_idx index. For upgardes, we drop the index, new installs do nothing.
+        Big int migration introduced the brin index main_jobevent_job_id_brin_idx index. For upgrades, we drop the index, new installs do nothing.
         I have seen the second index in my dev environment. I can not find where in the code it was created. Drop it just in case
         """
         cursor.execute('DROP INDEX IF EXISTS main_jobevent_job_id_brin_idx')

--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -42,7 +42,7 @@ def resolve_parent_role(f, role_path):
     Given a field and a path declared in parent_role from the field definition, like
         execute_role = ImplicitRoleField(parent_role='admin_role')
     This expects to be passed in (execute_role object, "admin_role")
-    It hould return the admin_role from that object
+    It should return the admin_role from that object
     """
     if role_path == 'singleton:system_administrator':
         return system_admin
@@ -182,7 +182,7 @@ def migrate_to_new_rbac(apps, schema_editor):
     if Permission.objects.count() == 0:
         raise RuntimeError('Running migrate_to_new_rbac requires DABPermission objects created first')
 
-    # remove add premissions that are not valid for migrations from old versions
+    # remove add permissions that are not valid for migrations from old versions
     for perm_str in ('add_organization', 'add_jobtemplate'):
         perm = Permission.objects.filter(codename=perm_str).first()
         if perm:

--- a/awx/main/migrations/_rbac.py
+++ b/awx/main/migrations/_rbac.py
@@ -218,7 +218,7 @@ def _restore_inventory_admins(apps, schema_editor, backward=False):
                 '{} {} on jt {} for users {} via inventory.organization {}'.format('Removing' if backward else 'Setting', jt_role, jt.pk, user_ids, org.pk)
             )
             if not backward:
-                # in reverse, explit role becomes redundant
+                # in reverse, explicit role becomes redundant
                 role.members.add(*user_ids)
             else:
                 role.members.remove(*user_ids)

--- a/awx/main/models/events.py
+++ b/awx/main/models/events.py
@@ -365,7 +365,7 @@ class BasePlaybookEvent(CreatedModifiedModel):
                         except DatabaseError:
                             logger.exception('Computed fields database error saving event {}'.format(self.pk))
 
-                    # find parent links and progagate changed=T and failed=T
+                    # find parent links and propagate changed=T and failed=T
                     changed = (
                         job.get_event_queryset()
                         .filter(changed=True)

--- a/awx/main/models/ha.py
+++ b/awx/main/models/ha.py
@@ -390,7 +390,7 @@ class Instance(HasPolicyEditsMixin, BaseModel):
             update_fields.extend(fields_to_update)
         update_fields.extend(['cpu_capacity', 'mem_capacity', 'capacity'])
 
-        # disabling activity stream will avoid extra queries, which is important for heatbeat actions
+        # disabling activity stream will avoid extra queries, which is important for heartbeat actions
         from awx.main.signals import disable_activity_stream
 
         with disable_activity_stream():

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1370,7 +1370,7 @@ class InventoryUpdate(UnifiedJob, InventorySourceOptions, JobNotificationMixin, 
         return urljoin(settings.TOWER_URL_BASE, "{}/jobs/inventory/{}".format(settings.OPTIONAL_UI_URL_PREFIX, self.pk))
 
     def get_actual_source_path(self):
-        '''Alias to source_path that combines with project path for for SCM file based sources'''
+        '''Alias to source_path that combines with project path for SCM file based sources'''
         if self.inventory_source_id is None or self.inventory_source.source_project_id is None:
             return self.source_path
         return os.path.join(self.inventory_source.source_project.get_project_path(check_if_exists=False), self.source_path)

--- a/awx/main/models/inventory.py
+++ b/awx/main/models/inventory.py
@@ -1071,7 +1071,7 @@ class InventorySourceOptions(BaseModel):
         elif source == 'scm' and cred and cred.credential_type.kind in ('insights', 'vault'):
             return _('Credentials of type insights and vault are disallowed for scm inventory sources.')
         elif source == 'openshift_virtualization' and cred and cred.credential_type.kind != 'kubernetes':
-            return _('Credentials of type kubernetes is requred for openshift_virtualization inventory sources.')
+            return _('Credentials of type kubernetes is required for openshift_virtualization inventory sources.')
         return None
 
     def get_cloud_credential(self):

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -248,7 +248,7 @@ class Role(models.Model):
         Updates our `ancestors` map to accurately reflect all of the ancestors for a role
 
         You should never need to call this. Signal handlers should be calling
-        this method when the role hierachy changes automatically.
+        this method when the role hierarchy changes automatically.
         """
         # The ancestry table
         # =================================================
@@ -345,7 +345,7 @@ class Role(models.Model):
             'roles_table': Role._meta.db_table,
         }
 
-        # SQLlite has a 1M sql statement limit.. since the django sqllite
+        # sqlite has a 1M sql statement limit.. since the django sqlite
         # driver isn't letting us pass in the ids through the preferred
         # parameter binding system, this function exists to obey this.
         # est max 12 bytes per number, used up to 2 times in a query,

--- a/awx/main/models/schedules.py
+++ b/awx/main/models/schedules.py
@@ -139,7 +139,7 @@ class Schedule(PrimordialModel, LaunchTimeConfig):
     enabled = models.BooleanField(default=True, help_text=_("Enables processing of this schedule."))
     dtstart = models.DateTimeField(null=True, default=None, editable=False, help_text=_("The first occurrence of the schedule occurs on or after this time."))
     dtend = models.DateTimeField(
-        null=True, default=None, editable=False, help_text=_("The last occurrence of the schedule occurs before this time, aftewards the schedule expires.")
+        null=True, default=None, editable=False, help_text=_("The last occurrence of the schedule occurs before this time, afterwards the schedule expires.")
     )
     rrule = models.TextField(help_text=_("A value representing the schedules iCal recurrence rule."))
     next_run = models.DateTimeField(null=True, default=None, editable=False, help_text=_("The next time that the scheduled action will run."))

--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1478,7 +1478,7 @@ class UnifiedJob(
             ScheduleDependencyManager().schedule()
 
         # Each type of unified job has a different Task class; get the
-        # appropirate one.
+        # appropriate one.
         # task_type = get_type_for_model(self)
 
         # Actually tell the task runner to run this task.

--- a/awx/main/models/workflow.py
+++ b/awx/main/models/workflow.py
@@ -275,7 +275,7 @@ class WorkflowJobNode(WorkflowNodeBase):
     identifier = models.CharField(
         max_length=512,
         blank=True,  # blank denotes pre-migration job nodes
-        help_text=_('An identifier coresponding to the workflow job template node that this node was created from.'),
+        help_text=_('An identifier corresponding to the workflow job template node that this node was created from.'),
     )
     instance_groups = OrderedManyToManyField(
         'InstanceGroup', related_name='workflow_job_node_instance_groups', blank=True, editable=False, through='WorkflowJobNodeBaseInstanceGroupMembership'
@@ -332,7 +332,7 @@ class WorkflowJobNode(WorkflowNodeBase):
                 wj_prompts_data['credentials'] = [cred for cred in node_pivoted_creds.values()]
 
             # NOTE: no special rules for instance_groups, because they do not merge
-            # or labels, because they do not propogate WFJT-->node at all
+            # or labels, because they do not propagate WFJT-->node at all
 
             # Combine WFJT prompts with node here, WFJT at higher level
             node_prompts_data.update(wj_prompts_data)
@@ -787,7 +787,7 @@ class WorkflowJob(UnifiedJob, WorkflowJobOptions, SurveyJobMixin, JobNotificatio
         else:
             r = super().prompts_dict(*args, **kwargs)
             # Workflow labels and job labels are treated separately
-            # that means that they do not propogate from WFJT / workflow job to jobs in workflow
+            # that means that they do not propagate from WFJT / workflow job to jobs in workflow
             r.pop('labels', None)
 
         return r

--- a/awx/main/redact.py
+++ b/awx/main/redact.py
@@ -34,8 +34,8 @@ class UriCleaner(object):
                     password = o.password
 
                 # Given a python MatchObject, with respect to redactedtext, find and
-                # replace the first occurance of username and the first and second
-                # occurance of password
+                # replace the first occurrence of username and the first and second
+                # occurrence of password
 
                 uri_str = redactedtext[match.start() : match.end()]
                 if username:

--- a/awx/main/routing.py
+++ b/awx/main/routing.py
@@ -31,7 +31,7 @@ class AWXProtocolTypeRouter(ProtocolTypeRouter):
 class MultipleURLRouterAdapter:
     """
     Django channels doesn't nicely support Auth_1(urls_1), Auth_2(urls_2), ..., Auth_n(urls_n)
-    This class allows assocating a websocket url with an auth
+    This class allows associating a websocket url with an auth
     Ordering matters. The first matching url will be used.
     """
 

--- a/awx/main/scheduler/dag_workflow.py
+++ b/awx/main/scheduler/dag_workflow.py
@@ -67,7 +67,7 @@ class WorkflowDAG(SimpleDAG):
     def _all_parents_met_convergence_criteria(self, node):
         # This function takes any node and checks that all it's parents have met their criteria to run the child.
         # This returns a boolean and is really only useful if the node is an ALL convergence node and is
-        # intended to be used in conjuction with the node property `all_parents_must_converge`
+        # intended to be used in conjunction with the node property `all_parents_must_converge`
         obj = node['node_object']
         parent_nodes = [p['node_object'] for p in self.get_parents(obj)]
         for p in parent_nodes:

--- a/awx/main/scheduler/task_manager.py
+++ b/awx/main/scheduler/task_manager.py
@@ -161,7 +161,7 @@ class TaskBase:
                         signal.signal(signal.SIGUSR1, original_sigusr1)
                     commit_start = time.time()
 
-                    logger.debug(f"Commiting {self.prefix} Scheduler changes")
+                    logger.debug(f"Committing {self.prefix} Scheduler changes")
 
                 if self.prefix == "task_manager":
                     self.subsystem_metrics.set(f"{self.prefix}_commit_seconds", time.time() - commit_start)

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -117,7 +117,7 @@ def rebuild_role_ancestor_list(reverse, model, instance, pk_set, action, **kwarg
 
 
 def sync_superuser_status_to_rbac(instance, **kwargs):
-    'When the is_superuser flag is changed on a user, reflect that in the membership of the System Admnistrator role'
+    'When the is_superuser flag is changed on a user, reflect that in the membership of the System Administrator role'
     if settings.ANSIBLE_BASE_ROLE_SYSTEM_ACTIVATED:
         return
     update_fields = kwargs.get('update_fields', None)
@@ -417,7 +417,7 @@ def activity_stream_delete(sender, instance, **kwargs):
         return
     # Inventory delete happens in the task system rather than request-response-cycle.
     # If we trigger this handler there we may fall into db-integrity-related race conditions.
-    # So we add flag verification to prevent normal signal handling. This funciton will be
+    # So we add flag verification to prevent normal signal handling. This function will be
     # explicitly called with flag on in Inventory.schedule_deletion.
     changes = {}
     if isinstance(instance, Inventory):

--- a/awx/main/tasks/host_indirect.py
+++ b/awx/main/tasks/host_indirect.py
@@ -48,7 +48,7 @@ def build_indirect_host_data(job: Job, job_event_queries: dict[str, dict[str, st
     job_event_queries_fqcn = {}
     for query_k, query_v in job_event_queries.items():
         if len(parts := query_k.split('.')) != 3:
-            logger.info(f"Skiping malformed query '{query_k}'. Expected to be of the form 'a.b.c'")
+            logger.info(f"Skipping malformed query '{query_k}'. Expected to be of the form 'a.b.c'")
             continue
         if parts[2] != '*':
             continue
@@ -177,7 +177,7 @@ def save_indirect_host_entries(job_id: int, wait_for_events: bool = True) -> Non
 
     with transaction.atomic():
         """
-        Pre-emptively set the job marker to 'events processed'. This prevents other instances from running the
+        Preemptively set the job marker to 'events processed'. This prevents other instances from running the
         same task.
         """
         try:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1967,7 +1967,7 @@ class RunInventoryUpdate(SourceControlMixin, BaseTask):
             raise
         except Exception:
             logger.exception('Exception saving {} content, rolling back changes.'.format(inventory_update.log_format))
-            raise PostRunError('Error occured while saving inventory data, see traceback or server logs', status='error', tb=traceback.format_exc())
+            raise PostRunError('Error occurred while saving inventory data, see traceback or server logs', status='error', tb=traceback.format_exc())
 
 
 @task(queue=get_task_queuename)

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -344,7 +344,7 @@ class BaseTask(object):
                 if this_path.count(':') == MAX_ISOLATED_PATH_COLON_DELIMITER:
                     src, dest, mount_option = this_path.split(':')
 
-                    # mount_option validation via performed via API, but since this can be overriden via settings.py
+                    # mount_option validation via performed via API, but since this can be overridden via settings.py
                     if mount_option not in CONTAINER_VOLUMES_MOUNT_TYPES:
                         mount_option = 'z'
                         logger.warning(f'The path {this_path} has volume mount type {mount_option} which is not supported. Using "z" instead.')
@@ -908,7 +908,7 @@ class SourceControlMixin(BaseTask):
         )
         if scm_branch and scm_branch != project.scm_branch:
             sync_metafields['scm_branch'] = scm_branch
-            sync_metafields['scm_clean'] = True  # to accomidate force pushes
+            sync_metafields['scm_clean'] = True  # to accommodate force pushes
         if 'update_' not in sync_metafields['job_tags']:
             sync_metafields['scm_revision'] = project.scm_revision
         local_project_sync = project.create_project_update(_eager_fields=sync_metafields)

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -474,10 +474,10 @@ class AWXReceptorJob:
             # when we start the job in receptor and when we associate the job <-> work_unit_id.
             # In that case, there will be work running in receptor and Controller will not know
             # which Job it is associated with.
-            # We do not programatically handle this case. Ideally, we would handle this with a reaper case.
+            # We do not programmatically handle this case. Ideally, we would handle this with a reaper case.
             # The two distinct job lifecycle log events below allow for us to at least detect when this
             # edge case occurs. If the lifecycle event work_unit_id_received occurs without the
-            # work_unit_id_assigned event then this case may have occured.
+            # work_unit_id_assigned event then this case may have occurred.
             self.task.instance.work_unit_id = result['unitid']  # Set work_unit_id in-memory only
             self.task.instance.log_lifecycle("work_unit_id_received")
             self.task.update_model(self.task.instance.pk, work_unit_id=result['unitid'])
@@ -520,7 +520,7 @@ class AWXReceptorJob:
                 signal_state.raise_exception = False
 
             if res.status == 'error':
-                # If ansible-runner ran, but an error occured at runtime, the traceback information
+                # If ansible-runner ran, but an error occurred at runtime, the traceback information
                 # is saved via the status_handler passed in to the processor.
                 if 'result_traceback' in self.task.runner_callback.extra_update_fields:
                     return res

--- a/awx/main/tests/data/projects/README.md
+++ b/awx/main/tests/data/projects/README.md
@@ -4,7 +4,7 @@ Each folder in this directory is usable as source for a project or role or colle
 which is used in tests, particularly the "awx/main/tests/live" tests.
 
 Although these are not git repositories, test fixtures will make copies,
-and in the coppied folders, run `git init` type commands, turning them into
+and in the copied folders, run `git init` type commands, turning them into
 git repos. This is done in the locations
 
  - `/var/lib/awx/projects`

--- a/awx/main/tests/factories/tower.py
+++ b/awx/main/tests/factories/tower.py
@@ -97,8 +97,8 @@ def generate_users(organization, teams, superuser, persisted, **kwargs):
     If a User object is encountered the User.username is used as a key for the lookup dict.
 
     A short hand for assigning a user to a team is available in the following format: "team_name:username".
-    If a string in that format is encounted an attempt to lookup the team by the key team_name from the teams
-    argumnent is made, a KeyError will be thrown if the team does not exist in the dict. The teams argument should
+    If a string in that format is encountered an attempt to lookup the team by the key team_name from the teams
+    argument is made, a KeyError will be thrown if the team does not exist in the dict. The teams argument should
     be a dict of {Team.name:Team}
     """
     users = {}
@@ -118,9 +118,9 @@ def generate_users(organization, teams, superuser, persisted, **kwargs):
 
 
 def generate_teams(organization, persisted, **kwargs):
-    """generate_teams evalutes a mixed list of Team objects and strings.
+    """generate_teams evaluates a mixed list of Team objects and strings.
     If a string is encountered a team with that string name is created and added to the lookup dict.
-    If a Team object is encounted the Team.name is used as a key for the lookup dict.
+    If a Team object is encountered the Team.name is used as a key for the lookup dict.
     """
     teams = {}
     if 'teams' in kwargs and kwargs.get('teams') is not None:

--- a/awx/main/tests/functional/api/test_credential.py
+++ b/awx/main/tests/functional/api/test_credential.py
@@ -130,7 +130,7 @@ def test_create_team_credential(post, get, team, organization, org_admin, team_m
     assert response.status_code == 200
     assert response.data['count'] == 1
 
-    # Assure that credential's organization is implictly set to team's org
+    # Assure that credential's organization is implicitly set to team's org
     assert response.data['results'][0]['summary_fields']['organization']['id'] == team.organization.id
 
 

--- a/awx/main/tests/functional/api/test_job_runtime_params.py
+++ b/awx/main/tests/functional/api/test_job_runtime_params.py
@@ -326,7 +326,7 @@ def test_job_launch_works_without_access_to_ig_if_ig_in_template(job_template_pr
     job_template.save()
     job_template.execute_role.members.add(rando)
 
-    # Make sure we get a 201 instead of a 403 since we are providing an override of just a subset of the instance gorup that was already added
+    # Make sure we get a 201 instead of a 403 since we are providing an override of just a subset of the instance group that was already added
     post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), dict(instance_groups=runtime_data['instance_groups']), rando, expect=201)
 
 
@@ -339,7 +339,7 @@ def test_job_launch_works_without_access_to_label_if_label_in_template(job_templ
     job_template.save()
     job_template.execute_role.members.add(rando)
 
-    # Make sure we get a 201 instead of a 403 since we are providing an override of just a subset of the instance gorup that was already added
+    # Make sure we get a 201 instead of a 403 since we are providing an override of just a subset of the instance group that was already added
     post(reverse('api:job_template_launch', kwargs={'pk': job_template.pk}), dict(labels=runtime_data['labels']), rando, expect=201)
 
 

--- a/awx/main/tests/functional/api/test_rbac_displays.py
+++ b/awx/main/tests/functional/api/test_rbac_displays.py
@@ -80,7 +80,7 @@ class TestJobTemplateCopyEdit:
     def test_validation_bad_data_copy_edit(self, admin_user, project):
         """
         If a required resource (inventory here) was deleted, copying not allowed
-        because doing so would caues a validation error
+        because doing so would cause a validation error
         """
 
         jt_res = JobTemplate.objects.create(
@@ -112,7 +112,7 @@ class TestJobTemplateCopyEdit:
 
     def test_jt_admin_copy_edit(self, jt_copy_edit, rando):
         """
-        JT admins wihout access to associated resources SHOULD NOT be able to copy
+        JT admins without access to associated resources SHOULD NOT be able to copy
         SHOULD be able to make nonsensitive changes"""
 
         # random user given JT admin access only
@@ -224,7 +224,7 @@ def test_user_roles_unattach(mocker, organization, alice, bob, mock_access_metho
 def test_team_roles_unattach_functional(team, team_member, inventory, get):
     team.member_role.children.add(inventory.admin_role)
     response = get(reverse('api:team_roles_list', kwargs={'pk': team.id}), team_member)
-    # Team member should be able to remove access to inventory, becauase
+    # Team member should be able to remove access to inventory, because
     # the inventory admin_role grants that ability
     assert response.data['results'][0]['summary_fields']['user_capabilities']['unattach']
 

--- a/awx/main/tests/functional/api/test_search_filter.py
+++ b/awx/main/tests/functional/api/test_search_filter.py
@@ -32,7 +32,7 @@ class TestSearchFilter:
         # Actually test the endpoint.
         host_list_url = reverse('api:host_list')
 
-        # Test if the OR releation works.
+        # Test if the OR relation works.
         request = factory.get(host_list_url, data={'groups__search': ['g1', 'g2']})
         request.user = admin
         response = HostList.as_view()(request)

--- a/awx/main/tests/functional/api/test_user.py
+++ b/awx/main/tests/functional/api/test_user.py
@@ -180,7 +180,7 @@ def test_user_create_with_django_password_validation_ext(post, delete, admin, us
     with override_settings(AUTH_PASSWORD_VALIDATORS=validators):
         response = post(reverse('api:user_list'), user_attrs, admin, middleware=SessionMiddleware(mock.Mock()))
         assert response.status_code == expected_status_code
-        # Delete user if it was created succesfully.
+        # Delete user if it was created successfully.
         if response.status_code == 201:
             response = delete(reverse('api:user_detail', kwargs={'pk': response.data['id']}), admin, middleware=SessionMiddleware(mock.Mock()))
             assert response.status_code == 204

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer.py
@@ -32,7 +32,7 @@ from ansible_base.rbac import permission_registry
 def test_round_trip_roles(organization, rando, role_name, setup_managed_roles):
     """
     Make an assignment with the old-style role,
-    get the equivelent new role
+    get the equivalent new role
     get the old role again
     """
     getattr(organization, role_name).members.add(rando)

--- a/awx/main/tests/functional/rbac/test_rbac_job.py
+++ b/awx/main/tests/functional/rbac/test_rbac_job.py
@@ -82,7 +82,7 @@ def test_superuser_superauditor_sees_orphans(normal_job, superuser, admin_user, 
 @pytest.mark.django_db
 def test_org_member_does_not_see_orphans(normal_job, org_member, project):
     normal_job.job_template = None
-    # Check that privledged access to project still does not grant access
+    # Check that privileged access to project still does not grant access
     project.admin_role.members.add(org_member)
     access = JobAccess(org_member)
     assert not access.can_read(normal_job)

--- a/awx/main/tests/functional/rbac/test_rbac_role.py
+++ b/awx/main/tests/functional/rbac/test_rbac_role.py
@@ -178,7 +178,7 @@ def test_orphaned_user_allowed(org_admin, rando, organization, org_credential):
     """
     We still allow adoption of orphaned* users by assigning them to
     organization member role, but only in the situation where the
-    org admin already posesses indirect access to all of the user's roles
+    org admin already possesses indirect access to all of the user's roles
     *orphaned means user is not a member of any organization
     """
     # give a descendent role to rando, to trigger the conditional

--- a/awx/main/tests/functional/tasks/test_host_indirect.py
+++ b/awx/main/tests/functional/tasks/test_host_indirect.py
@@ -203,7 +203,7 @@ def test_build_indirect_host_data_malformed_module_name(mock_logger_debug, bare_
 )
 def test_build_indirect_host_data_malformed_query(mock_logger_info, job_with_counted_event, query: str):
     assert build_indirect_host_data(job_with_counted_event, {query: {'query': TEST_JQ}}) == []
-    mock_logger_info.assert_called_once_with(f"Skiping malformed query '{query}'. Expected to be of the form 'a.b.c'")
+    mock_logger_info.assert_called_once_with(f"Skipping malformed query '{query}'. Expected to be of the form 'a.b.c'")
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -155,7 +155,7 @@ class TestJobReaper(object):
         # creating job at current time
         job = Job.objects.create(status='running', controller_node=i.hostname)
         reaper.reap(i, ref_time=ref_time)
-        # explictly refreshing from db to ensure up to date cache
+        # explicitly refreshing from db to ensure up to date cache
         job.refresh_from_db()
         assert job.started > ref_time
         assert job.status == 'running'

--- a/awx/main/tests/functional/test_inventory_source_injectors.py
+++ b/awx/main/tests/functional/test_inventory_source_injectors.py
@@ -99,7 +99,7 @@ def read_content(private_data_dir, raw_env, inventory_update):
     private_key_regex = re.compile(r'-----BEGIN ENCRYPTED PRIVATE KEY-----.*-----END ENCRYPTED PRIVATE KEY-----')
 
     # read directory content
-    # build a mapping of the file paths to aliases which will be constant accross runs
+    # build a mapping of the file paths to aliases which will be constant across runs
     dir_contents = {}
     referenced_paths = set()
     file_aliases = {}

--- a/awx/main/tests/live/tests/conftest.py
+++ b/awx/main/tests/live/tests/conftest.py
@@ -81,7 +81,7 @@ def wait_to_leave_status(job, status, timeout=30, sleep_time=0.1):
     """Wait until the job does NOT have the specified status with some timeout
 
     the default timeout is based on the task manager running a 20 second
-    schedule, and the API does not guarentee working jobs faster than this
+    schedule, and the API does not guarantee working jobs faster than this
     """
     start = time.time()
     while time.time() - start < timeout:

--- a/awx/main/tests/live/tests/dispatcherd/test_connection_recovery.py
+++ b/awx/main/tests/live/tests/dispatcherd/test_connection_recovery.py
@@ -40,7 +40,7 @@ def test_advisory_lock_error_clears():
 
     This is an "easier" test case than the next,
     because it passes just by fixing the DAB case,
-    and passing this does not generally guarentee that
+    and passing this does not generally guarantee that
     workers will not be left with a connection in a bad state.
     """
     min_workers = settings.service['pool_kwargs']['min_workers']

--- a/awx/main/tests/manual/workflows/parallel.py
+++ b/awx/main/tests/manual/workflows/parallel.py
@@ -27,7 +27,7 @@ def do_init_workflow(job_template_success, job_template_fail, job_template_never
     node_success.success_nodes.add(nodes_parallel[1])
     node_success.success_nodes.add(nodes_parallel[2])
 
-    # Add a failure node for each paralell node
+    # Add a failure node for each parallel node
     for i, n in enumerate(nodes_parallel):
         n.failure_nodes.add(nodes_never[i])
 

--- a/awx/main/tests/unit/models/test_job_template_unit.py
+++ b/awx/main/tests/unit/models/test_job_template_unit.py
@@ -28,7 +28,7 @@ def test_inventory_contradictions(job_template_factory):
 
 @pytest.mark.survey
 def test_job_template_survey_password_redaction(job_template_with_survey_passwords_unit):
-    """Tests the JobTemplate model's funciton to redact passwords from
+    """Tests the JobTemplate model's function to redact passwords from
     extra_vars - used when creating a new job"""
     assert job_template_with_survey_passwords_unit.survey_password_variables() == ['secret_key', 'SSN']
 

--- a/awx/main/tests/unit/models/test_survey_models.py
+++ b/awx/main/tests/unit/models/test_survey_models.py
@@ -125,7 +125,7 @@ def job_with_survey():
 
 @pytest.mark.survey
 def test_job_survey_password_redaction(job_with_survey):
-    """Tests the Job model's funciton to redact passwords from
+    """Tests the Job model's function to redact passwords from
     extra_vars - used when displaying job information"""
     assert json.loads(job_with_survey.display_extra_vars()) == {'submitter_email': 'foobar@redhat.com', 'secret_key': '$encrypted$', 'SSN': '$encrypted$'}
 
@@ -184,7 +184,7 @@ def test_display_survey_spec_encrypts_default(survey_spec_factory):
         ("multiplechoice", "", 0, 0, False, False, 'N/A'),  # historical bug
         ("multiplechoice", "zeb", 0, 0, False, False, 'N/A'),  # zeb not in choices
         ("multiplechoice", "coffee", 0, 0, True, True, 'coffee'),
-        ("multiselect", None, 0, 0, False, False, 'N/A'),  # NOTE: Behavior is arguable, value of [] may be prefered
+        ("multiselect", None, 0, 0, False, False, 'N/A'),  # NOTE: Behavior is arguable, value of [] may be preferred
         ("multiselect", "", 0, 0, False, False, 'N/A'),
         ("multiselect", ["zeb"], 0, 0, False, False, 'N/A'),
         ("multiselect", ["milk"], 0, 0, True, True, ["milk"]),

--- a/awx/main/tests/unit/scheduler/test_dag_workflow.py
+++ b/awx/main/tests/unit/scheduler/test_dag_workflow.py
@@ -325,7 +325,7 @@ class TestAllWorkflowNodes:
         assert 0 == len(nodes_to_run), "Convergence node should NOT be chosen to run because it is DNR"
 
     def test_workflow_all_converge_runs(self, workflow_all_converge_dnr):
-        # Trick the scheduler again to make sure the convergence node acutally runs
+        # Trick the scheduler again to make sure the convergence node actually runs
         g, nodes = workflow_all_converge_dnr
         nodes[1].job.status = 'failed'
         dnr_nodes = g.mark_dnr_nodes()

--- a/awx/main/tests/unit/test_capacity.py
+++ b/awx/main/tests/unit/test_capacity.py
@@ -147,7 +147,7 @@ def test_RBAC_reduced_filter(sample_cluster, create_ig_manager):
     tasks = [Job(status='waiting', execution_node='i1'), Job(status='waiting', execution_node='i2'), Job(status='waiting', execution_node='i3')]
     instance_groups_mgr = create_ig_manager([default], tasks)
     # Cross-links between groups not visible to current user,
-    # so a naieve accounting of capacities is returned instead
+    # so a naive accounting of capacities is returned instead
     assert instance_groups_mgr.get_consumed_capacity('default') == 43
 
 

--- a/awx/main/tests/unit/test_fields.py
+++ b/awx/main/tests/unit/test_fields.py
@@ -121,7 +121,7 @@ def test_cred_type_input_schema_validity(input_, valid):
         ({'file': {'template.username': '{{username}}', 'template.password': '{{pass}}'}}, True),
         # Use of unnamed file mutually exclusive with use of named files
         ({'file': {'template': '{{username}}', 'template.password': '{{pass}}'}}, False),
-        # References non-existant named file
+        # References non-existent named file
         ({'env': {'FROM_FILE': "{{tower.filename.cert}}"}}, False),
         # References unnamed file, but a file was never defined
         ({'env': {'FROM_FILE': "{{tower.filename}}"}}, False),

--- a/awx/main/tests/unit/utils/test_mem_inventory.py
+++ b/awx/main/tests/unit/utils/test_mem_inventory.py
@@ -19,7 +19,7 @@ def memory_inventory():
 
 @pytest.fixture
 def JSON_of_inv():
-    # Implemented as fixture becuase it may be change inside of tests
+    # Implemented as fixture because it may be change inside of tests
     return {
         "_meta": {"hostvars": {"group_host": {}, "my_host": {"foo": "bar"}}},
         "all": {"children": ["my_group", "ungrouped"]},

--- a/awx/main/utils/encryption.py
+++ b/awx/main/utils/encryption.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('awx.main.utils.encryption')
 
 
 class Fernet256(Fernet):
-    """Not techincally Fernet, but uses the base of the Fernet spec and uses AES-256-CBC
+    """Not technically Fernet, but uses the base of the Fernet spec and uses AES-256-CBC
     instead of AES-128-CBC. All other functionality remain identical.
     """
 

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -103,7 +103,7 @@ class ExternalLoggerEnabled(Filter):
 class DynamicLevelFilter(Filter):
     def filter(self, record):
         """Filters out logs that have a level below the threshold defined
-        by the databse setting LOG_AGGREGATOR_LEVEL
+        by the database setting LOG_AGGREGATOR_LEVEL
         """
         if record_is_blocked(record):
             # Fine to write denied loggers to file, apply default filtering level

--- a/awx/main/utils/filters.py
+++ b/awx/main/utils/filters.py
@@ -178,7 +178,7 @@ class SmartFilter(object):
         TODO: separate django filter requests from our custom json filter
               request so we don't process the key any. This could be
               accomplished using an allowed list or introspecting the
-              relationship refered to to see if it's a jsonb type.
+              relationship referred to, to see if it's a jsonb type.
         '''
 
         def _json_path_to_contains(self, k, v):

--- a/awx/main/utils/formatters.py
+++ b/awx/main/utils/formatters.py
@@ -278,6 +278,6 @@ class LogstashFormatter(LogstashFormatterBase):
 
         if settings.LOG_AGGREGATOR_TYPE == 'splunk':
             # splunk messages must have a top level "event" key when using the /services/collector/event receiver.
-            # The event receiver wont scan an event for a timestamp field therefore a time field must also be supplied containing epoch timestamp
+            # The event receiver won't scan an event for a timestamp field therefore a time field must also be supplied containing epoch timestamp
             message = {'time': record.created, 'event': message}
         return self.serialize(message)

--- a/awx/main/utils/handlers.py
+++ b/awx/main/utils/handlers.py
@@ -102,7 +102,7 @@ class SpecialInventoryHandler(logging.Handler):
 
         self.counter += 1
         msg = self.format(record)
-        n_lines = len(msg.strip().split('\n'))  # don't count line breaks at boundry of text
+        n_lines = len(msg.strip().split('\n'))  # don't count line breaks at boundary of text
         dispatch_data = dict(
             created=now().isoformat(), event='verbose', counter=self.counter, stdout=msg, start_line=self._current_line, end_line=self._current_line + n_lines
         )
@@ -151,7 +151,7 @@ class OTLPHandler(LoggingHandler):
             raise ValueError("endpoint required")
 
         if auth == 'basic' and (username is None or password is None):
-            raise ValueError("auth type basic requires username and passsword parameters")
+            raise ValueError("auth type basic requires username and password parameters")
 
         self.endpoint = endpoint
         self.service_name = service_name or (sys.argv[1] if len(sys.argv) > 1 else (sys.argv[0] or 'unknown_service'))

--- a/awx/main/utils/inventory_vars.py
+++ b/awx/main/utils/inventory_vars.py
@@ -134,7 +134,7 @@ class InventoryGroupVariables(dict):
         """
         Copy the current values of all variables into the internal dict.
 
-        Call this everytime the `_vars` structure has been modified.
+        Call this every time the `_vars` structure has been modified.
         """
         for name, inv_var in self._vars.items():
             self[name] = inv_var.value

--- a/awx/main/utils/mem_inventory.py
+++ b/awx/main/utils/mem_inventory.py
@@ -42,7 +42,7 @@ class MemGroup(MemObject):
         self.variables = {}
         self.parents = []
         # Used on the "all" group in place of previous global variables.
-        # maps host and group names to hosts to prevent redudant additions
+        # maps host and group names to hosts to prevent redundant additions
         self.all_hosts = {}
         self.all_groups = {}
         self.variables = {}

--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -204,7 +204,7 @@
       ANSIBLE_COLLECTIONS_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_collections"
       ANSIBLE_ROLES_PATH: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/requirements_roles"
       # Put the local tmp directory in same volume as collection destination
-      # otherwise, files cannot be moved accross volumes and will cause error
+      # otherwise, files cannot be moved across volumes and will cause error
       ANSIBLE_LOCAL_TEMP: "{{ projects_root }}/.__awx_cache/{{ local_path }}/stage/tmp"
   tasks:
     - name: Check content sync settings

--- a/awx/settings/__init__.py
+++ b/awx/settings/__init__.py
@@ -37,7 +37,7 @@ DYNACONF.set(
 
 #############################################################################################
 # Settings loaded before this point will be allowed to be overridden by the database settings
-# Any settings loaded after this point will be marked as as a read_only database setting
+# Any settings loaded after this point will be marked as a read_only database setting
 #############################################################################################
 
 # Load extra settings files from the following directories

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -994,7 +994,7 @@ HOST_METRIC_SUMMARY_TASK_LAST_TS = None
 HOST_METRIC_SUMMARY_TASK_INTERVAL = 7  # days
 
 
-# TODO: cmeyers, replace with with register pattern
+# TODO: cmeyers, replace with register pattern
 # The register pattern is particularly nice for this because we need
 # to know the process to start the thread that will be the server.
 # The registration location should be the same location as we would

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -399,7 +399,7 @@ AUTHENTICATION_BACKENDS = ('awx.main.backends.AWXModelBackend',)
 AUTH_BASIC_ENABLED = True
 
 # If set, specifies a URL that unauthenticated users will be redirected to
-# when trying to access a UI page that requries authentication.
+# when trying to access a UI page that requires authentication.
 LOGIN_REDIRECT_OVERRIDE = ''
 
 # Note: This setting may be overridden by database settings.
@@ -1121,7 +1121,7 @@ SYSTEM_USERNAME = None
 
 # For indirect host query processing
 # if a job is not immediently confirmed to have all events processed
-# it will be eligable for processing after this number of minutes
+# it will be eligible for processing after this number of minutes
 INDIRECT_HOST_QUERY_FALLBACK_MINUTES = 60
 
 # If an error happens in event collection, give up after this time

--- a/awx_collection/plugins/lookup/schedule_rrule.py
+++ b/awx_collection/plugins/lookup/schedule_rrule.py
@@ -231,7 +231,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError('Timezone parameter is not valid')
             timezone = kwargs['timezone']
 
-        # rrule puts a \n in the rule instad of a space and can't handle timezones
+        # rrule puts a \n in the rule instead of a space and can't handle timezones
         return_rrule = str(my_rule).replace('\n', ' ').replace('DTSTART:', 'DTSTART;TZID={0}:'.format(timezone))
         # AWX requires an interval. rrule will not add interval if it's set to 1
         if kwargs.get('every', 1) == 1:

--- a/awx_collection/plugins/lookup/schedule_rruleset.py
+++ b/awx_collection/plugins/lookup/schedule_rruleset.py
@@ -199,7 +199,7 @@ class LookupModule(LookupBase):
         if not isinstance(rule[field_name], list):
             rule[field_name] = rule[field_name].split(',')
         for value in rule[field_name]:
-            # If they have a list of strs we want to strip the str incase its space delineated
+            # If they have a list of strs we want to strip the str in case its space delineated
             if isinstance(value, str):
                 value = value.strip()
             # If value happens to be an int (from a list of ints) we need to coerce it into a str for the re.match

--- a/awx_collection/plugins/module_utils/awxkit.py
+++ b/awx_collection/plugins/module_utils/awxkit.py
@@ -29,7 +29,7 @@ class ControllerAWXKitModule(ControllerModule):
         if not HAS_AWX_KIT:
             self.fail_json(msg=missing_required_lib('awxkit'))
 
-        # Establish our conneciton object
+        # Establish our connection object
         self.connection = Connection(self.host, verify=self.verify_ssl)
 
     def authenticate(self):

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -306,10 +306,10 @@ class ControllerModule(AnsibleModule):
                             pass
 
                 except Exception as e:
-                    raise_from(ConfigFileException("An unknown exception occured trying to ini load config file: {0}".format(e)), e)
+                    raise_from(ConfigFileException("An unknown exception occurred trying to ini load config file: {0}".format(e)), e)
 
         except Exception as e:
-            raise_from(ConfigFileException("An unknown exception occured trying to load config file: {0}".format(e)), e)
+            raise_from(ConfigFileException("An unknown exception occurred trying to load config file: {0}".format(e)), e)
 
         # Backward compatibility: config files written for older collection
         # releases used the oauth_token key; map it to aap_token.
@@ -824,10 +824,10 @@ class ControllerAPIModule(ControllerModule):
     def delete_if_needed(self, existing_item, item_type=None, on_delete=None, auto_exit=True):
         # This will exit from the module on its own.
         # If the method successfully deletes an item and on_delete param is defined,
-        #   the on_delete parameter will be called as a method pasing in this object and the json from the response
+        #   the on_delete parameter will be called as a method passing in this object and the json from the response
         # This will return one of two things:
         #   1. None if the existing_item is not defined (so no delete needs to happen)
-        #   2. The response from AWX from calling the delete on the endpont. It's up to you to process the response and exit from the module
+        #   2. The response from AWX from calling the delete on the endpoint. It's up to you to process the response and exit from the module
         # Note: common error codes from the AWX API can cause the module to fail
         if existing_item:
             # If we have an item, we can try to delete it
@@ -919,7 +919,7 @@ class ControllerAPIModule(ControllerModule):
         if copy_from_lookup is None:
             self.fail_json(msg="A {0} with the name {1} was not able to be found.".format(item_type, copy_from_name_or_id))
 
-        # Do checks for copy permisions if warrented
+        # Do checks for copy permissions if warrented
         if item_type == 'workflow_job_template':
             copy_get_check = self.get_endpoint(copy_from_lookup['related']['copy'])
             if copy_get_check['status_code'] in [200]:
@@ -957,10 +957,10 @@ class ControllerAPIModule(ControllerModule):
 
         # This will exit from the module on its own
         # If the method successfully creates an item and on_create param is defined,
-        #    the on_create parameter will be called as a method pasing in this object and the json from the response
+        #    the on_create parameter will be called as a method passing in this object and the json from the response
         # This will return one of two things:
         #    1. None if the existing_item is already defined (so no create needs to happen)
-        #    2. The response from AWX from calling the patch on the endpont. It's up to you to process the response and exit from the module
+        #    2. The response from AWX from calling the patch on the endpoint. It's up to you to process the response and exit from the module
         # Note: common error codes from the AWX API can cause the module to fail
         response = None
         if not endpoint:
@@ -1080,7 +1080,7 @@ class ControllerAPIModule(ControllerModule):
     def update_if_needed(self, existing_item, new_item, item_type=None, on_update=None, auto_exit=True, associations=None):
         # This will exit from the module on its own
         # If the method successfully updates an item and on_update param is defined,
-        #   the on_update parameter will be called as a method pasing in this object and the json from the response
+        #   the on_update parameter will be called as a method passing in this object and the json from the response
         # This will return one of two things:
         #    1. None if the existing_item does not need to be updated
         #    2. The response from AWX from patching to the endpoint. It's up to you to process the response and exit from the module.

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -162,7 +162,7 @@ def main():
     }
     for arg in ['job_type', 'limit', 'forks', 'verbosity', 'extra_vars', 'become_enabled', 'diff_mode']:
         if module.params.get(arg):
-            # extra_var can receive a dict or a string, if a dict covert it to a string
+            # extra_var can receive a dict or a string, if a dict convert it to a string
             if arg == 'extra_vars' and not isinstance(module.params.get(arg), str):
                 post_data[arg] = json.dumps(module.params.get(arg))
             else:

--- a/awx_collection/plugins/modules/bulk_job_launch.py
+++ b/awx_collection/plugins/modules/bulk_job_launch.py
@@ -188,7 +188,7 @@ EXAMPLES = '''
     limit: bar
     credentials:
       - "My Credential"
-      - "suplementary cred"
+      - "supplementary cred"
     extra_vars: # these override / extend extra_data at the job level
       food: grape
       animal: owl
@@ -268,7 +268,7 @@ def main():
     module.json_output['changed'] = True
     module.json_output['id'] = result['json']['id']
     module.json_output['status'] = result['json']['status']
-    # This is for backwards compatability
+    # This is for backwards compatibility
     module.json_output['job_info'] = result['json']
 
     if not wait:

--- a/awx_collection/plugins/modules/import.py
+++ b/awx_collection/plugins/modules/import.py
@@ -50,7 +50,7 @@ EXAMPLES = '''
 
 from ..module_utils.awxkit import ControllerAWXKitModule
 
-# These two lines are not needed if awxkit changes to do programatic notifications on issues
+# These two lines are not needed if awxkit changes to do programmatic notifications on issues
 from ansible.module_utils.six.moves import StringIO
 import logging
 

--- a/awx_collection/plugins/modules/job_launch.py
+++ b/awx_collection/plugins/modules/job_launch.py
@@ -153,7 +153,7 @@ EXAMPLES = '''
     inventory: "My Inventory"
     credentials:
       - "My Credential"
-      - "suplementary cred"
+      - "supplementary cred"
   register: job
 - name: Wait for job max 120s
   job_wait:
@@ -184,7 +184,7 @@ def main():
         job_type=dict(choices=['run', 'check']),
         inventory=dict(),
         organization=dict(),
-        # Credentials will be a str instead of a list for backwards compatability
+        # Credentials will be a str instead of a list for backwards compatibility
         credentials=dict(type='list', aliases=['credential'], elements='str'),
         limit=dict(),
         tags=dict(type='list', elements='str'),

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -238,7 +238,7 @@ def wait_for_project_update(module, last_request):
             url=result['json']['url'], object_name=module.get_item_name(last_request), object_type='Project Update', timeout=timeout, interval=interval
         )
 
-        # Set Changed to correct value depending on if hash changed Also output refspec comparision
+        # Set Changed to correct value depending on if hash changed Also output refspec comparison
         module.json_output['changed'] = True
         if result_final['json']['scm_revision'] == scm_revision_original:
             module.json_output['changed'] = False

--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -300,7 +300,7 @@ def main():
         for item in credentials:
             association_fields['credentials'].append(module.resolve_name_to_id('credentials', item))
 
-    # We need to clear out the organization from the search fields the searches for labels and instance_groups doesnt support it and won't be needed anymore
+    # We need to clear out the organization from the search fields the searches for labels and instance_groups doesn't support it and won't be needed anymore
     if 'organization' in search_fields:
         del search_fields['organization']
 

--- a/awx_collection/plugins/modules/workflow_approval.py
+++ b/awx_collection/plugins/modules/workflow_approval.py
@@ -49,7 +49,7 @@ options:
       type: float
     timeout:
       description:
-        - Maximum time in seconds to wait for a workflow job to to reach approval node.
+        - Maximum time in seconds to wait for a workflow job to reach approval node.
       default: 10
       type: int
 extends_documentation_fragment: awx.awx.auth

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -170,7 +170,7 @@ options:
       elements: str
     workflow_nodes:
       description:
-        - A json list of nodes and their coresponding options. The following suboptions describe a single node.
+        - A json list of nodes and their corresponding options. The following suboptions describe a single node.
       type: list
       elements: dict
       aliases:
@@ -217,7 +217,7 @@ options:
           type: str
         skip_tags:
           description:
-            - Tags to skip, applied as a prompt, if job tempalte prompts for job tags
+            - Tags to skip, applied as a prompt, if job template prompts for job tags
           type: str
         limit:
           description:
@@ -465,7 +465,7 @@ EXAMPLES = '''
           always_nodes: []
           credentials:
             - local_cred
-            - suplementary cred
+            - supplementary cred
       - identifier: node201
         unified_job_template:
           organization:
@@ -988,7 +988,7 @@ def main():
         destroy_workflow_nodes(module, response, workflow_job_template_id)
         module.json_output['changed'] = True
 
-    # Work thorugh and lookup value for schema fields
+    # Work through and lookup value for schema fields
     if workflow_nodes:
         # Create Schema Nodes
         create_workflow_nodes(module, response, workflow_nodes, workflow_job_template_id)

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -50,7 +50,7 @@ options:
       type: str
     skip_tags:
       description:
-        - Tags to skip, applied as a prompt, if job tempalte prompts for job tags
+        - Tags to skip, applied as a prompt, if job template prompts for job tags
       type: str
     limit:
       description:

--- a/awx_collection/plugins/modules/workflow_launch.py
+++ b/awx_collection/plugins/modules/workflow_launch.py
@@ -196,7 +196,7 @@ def main():
     module.json_output['changed'] = True
     module.json_output['id'] = result['json']['id']
     module.json_output['status'] = result['json']['status']
-    # This is for backwards compatability
+    # This is for backwards compatibility
     module.json_output['job_info'] = {'id': result['json']['id']}
 
     if not wait:

--- a/awx_collection/test/awx/test_completeness.py
+++ b/awx_collection/test/awx/test_completeness.py
@@ -68,7 +68,7 @@ no_api_parameter_ok = {
     'job_template': ['survey_spec', 'organization'],
     'inventory_source': ['organization'],
     # Organization is how we are looking up job templates, Approval node is for workflow_approval_templates,
-    # lookup_organization is for specifiying the organization for the unified job template lookup
+    # lookup_organization is for specifying the organization for the unified job template lookup
     'workflow_job_template_node': ['organization', 'approval_node', 'lookup_organization'],
     # Survey is how we handle associations
     'workflow_job_template': ['survey_spec', 'destroy_current_nodes'],
@@ -76,7 +76,7 @@ no_api_parameter_ok = {
     'schedule': ['organization'],
     # ad hoc commands support interval and timeout since its more like job_launch
     'ad_hoc_command': ['interval', 'timeout', 'wait'],
-    # group parameters to perserve hosts and children.
+    # group parameters to preserve hosts and children.
     'group': ['preserve_existing_children', 'preserve_existing_hosts'],
     # new_username parameter to rename a user and organization allows for org admin user creation
     'user': ['new_username', 'organization'],

--- a/awx_collection/test/awx/test_instance.py
+++ b/awx_collection/test/awx/test_instance.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 
 
 @pytest.mark.filterwarnings(
-    # FIXME: Figure out where it is emited and what causes it.
+    # FIXME: Figure out where it is emitted and what causes it.
     # FIXME: The suppression should be made more specific or the cause fixed.
     # Ref: https://github.com/ansible/awx/pull/15620
     "ignore::RuntimeWarning",

--- a/awx_collection/test/awx/test_instance_group.py
+++ b/awx_collection/test/awx/test_instance_group.py
@@ -8,7 +8,7 @@ from awx.main.models import InstanceGroup, Instance
 
 
 @pytest.mark.filterwarnings(
-    # FIXME: Figure out where it is emited and what causes it.
+    # FIXME: Figure out where it is emitted and what causes it.
     # FIXME: The suppression should be made more specific or the cause fixed.
     # Ref: https://github.com/ansible/awx/pull/15620
     "ignore::RuntimeWarning",
@@ -28,7 +28,7 @@ def test_instance_group_create(run_module, admin_user):
     # Create a new instance in the DB
     new_instance = Instance.objects.create(hostname='foo.example.com')
 
-    # Set the new instance group only to the one instnace
+    # Set the new instance group only to the one instance
     result = run_module('instance_group', {'name': 'foo-group', 'instances': [new_instance.hostname], 'state': 'present'}, admin_user)
     assert not result.get('failed', False), result
     assert result['changed']
@@ -43,7 +43,7 @@ def test_instance_group_create(run_module, admin_user):
 
 
 @pytest.mark.filterwarnings(
-    # FIXME: Figure out where it is emited and what causes it.
+    # FIXME: Figure out where it is emitted and what causes it.
     # FIXME: The suppression should be made more specific or the cause fixed.
     # Ref: https://github.com/ansible/awx/pull/15620
     "ignore::RuntimeWarning",

--- a/awx_collection/test/awx/test_inventory_source.py
+++ b/awx_collection/test/awx/test_inventory_source.py
@@ -119,7 +119,7 @@ def test_falsy_value(run_module, admin_user, base_inventory):
 # update_on_launch	?	?	o	o	o	o		o	o		o		o	o	o
 # UoPL          	?	?	o	-	-	-		-	-		-		-	-	-
 # source_vars*		?	?	-	o	-	o		o	o		o		-	-	-
-# environmet vars*	?	?	o	-	-	-		-	-		-		-	-	o
+# environment vars*	?	?	o	-	-	-		-	-		-		-	-	o
 # source_script		?	?	-	-	-	-		-	-		-		-	-	r
 #
 # UoPL - update_on_project_launch

--- a/awx_collection/test/awx/test_schedule.py
+++ b/awx_collection/test/awx/test_schedule.py
@@ -127,7 +127,7 @@ def test_empty_schedule_rrule(collection_import, freq):
         ('month', dict(start_date='2020-4-16 03:45:07', month_day_number='32'), "month_day_number must be between 1 and 31"),
         # Test on_the as junk
         ('month', dict(start_date='2020-4-16 03:45:07', on_the='junk'), "on_the parameter must be two words separated by a space"),
-        # Test on_the with invalid occurance
+        # Test on_the with invalid occurrence
         ('month', dict(start_date='2020-4-16 03:45:07', on_the='junk wednesday'), "The first string of the on_the parameter is not valid"),
         # Test on_the with invalid weekday
         ('month', dict(start_date='2020-4-16 03:45:07', on_the='second junk'), "Weekday portion of on_the parameter is not valid"),

--- a/awx_collection/test/awx/test_workflow_job_template_node.py
+++ b/awx_collection/test/awx/test_workflow_job_template_node.py
@@ -9,7 +9,7 @@ from awx.main.models import WorkflowJobTemplateNode, WorkflowJobTemplate, JobTem
 
 
 pytestmark = pytest.mark.filterwarnings(
-    # FIXME: Figure out where it is emited and what causes it.
+    # FIXME: Figure out where it is emitted and what causes it.
     # FIXME: The suppression should be made more specific or the cause fixed.
     # Ref: https://github.com/ansible/awx/pull/15620
     "ignore::RuntimeWarning",

--- a/awx_collection/tests/integration/targets/demo_data/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/demo_data/tasks/main.yml
@@ -3,7 +3,7 @@
   organization:
     name: Default
 
-- name: HACK - delete orphaned projects from preload data where organization deletd
+- name: HACK - delete orphaned projects from preload data where organization deleted
   project:
     name: "{{ item['id'] }}"
     scm_type: git

--- a/awx_collection/tests/integration/targets/role/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role/tasks/main.yml
@@ -175,7 +175,7 @@
       awx.awx.role:
         user: "{{ username }}"
         role: execute
-        job_template: "non existant temp"
+        job_template: "non existent temp"
         state: present
       register: results
       ignore_errors: true

--- a/awx_collection/tests/integration/targets/role_team_assignment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role_team_assignment/tasks/main.yml
@@ -34,7 +34,7 @@
     that:
       - result.changed
 
-- name: Delete Role Team Assigment
+- name: Delete Role Team Assignment
   role_team_assignment:
     role_definition: test_view_jt
     team: All Stars

--- a/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/role_user_assignment/tasks/main.yml
@@ -34,7 +34,7 @@
     that:
       - result.changed
 
-- name: Delete Role User Assigment
+- name: Delete Role User Assignment
   role_user_assignment:
     role_definition: test_view_jt
     user: testing_user

--- a/awx_collection/tests/integration/targets/team/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/team/tasks/main.yml
@@ -8,7 +8,7 @@
   ansible.builtin.set_fact:
     team_name: "AWX-Collection-tests-team-team-{{ test_id }}"
 
-- name: Attempt to add a team to a non-existant Organization
+- name: Attempt to add a team to a non-existent Organization
   team:
     name: Test Team
     organization: Missing_Organization
@@ -53,7 +53,7 @@
     state: absent
   register: result
 
-- name: Assert reesult changed
+- name: Assert result changed
   ansible.builtin.assert:
     that:
       - result.changed

--- a/awx_collection/tools/roles/generate/templates/module.j2
+++ b/awx_collection/tools/roles/generate/templates/module.j2
@@ -3,7 +3,7 @@
 
 {# The following is set by the generate.yml file:
  #   item_type: the type of item i.e. 'teams'
- #   human_readable: the type with _ replaced with spaces i.e. worflow job template
+ #   human_readable: the type with _ replaced with spaces i.e. workflow job template
  #   singular_item_type: the type of an item replace singularized i.e. team
  #   type_map: a mapping of things like string to str
  #}

--- a/awx_collection/tools/template_galaxy.yml
+++ b/awx_collection/tools/template_galaxy.yml
@@ -27,13 +27,13 @@
       set_fact:
         collection_version_override: 0.0.1-devel
 
-    - name: Template the galaxy.yml source file (should be commited with your changes)
+    - name: Template the galaxy.yml source file (should be committed with your changes)
       template:
         src: "{{ collection_source }}/tools/roles/template_galaxy/templates/galaxy.yml.j2"
         dest: "{{ collection_source }}/galaxy.yml"
         force: true
 
-    - name: Template the README.md source file (should be commited with your changes)
+    - name: Template the README.md source file (should be committed with your changes)
       template:
         src: "{{ collection_source }}/tools/roles/template_galaxy/templates/README.md.j2"
         dest: "{{ collection_source }}/README.md"

--- a/awxkit/README.md
+++ b/awxkit/README.md
@@ -5,6 +5,6 @@ A Python library that backs the provided `awx` command line client.
 
 It can be installed by running `pip install awxkit`.
 
-The PyPI respository can be found [here](https://pypi.org/project/awxkit/).
+The PyPI repository can be found [here](https://pypi.org/project/awxkit/).
 
 For more information on installing the CLI and building the docs on how to use it, look [here](./awxkit/cli/docs).

--- a/awxkit/awxkit/api/client.py
+++ b/awxkit/awxkit/api/client.py
@@ -22,7 +22,7 @@ class Connection(object):
     def __init__(self, server, verify=False):
         self.server = server
         self.verify = verify
-        # Note: We use the old sessionid here incase someone is trying to connect to an older AWX version
+        # Note: We use the old sessionid here in case someone is trying to connect to an older AWX version
         # There is a check below so that if AWX returns an X-API-Session-Cookie-Name we will grab it and
         # connect with the new session cookie name.
         self.session_cookie_name = 'sessionid'

--- a/awxkit/awxkit/api/mixins/has_create.py
+++ b/awxkit/awxkit/api/mixins/has_create.py
@@ -50,7 +50,7 @@ def creation_order(graph):
 
 
 def separate_async_optionals(creation_order):
-    """In cases where creation group items share dependencies but as asymetric optionals,
+    """In cases where creation group items share dependencies but as asymmetric optionals,
     those that create them as actual dependencies to be later sourced as optionals
     need to be listed first
     """

--- a/awxkit/awxkit/api/pages/page.py
+++ b/awxkit/awxkit/api/pages/page.py
@@ -339,7 +339,7 @@ class PageList(object):
     @property
     def __item_class__(self):
         """Returns the class representing a single 'Page' item
-        With an inheritence of OrgListSubClass -> OrgList -> PageList -> Org -> Base -> Page, the following
+        With an inheritance of OrgListSubClass -> OrgList -> PageList -> Org -> Base -> Page, the following
         will return the parent class of the current object (e.g. 'Org').
 
         Obtaining a page type by registered endpoint is highly recommended over using this method.

--- a/awxkit/awxkit/api/registry.py
+++ b/awxkit/awxkit/api/registry.py
@@ -38,7 +38,7 @@ class URLRegistry(object):
 
     def register(self, *args):
         """Registers a single resource (generic python type or object) to either
-        1. a single url string (internally coverted via URLRegistry.url_pattern) and optional method or method iterable
+        1. a single url string (internally converted via URLRegistry.url_pattern) and optional method or method iterable
         2. a list or tuple of url string and optional method or method iterables
         for retrieval via get().
 

--- a/docs/container_groups.md
+++ b/docs/container_groups.md
@@ -8,7 +8,7 @@ the playbook run. This is known as the ephemeral execution model and
 ensures a clean environment for every job run.
 
 In some cases it is desirable to have the execution environment be "always-on",
-this is is done by manually creating an instance through the AWX API or UI. 
+this is done by manually creating an instance through the AWX API or UI. 
 
 
 ## Configuration

--- a/docs/development/minikube.md
+++ b/docs/development/minikube.md
@@ -52,7 +52,7 @@ $ docker push ${IMAGE_TAG_BASE}:${VERSION}
 
 ## Deploy AWX into Minikube using the AWX Operator
 
-If have have not made any changes to the AWX Dockerfile, run the following
+If you have not made any changes to the AWX Dockerfile, run the following
 command. If you need to test out changes to the Dockerfile, see the
 "Custom AWX Development Image for Kubernetes" section below.
 

--- a/docs/docsite/rst/contributor/report_issues.rst
+++ b/docs/docsite/rst/contributor/report_issues.rst
@@ -9,7 +9,7 @@ as possible. Version information, and an accurate reproducing scenario are criti
 
 Be sure to attach the ``component:docs`` label to your issue. These labels are determined by the template data. Please use the template and fill it out as accurately as possible.
 
-Please don't use the issue tracker as a way to ask how to do something. Instead, discuss it on on the Ansible Forum, or you can chat with us and ask questions on Matrix. See the :ref:`Communication guide<communication>` for details.
+Please don't use the issue tracker as a way to ask how to do something. Instead, discuss it on the Ansible Forum, or you can chat with us and ask questions on Matrix. See the :ref:`Communication guide<communication>` for details.
 
 Before opening a new issue, please use the issue search feature to see if what you're experiencing has already been reported. If you have any extra detail to provide, please comment. Otherwise, rather than posting a "me too" comment, please consider giving it a `"thumbs up" <https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comment>`_ to give us an indication of the severity of the problem.
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -313,4 +313,4 @@ When a user creates a notification template in `/api/v2/notification_templates`,
 
 Notifications assigned at certain levels will inherit traits defined on parent objects in different ways.  For example, ad hoc commands will use notifications defined on the Organization that the inventory is associated with.
 
-For more details on notifications, visit the [Notifications chapter](hhttps://ansible.readthedocs.io/projects/awx/en/latest/userguide/notifications.html) of the _Automating with AWX_ guide.
+For more details on notifications, visit the [Notifications chapter](https://ansible.readthedocs.io/projects/awx/en/latest/userguide/notifications.html) of the _Automating with AWX_ guide.

--- a/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
+++ b/tools/ansible/roles/dockerfile/templates/Dockerfile.j2
@@ -5,7 +5,7 @@
 ###
 
 {% if not headless|bool %}
-# UI_next build contaienr
+# UI_next build container
 FROM quay.io/centos/centos:stream9 AS ui-builder
 USER root
 RUN dnf -y update && dnf module -y enable nodejs:18 && dnf module -y install nodejs:18/common && dnf install -y make git

--- a/tools/community-bugscrub/generate-sheet.py
+++ b/tools/community-bugscrub/generate-sheet.py
@@ -12,7 +12,7 @@ def get_headers():
         access_token = os.environ[access_token_env_var]
         return {"Authorization": f"token {access_token}"}
     else:
-        print(f"{access_token_env_var} not present, performing unathenticated calls that might hit rate limits.")
+        print(f"{access_token_env_var} not present, performing unauthenticated calls that might hit rate limits.")
         return None
 
 

--- a/tools/data_generators/rbac_dummy_data_generator.py
+++ b/tools/data_generators/rbac_dummy_data_generator.py
@@ -181,7 +181,7 @@ class Rollback(Exception):
 
 # Normally the modified_by field is populated by the crum library automatically,
 # but since this is ran outside the request-response cycle that won't work.
-# It is disaled here.
+# It is disabled here.
 def mock_save(self, *args, **kwargs):
     return super(PrimordialModel, self).save(*args, **kwargs)
 
@@ -292,7 +292,7 @@ def make_the_data():
             for org in organizations:
                 org_teams = [t for t in org.teams.all()]
                 org_users = [u for u in org.member_role.members.all()]
-                print('  Spreading %d users accross %d teams for %s' % (len(org_users), len(org_teams), org.name))
+                print('  Spreading %d users across %d teams for %s' % (len(org_users), len(org_teams), org.name))
                 # Our normal spread for most users
                 cur_user_idx = 0
                 cur_team_idx = 0

--- a/tools/docker-compose/README.md
+++ b/tools/docker-compose/README.md
@@ -380,7 +380,7 @@ Once the containers are up we are ready to configure and plumb Splunk with AWX. 
 
 For routing traffic between AWX and Splunk we will use the internal docker compose network. The `Logging Aggregator` will be configured using the internal network machine name of `splunk`.
 
-Once you have have the collections installed (from above) you can run the playbook like:
+Once you have the collections installed (from above) you can run the playbook like:
 ```bash
 export CONTROLLER_USERNAME=<your username>
 export CONTROLLER_PASSWORD=<your password>

--- a/tools/docker-compose/editable_dependencies/README.md
+++ b/tools/docker-compose/editable_dependencies/README.md
@@ -52,7 +52,7 @@ or
 ln -s ../django-ansible-base tools/docker-compose/editable_dependencies/
 ```
 
-## How to remove indivisual editable dependencies
+## How to remove individual editable dependencies
 
 Simply removing the symlink from  `tools/docker-compose/editable_dependencies` **will cause problem**!
 

--- a/tools/sosreport/controller.py
+++ b/tools/sosreport/controller.py
@@ -22,7 +22,7 @@ SOSREPORT_CONTROLLER_COMMANDS = [
     "ls -ll /var/lib/awx",  # check permissions
     "ls -ll /var/lib/awx/venv",  # list all venvs
     "ls -ll /etc/tower",
-    "ls -ll /var/run/awx-receptor",  # list contents of dirctory where receptor socket should be
+    "ls -ll /var/run/awx-receptor",  # list contents of directory where receptor socket should be
     "ls -ll /etc/receptor",
     "receptorctl --socket /var/run/awx-receptor/receptor.sock status",  # Get information about the status of the mesh
     "receptorctl --socket /var/run/awx-receptor/receptor.sock work list",  # Get list of receptor work units


### PR DESCRIPTION
  ##### SUMMARY

  Spelling cleanup across the tree. Comments,
  docstrings, log messages, `help_text` and Ansible
  module `DOCUMENTATION` only — no identifiers are
  renamed, no logic is touched, and no strings that are
  matched or compared at runtime are altered. Every one
  of the 161 hunks is a single-line, single-word
  substitution, which is why the diff is exactly 163
  insertions against 163 deletions.

  Typos were found with `codespell` using the `clear`,
  `rare` and `informal` dictionaries, followed by a
  manual pass for accidentally doubled words, which
  `codespell` does not detect.

  Three commits:

  1. **`fix: correct spelling typos in comments, help 
  text and error messages`** — the initial batch:
  `anlytics` in the `LOG_AGGREGATOR_LEVEL` help text,
  `programatically` and `occured` in
  `tasks/receptor.py`, `occured` in a `PostRunError`
  message, and the `LICENSE_NON_EXISTANT_MESSAGE`
  constant in `inventory_import.py` (a module-private
  constant with both its definition and its single use
  updated together).

  2. **`docs: remove accidentally doubled words`** —
  eleven duplications such as `used to to configure`,
  `combines with project path for for SCM file based
  sources` and `marked as as a read_only database
  setting`. Left alone: `the roles that that user has
  access to see` in `test_rbac_api.py`, where the
  repetition is grammatical.

  3. **`docs: fix spelling in comments, docstrings and 
  messages`** — the bulk pass, 143 corrections including
  `compatability`, `occurance`, `coresponding`,
  `propogate`, `suplementary`, `accross`, `passsword`,
  `databse`, `eligable`, `heatbeat` and `hhttps`.

  **Translations.** Four of the corrected strings are
  wrapped in `gettext`, so their msgids change; two of
  those currently have translations in `awx/locale` (7
  and 5 languages respectively). The `.po` files are
  deliberately left untouched, since CONTRIBUTING.md
  notes they are regenerated during the translation
  release cycle.

  **Migrations.** Two corrected strings are model field
  `help_text` values. In each case the string is fixed
  both in the model and in the migration that introduced
  it — `models/schedules.py` with
  `0004_squashed_v310_release`, and `models/workflow.py`
  with `0112_v370_workflow_node_identifier` — so the
  migration state stays consistent with the models and
  `check_migrations` does not report a missing
  migration.

  **Deliberately excluded**, to keep the diff free of
  noise and of files that are not ours to change:

  - `licenses/` — third-party license texts
  - `awx/locale/` — generated translation catalogues
  - `docs/docsite/rst/rest_api/_swagger/` — vendored
  swagger-ui bundles
  - `awxkit/awxkit/utils/toposort.py` — third-party
  (True Blade Systems, Apache-2.0)
  - `browseable` in `awx/main/access.py` — spelled that
  way consistently in 12 comments; changing it is churn
  rather than a fix
  - Terms `codespell` flags that are correct in context:
  `checkin` (a Candlepin API field), `brin` (a
  PostgreSQL index type), and deliberate identifiers
  such as `untils`, `parms`, `indx` and `userA`

  ##### ISSUE TYPE
   - Bug, Docs Fix or other nominal change

  ##### COMPONENT NAME
   - API
   - Collection
   - CLI
   - Docs

  ##### STEPS TO REPRODUCE AND EXTRA INFO

  No behavior change, so there is nothing to reproduce.
  Verification performed on the branch:

  - every changed `.py` file byte-compiles
  - every changed YAML file parses
  - all 31 embedded `DOCUMENTATION` / `EXAMPLES` /
  `RETURN` blocks in the 20 changed collection modules
  still parse as YAML
  - no changed line exceeds `black`'s configured
  `line-length = 160`
  - the four corrections that introduce an apostrophe
  (`doesnt` → `doesn't`, `wont` → `won't`) all sit
  inside `COMMENT` tokens, confirmed with Python's own
  `tokenize` module, so none of them lands in a
  single-quoted string literal
  - re-running `codespell` over the tree afterwards
  reports no findings

  Distribution of the 113 changed files:

  | Area | Files |
  |---|---|
  | `awx/` API and core | 38 |
  | `awx_collection/` | 27 |
  | tests | 22 |
  | tooling and CI | 11 |
  | migrations (comments only) | 6 |
  | `awxkit/` | 5 |
  | `docs/` | 4 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected spelling, grammar, duplicated wording, and broken links across user guides, issue templates, help text, and API documentation.
  * Improved clarity of workflow, scheduling, container group, deployment, and integration instructions.
  * Updated visible error messages, task names, and examples for consistency.

* **Maintenance**
  * Standardized terminology and corrected labels in logs, messages, comments, and test descriptions without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->