### PR TITLE
fix: disable mintmaker to run pipeline-migration-tool

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,9 @@
   "tekton": {
     "enabled": true,
     "automerge": true,
-    "schedule": ["* */12 * * 1-5"]
+    "schedule": ["* */12 * * 1-5"],
+    "postUpgradeTasks": {
+      "commands": []
+    }
   }
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->
When mintmaker bumps tekton resources it is failing on running the pipeline-migration-tool. This runs as a post upgrade task and fails when trying to run against tekton bundles. Disabling this to allow CI checks to pass and merge updated pipeline bundles.

It is failing because we use tekton bundles and not inline pipelineSpec.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency maintenance settings while preserving the existing weekday schedule.
  * Added an explicit configuration for post-update tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->