### PR TITLE
AAP-87829 — Make composite index migration idempotent for upgrade paths

### DIFF
--- a/awx/main/migrations/0206_jobhostsummary_host_id_idx.py
+++ b/awx/main/migrations/0206_jobhostsummary_host_id_idx.py
@@ -7,11 +7,21 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.AddIndex(
-            model_name='jobhostsummary',
-            index=models.Index(
-                fields=['host', '-id'],
-                name='main_jobhostsumm_host_id_desc',
-            ),
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(
+                    sql="CREATE INDEX IF NOT EXISTS main_jobhostsumm_host_id_desc ON main_jobhostsummary (host_id, id DESC)",
+                    reverse_sql="DROP INDEX IF EXISTS main_jobhostsumm_host_id_desc",
+                ),
+            ],
+            state_operations=[
+                migrations.AddIndex(
+                    model_name='jobhostsummary',
+                    index=models.Index(
+                        fields=['host', '-id'],
+                        name='main_jobhostsumm_host_id_desc',
+                    ),
+                ),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary

- Forward-port of [tower#7895](https://github.com/ansible/tower/pull/7895) (stable-2.7)
- Migration `0206_jobhostsummary_host_id_idx` uses plain `AddIndex` which fails if the index already exists
- Customers on 2.6 may have created the index manually via `awx-manage create_host_summary_index` (AAP-87549) or the KCS raw SQL workaround
- Upgrading then fails with `relation "main_jobhostsumm_host_id_desc" already exists`
- Fix: wrap in `SeparateDatabaseAndState` with `CREATE INDEX IF NOT EXISTS`

Jira: [AAP-87829](https://redhat.atlassian.net/browse/AAP-87829)
Related: AAP-87549 (management command), AAP-81728 (2.6 migration backport), AAP-81517 (original composite index)

## Classification

Bug, Docs Fix or other nominal change

## Test plan

- [ ] Upgrade with pre-existing index — migration succeeds (no `relation already exists` error)
- [ ] Fresh install without pre-existing index — migration creates the index normally
- [ ] Verify index exists after migration: `\di main_jobhostsumm_host_id_desc`
- [ ] PostgreSQL 15 test results: [tower#7895 comment](https://github.com/ansible/tower/pull/7895#issuecomment-5281400476)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration handling for the job host summary index.
  * Ensured the index is created and reversed safely while keeping application state consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->