### PR TITLE
AAP-87549 — Add management command to create JobHostSummary composite index

### DIFF
--- a/awx/main/management/commands/create_host_summary_index.py
+++ b/awx/main/management/commands/create_host_summary_index.py
@@ -1,0 +1,59 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+
+
+class Command(BaseCommand):
+    help = 'Creates composite index (host_id, id DESC) on main_jobhostsummary to improve host list query performance.'
+
+    INDEX_NAME = 'main_jobhostsumm_host_id_desc'
+    TABLE_NAME = 'main_jobhostsummary'
+
+    def _index_status(self):
+        """Check whether the index exists in pg_class and whether it is valid.
+
+        Returns:
+            'valid'   - index exists and is usable; no action needed.
+            'invalid' - index exists but was left in an invalid state by a
+                        previous failed CREATE INDEX CONCURRENTLY; must be
+                        dropped before retrying.
+            None      - index does not exist; safe to create.
+        """
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_index.indisvalid " "FROM pg_class JOIN pg_index ON pg_class.oid = pg_index.indexrelid " "WHERE pg_class.relname = %s",
+                [self.INDEX_NAME],
+            )
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return 'valid' if row[0] else 'invalid'
+
+    def handle(self, *args, **options):
+        status = self._index_status()
+
+        if status == 'valid':
+            self.stdout.write(f"Index {self.INDEX_NAME} already exists, nothing to do.")
+            return
+
+        if status == 'invalid':
+            self.stdout.write(f"Dropping invalid index {self.INDEX_NAME} from a previous failed attempt...")
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP INDEX IF EXISTS {self.INDEX_NAME}")
+
+        self.stdout.write(f"Creating index {self.INDEX_NAME} on {self.TABLE_NAME} (host_id, id DESC) concurrently...")
+
+        # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+        connection.ensure_connection()
+        old_autocommit = connection.connection.autocommit
+        connection.connection.autocommit = True
+        try:
+            with connection.cursor() as cursor:
+                # Disable statement_timeout for this session — the customer may
+                # have set ALTER ROLE ... SET statement_timeout which would kill
+                # the index build on large tables.
+                cursor.execute("SET statement_timeout = 0")
+                cursor.execute(f"CREATE INDEX CONCURRENTLY {self.INDEX_NAME} " f"ON {self.TABLE_NAME} (host_id, id DESC)")
+        finally:
+            connection.connection.autocommit = old_autocommit
+
+        self.stdout.write(f"Index {self.INDEX_NAME} created successfully.")


### PR DESCRIPTION
## Summary

- Forward-port of [tower#7893](https://github.com/ansible/tower/pull/7893) (stable-2.6)
- Adds `awx-manage create_host_summary_index` management command
- Creates composite index `(host_id, id DESC)` on `main_jobhostsummary` using `CREATE INDEX CONCURRENTLY`
- Idempotent: detects existing valid/invalid indexes, handles failed prior attempts
- Disables `statement_timeout` for the session to avoid killing the build on large tables

Jira: [AAP-87549](https://redhat.atlassian.net/browse/AAP-87549)
Related: AAP-81728 (composite index migration), AAP-87829 (idempotent migration fix)

## Classification

New or Enhanced Feature

## Test plan

- [ ] `awx-manage create_host_summary_index` creates the index on a fresh database
- [ ] Running the command again reports "already exists, nothing to do"
- [ ] Command handles invalid indexes from failed `CREATE INDEX CONCURRENTLY` attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a database maintenance command to create an optimized host summary index.
  * Automatically detects and replaces an invalid existing index.
  * Performs index creation with minimal service disruption and restores database settings afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->