### PR TITLE
ANSTRAT-2273 — Add EXECUTION_NODE_REAP_DELAY to preserve jobs during transient disconnects

### DIFF
--- a/awx/main/tasks/system.py
+++ b/awx/main/tasks/system.py
@@ -781,11 +781,88 @@ def _heartbeat_check_versions(this_inst, instance_list):
 
 
 def _heartbeat_handle_lost_instances(lost_instances, this_inst):
-    """Handle lost instances by reaping their running jobs and marking them offline."""
+    """Handle lost instances by reaping their running jobs and marking them offline.
+
+    When EXECUTION_NODE_REAP_DELAY > 0, execution/hop node job reaping is
+    delayed to allow transient disconnects to recover. The node is marked
+    UNAVAILABLE immediately (zero capacity), but running jobs are preserved
+    until the reap deadline passes.
+    """
+    nowtime = now()
     for other_inst in lost_instances:
+        if (
+            settings.EXECUTION_NODE_REAP_DELAY > 0
+            and other_inst.node_type in ('execution', 'hop')
+            and other_inst.last_seen is not None
+        ):
+            grace_period = (
+                settings.CLUSTER_NODE_HEARTBEAT_PERIOD
+                * settings.CLUSTER_NODE_MISSED_HEARTBEAT_TOLERANCE
+            )
+            if other_inst.node_type in ('execution', 'hop'):
+                grace_period += settings.RECEPTOR_SERVICE_ADVERTISEMENT_PERIOD
+            unavailable_since = other_inst.last_seen + timedelta(seconds=grace_period)
+            reap_deadline = unavailable_since + timedelta(
+                seconds=settings.EXECUTION_NODE_REAP_DELAY
+            )
+            elapsed_since_lost = (nowtime - unavailable_since).total_seconds()
+            time_until_reap = (reap_deadline - nowtime).total_seconds()
+
+            if nowtime < reap_deadline:
+                if other_inst.node_state == Instance.States.READY:
+                    other_inst.mark_offline(
+                        errors=_(
+                            'Instance unreachable. Jobs preserved for %(delay)s seconds '
+                            'pending reconnection.'
+                        ) % {'delay': settings.EXECUTION_NODE_REAP_DELAY}
+                    )
+                    running_jobs = UnifiedJob.objects.filter(
+                        status='running', execution_node=other_inst.hostname
+                    ).count()
+                    logger.warning(
+                        'Instance %s unreachable (last_seen %s). '
+                        'Marked UNAVAILABLE, preserving %d running job(s). '
+                        'Will reap at %s (in %.0fs). [REAP_DELAY=%d]',
+                        other_inst.hostname, other_inst.last_seen,
+                        running_jobs,
+                        reap_deadline.strftime('%H:%M:%S UTC'),
+                        time_until_reap,
+                        settings.EXECUTION_NODE_REAP_DELAY,
+                    )
+                else:
+                    logger.info(
+                        'Instance %s still unreachable (%.0fs since lost, '
+                        'reap in %.0fs). Jobs preserved.',
+                        other_inst.hostname, elapsed_since_lost, time_until_reap,
+                    )
+                continue
+
+            running_jobs = UnifiedJob.objects.filter(
+                status='running', execution_node=other_inst.hostname
+            ).count()
+            logger.warning(
+                'Instance %s unreachable for %.0fs (REAP_DELAY=%d exceeded). '
+                'Reaping %d running job(s).',
+                other_inst.hostname, elapsed_since_lost,
+                settings.EXECUTION_NODE_REAP_DELAY, running_jobs,
+            )
+
         try:
-            # Any jobs marked as running will be marked as error
-            explanation = "Job reaped due to instance shutdown"
+            if (
+                settings.EXECUTION_NODE_REAP_DELAY > 0
+                and other_inst.node_type in ('execution', 'hop')
+            ):
+                explanation = (
+                    'Execution node unreachable for %d seconds '
+                    '(EXECUTION_NODE_REAP_DELAY=%d exceeded)'
+                    % (
+                        int((nowtime - other_inst.last_seen).total_seconds())
+                        if other_inst.last_seen else 0,
+                        settings.EXECUTION_NODE_REAP_DELAY,
+                    )
+                )
+            else:
+                explanation = "Job reaped due to instance shutdown"
             reaper.reap(other_inst, job_explanation=explanation)
             # Any jobs that were waiting to be processed by this node will be handed back to task manager
             UnifiedJob.objects.filter(status='waiting', controller_node=other_inst.hostname).update(status='pending', controller_node='', execution_node='')

--- a/awx/main/tests/functional/test_dispatch.py
+++ b/awx/main/tests/functional/test_dispatch.py
@@ -101,6 +101,77 @@ class TestJobReaper(object):
         assert job.controller_node == ''
         assert job.execution_node == ''
 
+    def test_reap_delay_preserves_running_jobs(self, mocker):
+        """When EXECUTION_NODE_REAP_DELAY > 0 and the reap deadline has not passed,
+        running jobs on lost execution nodes should be preserved."""
+        mocker.patch('awx.main.tasks.system.settings.EXECUTION_NODE_REAP_DELAY', 300)
+        mocker.patch('awx.main.tasks.system.settings.CLUSTER_NODE_HEARTBEAT_PERIOD', 60)
+        mocker.patch('awx.main.tasks.system.settings.CLUSTER_NODE_MISSED_HEARTBEAT_TOLERANCE', 2)
+        mocker.patch('awx.main.tasks.system.settings.RECEPTOR_SERVICE_ADVERTISEMENT_PERIOD', 60)
+
+        this_inst = Instance(hostname='awx')
+        this_inst.save()
+        lost_inst = Instance(
+            hostname='lost-exec',
+            node_type=Instance.Types.EXECUTION,
+            node_state=Instance.States.READY,
+            last_seen=tz_now() - datetime.timedelta(seconds=200),
+        )
+        lost_inst.save()
+        job = Job.objects.create(status='running', execution_node=lost_inst.hostname)
+
+        system._heartbeat_handle_lost_instances([lost_inst], this_inst)
+
+        job.refresh_from_db()
+        lost_inst.refresh_from_db()
+        assert job.status == 'running'
+        assert lost_inst.node_state == Instance.States.UNAVAILABLE
+
+    def test_reap_delay_reaps_after_deadline(self, mocker):
+        """When the reap deadline has passed, jobs should be reaped with a descriptive explanation."""
+        mocker.patch('awx.main.tasks.system.settings.EXECUTION_NODE_REAP_DELAY', 300)
+        mocker.patch('awx.main.tasks.system.settings.CLUSTER_NODE_HEARTBEAT_PERIOD', 60)
+        mocker.patch('awx.main.tasks.system.settings.CLUSTER_NODE_MISSED_HEARTBEAT_TOLERANCE', 2)
+        mocker.patch('awx.main.tasks.system.settings.RECEPTOR_SERVICE_ADVERTISEMENT_PERIOD', 60)
+
+        this_inst = Instance(hostname='awx')
+        this_inst.save()
+        lost_inst = Instance(
+            hostname='lost-exec',
+            node_type=Instance.Types.EXECUTION,
+            node_state=Instance.States.READY,
+            last_seen=tz_now() - datetime.timedelta(seconds=600),
+        )
+        lost_inst.save()
+        job = Job.objects.create(status='running', execution_node=lost_inst.hostname, controller_node='')
+
+        system._heartbeat_handle_lost_instances([lost_inst], this_inst)
+
+        job.refresh_from_db()
+        assert job.status == 'failed'
+        assert 'EXECUTION_NODE_REAP_DELAY' in job.job_explanation
+
+    def test_reap_delay_zero_immediate_reap(self, mocker):
+        """When EXECUTION_NODE_REAP_DELAY is 0, jobs should be reaped immediately (legacy behavior)."""
+        mocker.patch('awx.main.tasks.system.settings.EXECUTION_NODE_REAP_DELAY', 0)
+
+        this_inst = Instance(hostname='awx')
+        this_inst.save()
+        lost_inst = Instance(
+            hostname='lost-exec',
+            node_type=Instance.Types.EXECUTION,
+            node_state=Instance.States.READY,
+            last_seen=tz_now() - datetime.timedelta(seconds=200),
+        )
+        lost_inst.save()
+        job = Job.objects.create(status='running', execution_node=lost_inst.hostname, controller_node='')
+
+        system._heartbeat_handle_lost_instances([lost_inst], this_inst)
+
+        job.refresh_from_db()
+        assert job.status == 'failed'
+        assert 'instance shutdown' in job.job_explanation
+
     @pytest.mark.parametrize(
         'excluded_uuids, fail, started',
         [

--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -420,6 +420,10 @@ CLUSTER_NODE_MISSED_HEARTBEAT_TOLERANCE = 2
 RECEPTOR_SERVICE_ADVERTISEMENT_PERIOD = 60  # https://github.com/ansible/receptor/blob/aa1d589e154d8a0cb99a220aff8f98faf2273be6/pkg/netceptor/netceptor.go#L34
 EXECUTION_NODE_REMEDIATION_CHECKS = 60 * 30  # once every 30 minutes check if an execution node errors have been resolved
 
+# Seconds to delay reaping jobs on lost execution/hop nodes.
+# 0 = immediate reap (legacy behavior).
+# >0 = delay reap to allow transient disconnects to recover.
+EXECUTION_NODE_REAP_DELAY = 300
 # Amount of time dispatcher will try to reconnect to database for jobs and consuming new work
 DISPATCHER_DB_DOWNTIME_TOLERANCE = 40
 


### PR DESCRIPTION
##### SUMMARY

When an execution or hop node becomes temporarily unreachable (network blip, hop restart, transient partition), the controller immediately reaps all running jobs on that node with "Job reaped due to instance shutdown" — even though the ansible-runner process on the EE is still alive and the playbook is still running.

This PR adds `EXECUTION_NODE_REAP_DELAY` (default: 300 seconds) to delay job reaping for execution and hop nodes, giving the mesh time to reconnect before killing jobs.

**How it works:**
- Node detected as lost → marked UNAVAILABLE immediately (zero capacity, no new work dispatched)
- Running jobs are **preserved** until `last_seen + grace_period + EXECUTION_NODE_REAP_DELAY`
- If the node reconnects before the deadline → jobs continue normally
- If the deadline passes → jobs are reaped with a descriptive explanation
- Set `EXECUTION_NODE_REAP_DELAY = 0` to restore legacy immediate-reap behavior

**Timing with defaults** (TOLERANCE=2, PERIOD=60s, AD_PERIOD=60s):
- Detection: 180s after last heartbeat
- Reap deadline: 480s after last heartbeat (180s + 300s delay)

**No migration required** — the reap deadline is computed from the existing `last_seen` field.

**Validated on a live HADR cluster:**
- SC-039: Job survived 300s full network disconnect, completed normally after restore
- SC-016 (krkn, 300s sustained loss): 300s jobs had zero outage
- SC-017 (krkn, network flapping): score 93/100, 5/6 SLOs passed
- ansible-runner confirmed isolated from mesh (writes to file, not pipe — SIGPIPE impossible)
- Receptor confirmed to reconnect automatically with backoff + startpos resume

related AAPRFE-583

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

To reproduce the problem (without this fix):
1. Launch a long-running job on an external execution node
2. Block receptor port 27199 from controller pods (or kill a hop node)
3. Wait ~180s — the controller marks the node as lost and reaps all running jobs
4. The ansible-runner process on the EE is still alive and the playbook completes, but the controller has already marked the job as `error`

With this fix:
- The job is preserved for an additional 300s (configurable)
- If connectivity is restored within that window, the job continues normally
- Controller logs show: "Instance X unreachable. Marked UNAVAILABLE, preserving N running job(s). Will reap at HH:MM:SS UTC (in Ns)."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable five-minute delay before reaping jobs on unreachable execution and hop nodes.
  * Unreachable nodes are marked unavailable immediately while active jobs remain preserved during the delay.
  * Jobs are automatically reaped after the delay with an explanation specific to the lost node.

* **Configuration**
  * Set the delay to `0` to retain immediate job reaping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->