### PR TITLE
AAP-87084 — Replace UNION with OR + pre-computed role set in unified job RBAC query

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.db.models import Q, Prefetch
 from django.contrib.auth.models import User
 from django.utils.translation import gettext_lazy as _
+from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist, FieldDoesNotExist
 
 # Django REST Framework
@@ -19,7 +20,7 @@ from rest_framework.exceptions import ParseError, PermissionDenied
 
 # django-ansible-base
 from ansible_base.lib.utils.validation import to_python_boolean
-from ansible_base.rbac.models import RoleEvaluation
+from ansible_base.rbac.models import RoleEvaluation, RoleUserAssignment
 from ansible_base.rbac.policies import visible_users
 from ansible_base.rbac import permission_registry
 
@@ -2507,39 +2508,75 @@ class UnifiedJobAccess(BaseAccess):
     # )
 
     def filtered_queryset(self):
-        inv_pk_qs = Inventory.access_ids_qs(self.user, 'view')
+        # AAP-87084 / AAP-87087: Pre-compute role IDs once to avoid 4x redundant
+        # roleuserassignment scans, and use OR (not UNION) to allow single-pass
+        # filtering with early LIMIT exit.
+        user_role_ids = list(RoleUserAssignment.objects.filter(user_id=self.user.id).values_list('object_role_id', flat=True))
+        if not user_role_ids:
+            return self.model.objects.none()
 
-        by_template = (
-            self.model.objects.filter(unified_job_template_id__in=UnifiedJobTemplate.accessible_pk_qs(self.user, 'read_role'))
-            .order_by()
-            .values_list('pk', flat=True)
-        )
+        user_singletons = self.user.singleton_permissions()
 
-        by_inventory_update = (
-            InventoryUpdate.objects.filter(
-                inventory_source__inventory__id__in=inv_pk_qs,
+        role_subclasses = UnifiedJobTemplate._submodels_with_roles()
+        ujt_codenames = [f'view_{cls._meta.model_name}' for cls in role_subclasses]
+        if not (set(ujt_codenames) - user_singletons):
+            ujt_accessible = UnifiedJobTemplate.objects.filter(polymorphic_ctype__in=ContentType.objects.get_for_models(*role_subclasses).values()).values_list(
+                'id', flat=True
             )
-            .order_by()
-            .values_list('pk', flat=True)
-        )
-
-        by_adhoc = (
-            AdHocCommand.objects.filter(
-                inventory__id__in=inv_pk_qs,
+        else:
+            dab_role_cts = permission_registry.content_type_model.objects.get_for_models(*role_subclasses).values()
+            ujt_accessible = (
+                RoleEvaluation.objects.filter(
+                    role_id__in=user_role_ids,
+                    codename__in=ujt_codenames,
+                    content_type_id__in=[ct.id for ct in dab_role_cts],
+                )
+                .values_list('object_id')
+                .distinct()
             )
-            .order_by()
-            .values_list('pk', flat=True)
-        )
 
-        by_org_auditor = (
-            self.model.objects.filter(
-                organization__in=Organization.access_ids_qs(self.user, 'audit_organization'),
+        if 'view_inventory' in user_singletons:
+            inv_accessible = Inventory.objects.values_list('id', flat=True)
+        else:
+            inv_ct_id = permission_registry.content_type_model.objects.get_for_model(Inventory).id
+            inv_accessible = (
+                RoleEvaluation.objects.filter(
+                    role_id__in=user_role_ids,
+                    codename='view_inventory',
+                    content_type_id=inv_ct_id,
+                )
+                .values_list('object_id')
+                .distinct()
             )
-            .order_by()
-            .values_list('pk', flat=True)
-        )
 
-        return self.model.objects.filter(pk__in=by_template.union(by_inventory_update, by_adhoc, by_org_auditor))
+        if 'audit_organization' in user_singletons:
+            org_accessible = Organization.objects.values_list('id', flat=True)
+        else:
+            org_ct_id = permission_registry.content_type_model.objects.get_for_model(Organization).id
+            org_accessible = (
+                RoleEvaluation.objects.filter(
+                    role_id__in=user_role_ids,
+                    codename='audit_organization',
+                    content_type_id=org_ct_id,
+                )
+                .values_list('object_id')
+                .distinct()
+            )
+
+        return self.model.objects.filter(
+            Q(unified_job_template_id__in=ujt_accessible)
+            | Q(
+                pk__in=InventoryUpdate.objects.filter(
+                    inventory_source__inventory__id__in=inv_accessible,
+                ).values('pk')
+            )
+            | Q(
+                pk__in=AdHocCommand.objects.filter(
+                    inventory__id__in=inv_accessible,
+                ).values('pk')
+            )
+            | Q(organization__in=org_accessible)
+        )
 
     def get_queryset(self):
         return super(UnifiedJobAccess, self).get_queryset().filter(workflowapproval__isnull=True)

--- a/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
+++ b/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
@@ -39,6 +39,7 @@ def test_unified_job_list_uses_or_not_union(user, organization, inventory, setup
     assert response.data['count'] >= 3
 
     uj_rbac_queries = [q['sql'] for q in ctx.captured_queries if 'main_unifiedjob' in q['sql'] and 'dab_rbac_roleevaluation' in q['sql']]
+    assert uj_rbac_queries, "Expected a unified-job RBAC query"
     for sql in uj_rbac_queries:
         assert 'UNION' not in sql, "RBAC query should use OR, not UNION"
 

--- a/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
+++ b/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
@@ -80,6 +80,40 @@ def test_unified_job_list_inventory_viewer_sees_inventory_updates(user, setup_ma
 
 
 @pytest.mark.django_db
+def test_unified_job_list_singleton_permissions(user, organization, inventory, setup_managed_roles, get):
+    """Users with global (singleton) view permissions see jobs via shortcut paths
+    that bypass RoleEvaluation queries entirely."""
+    singleton_user = user('uj-singleton')
+    RoleDefinition.objects.get(name='Organization Admin').give_permission(singleton_user, organization)
+
+    project = Project.objects.create(name='uj-singleton-project', organization=organization)
+    jt = JobTemplate.objects.create(name='uj-singleton-jt', project=project, inventory=inventory, organization=organization)
+    job = jt.create_unified_job()
+
+    inv_src = InventorySource.objects.create(name='uj-singleton-invsrc', inventory=inventory, source='ec2')
+    inv_update = InventoryUpdate.objects.create(inventory_source=inv_src, source=inv_src.source)
+
+    adhoc = AdHocCommand.objects.create(name='uj-singleton-adhoc', inventory=inventory)
+
+    # Inject singleton permissions to exercise the shortcut branches in
+    # filtered_queryset() without needing a global RoleDefinition.
+    singleton_user._singleton_permissions = {
+        'view_jobtemplate',
+        'view_project',
+        'view_workflowjobtemplate',
+        'view_inventory',
+        'audit_organization',
+    }
+
+    response = get(reverse('api:unified_job_list'), singleton_user)
+    assert response.status_code == 200
+    result_ids = [r['id'] for r in response.data['results']]
+    assert job.pk in result_ids
+    assert inv_update.pk in result_ids
+    assert adhoc.pk in result_ids
+
+
+@pytest.mark.django_db
 def test_unified_job_list_rando_sees_nothing(rando, setup_managed_roles, get):
     """Unprivileged user sees no unified jobs."""
     org = Organization.objects.create(name='uj-rando-org')

--- a/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
+++ b/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
@@ -18,8 +18,8 @@ from awx.main.models import (
 
 
 @pytest.mark.django_db
-def test_unified_job_list_uses_union(user, organization, inventory, setup_managed_roles, get):
-    """The unified job list RBAC query uses UNION instead of OR to allow per-branch query planning."""
+def test_unified_job_list_uses_or_not_union(user, organization, inventory, setup_managed_roles, get):
+    """The unified job list RBAC query uses OR-based filtering, not UNION."""
     org_admin = user('uj-org-admin')
     RoleDefinition.objects.get(name='Organization Admin').give_permission(org_admin, organization)
 
@@ -38,8 +38,9 @@ def test_unified_job_list_uses_union(user, organization, inventory, setup_manage
     assert response.status_code == 200
     assert response.data['count'] >= 3
 
-    uj_rbac_queries = [q['sql'] for q in ctx.captured_queries if 'UNION' in q['sql'] and 'main_unifiedjob' in q['sql']]
-    assert uj_rbac_queries, "Expected at least one query using UNION for unified job RBAC filtering"
+    uj_rbac_queries = [q['sql'] for q in ctx.captured_queries if 'main_unifiedjob' in q['sql'] and 'dab_rbac_roleevaluation' in q['sql']]
+    for sql in uj_rbac_queries:
+        assert 'UNION' not in sql, "RBAC query should use OR, not UNION"
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
+++ b/awx/main/tests/functional/dab_rbac/test_unified_job_access.py
@@ -13,6 +13,7 @@ from awx.main.models import (
     JobTemplate,
     Organization,
     Project,
+    Team,
     UnifiedJob,
 )
 
@@ -111,6 +112,28 @@ def test_unified_job_list_singleton_permissions(user, organization, inventory, s
     assert job.pk in result_ids
     assert inv_update.pk in result_ids
     assert adhoc.pk in result_ids
+
+
+@pytest.mark.django_db
+def test_unified_job_list_team_member_sees_team_granted_jobs(user, setup_managed_roles, get):
+    """A user who can view a JT only through a team assignment must see
+    the corresponding unified jobs in the list."""
+    org = Organization.objects.create(name='uj-team-org')
+    team = Team.objects.create(name='uj-test-team', organization=org)
+    team_user = user('uj-team-member')
+
+    RoleDefinition.objects.get(name='Team Member').give_permission(team_user, team)
+
+    inventory = org.inventories.create(name='uj-team-inv')
+    project = Project.objects.create(name='uj-team-project', organization=org)
+    jt = JobTemplate.objects.create(name='uj-team-jt', project=project, inventory=inventory, organization=org)
+    RoleDefinition.objects.get(name='JobTemplate Execute').give_permission(team, jt)
+    job = jt.create_unified_job()
+
+    response = get(reverse('api:unified_job_list'), team_user)
+    assert response.status_code == 200
+    result_ids = [r['id'] for r in response.data['results']]
+    assert job.pk in result_ids, f"Team member should see job {job.pk} via team-granted JT execute permission, " f"but got result IDs: {result_ids}"
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- Replaces the UNION ALL approach in `UnifiedJobAccess.filtered_queryset()` (introduced by AAP-81173) with OR-based filtering using a pre-computed role ID set
- Pre-computes the user's role IDs once via `RoleUserAssignment` query, then passes them as literal parameters to `RoleEvaluation` filters across all four RBAC branches
- Eliminates 4x redundant `roleuserassignment` subquery scans and restores single-pass filtering with early LIMIT exit

## Classification

New or Enhanced Feature

## Problem

AAP-81173 replaced the 4-way OR filter with UNION ALL to enable per-branch index use. However, the UNION forces PostgreSQL to materialize ALL accessible job IDs across all four RBAC branches before any filtering, ordering, or LIMIT can apply:

| Query | 2.6-stable | 2.6-next | Regression |
|-------|-----------|----------|------------|
| `SELECT_unified_job_RBAC` (jobs list) | 36 ms/call | 366 ms/call | **+917%** |
| `date_trunc` (dashboard aggregation) | 88.9 ms/call | 261.5 ms/call | **+194%** |

Additionally, each UNION branch independently scans `dab_rbac_roleuserassignment` (4x redundant), accounting for ~47% of dashboard query cost.

## Fix

The "third approach" avoids both the old OR problem (redundant RBAC computation per branch) and the UNION problem (full materialization before LIMIT):

1. **Single RBAC computation**: Materialize the user's `object_role_id` set once as a Python list (~290 IDs for a typical user, ~1ms query)
2. **Literal parameter injection**: Use `role_id__in=[literal_list]` in RoleEvaluation filters — PostgreSQL uses HashAggregate (O(1) per lookup) instead of nested-loop subquery scans
3. **OR-based filtering**: Single-pass evaluation of all four RBAC branches with early LIMIT exit
4. **Dashboard fix for free**: `DashboardJobsGraphView` calls through `get_user_queryset()` → `filtered_queryset()`, so the aggregation query (`COUNT(DISTINCT id) GROUP BY DATE_TRUNC`) also benefits — no UNION materialization before GROUP BY

The `UnifiedJobPaginator` (from AAP-81173) is kept as a safety net for COUNT performance.

## Test plan

- [x] All 5 `test_unified_job_access.py` tests pass (updated UNION→OR assertion, 4 semantic tests unchanged)
- [x] All 135 broader unified job functional tests pass (`pytest -k unified_job`)
- [ ] Scale Lab validation: expect `SELECT_unified_job_RBAC` to drop from 366ms back toward 36ms per call
- [ ] Scale Lab validation: expect `date_trunc_unified_job_dashboard` to drop from 261ms toward 89ms per call

Resolves: AAP-87084, AAP-87087

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved access filtering for unified jobs and related resources.
  - Correctly handles users without assigned roles and users with individual or team-granted permissions.
  - Ensures consistent access to workflow templates, inventories, inventory updates, ad hoc commands, and audited organizations.

- **Performance**
  - Streamlined permission evaluation to improve query efficiency and access-check responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->