### PR TITLE
AAP-88824 Drop Python 3.11 references from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 -include awx/ui/Makefile
 
-PYTHON := $(notdir $(shell for i in python3.12 python3.11 python3; do command -v $$i; done|sed 1q))
+PYTHON := $(notdir $(shell for i in python3.12 python3; do command -v $$i; done|sed 1q))
 SHELL := bash
 DOCKER_COMPOSE ?= docker compose
 OFFICIAL ?= no
@@ -28,7 +28,7 @@ TEST_DIRS ?= awx/main/tests/unit awx/main/tests/functional awx/conf/tests
 PARALLEL_TESTS ?= -n auto
 # collection integration test directories (defaults to all)
 COLLECTION_TEST_TARGET ?=
-# Python version for ansible-test (must be 3.11, 3.12, or 3.13)
+# Python version for ansible-test (must be 3.12 or 3.13)
 ANSIBLE_TEST_PYTHON_VERSION ?= 3.13
 # args for collection install
 COLLECTION_PACKAGE ?= awx


### PR DESCRIPTION
## Summary
- Remove python3.11 from the PYTHON discovery fallback chain in Makefile (3.12 is already first, python3 is the catch-all)
- Update ansible-test version comment to reflect 3.12+ only

Dockerfile.dev, Dockerfile.j2 template, and CI workflows were already on 3.12+. This cleans up the last two 3.11 references.

## Test plan
- [ ] Verify `make` still finds python correctly on dev machines
- [ ] Verify CI passes (no 3.11 matrix entries existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated Python discovery to prioritize Python 3.12, with fallback support for the system’s default Python 3 installation.
  * Removed automatic selection of Python 3.11.

* **Documentation**
  * Clarified that ansible-test supports Python 3.12 and Python 3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API