### PR TITLE
Bulk-load recent_jobs for the host list instead of one query per host

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -25,6 +25,7 @@ from django.contrib.auth.password_validation import validate_password as django_
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist, ValidationError as DjangoValidationError
 from django.db import models
+from django.db.models.functions import RowNumber
 from django.utils.translation import gettext_lazy as _
 from django.utils.encoding import force_str
 from django.utils.text import capfirst
@@ -1896,6 +1897,56 @@ class InventoryScriptSerializer(InventorySerializer):
         fields = ()
 
 
+RECENT_JOBS_COUNT = 5
+
+
+def attach_recent_job_host_summaries(hosts):
+    """Load the newest RECENT_JOBS_COUNT JobHostSummary rows for each of hosts.
+
+    HostSerializer.get_summary_fields() builds its recent_jobs entry by slicing
+    the summaries of a single host, which costs one query per serialized host.
+    A window function ranks the summaries per host inside the database, so the
+    whole page is covered by one query per relation instead.
+    """
+    hosts_by_relation = {}
+    for host in hosts:
+        host._recent_job_host_summaries = []
+        # constructed inventories track their runs through a separate FK
+        relation = 'constructed_host' if host.inventory.kind == 'constructed' else 'host'
+        hosts_by_relation.setdefault(relation, {})[host.pk] = host
+
+    for relation, hosts_by_id in hosts_by_relation.items():
+        rank = models.Window(
+            expression=RowNumber(),
+            partition_by=[models.F('{}_id'.format(relation))],
+            order_by=models.F('created').desc(),
+        )
+        summaries = (
+            JobHostSummary.objects.filter(**{'{}_id__in'.format(relation): list(hosts_by_id)})
+            .annotate(_recent_rank=rank)
+            .filter(_recent_rank__lte=RECENT_JOBS_COUNT)
+            .select_related('job__job_template')
+            .defer('job__extra_vars', 'job__artifacts')
+        )
+        for summary in summaries:
+            hosts_by_id[getattr(summary, '{}_id'.format(relation))]._recent_job_host_summaries.append(summary)
+
+    # the window orders rows within each partition, but the outer query is free
+    # to return them in any order, so put each host's list back in -created order
+    for host in hosts:
+        host._recent_job_host_summaries.sort(key=lambda summary: summary.created, reverse=True)
+
+
+class HostListSerializer(serializers.ListSerializer):
+    """Bulk-loads the per-host data that get_summary_fields() would otherwise
+    fetch one host at a time."""
+
+    def to_representation(self, data):
+        hosts = list(data.all() if isinstance(data, models.Manager) else data)
+        attach_recent_job_host_summaries(hosts)
+        return super().to_representation(hosts)
+
+
 class HostSerializer(CleanTextMixin, BaseSerializerWithVariables):
     show_capabilities = ['edit', 'delete']
     capabilities_prefetch = [{'edit': 'inventory.change'}]
@@ -1918,6 +1969,7 @@ class HostSerializer(CleanTextMixin, BaseSerializerWithVariables):
 
     class Meta:
         model = Host
+        list_serializer_class = HostListSerializer
         fields = (
             '*',
             'inventory',
@@ -1997,10 +2049,17 @@ class HostSerializer(CleanTextMixin, BaseSerializerWithVariables):
             group_list = [{'id': g.id, 'name': g.name} for g in obj.groups.all().order_by('id')[:5]]
         group_cnt = obj.groups.count()
         d.setdefault('groups', {'count': group_cnt, 'results': group_list})
-        if obj.inventory.kind == 'constructed':
-            summaries_qs = obj.constructed_host_summaries
+        if hasattr(obj, '_recent_job_host_summaries'):
+            # bulk-loaded for the whole page by HostListSerializer
+            recent_summaries = obj._recent_job_host_summaries
         else:
-            summaries_qs = obj.job_host_summaries
+            if obj.inventory.kind == 'constructed':
+                summaries_qs = obj.constructed_host_summaries
+            else:
+                summaries_qs = obj.job_host_summaries
+            recent_summaries = (
+                summaries_qs.select_related('job__job_template').order_by('-created').defer('job__extra_vars', 'job__artifacts')[:RECENT_JOBS_COUNT]
+            )
         d.setdefault(
             'recent_jobs',
             [
@@ -2011,7 +2070,7 @@ class HostSerializer(CleanTextMixin, BaseSerializerWithVariables):
                     'status': j.job.status,
                     'finished': j.job.finished,
                 }
-                for j in summaries_qs.select_related('job__job_template').order_by('-created').defer('job__extra_vars', 'job__artifacts')[:5]
+                for j in recent_summaries
             ],
         )
         return d

--- a/awx/main/tests/functional/api/test_host_recent_jobs.py
+++ b/awx/main/tests/functional/api/test_host_recent_jobs.py
@@ -1,0 +1,75 @@
+import pytest
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from awx.api.versioning import reverse
+
+from awx.main.models import Organization, Inventory, Host, Job, JobHostSummary
+
+
+def _build_inventory(name, host_count, job_count):
+    org = Organization.objects.create(name='org-%s' % name)
+    inventory = Inventory.objects.create(name='inv-%s' % name, organization=org)
+    jobs = [Job.objects.create(name='job-%s-%d' % (name, i), inventory=inventory) for i in range(job_count)]
+    for i in range(host_count):
+        host = Host.objects.create(name='host-%s-%d' % (name, i), inventory=inventory)
+        for job in jobs:
+            JobHostSummary.objects.create(job=job, host=host, host_name=host.name)
+    return inventory, jobs
+
+
+def _summary_queries(captured):
+    return [query for query in captured if 'main_jobhostsummary' in query['sql']]
+
+
+@pytest.mark.django_db
+def test_recent_jobs_query_count_is_independent_of_page_size(get, admin):
+    """The host list must not read job host summaries once per row."""
+    counts = {}
+    for host_count in (2, 10):
+        inventory, _ = _build_inventory('n%d' % host_count, host_count, job_count=8)
+        url = '%s?inventory=%d&page_size=200' % (reverse('api:host_list'), inventory.pk)
+        get(url, admin)  # warm anything cached outside the queries we care about
+        with CaptureQueriesContext(connection) as ctx:
+            response = get(url, admin)
+        assert len(response.data['results']) == host_count
+        counts[host_count] = len(_summary_queries(ctx.captured_queries))
+
+    assert counts[2] == counts[10], 'job host summary queries scale with the number of hosts: %r' % counts
+
+
+@pytest.mark.django_db
+def test_recent_jobs_returns_the_five_newest_per_host(get, admin):
+    inventory, jobs = _build_inventory('newest', host_count=3, job_count=8)
+    url = '%s?inventory=%d&page_size=200' % (reverse('api:host_list'), inventory.pk)
+
+    response = get(url, admin)
+
+    newest = [job.id for job in sorted(jobs, key=lambda job: job.id, reverse=True)[:5]]
+    for result in response.data['results']:
+        recent = result['summary_fields']['recent_jobs']
+        assert [entry['id'] for entry in recent] == newest
+
+
+@pytest.mark.django_db
+def test_recent_jobs_on_host_detail(get, admin):
+    """The detail view serializes a single host, so it keeps the per-object path."""
+    inventory, jobs = _build_inventory('detail', host_count=1, job_count=8)
+    host = inventory.hosts.first()
+
+    response = get(reverse('api:host_detail', kwargs={'pk': host.pk}), admin)
+
+    newest = [job.id for job in sorted(jobs, key=lambda job: job.id, reverse=True)[:5]]
+    assert [entry['id'] for entry in response.data['summary_fields']['recent_jobs']] == newest
+
+
+@pytest.mark.django_db
+def test_recent_jobs_empty_for_hosts_that_never_ran(get, admin):
+    org = Organization.objects.create(name='org-never')
+    inventory = Inventory.objects.create(name='inv-never', organization=org)
+    Host.objects.create(name='host-never', inventory=inventory)
+
+    response = get('%s?inventory=%d' % (reverse('api:host_list'), inventory.pk), admin)
+
+    assert response.data['results'][0]['summary_fields']['recent_jobs'] == []


### PR DESCRIPTION
##### SUMMARY

`HostSerializer.get_summary_fields()` builds its `recent_jobs` entry by slicing the job host summaries of one host:

```python
for j in summaries_qs.select_related('job__job_template').order_by('-created').defer('job__extra_vars', 'job__artifacts')[:5]
```

That runs once per serialized host, so the query count on `/api/v2/hosts/` tracks the page size. Measured on `devel` at `df97f07` through the functional test harness, hosts each having 8 job runs:

| hosts on the page | total queries | of which read `main_jobhostsummary` |
|---|---|---|
| 5 | 12 | 8 |
| 20 | 27 | 23 |
| 50 | 57 | 53 |

This ranks the summaries per host with a window function so a single query covers the whole page, and hands the result to the serializer through a `ListSerializer`. Same requests after the change:

| hosts on the page | total queries | of which read `main_jobhostsummary` |
|---|---|---|
| 5 | 8 | 4 |
| 20 | 8 | 4 |
| 50 | 8 | 4 |

`recent_jobs` still holds the same five newest entries per host.

Notes on the approach:

- `devel` bulk-loads `Host.latest_summary` since `HostLatestSummaryQuerySet` landed: the id of the latest summary comes from a `Subquery` annotation on the host queryset, the rows from one `in_bulk()`. Three of the four queries still reading `main_jobhostsummary` are that pattern, counting the paginator's `COUNT(*)`, which carries the annotation. The fourth is the window query added here. The two do not overlap: the annotation returns the single latest row per host, `recent_jobs` needs the newest five.
- Django has supported filtering against window functions since 4.2, and `requirements.txt` pins Django 5.2.
- The `select_related('job__job_template')` survives the subquery Django wraps the window filter in, so rows still carry the job template without further queries. Verified by reading `j.job.job_template` back with a query counter open.
- The window orders rows inside each partition, but the outer query is free to return them in any order, so each host's list is re-sorted by `-created` in Python. Five items per host.
- Hosts in a constructed inventory reach their runs through `constructed_host` rather than `host`, so they are grouped separately. A page mixing both kinds costs one more query, still constant in the number of hosts.
- The detail view serializes a single host and keeps the existing per-object path. `get_summary_fields()` falls back to it whenever the bulk-loaded attribute is absent, so nothing outside `ListSerializer` has to change.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

Create an inventory whose hosts each have several job host summaries, then request the host list with a counter around the request:

```python
with CaptureQueriesContext(connection) as cap:
    view(request)   # /api/v2/hosts/?inventory=<id>&page_size=200
print(len([q for q in cap.captured_queries if 'main_jobhostsummary' in q['sql']]))
```

The count grows with the number of hosts on the page.

New tests in `awx/main/tests/functional/api/test_host_recent_jobs.py` cover the query count being independent of page size, the five-newest ordering on both list and detail, and hosts that have never run. The query-count test fails on `devel` and passes with this change; the other three pass either way, since the payload is unchanged by design.

Full API suites pass with the change applied:

```
py.test -q awx/main/tests/functional/api/ awx/main/tests/unit/api/
1320 passed, 1 skipped in 689.19s (0:11:29)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved host list responses by efficiently loading recent job summaries in bulk.
  - Response performance now remains consistent as the number of hosts or page size increases.

- **Bug Fixes**
  - Hosts display their five most recent job summaries correctly.
  - Hosts without executed jobs now return an empty recent-jobs list.
  - Host detail views continue to provide accurate recent-job information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->