### PR TITLE
AAPRFE-3063 Add aap_session_id auth for SSO session cookie support

### DIFF
--- a/awx_collection/plugins/doc_fragments/auth_session_id.py
+++ b/awx_collection/plugins/doc_fragments/auth_session_id.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Automation Platform Controller documentation fragment
+    DOCUMENTATION = r'''
+options:
+  aap_session_id:
+    description:
+    - Authenticate using session cookies obtained via other means such as Single Sign-On.
+    - This is a dictionary requiring two keys, C(csrftoken) and C(gateway_sessionid),
+      which are provided as authentication cookies.
+    - If value not set, will try environment variable C(AAP_SESSION_ID) and then
+      C(CONTROLLER_SESSION_ID) or C(GATEWAY_SESSION_ID).
+    type: dict
+    required: False
+    version_added: "4.6.0"
+    aliases: [ controller_session_id, gateway_session_id ]
+'''
+
+

--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -9,7 +9,7 @@ from ansible.module_utils.six import PY2
 from ansible.module_utils.six import raise_from
 from ansible.module_utils.six.moves import StringIO
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.six.moves.http_cookiejar import CookieJar
+from ansible.module_utils.six.moves.http_cookiejar import CookieJar, Cookie
 from ansible.module_utils.six.moves.urllib.parse import urlparse, urlencode, quote
 from ansible.module_utils.six.moves.configparser import ConfigParser, NoOptionError
 from base64 import b64encode
@@ -120,6 +120,7 @@ class ControllerModule(AnsibleModule):
         'max_retries': 'max_retries',
         'retry_backoff_factor': 'retry_backoff_factor',
         'aap_token': 'aap_token',
+        'aap_session_id': 'aap_session_id'
     }
     host = '127.0.0.1'
     username = None
@@ -365,13 +366,28 @@ class ControllerAPIModule(ControllerModule):
         'controller': 'Red Hat Ansible Automation Platform',
     }
     session = None
+    aap_session_id = None
+
     IDENTITY_FIELDS = {'users': 'username', 'workflow_job_template_nodes': 'identifier', 'instances': 'hostname'}
     ENCRYPTED_STRING = "$encrypted$"
+    AUTH_ARGSPEC = dict(
+        aap_session_id=dict(
+            type='dict',
+            no_log=True,
+            aliases=['controller_session_id', 'gateway_session_id'],
+            required=False,
+            fallback=(env_fallback, ['CONTROLLER_SESSION_ID', 'AAP_SESSION_ID', 'GATEWAY_SESSION_ID'])
+        )
+    )
 
     def __init__(self, argument_spec, direct_params=None, error_callback=None, warn_callback=None, **kwargs):
         kwargs['supports_check_mode'] = True
 
-        super().__init__(argument_spec=argument_spec, direct_params=direct_params, error_callback=error_callback, warn_callback=warn_callback, **kwargs)
+        full_argspec = {}
+        full_argspec.update(ControllerAPIModule.AUTH_ARGSPEC)
+        full_argspec.update(argument_spec)
+
+        super().__init__(argument_spec=full_argspec, direct_params=direct_params, error_callback=error_callback, warn_callback=warn_callback, **kwargs)
         self.session = Request(cookies=CookieJar(), timeout=self.request_timeout, validate_certs=self.verify_ssl)
 
         if 'update_secrets' in self.params:
@@ -596,7 +612,8 @@ class ControllerAPIModule(ControllerModule):
         # Extract the headers, this will be used in a couple of places
         headers = kwargs.get('headers', {})
 
-        headers['Authorization'] = self._get_authorization_header(**kwargs)
+        if not self.authenticated:
+            self.authenticate(**kwargs)
 
         if method in ['POST', 'PUT', 'PATCH']:
             headers.setdefault('Content-Type', 'application/json')
@@ -780,27 +797,11 @@ class ControllerAPIModule(ControllerModule):
 
         return prefix
 
-    def _get_authorization_header(self, **kwargs):
-        if self.aap_token:
-            # A token (e.g. issued by the AAP gateway) is validated by the server on
-            # every request, so no login round-trip is needed
-            return 'Bearer {0}'.format(self.aap_token)
-
-        # Authenticate to AWX (if not already done so)
-        if not self.authenticated:
-            # This method will set a cookie in the cookie jar for us
-            self.authenticate(**kwargs)
-
-        return self._get_basic_authorization_header()
-
-    def _get_basic_authorization_header(self):
-        basic_credentials = b64encode("{0}:{1}".format(self.username, self.password).encode()).decode()
-        return "Basic {0}".format(basic_credentials)
-
     def _authenticate_with_basic_auth(self):
         if self.username and self.password:
             # use api url /api/v2/me to get current user info as a testing request
             me_url = self.build_url("me").geturl()
+            self.session.headers["Authorization"] = "Basic {0}".format(b64encode("{0}:{1}".format(self.username, self.password).encode()).decode())
             self.session.open(
                 "GET",
                 me_url,
@@ -808,14 +809,64 @@ class ControllerAPIModule(ControllerModule):
                 timeout=self.request_timeout,
                 follow_redirects=True,
                 headers={
-                    "Content-Type": "application/json",
-                    "Authorization": self._get_basic_authorization_header(),
+                    "Content-Type": "application/json"
                 },
             )
 
+    def _authenticate_with_session_cookies(self):
+        if self.aap_session_id:
+            if 'csrftoken' not in self.aap_session_id and 'gateway_sessionid' not in self.aap_session_id:
+                self.fail_json(msg="aap_session_id must contain both 'csrftoken' and 'gateway_sessionid' keys.")
+            if 'csrftoken' not in self.aap_session_id:
+                self.fail_json(msg="aap_session_id is missing the required 'csrftoken' key.")
+            if 'gateway_sessionid' not in self.aap_session_id:
+                self.fail_json(msg="aap_session_id is missing the required 'gateway_sessionid' key.")
+            for k in ['csrftoken', 'gateway_sessionid']:
+                c = Cookie(
+                    version=0, name=k, value=self.aap_session_id[k], port=None, port_specified=False,
+                    domain=self.url.hostname, domain_specified=True, domain_initial_dot=False,
+                    path='/', path_specified=True, secure=False, expires=None,
+                    discard=True, comment=None, comment_url=None, rest={'HttpOnly': None}
+                )
+                self.session.cookies.set_cookie(c)
+
+            self.session.headers.update({
+                "X-Csrftoken": self.aap_session_id["csrftoken"],
+                "Referer": self.host
+            })
+
+            me_url = self.build_url("me").geturl()
+
+            self.session.open(
+                "GET",
+                me_url,
+                validate_certs=self.verify_ssl,
+                timeout=self.request_timeout,
+                follow_redirects=True
+            )
+        else:
+            self.fail_json(msg="This is a bug. This control path should not be followed. " \
+                            "The function, _authenticate_with_session_cookies, should not be called " \
+                            "if self.aap_session_id is not declared.")
+
+    def _authenticate_with_aap_token(self):
+        if self.aap_token:
+            # A token (e.g. issued by the AAP gateway) is validated by the server on
+            # every request, so no login round-trip is needed
+            self.session.headers["Authorization"] = 'Bearer {0}'.format(self.aap_token)
+
     def authenticate(self, **kwargs):
         try:
-            self._authenticate_with_basic_auth()
+            if self.authenticated:
+                return
+            elif self.aap_token:
+                self._authenticate_with_aap_token()
+            elif self.username and self.password:
+                self._authenticate_with_basic_auth()
+            elif self.aap_session_id:
+                self._authenticate_with_session_cookies()
+            else:
+                raise Exception("No authentication information found.")
         except Exception as exp:
             self.fail_json(msg='Failed to get user info: {0}'.format(exp))
 

--- a/awx_collection/plugins/modules/ad_hoc_command.py
+++ b/awx_collection/plugins/modules/ad_hoc_command.py
@@ -91,7 +91,7 @@ options:
         - If waiting for the command to complete this will abort after this
           amount of seconds
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/ad_hoc_command_cancel.py
+++ b/awx_collection/plugins/modules/ad_hoc_command_cancel.py
@@ -43,7 +43,7 @@ options:
         - Not specifying means the task will wait until the controller cancels the command.
       type: int
       default: 0
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/ad_hoc_command_wait.py
+++ b/awx_collection/plugins/modules/ad_hoc_command_wait.py
@@ -36,7 +36,7 @@ options:
       description:
         - Maximum time in seconds to wait for a ad hoc command to finish.
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/bulk_host_create.py
+++ b/awx_collection/plugins/modules/bulk_host_create.py
@@ -51,7 +51,7 @@ options:
         - Inventory name, ID, or named URL the hosts should be made a member of.
       required: True
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/bulk_host_delete.py
+++ b/awx_collection/plugins/modules/bulk_host_delete.py
@@ -24,7 +24,7 @@ options:
       required: True
       type: list
       elements: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/bulk_job_launch.py
+++ b/awx_collection/plugins/modules/bulk_job_launch.py
@@ -163,7 +163,7 @@ options:
       required: False
       default: 2
       type: float
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 RETURN = '''

--- a/awx_collection/plugins/modules/controller_meta.py
+++ b/awx_collection/plugins/modules/controller_meta.py
@@ -20,7 +20,7 @@ description:
     - Allows a user to find out what collection this module exists in.
     - This takes common module parameters, but does nothing with them.
 options: {}
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/credential.py
+++ b/awx_collection/plugins/modules/credential.py
@@ -111,7 +111,7 @@ options:
       default: "present"
       type: str
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 
 notes:
   - Values `inputs` and the other deprecated fields (such as `tenant`) are replacements of existing values.

--- a/awx_collection/plugins/modules/credential_input_source.py
+++ b/awx_collection/plugins/modules/credential_input_source.py
@@ -52,7 +52,7 @@ options:
       default: "present"
       type: str
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/credential_type.py
+++ b/awx_collection/plugins/modules/credential_type.py
@@ -61,7 +61,7 @@ options:
       default: "present"
       choices: ["present", "absent", "exists"]
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/execution_environment.py
+++ b/awx_collection/plugins/modules/execution_environment.py
@@ -58,7 +58,7 @@ options:
       choices: ["always", "missing", "never"]
       default: 'missing'
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/group.py
+++ b/awx_collection/plugins/modules/group.py
@@ -73,7 +73,7 @@ options:
       description:
         - A new name for this group (for renaming)
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/host.py
+++ b/awx_collection/plugins/modules/host.py
@@ -53,7 +53,7 @@ options:
       choices: ["present", "absent", "exists"]
       default: "present"
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/instance.py
+++ b/awx_collection/plugins/modules/instance.py
@@ -77,7 +77,7 @@ options:
         - If enabled, control plane nodes will automatically peer to this node.
       required: False
       type: bool
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/instance_group.py
+++ b/awx_collection/plugins/modules/instance_group.py
@@ -84,7 +84,7 @@ options:
       choices: ["present", "absent", "exists"]
       default: "present"
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -80,7 +80,7 @@ options:
       default: "present"
       choices: ["present", "absent", "exists"]
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/inventory_source.py
+++ b/awx_collection/plugins/modules/inventory_source.py
@@ -140,7 +140,7 @@ options:
       description:
         - Name of the inventory source's inventory's organization.
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/inventory_source_update.py
+++ b/awx_collection/plugins/modules/inventory_source_update.py
@@ -53,7 +53,7 @@ options:
         - If waiting for the job to complete this will abort after this
           amount of seconds
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/job_cancel.py
+++ b/awx_collection/plugins/modules/job_cancel.py
@@ -31,7 +31,7 @@ options:
         - Fail loudly if the I(job_id) can not be canceled
       default: False
       type: bool
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/job_launch.py
+++ b/awx_collection/plugins/modules/job_launch.py
@@ -129,7 +129,7 @@ options:
         - If waiting for the job to complete this will abort after this
           amount of seconds. This happens on the module side.
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/job_list.py
+++ b/awx_collection/plugins/modules/job_list.py
@@ -39,7 +39,7 @@ options:
       description:
         - Query used to further filter the list of jobs. C({"foo":"bar"}) will be passed at C(?foo=bar)
       type: dict
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/job_template.py
+++ b/awx_collection/plugins/modules/job_template.py
@@ -317,7 +317,7 @@ options:
         - Prevent falling back to instance groups set on the associated inventory or organization
       type: bool
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 
 notes:
   - JSON for survey_spec can be found in the API Documentation. See

--- a/awx_collection/plugins/modules/job_wait.py
+++ b/awx_collection/plugins/modules/job_wait.py
@@ -43,7 +43,7 @@ options:
       choices: ['project_updates', 'jobs', 'inventory_updates', 'workflow_jobs']
       default: 'jobs'
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/label.py
+++ b/awx_collection/plugins/modules/label.py
@@ -43,7 +43,7 @@ options:
       default: "present"
       choices: ["present", "exists"]
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/license.py
+++ b/awx_collection/plugins/modules/license.py
@@ -42,7 +42,7 @@ options:
       default: "present"
       choices: ["present", "absent"]
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 RETURN = ''' # '''

--- a/awx_collection/plugins/modules/notification_template.py
+++ b/awx_collection/plugins/modules/notification_template.py
@@ -100,7 +100,7 @@ options:
       default: "present"
       choices: ["present", "absent", "exists"]
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/organization.py
+++ b/awx_collection/plugins/modules/organization.py
@@ -84,7 +84,7 @@ options:
         - list of Ansible Galaxy credential names, IDs, or named URLs to associate to the organization
       type: list
       elements: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -166,7 +166,7 @@ options:
         - If signature validation credential is provided, signature validation will be enabled.
       type: str
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/project_update.py
+++ b/awx_collection/plugins/modules/project_update.py
@@ -48,7 +48,7 @@ options:
         - If waiting for the project to update this will abort after this
           amount of seconds
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 RETURN = '''

--- a/awx_collection/plugins/modules/role.py
+++ b/awx_collection/plugins/modules/role.py
@@ -146,7 +146,7 @@ options:
       choices: ["present", "absent"]
       type: str
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/role_definition.py
+++ b/awx_collection/plugins/modules/role_definition.py
@@ -47,7 +47,7 @@ options:
             - present
             - absent
         type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/role_team_assignment.py
+++ b/awx_collection/plugins/modules/role_team_assignment.py
@@ -53,7 +53,7 @@ options:
             - present
             - absent
         type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/role_user_assignment.py
+++ b/awx_collection/plugins/modules/role_user_assignment.py
@@ -53,7 +53,7 @@ options:
             - present
             - absent
         type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/schedule.py
+++ b/awx_collection/plugins/modules/schedule.py
@@ -149,7 +149,7 @@ options:
       choices: ["present", "absent", "exists"]
       default: "present"
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/settings.py
+++ b/awx_collection/plugins/modules/settings.py
@@ -37,7 +37,7 @@ options:
       type: dict
 requirements:
   - pyyaml
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/subscriptions.py
+++ b/awx_collection/plugins/modules/subscriptions.py
@@ -49,7 +49,7 @@ options:
       required: False
       type: dict
       default: {}
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 RETURN = '''

--- a/awx_collection/plugins/modules/team.py
+++ b/awx_collection/plugins/modules/team.py
@@ -45,7 +45,7 @@ options:
       choices: ["present", "absent", "exists"]
       default: "present"
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/user.py
+++ b/awx_collection/plugins/modules/user.py
@@ -72,7 +72,7 @@ options:
       choices: ["present", "absent", "exists"]
       default: "present"
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 

--- a/awx_collection/plugins/modules/workflow_approval.py
+++ b/awx_collection/plugins/modules/workflow_approval.py
@@ -52,7 +52,7 @@ options:
         - Maximum time in seconds to wait for a workflow job to to reach approval node.
       default: 10
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 """
 
 

--- a/awx_collection/plugins/modules/workflow_job_template.py
+++ b/awx_collection/plugins/modules/workflow_job_template.py
@@ -435,7 +435,7 @@ options:
       aliases:
         - destroy_current_schema
 
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/workflow_job_template_node.py
+++ b/awx_collection/plugins/modules/workflow_job_template_node.py
@@ -182,7 +182,7 @@ options:
       choices: ["present", "absent", "exists"]
       default: "present"
       type: str
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 EXAMPLES = '''

--- a/awx_collection/plugins/modules/workflow_launch.py
+++ b/awx_collection/plugins/modules/workflow_launch.py
@@ -74,7 +74,7 @@ options:
         - If waiting for the workflow to complete this will abort after this
           amount of seconds
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 '''
 
 RETURN = '''

--- a/awx_collection/plugins/modules/workflow_node_wait.py
+++ b/awx_collection/plugins/modules/workflow_node_wait.py
@@ -46,7 +46,7 @@ options:
         - Maximum time in seconds to wait for a workflow job to reach approval node.
       default: 10
       type: int
-extends_documentation_fragment: awx.awx.auth
+extends_documentation_fragment: awx.awx.auth_session_id, awx.awx.auth
 """
 
 

--- a/awx_collection/test/awx/test_session_id_auth.py
+++ b/awx_collection/test/awx/test_session_id_auth.py
@@ -1,0 +1,224 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+from requests.models import Response
+from unittest import mock
+
+
+def getheader(self, header_name, default):
+    return default
+
+
+def read(self):
+    return json.dumps({})
+
+
+def status(self):
+    return 200
+
+
+def make_recorder():
+    """Build a mock for Request.open that records every call made through it."""
+    calls = []
+
+    def opener(self, method, url, **kwargs):
+        calls.append({'method': method, 'url': url, 'headers': kwargs.get('headers') or {}})
+        r = Response()
+        r.getheader = getheader.__get__(r)
+        r.read = read.__get__(r)
+        r.status = status.__get__(r)
+        return r
+
+    return opener, calls
+
+
+def make_module(collection_import, module_args, **kwargs):
+    ControllerAPIModule = collection_import('plugins.module_utils.controller_api').ControllerAPIModule
+    cli_data = {'ANSIBLE_MODULE_ARGS': module_args}
+    with mock.patch.object(basic, '_ANSIBLE_ARGS', to_bytes(json.dumps(cli_data))):
+        if hasattr(basic, '_ANSIBLE_PROFILE'):
+            with mock.patch.object(basic, '_ANSIBLE_PROFILE', 'legacy'):
+                return ControllerAPIModule(argument_spec=dict(), **kwargs)
+        return ControllerAPIModule(argument_spec=dict(), **kwargs)
+
+
+def test_session_id_sets_cookies_and_headers(collection_import):
+    session_id = {'csrftoken': 'my-csrf-token', 'gateway_sessionid': 'my-session-id'}
+    module = make_module(collection_import, {'aap_session_id': session_id})
+    assert module.aap_session_id == session_id
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.get_endpoint('ping')
+
+    assert len(calls) == 2, calls
+    assert calls[0]['method'] == 'GET'
+    assert '/me/' in calls[0]['url']
+    assert module.authenticated is True
+
+    cookies = {c.name: c.value for c in module.session.cookies}
+    assert cookies['csrftoken'] == 'my-csrf-token'
+    assert cookies['gateway_sessionid'] == 'my-session-id'
+
+    assert module.session.headers.get('X-Csrftoken') == 'my-csrf-token'
+    assert module.session.headers.get('Referer') is not None
+
+
+def test_session_id_auth_probe_then_actual_request(collection_import):
+    session_id = {'csrftoken': 'tok', 'gateway_sessionid': 'sess'}
+    module = make_module(collection_import, {'aap_session_id': session_id})
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.get_endpoint('ping')
+
+    assert len(calls) == 2
+    assert '/me/' in calls[0]['url']
+    assert '/ping/' in calls[1]['url']
+
+
+def test_session_id_missing_csrftoken_fails(collection_import):
+    errors = []
+
+    def error_callback(**kwargs):
+        errors.append(kwargs)
+        raise SystemExit(1)
+
+    module = make_module(
+        collection_import,
+        {'aap_session_id': {'gateway_sessionid': 'sess'}},
+        error_callback=error_callback,
+    )
+
+    with pytest.raises(SystemExit):
+        module.authenticate()
+
+    assert len(errors) == 1
+    assert 'csrftoken' in errors[0]['msg']
+
+
+def test_session_id_missing_gateway_sessionid_fails(collection_import):
+    errors = []
+
+    def error_callback(**kwargs):
+        errors.append(kwargs)
+        raise SystemExit(1)
+
+    module = make_module(
+        collection_import,
+        {'aap_session_id': {'csrftoken': 'tok'}},
+        error_callback=error_callback,
+    )
+
+    with pytest.raises(SystemExit):
+        module.authenticate()
+
+    assert len(errors) == 1
+    assert 'gateway_sessionid' in errors[0]['msg']
+
+
+def test_session_id_missing_both_keys_fails(collection_import):
+    errors = []
+
+    def error_callback(**kwargs):
+        errors.append(kwargs)
+        raise SystemExit(1)
+
+    module = make_module(
+        collection_import,
+        {'aap_session_id': {'unrelated_key': 'value'}},
+        error_callback=error_callback,
+    )
+
+    with pytest.raises(SystemExit):
+        module.authenticate()
+
+    assert len(errors) == 1
+    assert 'csrftoken' in errors[0]['msg'] and 'gateway_sessionid' in errors[0]['msg']
+
+
+def test_token_takes_priority_over_session_id(collection_import):
+    """When both aap_token and aap_session_id are provided, token wins."""
+    session_id = {'csrftoken': 'tok', 'gateway_sessionid': 'sess'}
+    module = make_module(collection_import, {
+        'aap_token': 'my-bearer-token',
+        'aap_session_id': session_id,
+    })
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.get_endpoint('ping')
+
+    assert len(calls) == 1, calls
+    assert module.session.headers.get('Authorization') == 'Bearer my-bearer-token'
+    cookies = {c.name: c.value for c in module.session.cookies}
+    assert 'gateway_sessionid' not in cookies
+
+
+def test_basic_auth_takes_priority_over_session_id(collection_import):
+    """When both username/password and aap_session_id are provided, basic auth wins."""
+    session_id = {'csrftoken': 'tok', 'gateway_sessionid': 'sess'}
+    module = make_module(collection_import, {
+        'controller_username': 'admin',
+        'controller_password': 'secret',
+        'aap_session_id': session_id,
+    })
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.get_endpoint('ping')
+
+    assert len(calls) == 2, calls
+    assert module.session.headers.get('Authorization', '').startswith('Basic ')
+    cookies = {c.name: c.value for c in module.session.cookies}
+    assert 'gateway_sessionid' not in cookies
+
+
+@pytest.mark.parametrize('param', ['controller_session_id', 'gateway_session_id'])
+def test_session_id_legacy_aliases(collection_import, param):
+    session_id = {'csrftoken': 'tok', 'gateway_sessionid': 'sess'}
+    module = make_module(collection_import, {param: session_id})
+    assert module.aap_session_id == session_id
+
+
+def test_session_id_not_authenticated_until_authenticate_called(collection_import):
+    session_id = {'csrftoken': 'tok', 'gateway_sessionid': 'sess'}
+    module = make_module(collection_import, {'aap_session_id': session_id})
+    assert module.authenticated is False
+
+
+def test_no_auth_info_fails(collection_import):
+    errors = []
+
+    def error_callback(**kwargs):
+        errors.append(kwargs)
+        raise SystemExit(1)
+
+    module = make_module(collection_import, {}, error_callback=error_callback)
+
+    with pytest.raises(SystemExit):
+        module.authenticate()
+
+    assert len(errors) == 1
+    assert 'No authentication information found' in errors[0]['msg'] or 'Failed to get user info' in errors[0]['msg']
+
+
+def test_authenticate_is_idempotent(collection_import):
+    """Calling authenticate() twice should not re-authenticate."""
+    session_id = {'csrftoken': 'tok', 'gateway_sessionid': 'sess'}
+    module = make_module(collection_import, {'aap_session_id': session_id})
+
+    opener, calls = make_recorder()
+    with mock.patch('ansible.module_utils.urls.Request.open', new=opener):
+        module.authenticate()
+        module.authenticate()
+
+    me_calls = [c for c in calls if '/me/' in c['url']]
+    assert len(me_calls) == 1

--- a/awx_collection/test/awx/test_token_auth.py
+++ b/awx_collection/test/awx/test_token_auth.py
@@ -70,8 +70,7 @@ def test_aap_token_sends_bearer_header(collection_import, token_value):
 
     assert len(calls) == 1, calls
     assert calls[0]['headers']['Authorization'] == 'Bearer a-token-string'
-    # a token needs no login round-trip
-    assert module.authenticated is False
+    assert module.authenticated is True
 
 
 @pytest.mark.parametrize('param', ['oauth_token', 'controller_oauthtoken', 'tower_oauthtoken'])


### PR DESCRIPTION
##### SUMMARY

Adds `aap_session_id` as a new authentication method for the AWX collection, enabling users who authenticate via SSO (or other external means) to pass their existing session cookies (`csrftoken` and `gateway_sessionid`) to collection modules instead of requiring basic auth credentials or an OAuth token - something that is not possible in highly compliant environments.

**What changed:**

- **New auth path**: `_authenticate_with_session_cookies()` injects the provided CSRF token and gateway session ID as cookies on the session and sets the `X-Csrftoken` and `Referer` headers, then validates against `/api/v2/me/`.
- **Refactored `authenticate()` dispatcher**: Replaced the inline `_get_authorization_header()` / `_get_basic_authorization_header()` pattern with a single `authenticate()` method that dispatches to the correct strategy: `aap_token` > `basic auth` > `session cookies`. Auth headers are now set on the persistent session rather than per-request.
- **New `auth_session_id` doc fragment**: Documents the `aap_session_id` parameter, its aliases (`controller_session_id`, `gateway_session_id`), and env var fallbacks (`AAP_SESSION_ID`, `CONTROLLER_SESSION_ID`, `GATEWAY_SESSION_ID`). Added to all 43 modules except for import and export which utilize AWXKIT.
- **New argspec on `ControllerAPIModule`**: `aap_session_id` is defined with `type=dict`, `no_log=True`, and env var fallback.
- **Unit tests**: 12 new tests covering the happy path (cookies/headers set, auth probe fires), validation errors (missing keys), auth priority (token > basic > session), aliases, idempotency, and the no-credentials error case.

Auth priority order: Bearer token > username/password > session cookies.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection

##### STEPS TO REPRODUCE AND EXTRA INFO

To use session cookie auth, obtain `csrftoken` and `gateway_sessionid` values from an authenticated browser session or SSO flow, then pass them to any collection module:

```yaml
- name: List projects using SSO session cookies
  awx.awx.job_list:
    aap_session_id:
      csrftoken: "<your-csrf-token>"
      gateway_sessionid: "<your-session-id>"
    controller_host: "https://aap.example.com"
```

Or via environment variables:
```bash
export AAP_SESSION_ID='{"csrftoken": "<token>", "gateway_sessionid": "<session>"}'
```

Missing or incomplete `aap_session_id` dicts produce clear validation errors:
```
FAILED! => {"msg": "aap_session_id must contain both 'csrftoken' and 'gateway_sessionid' keys."}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session-cookie authentication using an `aap_session_id` credential, with environment-variable support and legacy aliases.
  * Added CSRF protection and session validation during authentication.
  * Preserved support for token and basic authentication.

* **Documentation**
  * Updated supported modules to document session-cookie authentication options.

* **Tests**
  * Added comprehensive coverage for session authentication, credential precedence, validation, aliases, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->