### PR TITLE
Handle list_collections() failures gracefully in indirect_instance_count callback

### DIFF
--- a/awx/main/tests/unit/test_indirect_query_discovery.py
+++ b/awx/main/tests/unit/test_indirect_query_discovery.py
@@ -427,8 +427,7 @@ class TestListCollectionsFailureResilience:
     """
 
     @mock.patch('awx.playbooks.library.indirect_instance_count.list_collections')
-    @mock.patch.dict('os.environ', {'AWX_ISOLATED_DATA_DIR': '/tmp/artifacts'})
-    def test_ansible_data_still_written_when_list_collections_raises(self, mock_list_collections):
+    def test_ansible_data_still_written_when_list_collections_raises(self, mock_list_collections, tmp_path):
         from awx.playbooks.library.indirect_instance_count import CallbackModule
 
         mock_list_collections.side_effect = KeyError('ignore_certs')
@@ -445,8 +444,9 @@ class TestListCollectionsFailureResilience:
                 handle.write = lambda data: written.setdefault('data', data)
             return handle
 
-        with mock.patch('builtins.open', side_effect=fake_open):
-            callback.v2_playbook_on_stats(mock.Mock())
+        with mock.patch.dict('os.environ', {'AWX_ISOLATED_DATA_DIR': str(tmp_path)}):
+            with mock.patch('builtins.open', side_effect=fake_open):
+                callback.v2_playbook_on_stats(mock.Mock())
 
         callback._display.warning.assert_called_once()
         assert "ignore_certs" in callback._display.warning.call_args[0][0]
@@ -456,8 +456,7 @@ class TestListCollectionsFailureResilience:
         assert 'ansible_version' in payload
 
     @mock.patch('awx.playbooks.library.indirect_instance_count.list_collections')
-    @mock.patch.dict('os.environ', {'AWX_ISOLATED_DATA_DIR': '/tmp/artifacts'})
-    def test_no_warning_when_list_collections_succeeds(self, mock_list_collections):
+    def test_no_warning_when_list_collections_succeeds(self, mock_list_collections, tmp_path):
         from awx.playbooks.library.indirect_instance_count import CallbackModule
 
         mock_list_collections.return_value = [mock.Mock(namespace='demo', name='query', ver='1.0.0', fqcn='demo.query')]
@@ -466,9 +465,10 @@ class TestListCollectionsFailureResilience:
         callback._display = mock.Mock()
         callback.set_option('collect_host_queries', False)
 
-        with mock.patch('builtins.open', mock.mock_open()):
-            with mock.patch('json.dumps', return_value='{}'):
-                callback.v2_playbook_on_stats(mock.Mock())
+        with mock.patch.dict('os.environ', {'AWX_ISOLATED_DATA_DIR': str(tmp_path)}):
+            with mock.patch('builtins.open', mock.mock_open()):
+                with mock.patch('json.dumps', return_value='{}'):
+                    callback.v2_playbook_on_stats(mock.Mock())
 
         callback._display.warning.assert_not_called()
 

--- a/awx/main/tests/unit/test_indirect_query_discovery.py
+++ b/awx/main/tests/unit/test_indirect_query_discovery.py
@@ -3,6 +3,7 @@ Unit tests for external query discovery and version fallback logic.
 Tests for AAP-58456: Unit Test Suite for External Query Handling
 """
 
+import json
 import sys
 from io import StringIO
 from unittest import mock
@@ -414,6 +415,62 @@ class TestExternalQueryDiscovery:
         mock_list_collections.assert_called_once()
         mock_files.assert_not_called()
         mock_fallback.assert_not_called()
+
+
+class TestListCollectionsFailureResilience:
+    """list_collections() reuses ansible-galaxy CLI internals (with_collection_artifacts_manager)
+    that read CLI-only context.CLIARGS entries directly. Since AAP-74343 this callback always
+    runs (previously it only ran when FEATURE_INDIRECT_NODE_COUNTING_ENABLED was on), so any
+    latent fragility in those internals now affects every job, not just opted-in ones. A failure
+    here should degrade gracefully instead of aborting the whole callback and losing
+    ansible_version/installed_collections for the job.
+    """
+
+    @mock.patch('awx.playbooks.library.indirect_instance_count.list_collections')
+    @mock.patch.dict('os.environ', {'AWX_ISOLATED_DATA_DIR': '/tmp/artifacts'})
+    def test_ansible_data_still_written_when_list_collections_raises(self, mock_list_collections):
+        from awx.playbooks.library.indirect_instance_count import CallbackModule
+
+        mock_list_collections.side_effect = KeyError('ignore_certs')
+
+        callback = CallbackModule()
+        callback._display = mock.Mock()
+        callback.set_option('collect_host_queries', True)
+
+        written = {}
+
+        def fake_open(path, mode='r', *args, **kwargs):
+            handle = mock.mock_open()()
+            if 'w' in mode:
+                handle.write = lambda data: written.setdefault('data', data)
+            return handle
+
+        with mock.patch('builtins.open', side_effect=fake_open):
+            callback.v2_playbook_on_stats(mock.Mock())
+
+        callback._display.warning.assert_called_once()
+        assert "ignore_certs" in callback._display.warning.call_args[0][0]
+
+        payload = json.loads(written['data'])
+        assert payload['installed_collections'] == {}
+        assert 'ansible_version' in payload
+
+    @mock.patch('awx.playbooks.library.indirect_instance_count.list_collections')
+    @mock.patch.dict('os.environ', {'AWX_ISOLATED_DATA_DIR': '/tmp/artifacts'})
+    def test_no_warning_when_list_collections_succeeds(self, mock_list_collections):
+        from awx.playbooks.library.indirect_instance_count import CallbackModule
+
+        mock_list_collections.return_value = [mock.Mock(namespace='demo', name='query', ver='1.0.0', fqcn='demo.query')]
+
+        callback = CallbackModule()
+        callback._display = mock.Mock()
+        callback.set_option('collect_host_queries', False)
+
+        with mock.patch('builtins.open', mock.mock_open()):
+            with mock.patch('json.dumps', return_value='{}'):
+                callback.v2_playbook_on_stats(mock.Mock())
+
+        callback._display.warning.assert_not_called()
 
 
 class TestPrivateDataDirIntegration:

--- a/awx/playbooks/library/indirect_instance_count.py
+++ b/awx/playbooks/library/indirect_instance_count.py
@@ -178,7 +178,20 @@ class CallbackModule(CallbackBase):
         collect_host_queries = self.get_option('collect_host_queries')
 
         collections_print = {}
-        for candidate in list_collections():
+        try:
+            candidates = list_collections()
+        except Exception as exc:
+            # list_collections() reuses ansible-core's ansible-galaxy CLI internals
+            # (with_collection_artifacts_manager), which assume they are always invoked
+            # from the ansible-galaxy CLI and read CLI-only context.CLIARGS entries
+            # directly. Outside that CLI context (i.e. here, in a playbook run) those
+            # entries are absent, so ansible-core can raise unexpectedly. Degrade to an
+            # empty collection list instead of losing ansible_version/installed_collections
+            # for the whole job.
+            self._display.warning(f"indirect_instance_count: failed to enumerate installed collections, skipping: {exc}")
+            candidates = []
+
+        for candidate in candidates:
             collection_print = {
                 'version': candidate.ver,
             }


### PR DESCRIPTION
## Summary

- `indirect_instance_count`'s `list_collections()` reuses ansible-core's `ansible-galaxy` CLI internals (`with_collection_artifacts_manager`), which read CLI-only `context.CLIARGS` entries directly (e.g. `concrete_artifact_manager.py` / `ansible/utils/galaxy.py` do a bare `context.CLIARGS['ignore_certs']` dict access). Outside a CLI context — such as this playbook callback — `CLIARGS` is empty, so ansible-core can raise unexpectedly (`KeyError: 'ignore_certs'`).
- Since #16453 (AAP-74343) this callback runs **unconditionally on every job**, whereas previously it only ran when `FEATURE_INDIRECT_NODE_COUNTING_ENABLED` was on. That change (correctly) decoupled baseline `installed_collections`/`ansible_version` persistence from the feature flag, but as a side effect it took this pre-existing `list_collections()` fragility from "only affects opted-in tech-preview installs" to "affects every job on every AWX/AAP install." Neither the PR discussion nor its tests exercised this failure path.
- Today, when it happens, the whole callback aborts: `ansible_data.json` is never written, `installed_collections`/`ansible_version` are lost for the job, and the operator sees a generic, confusing warning:
  ```
  [WARNING]: Failure using method (v2_playbook_on_stats) in callback plugin (...): 'ignore_certs'
  ```
- This PR wraps the `list_collections()` call so a failure degrades to an empty collection list instead of aborting the callback. `ansible_version` still gets persisted (the original goal of AAP-74343) — only `installed_collections` is empty for that job — and the warning now identifies the actual failure instead of a bare `KeyError` repr.

## Reproduction

I could not yet trigger the underlying ansible-core `KeyError` "naturally" from a clean collection set — I tested this callback end-to-end against ansible-core 2.16.19, 2.19.11, and 2.21.2, and against a live AAP 2.7 install (real `ee-supported-rhel9` execution environment), all clean. But the failure mode is real and reproducible by construction: `list_collections()`'s `find_existing_collections()` call can reach ansible-core code paths that do bare `context.CLIARGS[...]` lookups, and `context.CLIARGS` is provably empty outside the `ansible-galaxy` CLI. Forcing `list_collections()` to raise reproduces the exact reported warning text byte-for-byte, and the fix in this PR resolves it — see the new test class `TestListCollectionsFailureResilience`.

## Issue Type

Bug, Docs Fix or other nominal change

## Test plan

- [x] New test: `ansible_data.json` is still written (with `ansible_version` populated, `installed_collections` empty) when `list_collections()` raises
- [x] New test: no spurious warning is logged when `list_collections()` succeeds normally
- [x] Existing `test_indirect_query_discovery.py` suite (13 tests) still passes unchanged
- [x] `black --check` clean at the repo's configured line-length/settings
- [ ] CI

## Related

- Red Hat Jira: [AAP-87979](https://issues.redhat.com/browse/AAP-87979)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when discovering installed Ansible collections.
  * Ansible metadata is now still written if collection discovery fails.
  * Discovery errors generate a warning instead of interrupting processing.
  * Successful collection discovery continues without unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->