### PR TITLE
fix: scope inventory lookup by organization

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -537,8 +537,8 @@ class ControllerAPIModule(ControllerModule):
     def get_exactly_one(self, endpoint, name_or_id=None, **kwargs):
         return self.get_one(endpoint, name_or_id=name_or_id, allow_none=False, **kwargs)
 
-    def resolve_name_to_id(self, endpoint, name_or_id):
-        return self.get_exactly_one(endpoint, name_or_id)['id']
+    def resolve_name_to_id(self, endpoint, name_or_id, **kwargs):
+        return self.get_exactly_one(endpoint, name_or_id, **kwargs)['id']
 
     def is_retryable(self, status_code, method, endpoint):
         """

--- a/awx_collection/plugins/modules/inventory.py
+++ b/awx_collection/plugins/modules/inventory.py
@@ -221,7 +221,9 @@ def main():
         if input_inventory_names is not None:
             association_fields['input_inventories'] = []
             for item in input_inventory_names:
-                association_fields['input_inventories'].append(module.resolve_name_to_id('inventories', item))
+                association_fields['input_inventories'].append(
+    module.resolve_name_to_id('inventories', item, data={'organization': org_id})
+)
 
     # If the state was present and we can let the module build or update the existing inventory, this will return on its own
     module.create_or_update_if_needed(


### PR DESCRIPTION
## Summary

Scope constructed inventory input inventory lookups to the selected organization.

## Changes

- Allow `resolve_name_to_id()` to accept additional lookup parameters.
- Pass the organization when resolving `input_inventories`.

## Testing

- `python -m compileall awx_collection/plugins/modules/inventory.py awx_collection/plugins/module_utils/controller_api.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inventory name lookups are now correctly scoped to the selected organization.
  * Inventory-related operations can pass additional request options when resolving names to IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->