### PR TITLE
[AAP-86982] DO NOT MERGE — Test DAB fix for plan=[] ResourceType regression

### DIFF
--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -20,5 +20,5 @@
 certifi @ git+https://github.com/ansible/system-certifi.git@devel
 ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel
 awx-plugins-core[credentials-github-app] @ git+https://github.com/ansible/awx-plugins.git@devel
-django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel
+django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@AAP-86982-fix-plan-skip
 awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git


### PR DESCRIPTION
## Summary

- Temporary PR to validate that [ansible/django-ansible-base#1095](https://github.com/ansible/django-ansible-base/pull/1095) fixes the 2432 api-test CI errors caused by DAB PR #1094's `plan=[]` early-return skipping ResourceType creation.
- Points `requirements_git.txt` at the DAB fix branch `AAP-86982-fix-plan-skip` instead of `devel`.

## DO NOT MERGE

Close this PR after CI confirms the fix works. The actual fix is in DAB PR [#1095](https://github.com/ansible/django-ansible-base/pull/1095).

## Test plan

- [ ] api-test CI passes (the 2432 errors from DAB PR #1094 are resolved)

Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency reference to use a targeted maintenance branch.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->