### PR TITLE
fix: bump daphne to 4.2.2

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -11,7 +11,7 @@ channels
 channels-redis
 cryptography
 Cython
-daphne
+daphne>=4.2.2
 distro
 django>=5.2,<5.3  # Django 5.2 LTS, allow patch updates
 django-cors-headers

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -117,7 +117,7 @@ cryptography==46.0.3
     #   service-identity
 cython==3.1.3
     # via -r /awx_devel/requirements/requirements.in
-daphne==4.2.1
+daphne==4.2.2
     # via -r /awx_devel/requirements/requirements.in
 dispatcherd[pg-notify]==2026.3.25
     # via -r /awx_devel/requirements/requirements.in


### PR DESCRIPTION
##### SUMMARY
Bump version of daphne dependency.

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Daphne dependency to version 4.2.2 or newer.
  * Refreshed the locked dependency version to 4.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->