### PR TITLE
AAP-89036: Prefer direct input value over external input_source during PATCH

### DIFF
--- a/awx/main/models/credential.py
+++ b/awx/main/models/credential.py
@@ -305,6 +305,18 @@ class Credential(PasswordFieldsModel, CommonModelNameNotUnique, ResourceMixin):
         :param default(optional[str]): A default return value to use.
         """
         if self.credential_type.kind != 'external' and field_name in self.dynamic_input_fields:
+            # If a direct (non-placeholder) value exists in inputs, prefer it
+            # over the dynamic input_source. This allows PATCH requests to
+            # override an externally-sourced field without triggering a live
+            # call to the external credential backend (AAP-89036).
+            direct_value = self.inputs.get(field_name)
+            if direct_value not in (None, '', '$encrypted$'):
+                if field_name in self.credential_type.secret_fields:
+                    try:
+                        return decrypt_field(self, field_name)
+                    except AttributeError:
+                        pass
+                return direct_value
             return self._get_dynamic_input(field_name)
         if field_name in self.credential_type.secret_fields:
             try:

--- a/awx/main/tests/functional/test_credential.py
+++ b/awx/main/tests/functional/test_credential.py
@@ -2,10 +2,11 @@
 # All Rights Reserved.
 
 import pytest
+from unittest.mock import PropertyMock, patch
 from django.core.exceptions import ValidationError
 
 from awx.main.utils import decrypt_field
-from awx.main.models import Credential, CredentialType
+from awx.main.models import Credential, CredentialType, CredentialInputSource
 
 from rest_framework import serializers
 
@@ -380,3 +381,131 @@ def test_idempotent_credential_type_setup():
 
     CredentialType.setup_tower_managed_defaults()
     assert CredentialType.objects.count() == total
+
+
+@pytest.mark.django_db
+def test_get_input_prefers_direct_value_over_dynamic_source(organization_factory):
+    """
+    When a credential has an input_source (e.g. HashiCorp Vault) attached to
+    a field AND a direct value is provided in inputs (e.g. via PATCH), the
+    direct value should be returned without calling the external backend.
+    Regression test for AAP-89036.
+    """
+    organization = organization_factory('test').organization
+
+    external_type = CredentialType(
+        kind='external',
+        name='HashiCorp Vault Secret Lookup',
+        inputs={'fields': [{'id': 'url', 'type': 'string'}, {'id': 'token', 'type': 'string', 'secret': True}]},
+    )
+    external_type.save()
+
+    ssh_type = CredentialType(
+        kind='ssh',
+        name='Machine',
+        managed=True,
+        inputs={
+            'fields': [
+                {'id': 'username', 'type': 'string'},
+                {'id': 'ssh_key_data', 'type': 'string', 'secret': True, 'multiline': True},
+            ]
+        },
+    )
+    ssh_type.save()
+
+    source_cred = Credential(
+        organization=organization,
+        credential_type=external_type,
+        name='Vault Lookup',
+        inputs={'url': 'https://vault.example.com', 'token': 'fake-token'},
+    )
+    source_cred.save()
+
+    target_cred = Credential(
+        organization=organization,
+        credential_type=ssh_type,
+        name='My Machine Cred',
+        inputs={'username': 'myuser'},
+    )
+    target_cred.save()
+
+    CredentialInputSource.objects.create(
+        target_credential=target_cred,
+        source_credential=source_cred,
+        input_field_name='ssh_key_data',
+        metadata={'secret_path': 'secret/data/ssh-keys', 'secret_key': 'private_key'},
+    )
+
+    # Clear cached_property so dynamic_input_fields picks up the new source
+    if 'dynamic_input_fields' in target_cred.__dict__:
+        del target_cred.__dict__['dynamic_input_fields']
+
+    assert 'ssh_key_data' in target_cred.dynamic_input_fields
+
+    # Simulate a PATCH that sets a new direct value for ssh_key_data
+    target_cred.inputs['ssh_key_data'] = 'direct-new-key-value'
+
+    # get_input should return the direct value WITHOUT calling _get_dynamic_input
+    with patch.object(Credential, '_get_dynamic_input', side_effect=RuntimeError('Should not be called')) as mock_dynamic:
+        result = target_cred.get_input('ssh_key_data')
+
+    assert result == 'direct-new-key-value'
+    mock_dynamic.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_get_input_falls_back_to_dynamic_when_no_direct_value(organization_factory):
+    """
+    When a credential has an input_source and the direct value is empty or
+    absent, get_input() should still delegate to the dynamic input path.
+    """
+    organization = organization_factory('test').organization
+
+    external_type = CredentialType(
+        kind='external',
+        name='External Lookup',
+        inputs={'fields': [{'id': 'url', 'type': 'string'}]},
+    )
+    external_type.save()
+
+    custom_type = CredentialType(
+        kind='cloud',
+        name='Custom Cloud',
+        inputs={'fields': [{'id': 'api_key', 'type': 'string'}]},
+    )
+    custom_type.save()
+
+    source_cred = Credential(
+        organization=organization,
+        credential_type=external_type,
+        name='External Source',
+        inputs={'url': 'https://external.example.com'},
+    )
+    source_cred.save()
+
+    target_cred = Credential(
+        organization=organization,
+        credential_type=custom_type,
+        name='Cloud Cred',
+        inputs={},
+    )
+    target_cred.save()
+
+    CredentialInputSource.objects.create(
+        target_credential=target_cred,
+        source_credential=source_cred,
+        input_field_name='api_key',
+        metadata={},
+    )
+
+    if 'dynamic_input_fields' in target_cred.__dict__:
+        del target_cred.__dict__['dynamic_input_fields']
+
+    assert 'api_key' in target_cred.dynamic_input_fields
+
+    # No direct value in inputs -- should call _get_dynamic_input
+    with patch.object(Credential, '_get_dynamic_input', return_value='dynamic-value') as mock_dynamic:
+        result = target_cred.get_input('api_key')
+
+    assert result == 'dynamic-value'
+    mock_dynamic.assert_called_once_with('api_key')


### PR DESCRIPTION
## Summary

- Fixes a bug where `Credential.get_input()` unconditionally delegates to the external credential backend (e.g. HashiCorp Vault) when an `input_source` is attached, even when a direct value is being provided via PATCH.
- This caused HTTP 500 if the backend was unreachable, or silently discarded the new value if the backend was reachable.
- The fix checks for a non-placeholder direct value in `self.inputs` before falling through to `_get_dynamic_input()`, allowing PATCH requests to override externally-sourced fields.

## Issue

[AAP-89036](https://redhat.atlassian.net/browse/AAP-89036)

## Root Cause

In `awx/main/models/credential.py`, `get_input()` checks `dynamic_input_fields` first and always routes to `_get_dynamic_input()` which makes a live network call to the external backend. There was no guard to check whether a direct value was being supplied in an update context.

## Changes

- **`awx/main/models/credential.py`**: Modified `get_input()` to check if a direct (non-placeholder) value exists in `self.inputs` before delegating to the dynamic input source. If a direct value is present, it is returned (with decryption for secret fields), bypassing the external backend call.
- **`awx/main/tests/functional/test_credential.py`**: Added two regression tests:
  - `test_get_input_prefers_direct_value_over_dynamic_source` — verifies direct values take precedence
  - `test_get_input_falls_back_to_dynamic_when_no_direct_value` — verifies the dynamic path still works when no direct value is present

## Test plan

- [x] New unit tests pass
- [ ] Manual test: Create credential with Vault input_source, PATCH with new direct `ssh_key_data` — should succeed without contacting Vault
- [ ] Manual test: Credential with input_source and no direct override — should still fetch from Vault as before
- [ ] Existing credential test suite passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Credential values now prioritize directly provided inputs over dynamically retrieved values.
  * Secret inputs are decrypted when possible, with graceful fallback to the provided value if decryption fails.
  * Dynamic input retrieval remains available when no direct value is supplied.

* **Tests**
  * Added regression coverage for direct input handling and dynamic lookup fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->