### PR TITLE
Fix TLS verification when a container group credential has no CA data

### DIFF
--- a/awx/main/scheduler/kubernetes.py
+++ b/awx/main/scheduler/kubernetes.py
@@ -144,16 +144,16 @@ class PodManager(object):
         # this feels a little janky, but it's what k8s' own code does
         # internally when it reads kube config files from disk:
         # https://github.com/kubernetes-client/python-base/blob/0b208334ef0247aad9afcaae8003954423b61a0d/config/kube_config.py#L643
+        cfg = type.__call__(client.Configuration)
         if self.credential:
             loader = config.kube_config.KubeConfigLoader(config_dict=self.kube_config)
-            cfg = type.__call__(client.Configuration)
             loader.load_and_set(cfg)
-            api = client.CoreV1Api(api_client=client.ApiClient(configuration=cfg))
         else:
-            config.load_incluster_config()
-            api = client.CoreV1Api()
+            # pass an explicit configuration so the in-cluster loader does not
+            # mutate (and leak its bearer token into) the process-wide default
+            config.load_incluster_config(client_configuration=cfg)
 
-        return api
+        return client.CoreV1Api(api_client=client.ApiClient(configuration=cfg))
 
     @property
     def pod_name(self):
@@ -192,10 +192,24 @@ def generate_tmp_kube_config(credential, namespace):
         "current-context": host_input,
     }
 
-    if credential.get_input('verify_ssl') and 'ssl_ca_cert' in credential.inputs:
-        config["clusters"][0]["cluster"]["certificate-authority-data"] = b64encode(
+    apply_tls_verification(config, credential)
+    return config
+
+
+def apply_tls_verification(kube_config, credential):
+    """Set the cluster's TLS verification keys on a generated kube config.
+
+    The "Certificate Authority data" input is optional, so it can be present but
+    empty. Testing for the key rather than its value leaves verification enabled
+    with no CA at all, which silently falls back to whatever bundle the client
+    happens to default to. Leaving both keys unset is the honest way to express
+    "verify against the container's system trust store", which is what the
+    operator's bundle_cacert_secret populates.
+    """
+    cluster = kube_config["clusters"][0]["cluster"]
+    if not credential.get_input('verify_ssl'):
+        cluster["insecure-skip-tls-verify"] = True
+    elif credential.get_input('ssl_ca_cert', default=''):
+        cluster["certificate-authority-data"] = b64encode(
             credential.get_input('ssl_ca_cert').encode()  # encode to bytes
         ).decode()  # decode the base64 data into a str
-    else:
-        config["clusters"][0]["cluster"]["insecure-skip-tls-verify"] = True
-    return config

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -1,5 +1,4 @@
 # Python
-from base64 import b64encode
 from collections import namedtuple
 import concurrent.futures
 from enum import Enum
@@ -737,6 +736,8 @@ class AWXReceptorJob:
 
     @property
     def kube_config(self):
+        from awx.main.scheduler.kubernetes import apply_tls_verification  # prevent circular import
+
         host_input = self.credential.get_input('host')
         config = {
             "apiVersion": "v1",
@@ -748,12 +749,7 @@ class AWXReceptorJob:
             "current-context": host_input,
         }
 
-        if self.credential.get_input('verify_ssl') and 'ssl_ca_cert' in self.credential.inputs:
-            config["clusters"][0]["cluster"]["certificate-authority-data"] = b64encode(
-                self.credential.get_input('ssl_ca_cert').encode()  # encode to bytes
-            ).decode()  # decode the base64 data into a str
-        else:
-            config["clusters"][0]["cluster"]["insecure-skip-tls-verify"] = True
+        apply_tls_verification(config, self.credential)
         return config
 
 

--- a/awx/main/tests/functional/task_management/test_container_groups.py
+++ b/awx/main/tests/functional/task_management/test_container_groups.py
@@ -101,3 +101,37 @@ def test_kubectl_ssl_verification(containerized_job, default_job_execution_envir
     receptor_job = AWXReceptorJob(rj, runner_params={'settings': {}})
     ca_data = receptor_job.kube_config['clusters'][0]['cluster']['certificate-authority-data']
     assert cert.stdout == base64.b64decode(ca_data.encode())
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'verify_ssl, ssl_ca_cert, expected',
+    [
+        # a CA was supplied, so pin verification to it
+        (True, 'my-ca-data', {'certificate-authority-data': base64.b64encode(b'my-ca-data').decode()}),
+        # verification is on but no CA was supplied, whether the input is absent
+        # or merely empty: neither key is set, so the client verifies against the
+        # container's system trust store instead of whichever bundle it happens
+        # to default to
+        (True, '', {}),
+        (True, None, {}),
+        (False, '', {'insecure-skip-tls-verify': True}),
+        # an explicitly disabled verify_ssl wins over a stored CA
+        (False, 'my-ca-data', {'insecure-skip-tls-verify': True}),
+    ],
+)
+def test_kube_config_tls_verification(containerized_job, default_job_execution_environment, verify_ssl, ssl_ca_cert, expected):
+    containerized_job.execution_environment = default_job_execution_environment
+    cred = containerized_job.instance_group.credential
+    cred.inputs['verify_ssl'] = verify_ssl
+    if ssl_ca_cert is None:
+        cred.inputs.pop('ssl_ca_cert', None)
+    else:
+        cred.inputs['ssl_ca_cert'] = ssl_ca_cert
+    cred.save()
+
+    RunJob = namedtuple('RunJob', ['instance', 'build_execution_environment_params'])
+    rj = RunJob(instance=containerized_job, build_execution_environment_params=lambda x: {})
+    cluster = AWXReceptorJob(rj, runner_params={'settings': {}}).kube_config['clusters'][0]['cluster']
+
+    assert {key: value for key, value in cluster.items() if key != 'server'} == expected


### PR DESCRIPTION
##### SUMMARY

The "Certificate Authority data" input on the *OpenShift or Kubernetes API Bearer Token* credential is optional, but `generate_tmp_kube_config()` decides what to do based on the **presence** of the input rather than its **value**:

```python
if credential.get_input('verify_ssl') and 'ssl_ca_cert' in credential.inputs:
```

A credential with "Verify SSL" enabled and an empty CA therefore emits `certificate-authority-data: ""`. `FileOrData.as_file()` treats empty data as no data and returns `None`, so `Configuration.ssl_ca_cert` ends up `None` while `verify_ssl` stays `True`. Verification then falls back to whichever bundle the client defaults to, and that default is not stable across the versions AWX has shipped:

| `kubernetes` | `rest.py` behaviour when `ssl_ca_cert` is `None` |
|---|---|
| `< 36` | `ca_certs = certifi.where()`, so the Mozilla bundle |
| `>= 36` | `ca_certs=configuration.ssl_ca_cert` passed straight through, so urllib3 calls `load_default_certs()` and uses the system trust store |

Probing that path with the same kube config on both sides of the bump:

```
kubernetes 29.0.0   empty CA data   verify_ssl=True   ca_certs='.../certifi/cacert.pem'   cert_reqs=CERT_REQUIRED
kubernetes 36.0.2   empty CA data   verify_ssl=True   ca_certs=None                       cert_reqs=CERT_REQUIRED
```

Neither is what the user asked for. This changes the check to test the value and to leave *both* cluster keys unset when verification is on with no CA supplied, which expresses "verify against the container's system trust store" directly. That is also what the operator's [`bundle_cacert_secret`](https://docs.ansible.com/projects/awx-operator/en/latest/user-guide/advanced-configuration/trusting-a-custom-certificate-authority.html) populates, so the documented way to trust a custom CA now works for this code path. `AWXReceptorJob.kube_config` carried the same check and now shares the helper.

Second, unrelated but adjacent: `PodManager.kube_api` calls `config.load_incluster_config()` with no arguments, which mutates the process-wide `Configuration` default with the service account bearer token. Since `kubernetes` 36, `Configuration.set_default()` no longer deep-copies what it is given, so that default is shared rather than snapshotted. Passing an explicit `Configuration` keeps it contained and matches what the credential branch already does.

Behaviour after the change:

| Verify SSL | CA data | generated cluster keys |
|---|---|---|
| on | set | `certificate-authority-data` |
| on | empty or absent | neither (system trust store) |
| off | any | `insecure-skip-tls-verify: true` |

Only the middle row changes. Credentials that supply a CA, and credentials with verification off, are untouched.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

Create a container group whose credential has "Verify SSL" checked and "Certificate Authority data" left empty, against a cluster whose API certificate is signed by a private CA that is installed in the task container's system trust store (for example via `bundle_cacert_secret`). Launching a job fails while listing pods:

```
awx.main.scheduler Failed to list pods for container group <name>
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='...', port=443):
Max retries exceeded with url: /api/v1/namespaces/<ns>/pods?labelSelector=ansible-awx%3D...
(Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: unable to get local issuer certificate (_ssl.c:998)')))
```

Adding the CA to the system trust store does not help before this change, because the client is verifying against `configuration.ssl_ca_cert` semantics rather than the system store, and the fallback bundle it lands on contains neither the private CA nor anything that chains to it.

New parametrized test coverage for the four input combinations is included in `awx/main/tests/functional/task_management/test_container_groups.py`. `black` and `flake8` (per `tox.ini`) are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kubernetes connection configuration to prevent unintended changes to shared settings.
  - Corrected TLS certificate handling for Kubernetes integrations.
  - Ensured explicitly configured insecure verification takes precedence.
  - Improved behavior when certificates are missing or empty, using the system trust store when appropriate.

- **Tests**
  - Added coverage for secure, insecure, certificate-based, and system trust-store TLS scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->