### PR TITLE
fix(notifications): include optional api url prefix in job notification urls

### DIFF
--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -322,6 +322,7 @@ class JobNotificationMixin(object):
         """Returns a stub context that can be used for validating notification messages.
         Context has the same structure as the context that will actually be used to render
         a notification message."""
+        _prefix = settings.OPTIONAL_API_URLPATTERN_PREFIX.strip('/')
         context = {
             'job': {
                 'allow_simultaneous': False,
@@ -390,9 +391,7 @@ class JobNotificationMixin(object):
                 },
                 'timeout': 0,
                 'type': 'job',
-                'url': '/api/{prefix}v2/jobs/13/'.format(
-                    prefix=f"{settings.OPTIONAL_API_URLPATTERN_PREFIX.strip('/')}/" if settings.OPTIONAL_API_URLPATTERN_PREFIX else ""
-                ),
+                'url': '/api/{prefix}v2/jobs/13/'.format(prefix=f"{_prefix}/" if _prefix else ""),
                 'use_fact_cache': False,
                 'verbosity': 0,
             },
@@ -468,8 +467,8 @@ class JobNotificationMixin(object):
         from awx.api.serializers import UnifiedJobSerializer
 
         job_serialization = UnifiedJobSerializer(self).to_representation(self)
-        if job_serialization.get('url') and settings.OPTIONAL_API_URLPATTERN_PREFIX:
-            prefix = settings.OPTIONAL_API_URLPATTERN_PREFIX.strip('/')
+        prefix = settings.OPTIONAL_API_URLPATTERN_PREFIX.strip('/')
+        if job_serialization.get('url') and prefix:
             job_serialization['url'] = job_serialization['url'].replace('/api/', f'/api/{prefix}/', 1)
         context = self.context(job_serialization)
 

--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -391,7 +391,7 @@ class JobNotificationMixin(object):
                 'timeout': 0,
                 'type': 'job',
                 'url': '/api/{prefix}v2/jobs/13/'.format(
-                    prefix=f"{settings.OPTIONAL_API_URLPATTERN_PREFIX}/" if settings.OPTIONAL_API_URLPATTERN_PREFIX else ""
+                    prefix=f"{settings.OPTIONAL_API_URLPATTERN_PREFIX.strip('/')}/" if settings.OPTIONAL_API_URLPATTERN_PREFIX else ""
                 ),
                 'use_fact_cache': False,
                 'verbosity': 0,

--- a/awx/main/models/notifications.py
+++ b/awx/main/models/notifications.py
@@ -390,7 +390,9 @@ class JobNotificationMixin(object):
                 },
                 'timeout': 0,
                 'type': 'job',
-                'url': '/api/v2/jobs/13/',
+                'url': '/api/{prefix}v2/jobs/13/'.format(
+                    prefix=f"{settings.OPTIONAL_API_URLPATTERN_PREFIX}/" if settings.OPTIONAL_API_URLPATTERN_PREFIX else ""
+                ),
                 'use_fact_cache': False,
                 'verbosity': 0,
             },
@@ -466,6 +468,9 @@ class JobNotificationMixin(object):
         from awx.api.serializers import UnifiedJobSerializer
 
         job_serialization = UnifiedJobSerializer(self).to_representation(self)
+        if job_serialization.get('url') and settings.OPTIONAL_API_URLPATTERN_PREFIX:
+            prefix = settings.OPTIONAL_API_URLPATTERN_PREFIX.strip('/')
+            job_serialization['url'] = job_serialization['url'].replace('/api/', f'/api/{prefix}/', 1)
         context = self.context(job_serialization)
 
         msg_template = body_template = None

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -177,6 +177,21 @@ class TestJobNotificationMixin(object):
         assert msg == f'/api/myprefix/v2/jobs/{job.pk}/'
         assert body == f'/api/myprefix/v2/jobs/{job.pk}/'
 
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='///')
+    def test_context_stub_url_prefix_all_slashes(self):
+        context = JobNotificationMixin.context_stub()
+        assert context['job']['url'] == '/api/v2/jobs/13/'
+
+    @pytest.mark.django_db
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='///')
+    def test_build_notification_message_url_prefix_all_slashes(self, notification_template):
+        notification_template.messages = {'started': {'message': '{{ job.url }}', 'body': '{{ job.url }}'}}
+        notification_template.save()
+        job = Job.objects.create(name='test-job')
+        msg, body = job.build_notification_message(notification_template, 'running')
+        assert msg == f'/api/v2/jobs/{job.pk}/'
+        assert body == f'/api/v2/jobs/{job.pk}/'
+
     def test_context_stub(self):
         """The context stub is a fake context used to validate custom notification messages. Ensure that
         this also has the expected structure. Furthermore, ensure that the stub context contains

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -3,6 +3,7 @@ from copy import deepcopy
 import datetime
 
 import pytest
+from django.test import override_settings
 
 # from awx.main.models import NotificationTemplates, Notifications, JobNotificationMixin
 from awx.main.models import AdHocCommand, InventoryUpdate, Job, JobNotificationMixin, ProjectUpdate, Schedule, SystemJob, WorkflowJob
@@ -130,6 +131,45 @@ class TestJobNotificationMixin(object):
         job_serialization = UnifiedJobSerializer(job).to_representation(job)
         context = job.context(job_serialization)
         assert '批量安装项目' in context['job_metadata']
+
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='')
+    def test_context_stub_url_no_prefix(self):
+        context = JobNotificationMixin.context_stub()
+        assert context['job']['url'] == '/api/v2/jobs/13/'
+
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='myprefix')
+    def test_context_stub_url_with_prefix(self):
+        context = JobNotificationMixin.context_stub()
+        assert context['job']['url'] == '/api/myprefix/v2/jobs/13/'
+
+    @pytest.mark.django_db
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='')
+    def test_build_notification_message_url_no_prefix(self, notification_template):
+        notification_template.messages = {'started': {'message': '{{ job.url }}', 'body': '{{ job.url }}'}}
+        notification_template.save()
+        job = Job.objects.create(name='test-job')
+        msg, body = job.build_notification_message(notification_template, 'running')
+        assert '/api/v2/' in body
+        assert 'myprefix' not in body
+
+    @pytest.mark.django_db
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='myprefix')
+    def test_build_notification_message_url_with_prefix(self, notification_template):
+        notification_template.messages = {'started': {'message': '{{ job.url }}', 'body': '{{ job.url }}'}}
+        notification_template.save()
+        job = Job.objects.create(name='test-job')
+        msg, body = job.build_notification_message(notification_template, 'running')
+        assert '/api/myprefix/v2/' in body
+
+    @pytest.mark.django_db
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='/myprefix/')
+    def test_build_notification_message_url_prefix_strips_slashes(self, notification_template):
+        notification_template.messages = {'started': {'message': '{{ job.url }}', 'body': '{{ job.url }}'}}
+        notification_template.save()
+        job = Job.objects.create(name='test-job')
+        msg, body = job.build_notification_message(notification_template, 'running')
+        assert '/api/myprefix/v2/' in body
+        assert '/api//myprefix//' not in body
 
     def test_context_stub(self):
         """The context stub is a fake context used to validate custom notification messages. Ensure that

--- a/awx/main/tests/functional/models/test_notifications.py
+++ b/awx/main/tests/functional/models/test_notifications.py
@@ -142,6 +142,11 @@ class TestJobNotificationMixin(object):
         context = JobNotificationMixin.context_stub()
         assert context['job']['url'] == '/api/myprefix/v2/jobs/13/'
 
+    @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='/myprefix/')
+    def test_context_stub_url_prefix_strips_slashes(self):
+        context = JobNotificationMixin.context_stub()
+        assert context['job']['url'] == '/api/myprefix/v2/jobs/13/'
+
     @pytest.mark.django_db
     @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='')
     def test_build_notification_message_url_no_prefix(self, notification_template):
@@ -149,8 +154,8 @@ class TestJobNotificationMixin(object):
         notification_template.save()
         job = Job.objects.create(name='test-job')
         msg, body = job.build_notification_message(notification_template, 'running')
-        assert '/api/v2/' in body
-        assert 'myprefix' not in body
+        assert msg == f'/api/v2/jobs/{job.pk}/'
+        assert body == f'/api/v2/jobs/{job.pk}/'
 
     @pytest.mark.django_db
     @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='myprefix')
@@ -159,7 +164,8 @@ class TestJobNotificationMixin(object):
         notification_template.save()
         job = Job.objects.create(name='test-job')
         msg, body = job.build_notification_message(notification_template, 'running')
-        assert '/api/myprefix/v2/' in body
+        assert msg == f'/api/myprefix/v2/jobs/{job.pk}/'
+        assert body == f'/api/myprefix/v2/jobs/{job.pk}/'
 
     @pytest.mark.django_db
     @override_settings(OPTIONAL_API_URLPATTERN_PREFIX='/myprefix/')
@@ -168,8 +174,8 @@ class TestJobNotificationMixin(object):
         notification_template.save()
         job = Job.objects.create(name='test-job')
         msg, body = job.build_notification_message(notification_template, 'running')
-        assert '/api/myprefix/v2/' in body
-        assert '/api//myprefix//' not in body
+        assert msg == f'/api/myprefix/v2/jobs/{job.pk}/'
+        assert body == f'/api/myprefix/v2/jobs/{job.pk}/'
 
     def test_context_stub(self):
         """The context stub is a fake context used to validate custom notification messages. Ensure that


### PR DESCRIPTION
##### SUMMARY
Notification payloads included hardcoded `/api/v2/` URLs that did not
respect the `OPTIONAL_API_URLPATTERN_PREFIX` setting. When AWX is
deployed with a custom API URL prefix, the `url` field in outbound job
notifications pointed to an unreachable path.

Two fixes are applied in `notifications.py`:
1. The test fixture URL is made dynamic using the prefix setting.
2. Before the notification context is assembled, the serialized job URL
   is rewritten to inject the prefix when one is configured.

related AAP-63939

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### COMPONENT NAME
- API

##### STEPS TO REPRODUCE AND EXTRA INFO
1. Deploy AWX with `OPTIONAL_API_URLPATTERN_PREFIX` set to a non-empty value (e.g. `awx`).
2. Trigger a job that has a notification template attached.
3. Observe that the `url` field in the notification payload is `/api/v2/jobs/<id>/` instead of `/api/awx/v2/jobs/<id>/`.

After this fix the URL in the notification payload correctly includes the configured prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notification messages now use the configured API URL prefix when generating links.
  * Notification context URLs and serialized job links are rendered with the correct API path.
  * API URL prefixes are normalized to prevent duplicate slashes.
  * Links remain correctly formatted whether the prefix is empty, includes surrounding slashes, or consists entirely of slashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->