### PR TITLE
Add export options to omit inventory hosts and groups

### DIFF
--- a/awx_collection/plugins/modules/export.py
+++ b/awx_collection/plugins/modules/export.py
@@ -91,6 +91,24 @@ options:
         - schedule names, IDs, or named URLs to export
       type: list
       elements: str
+    exclude_inventory_children:
+      description:
+        - Names or IDs of inventories whose hosts and groups will be left out of the export.
+        - The inventories themselves are still exported.
+        - Inventory sources are a separate asset type, so select I(inventory_sources) as well if the omitted
+          hosts and groups are meant to be recreated by a source synchronization after an import.
+        - Note that manually added hosts and groups are omitted as well, and no source will restore them.
+      type: list
+      elements: str
+    exclude_dynamic_inventory_children:
+      description:
+        - Leave the hosts and groups of every inventory that has at least one inventory source out of the export.
+        - Inventory sources are a separate asset type, so select I(inventory_sources) as well, otherwise the
+          export carries neither the children nor the sources that would recreate them.
+        - Given that, the omitted hosts and groups are recreated when the sources are synchronized after an import.
+        - Note that manually added hosts and groups of such an inventory are omitted as well, and no source will restore them.
+      type: bool
+      default: false
 requirements:
   - "awxkit >= 9.3.0"
 notes:
@@ -115,6 +133,20 @@ EXAMPLES = '''
 - name: Export a list of inventories
   export:
     inventory: ['My Inventory 1', 'My Inventory 2']
+
+- name: Export all inventories without the hosts and groups of the dynamic ones
+  export:
+    inventory: 'all'
+    # the sources are what recreate the omitted hosts and groups on the next sync
+    inventory_sources: 'all'
+    exclude_dynamic_inventory_children: true
+
+- name: Export all assets, skipping the children of two known dynamic inventories
+  export:
+    all: true
+    exclude_inventory_children:
+      - 'My Cloud Inventory'
+      - 'My Other Cloud Inventory'
 '''
 
 import logging
@@ -128,10 +160,19 @@ try:
 except ImportError:
     HAS_EXPORTABLE_RESOURCES = False
 
+try:
+    from awxkit.api.pages.api import INVENTORY_CHILDREN  # noqa: F401
+
+    HAS_EXCLUDABLE_INVENTORY_CHILDREN = True
+except ImportError:
+    HAS_EXCLUDABLE_INVENTORY_CHILDREN = False
+
 
 def main():
     argument_spec = dict(
         all=dict(type='bool', default=False),
+        exclude_inventory_children=dict(type='list', elements='str'),
+        exclude_dynamic_inventory_children=dict(type='bool', default=False),
     )
 
     # We are not going to raise an error here because the __init__ method of ControllerAWXKitModule will do that for us
@@ -160,6 +201,16 @@ def main():
         else:
             # Otherwise we take either the string or None (if the parameter was not passed) to get one or no items
             export_args[resource] = module.params.get(resource)
+
+    # Only pass the exclusions on when they were asked for, so that an older awxkit,
+    # which would reject the unknown keywords, keeps working for everyone else
+    exclude_inventory_children = module.params.get('exclude_inventory_children')
+    exclude_dynamic_inventory_children = module.params.get('exclude_dynamic_inventory_children')
+    if exclude_inventory_children or exclude_dynamic_inventory_children:
+        if not HAS_EXCLUDABLE_INVENTORY_CHILDREN:
+            module.fail_json(msg="Your version of awxkit does not support excluding the children of an inventory from an export")
+        export_args['exclude_inventory_children'] = exclude_inventory_children
+        export_args['exclude_dynamic_inventory_children'] = exclude_dynamic_inventory_children
 
     # Currently the export process does not return anything on error
     # It simply just logs to Python's logger

--- a/awx_collection/test/awx/test_export.py
+++ b/awx_collection/test/awx/test_export.py
@@ -5,6 +5,7 @@ __metaclass__ = type
 import pytest
 
 from awx.main.models.execution_environments import ExecutionEnvironment
+from awx.main.models.inventory import Inventory, InventorySource
 from awx.main.models.jobs import JobTemplate
 
 from awx.main.tests.functional.conftest import user, system_auditor  # noqa: F401; pylint: disable=unused-import
@@ -38,6 +39,28 @@ def job_template(project, inventory, organization, machine_credential):
 @pytest.fixture
 def execution_environment(organization):
     return ExecutionEnvironment.objects.create(name="test-ee", description="test-ee", managed=False, organization=organization)
+
+
+@pytest.fixture
+def static_inventory(organization):
+    inv = Inventory.objects.create(name='test-static-inv', organization=organization)
+    inv.groups.create(name='static-group').hosts.create(name='static-host', inventory=inv)
+    return inv
+
+
+@pytest.fixture
+def dynamic_inventory(organization):
+    inv = Inventory.objects.create(name='test-dynamic-inv', organization=organization)
+    InventorySource.objects.create(name='test-dynamic-inv-source', inventory=inv, source='ec2')
+    inv.groups.create(name='dynamic-group').hosts.create(name='dynamic-host', inventory=inv)
+    # has_inventory_sources is a computed field, and it is what marks an inventory as dynamic
+    inv.update_computed_fields()
+    inv.refresh_from_db()
+    return inv
+
+
+def child_names(exported_inventory, key):
+    return [child['name'] for child in exported_inventory.get('related', {}).get(key, [])]
 
 
 def find_by(result, name, key, value):
@@ -147,3 +170,64 @@ def test_export_system_auditor(run_module, organization, system_auditor):  # noq
     assert 'assets' in result
 
     find_by(result['assets'], 'organizations', 'name', 'Default')
+
+
+@pytest.mark.django_db
+def test_export_inventory_children_by_default(run_module, admin_user, dynamic_inventory):
+    """Without either exclusion the hosts and groups of a dynamic inventory are still exported."""
+    result = run_module('export', dict(inventory='all'), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    inv = find_by(result['assets'], 'inventory', 'name', 'test-dynamic-inv')
+    assert child_names(inv, 'hosts') == ['dynamic-host']
+    assert child_names(inv, 'groups') == ['dynamic-group']
+
+
+@pytest.mark.django_db
+def test_export_exclude_inventory_children_by_name(run_module, admin_user, dynamic_inventory, static_inventory):
+    result = run_module('export', dict(inventory='all', exclude_inventory_children=['test-dynamic-inv']), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    excluded = find_by(result['assets'], 'inventory', 'name', 'test-dynamic-inv')
+    assert child_names(excluded, 'hosts') == []
+    assert child_names(excluded, 'groups') == []
+
+    # an inventory that was not named keeps its children
+    kept = find_by(result['assets'], 'inventory', 'name', 'test-static-inv')
+    assert child_names(kept, 'hosts') == ['static-host']
+    assert child_names(kept, 'groups') == ['static-group']
+
+
+@pytest.mark.django_db
+def test_export_exclude_inventory_children_by_id(run_module, admin_user, dynamic_inventory):
+    result = run_module('export', dict(inventory='all', exclude_inventory_children=[str(dynamic_inventory.id)]), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    excluded = find_by(result['assets'], 'inventory', 'name', 'test-dynamic-inv')
+    assert child_names(excluded, 'hosts') == []
+    assert child_names(excluded, 'groups') == []
+
+
+@pytest.mark.django_db
+def test_export_exclude_dynamic_inventory_children(run_module, admin_user, dynamic_inventory, static_inventory):
+    """Only the inventories that have an inventory source lose their children."""
+    result = run_module('export', dict(inventory='all', exclude_dynamic_inventory_children=True), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    excluded = find_by(result['assets'], 'inventory', 'name', 'test-dynamic-inv')
+    assert child_names(excluded, 'hosts') == []
+    assert child_names(excluded, 'groups') == []
+
+    kept = find_by(result['assets'], 'inventory', 'name', 'test-static-inv')
+    assert child_names(kept, 'hosts') == ['static-host']
+    assert child_names(kept, 'groups') == ['static-group']
+
+
+@pytest.mark.django_db
+def test_export_inventory_source_still_exported_when_children_excluded(run_module, admin_user, dynamic_inventory):
+    """The inventory and its source survive the exclusion, so the children can be rebuilt on import."""
+    result = run_module('export', dict(inventory='all', inventory_sources='all', exclude_dynamic_inventory_children=True), admin_user)
+    assert not result.get('failed', False), result.get('msg', result)
+
+    find_by(result['assets'], 'inventory', 'name', 'test-dynamic-inv')
+    find_by(result['assets'], 'inventory_sources', 'name', 'test-dynamic-inv-source')

--- a/awx_collection/tests/integration/targets/export/tasks/main.yml
+++ b/awx_collection/tests/integration/targets/export/tasks/main.yml
@@ -9,6 +9,8 @@
     org_name1: "AWX-Collection-tests-export-organization-{{ test_id }}"
     org_name2: "AWX-Collection-tests-export-organization2-{{ test_id }}"
     inventory_name1: "AWX-Collection-tests-export-inv1-{{ test_id }}"
+    group_name1: "AWX-Collection-tests-export-group1-{{ test_id }}"
+    host_name1: "AWX-Collection-tests-export-host1-{{ test_id }}"
 
 - block:
     - name: Create some organizations
@@ -95,6 +97,53 @@
           - string_asserts is successful
           - string_asserts['assets']['organizations'] | length() >= 1
           - "org_name2 in (string_asserts['assets']['organizations'] | map(attribute='name') )"
+
+    - name: Add a group to the inventory
+      group:
+        name: "{{ group_name1 }}"
+        inventory: "{{ inventory_name1 }}"
+
+    - name: Add a host to the inventory
+      host:
+        name: "{{ host_name1 }}"
+        inventory: "{{ inventory_name1 }}"
+
+    - name: Export inventories with their children
+      export:
+        inventory: 'all'
+      register: children_export
+
+    - name: Pick out the inventory we created
+      set_fact:
+        exported_inventory: "{{ children_export['assets']['inventory'] | selectattr('name', 'equalto', inventory_name1) | first }}"
+
+    - assert:
+        that:
+          - children_export is successful
+          - children_export is not changed
+          - "host_name1 in (exported_inventory['related']['hosts'] | map(attribute='name'))"
+          - "group_name1 in (exported_inventory['related']['groups'] | map(attribute='name'))"
+
+    # Note that exclude_dynamic_inventory_children is only covered by the unit tests.  It keys off the
+    # has_inventory_sources computed field, which is refreshed by a background task after an inventory
+    # source is created, so asserting on it here would race with that task.
+    - name: Export inventories, leaving out the children of the one we created
+      export:
+        inventory: 'all'
+        exclude_inventory_children:
+          - "{{ inventory_name1 }}"
+      register: excluded_children_export
+
+    - name: Pick out the inventory we excluded
+      set_fact:
+        excluded_inventory: "{{ excluded_children_export['assets']['inventory'] | selectattr('name', 'equalto', inventory_name1) | first }}"
+
+    - assert:
+        that:
+          - excluded_children_export is successful
+          - excluded_children_export is not changed
+          - "'hosts' not in (excluded_inventory['related'] | default({}))"
+          - "'groups' not in (excluded_inventory['related'] | default({}))"
   always:
     - name: Remove our inventory
       inventory:

--- a/awxkit/awxkit/api/pages/api.py
+++ b/awxkit/awxkit/api/pages/api.py
@@ -64,6 +64,12 @@ DEPENDENT_NONEXPORT = [
 ]
 
 
+# Related views of an Inventory that hold its child objects.  These may be
+# omitted from an export, which is useful for inventories that are populated
+# from an inventory source and can be repopulated on import.
+INVENTORY_CHILDREN = ['hosts', 'groups']
+
+
 class Api(base.Base):
     pass
 
@@ -135,6 +141,10 @@ class ApiV2(base.Base):
         for key, rel_endpoint in _page.related.items():
             # skip if no endpoint for this related object
             if not rel_endpoint:
+                continue
+
+            # skip the hosts and groups of an inventory the caller asked to omit them for
+            if key in INVENTORY_CHILDREN and self._skip_inventory_children(_page):
                 continue
 
             rel = rel_endpoint._create()
@@ -213,6 +223,28 @@ class ApiV2(base.Base):
         assets = (self._export(asset, post_fields) for asset in endpoint.results)
         return [asset for asset in assets if asset is not None]
 
+    def _skip_inventory_children(self, _page):
+        """Determine whether the hosts and groups of an inventory should be left out of the export.
+
+        Children are omitted when the inventory was named in ``exclude_inventory_children``,
+        or when ``exclude_dynamic_inventory_children`` is set and the inventory has at least
+        one inventory source.
+        """
+        if _page.__item_class__.__name__ != 'Inventory':
+            return False
+
+        if getattr(self, '_exclude_dynamic_inventory_children', False) and _page.json.get('has_inventory_sources'):
+            return True
+
+        for identifier in getattr(self, '_exclude_inventory_children', None) or []:
+            if self._check_for_int(identifier):
+                if int(identifier) == _page.json.get('id'):
+                    return True
+            elif identifier == _page.json.get('name'):
+                return True
+
+        return False
+
     def _check_for_int(self, value):
         return isinstance(value, int) or (isinstance(value, str) and value.isdecimal())
 
@@ -234,6 +266,8 @@ class ApiV2(base.Base):
 
     def export_assets(self, **kwargs):
         self._cache = page.PageCache(self.connection)
+        self._exclude_dynamic_inventory_children = bool(kwargs.pop('exclude_dynamic_inventory_children', False))
+        self._exclude_inventory_children = kwargs.pop('exclude_inventory_children', None) or []
 
         # If no resource kwargs are explicitly used, export everything.
         all_resources = all(kwargs.get(resource) is None for resource in EXPORTABLE_RESOURCES)

--- a/awxkit/awxkit/cli/resource.py
+++ b/awxkit/awxkit/cli/resource.py
@@ -121,6 +121,18 @@ class Export(CustomCommand):
             # 3) the resource flag is used with an argument, and the attr will be that argument's value
             resources.add_argument('--{}'.format(resource), nargs='*')
 
+        options = parser.add_argument_group('options')
+        options.add_argument(
+            '--exclude-inventory-children',
+            nargs='*',
+            help='names or IDs of inventories whose hosts and groups will be left out of the export',
+        )
+        options.add_argument(
+            '--exclude-dynamic-inventory-children',
+            action='store_true',
+            help='leave the hosts and groups of every inventory that has an inventory source out of the export',
+        )
+
     def handle(self, client, parser):
         self.extend_parser(parser)
         parser.usage = 'awx export > exportfile'
@@ -132,6 +144,8 @@ class Export(CustomCommand):
 
         parsed = parser.parse_known_args()[0]
         kwargs = {resource: getattr(parsed, resource, None) for resource in EXPORTABLE_RESOURCES}
+        kwargs['exclude_inventory_children'] = getattr(parsed, 'exclude_inventory_children', None)
+        kwargs['exclude_dynamic_inventory_children'] = getattr(parsed, 'exclude_dynamic_inventory_children', False)
 
         client.authenticate()
         data = client.v2.export_assets(**kwargs)


### PR DESCRIPTION
##### SUMMARY

related #16175

Exporting an inventory also exports every host and group it contains. For a
dynamic inventory those objects are recreated the next time the inventory
source syncs, so carrying them through an export and a later import costs
time without adding information. On large inventories that dominates the
run.

This adds two opt-in options to the `export` module:

- `exclude_inventory_children` — a list of inventory names or IDs whose
  hosts and groups are left out
- `exclude_dynamic_inventory_children` — a bool that applies to every
  inventory reporting `has_inventory_sources`

Both default to off, so an export that does not ask for them is byte-for-byte
unchanged.

Inventory sources are a separate asset type in `EXPORTABLE_RESOURCES`, not a
related object of an inventory, so they are exported only when selected.
Select them alongside the exclusion if the omitted hosts and groups are meant
to be recreated by a source sync after an import — otherwise the export
carries neither the children nor the sources that would rebuild them. The
option descriptions say so, and the examples below select both.

Known limitation, documented on both options: hosts and groups added by hand
to an excluded inventory are dropped too, and no inventory source will
restore them.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Collection
 - CLI

##### STEPS TO REPRODUCE AND EXTRA INFO

```yaml
- name: Export all inventories without the children of the dynamic ones
  export:
    inventory: 'all'
    # the sources are what recreate the omitted hosts and groups on the next sync
    inventory_sources: 'all'
    exclude_dynamic_inventory_children: true

- name: Export everything, skipping the children of two named inventories
  export:
    all: true
    exclude_inventory_children:
      - 'My Cloud Inventory'
      - 'My Other Cloud Inventory'
```

The second example needs no explicit source selection, since `all` already
covers every asset type.

Equivalent on the CLI:

```
awx export --inventory --inventory_sources --exclude-dynamic-inventory-children
```

Test results:

```
$ make test_collection COLLECTION_TEST_DIRS=awx_collection/test/awx/test_export.py
test_export PASSED
test_export_simple PASSED
test_export_system_auditor PASSED
test_export_inventory_children_by_default PASSED
test_export_exclude_inventory_children_by_name PASSED
test_export_exclude_inventory_children_by_id PASSED
test_export_exclude_dynamic_inventory_children PASSED
test_export_inventory_source_still_exported_when_children_excluded PASSED
============================== 8 passed in 18.98s ==============================

$ py.test awx_collection/test/awx
206 passed in 45.74s

$ cd awxkit && tox -e test
286 passed in 17.20s
```

Integration tests have not been run against a live instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to exclude hosts and groups from selected inventories during exports.
  * Added an option to exclude children from all inventories that use inventory sources.
  * Exclusions can be specified by inventory name or ID.
  * Inventory sources continue to be exported when their child hosts and groups are excluded.
* **Bug Fixes**
  * Export commands now report an error when requested exclusions are unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->