### PR TITLE
fix: do not delete any of the jwt managed roles during cleanup

### DIFF
--- a/awx/main/migrations/_dab_rbac.py
+++ b/awx/main/migrations/_dab_rbac.py
@@ -429,7 +429,11 @@ def setup_managed_role_definitions(apps, schema_editor):
         )
     )
 
-    unexpected_role_definitions = RoleDefinition.objects.filter(managed=True).exclude(pk__in=[rd.pk for rd in managed_role_definitions])
+    unexpected_role_definitions = (
+        RoleDefinition.objects.filter(managed=True)
+        .exclude(pk__in=[rd.pk for rd in managed_role_definitions])
+        .exclude(name__in=settings.ANSIBLE_BASE_JWT_MANAGED_ROLES)
+    )
     for role_definition in unexpected_role_definitions:
         logger.info(f'Deleting old managed role definition {role_definition.name}, pk={role_definition.pk}')
         role_definition.delete()


### PR DESCRIPTION
##### SUMMARY

The cleanup was deleting any managed role definition not created by setup_managed_role_definitions itself. This also removes JWT-managed roles like Platform Auditor that are created separately and still needed — CASCADE-deleting their user and team assignments in the process.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API




##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
devel
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated role cleanup to preserve JWT-managed role definitions.
  * Prevented configured JWT-managed roles from being removed during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->