### PR TITLE
[AAP-86775] Remove dab_post_migrate hook, use data migration for member_organization

### DIFF
--- a/awx/main/apps.py
+++ b/awx/main/apps.py
@@ -67,28 +67,5 @@ class MainConfig(AppConfig):
         super().ready()
 
         self.configure_dispatcherd()
-
-        from ansible_base.rbac.triggers import dab_post_migrate
-
-        dab_post_migrate.connect(self._sync_managed_role_definitions, dispatch_uid='awx-sync-managed-role-definitions')
-
         self.load_named_url_feature()
         pre_migrate.connect(self.check_db_requirement, sender=self)
-
-    @staticmethod
-    def _sync_managed_role_definitions(sender, **kwargs):
-        from django.apps import apps as global_apps
-
-        from ansible_base.resource_registry.signals.handlers import no_reverse_sync
-
-        # NOTE: setup_managed_role_definitions lives in the migrations module because
-        # it is also called from migration 0192. Ideally this would be extracted to a
-        # shared non-migration module, but doing so requires updating the migration
-        # import, which is a broader refactor (see also models/rbac.py imports).
-        from awx.main.migrations._dab_rbac import setup_managed_role_definitions
-
-        # During post-migrate the resource server (gateway) may not be ready
-        # (e.g. migrate_service_data still holds a 423 lock).  Disable reverse
-        # sync for this call — gateway reconciles via migrate_service_data.
-        with no_reverse_sync():
-            setup_managed_role_definitions(global_apps, None)

--- a/awx/main/migrations/0208_add_member_organization_to_org_child_admins.py
+++ b/awx/main/migrations/0208_add_member_organization_to_org_child_admins.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+ORG_CHILD_ADMIN_ROLES = [
+    'Organization Project Admin',
+    'Organization Credential Admin',
+    'Organization Inventory Admin',
+    'Organization NotificationTemplate Admin',
+    'Organization WorkflowJobTemplate Admin',
+    'Organization ExecutionEnvironment Admin',
+]
+
+
+def add_member_organization_perm(apps, schema_editor):
+    """
+    Add member_organization permission to Organization *Child* Admin roles.
+
+    Without this permission, users granted these roles receive 403 on create
+    (POST) operations even though the specific add_* permission is present.
+    See: AAP-82221
+    """
+    RoleDefinition = apps.get_model('dab_rbac', 'RoleDefinition')
+    DABPermission = apps.get_model('dab_rbac', 'DABPermission')
+
+    try:
+        DABContentType = apps.get_model('dab_rbac', 'DABContentType')
+    except LookupError:
+        DABContentType = apps.get_model('contenttypes', 'ContentType')
+
+    Organization = apps.get_model('main', 'Organization')
+    org_ct = DABContentType.objects.get_for_model(Organization)
+
+    member_perm = DABPermission.objects.filter(codename='member_organization', content_type=org_ct).first()
+    if not member_perm:
+        return
+
+    for rd in RoleDefinition.objects.filter(name__in=ORG_CHILD_ADMIN_ROLES, managed=True):
+        rd.permissions.add(member_perm)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('main', '0207_alter_skip_tags_to_textfield'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_member_organization_perm, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
##### SUMMARY

- Removes the `dab_post_migrate` signal handler that calls `setup_managed_role_definitions` on every `manage.py migrate` run
- Replaces it with a one-time data migration (0208) that adds `member_organization` to the 6 Organization Child Admin roles

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - API

##### ROOT CAUSE

PR #16545 connected `setup_managed_role_definitions` to `dab_post_migrate` to ensure existing installs get `member_organization` added on upgrade. However, this causes `setup_managed_role_definitions` to run a second time after all migrations complete, using `DABContentType` (from `dab_rbac.0002`) instead of `contenttypes.ContentType` (used by the first run in migration 0192). The FK mismatch causes `Permission.objects.filter(content_type=ct)` to return partial results, overwriting Organization Admin permissions from 46 down to a subset — breaking create/update/delete operations for inventory, project, and job_template resources.

Additionally, the cleanup block deletes managed RoleDefinitions not in its creation list, CASCADE-deleting JWT-managed roles like Platform Auditor (partially addressed by #16590).

##### EVIDENCE FROM PIPELINE

- Build 127 (Aug 5-6, first build after tower 7614 backport): RBAC tests start failing
- All Organization Admin tests fail (16/18), while object-level roles (Inventory Admin) pass (18/18)
- Specifically: create_inventories, create_projects, create_job_templates, launch_job all get 403
- create_credentials passes (partial ContentType mapping)
- Controller migration log confirms second `setup_managed_role_definitions` run and Platform Auditor deletion

##### FIX APPROACH

A data migration is the correct Django pattern for a one-time permission fixup on upgrade. It:
- Runs once (not on every future migrate)
- Uses correct migration-state models (no ContentType mismatch)
- Touches only the 6 roles that need `member_organization`
- Has no side effects (no deletion, no permission overwrite)

Closes: https://redhat.atlassian.net/browse/AAP-86775

---
**Note:** This PR was developed with assistance from Claude AI assistant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organization Child Admin roles now include permission to manage member organizations when available.

* **Maintenance**
  * Improved role permission handling during database migrations.
  * Existing URL loading and pre-migration validation remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->