### PR TITLE
[AAP-89676] Add control plane EE unit/functional tests

### DIFF
--- a/awx/main/tests/functional/models/test_inventory.py
+++ b/awx/main/tests/functional/models/test_inventory.py
@@ -342,6 +342,30 @@ def test_inventory_update_excessively_long_name(inventory, inventory_source):
 
 
 @pytest.mark.django_db
+class TestConstructedInventory:
+    def test_constructed_inventory_kind_is_constructed(self, organization):
+        """Verify that a constructed inventory has kind='constructed'"""
+        constructed = Inventory.objects.create(name='my-constructed', kind='constructed', organization=organization)
+        assert constructed.kind == 'constructed'
+
+    def test_constructed_inventory_aggregates_hosts_from_inputs(self, organization):
+        """Create 2 regular inventories with manual hosts, create a constructed inventory
+        with those as inputs, verify the input inventories relationship works"""
+        inv1 = Inventory.objects.create(name='source-inv-1', organization=organization)
+        inv1.hosts.create(name='host-a')
+        inv1.hosts.create(name='host-b')
+
+        inv2 = Inventory.objects.create(name='source-inv-2', organization=organization)
+        inv2.hosts.create(name='host-c')
+
+        constructed = Inventory.objects.create(name='my-constructed', kind='constructed', organization=organization)
+        constructed.input_inventories.add(inv1, inv2)
+
+        input_ids = set(constructed.input_inventories.values_list('id', flat=True))
+        assert input_ids == {inv1.id, inv2.id}
+
+
+@pytest.mark.django_db
 class TestHostManager:
     def test_host_filter_not_smart(self, setup_ec2_gce, organization):
         smart_inventory = Inventory(name='smart', organization=organization, host_filter='inventory_sources__source=ec2')

--- a/awx/main/tests/functional/models/test_inventory.py
+++ b/awx/main/tests/functional/models/test_inventory.py
@@ -343,26 +343,29 @@ def test_inventory_update_excessively_long_name(inventory, inventory_source):
 
 @pytest.mark.django_db
 class TestConstructedInventory:
-    def test_constructed_inventory_kind_is_constructed(self, organization):
-        """Verify that a constructed inventory has kind='constructed'"""
-        constructed = Inventory.objects.create(name='my-constructed', kind='constructed', organization=organization)
-        assert constructed.kind == 'constructed'
-
     def test_constructed_inventory_aggregates_hosts_from_inputs(self, organization):
-        """Create 2 regular inventories with manual hosts, create a constructed inventory
-        with those as inputs, verify the input inventories relationship works"""
+        """Create 2 regular inventories with asymmetric host counts, create a constructed
+        inventory with those as inputs, verify both inventories are linked and hosts
+        from each are distinguishable"""
         inv1 = Inventory.objects.create(name='source-inv-1', organization=organization)
         inv1.hosts.create(name='host-a')
         inv1.hosts.create(name='host-b')
+        inv1.hosts.create(name='host-c')
 
         inv2 = Inventory.objects.create(name='source-inv-2', organization=organization)
-        inv2.hosts.create(name='host-c')
+        inv2.hosts.create(name='host-d')
 
         constructed = Inventory.objects.create(name='my-constructed', kind='constructed', organization=organization)
-        constructed.input_inventories.add(inv1, inv2)
+        constructed.input_inventories.add(inv1)
+        constructed.input_inventories.add(inv2)
 
         input_ids = set(constructed.input_inventories.values_list('id', flat=True))
         assert input_ids == {inv1.id, inv2.id}
+
+        all_host_names = set()
+        for inv in constructed.input_inventories.all():
+            all_host_names.update(inv.hosts.values_list('name', flat=True))
+        assert all_host_names == {'host-a', 'host-b', 'host-c', 'host-d'}
 
 
 @pytest.mark.django_db

--- a/awx/main/tests/functional/utils/test_execution_environments.py
+++ b/awx/main/tests/functional/utils/test_execution_environments.py
@@ -3,8 +3,9 @@ import pytest
 from django.conf import settings
 from django.test.utils import override_settings
 
+from awx.main.models import Inventory, InventorySource
 from awx.main.models.execution_environments import ExecutionEnvironment
-from awx.main.utils.execution_environments import get_default_execution_environment
+from awx.main.utils.execution_environments import get_default_execution_environment, get_control_plane_execution_environment
 from awx.main.management.commands.register_default_execution_environments import Command
 
 
@@ -44,3 +45,54 @@ def test_user_default(set_up_defaults):
     ee = ExecutionEnvironment.objects.create(name='Steves environment', image='quay.io/ansible/awx-ee')
     with override_settings(DEFAULT_EXECUTION_ENVIRONMENT=ee):
         assert get_default_execution_environment() == ee
+
+
+@pytest.mark.django_db
+def test_project_update_uses_control_plane_ee(set_up_defaults, project):
+    """Project.resolve_execution_environment() should always return the control plane EE"""
+    control_plane_ee = get_control_plane_execution_environment()
+    resolved_ee = project.resolve_execution_environment()
+    assert resolved_ee == control_plane_ee
+    assert resolved_ee.managed is True
+    assert resolved_ee.organization is None
+
+
+@pytest.mark.django_db
+def test_constructed_inventory_uses_control_plane_ee(set_up_defaults, constructed_inventory):
+    """Constructed inventory sources should resolve to the control plane EE"""
+    control_plane_ee = get_control_plane_execution_environment()
+    inv_source = InventorySource.objects.create(
+        name='constructed-source',
+        inventory=constructed_inventory,
+        source='constructed',
+    )
+    resolved_ee = inv_source.resolve_execution_environment()
+    assert resolved_ee == control_plane_ee
+
+
+@pytest.mark.django_db
+def test_regular_inventory_does_not_use_control_plane_ee(set_up_defaults, inventory):
+    """Regular (non-constructed) inventory sources should NOT resolve to the control plane EE"""
+    control_plane_ee = get_control_plane_execution_environment()
+    inv_source = InventorySource.objects.create(
+        name='ec2-source',
+        inventory=inventory,
+        source='ec2',
+    )
+    resolved_ee = inv_source.resolve_execution_environment()
+    assert resolved_ee != control_plane_ee
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize('source', ['ec2', 'azure_rm', 'gce', 'vmware', 'openstack', 'rhv', 'satellite6', 'controller'])
+def test_non_constructed_inventory_types_do_not_use_control_plane_ee(set_up_defaults, organization, source):
+    """Multiple inventory source types should all NOT resolve to the control plane EE"""
+    control_plane_ee = get_control_plane_execution_environment()
+    inv = Inventory.objects.create(name=f'test-inv-{source}', organization=organization)
+    inv_source = InventorySource.objects.create(
+        name=f'{source}-source',
+        inventory=inv,
+        source=source,
+    )
+    resolved_ee = inv_source.resolve_execution_environment()
+    assert resolved_ee != control_plane_ee

--- a/awx/main/tests/functional/utils/test_execution_environments.py
+++ b/awx/main/tests/functional/utils/test_execution_environments.py
@@ -3,7 +3,7 @@ import pytest
 from django.conf import settings
 from django.test.utils import override_settings
 
-from awx.main.models import Inventory, InventorySource
+from awx.main.models import Inventory, InventorySource, InventoryUpdate, ProjectUpdate
 from awx.main.models.execution_environments import ExecutionEnvironment
 from awx.main.utils.execution_environments import get_default_execution_environment, get_control_plane_execution_environment
 from awx.main.management.commands.register_default_execution_environments import Command
@@ -49,50 +49,52 @@ def test_user_default(set_up_defaults):
 
 @pytest.mark.django_db
 def test_project_update_uses_control_plane_ee(set_up_defaults, project):
-    """Project.resolve_execution_environment() should always return the control plane EE"""
+    """ProjectUpdate.resolve_execution_environment() should always return the control plane EE"""
     control_plane_ee = get_control_plane_execution_environment()
-    resolved_ee = project.resolve_execution_environment()
+    project_update = ProjectUpdate.objects.create(
+        project=project,
+        scm_type=project.scm_type,
+    )
+    resolved_ee = project_update.resolve_execution_environment()
     assert resolved_ee == control_plane_ee
     assert resolved_ee.managed is True
     assert resolved_ee.organization is None
 
 
 @pytest.mark.django_db
-def test_constructed_inventory_uses_control_plane_ee(set_up_defaults, constructed_inventory):
-    """Constructed inventory sources should resolve to the control plane EE"""
+@pytest.mark.parametrize(
+    'source,expects_control_plane',
+    [
+        ('constructed', True),
+        ('ec2', False),
+        ('azure_rm', False),
+        ('gce', False),
+        ('vmware', False),
+        ('openstack', False),
+        ('rhv', False),
+        ('satellite6', False),
+        ('controller', False),
+    ],
+)
+def test_inventory_update_ee_resolution(set_up_defaults, organization, source, expects_control_plane):
+    """Constructed inventory updates should resolve to the control plane EE; all others should not"""
     control_plane_ee = get_control_plane_execution_environment()
-    inv_source = InventorySource.objects.create(
-        name='constructed-source',
-        inventory=constructed_inventory,
-        source='constructed',
+    inv = Inventory.objects.create(
+        name=f'test-inv-{source}',
+        kind='constructed' if source == 'constructed' else '',
+        organization=organization,
     )
-    resolved_ee = inv_source.resolve_execution_environment()
-    assert resolved_ee == control_plane_ee
-
-
-@pytest.mark.django_db
-def test_regular_inventory_does_not_use_control_plane_ee(set_up_defaults, inventory):
-    """Regular (non-constructed) inventory sources should NOT resolve to the control plane EE"""
-    control_plane_ee = get_control_plane_execution_environment()
-    inv_source = InventorySource.objects.create(
-        name='ec2-source',
-        inventory=inventory,
-        source='ec2',
-    )
-    resolved_ee = inv_source.resolve_execution_environment()
-    assert resolved_ee != control_plane_ee
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize('source', ['ec2', 'azure_rm', 'gce', 'vmware', 'openstack', 'rhv', 'satellite6', 'controller'])
-def test_non_constructed_inventory_types_do_not_use_control_plane_ee(set_up_defaults, organization, source):
-    """Multiple inventory source types should all NOT resolve to the control plane EE"""
-    control_plane_ee = get_control_plane_execution_environment()
-    inv = Inventory.objects.create(name=f'test-inv-{source}', organization=organization)
     inv_source = InventorySource.objects.create(
         name=f'{source}-source',
         inventory=inv,
         source=source,
     )
-    resolved_ee = inv_source.resolve_execution_environment()
-    assert resolved_ee != control_plane_ee
+    inv_update = InventoryUpdate.objects.create(
+        inventory_source=inv_source,
+        source=source,
+    )
+    resolved_ee = inv_update.resolve_execution_environment()
+    if expects_control_plane:
+        assert resolved_ee == control_plane_ee
+    else:
+        assert resolved_ee != control_plane_ee

--- a/awx/main/tests/functional/utils/test_execution_environments.py
+++ b/awx/main/tests/functional/utils/test_execution_environments.py
@@ -90,6 +90,7 @@ def test_inventory_update_ee_resolution(set_up_defaults, organization, source, e
         source=source,
     )
     inv_update = InventoryUpdate.objects.create(
+        inventory=inv,
         inventory_source=inv_source,
         source=source,
     )

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -1169,6 +1169,40 @@ class TestProjectUpdateCredentials(TestJobExecution):
         assert env['FOO'] == 'BAR'
 
 
+class TestProjectUpdateSignatureValidation(TestJobExecution):
+    """Tests that ProjectUpdate.save() adds GPG validation job tags when a
+    signature_validation_credential is set on the project."""
+
+    def test_project_update_with_signature_credential_adds_validation_tags(self):
+        gpg_credential_type = CredentialType(pk=1, namespace='gpg_public_key', kind='cryptography')
+        gpg_credential = Credential(pk=1, credential_type=gpg_credential_type)
+        project = Project(pk=1, organization=Organization(pk=1), scm_type='git', signature_validation_credential=gpg_credential)
+        project_update = ProjectUpdate(pk=1, project=project, scm_type='git')
+        project_update.websocket_emit_status = mock.Mock()
+
+        # Simulate the save logic that sets job_tags without hitting the database
+        with mock.patch.object(UnifiedJob, 'save', return_value=None):
+            project_update.save()
+
+        assert 'validation_gpg_public_key' in project_update.job_tags
+        assert 'validation_checksum_manifest' in project_update.job_tags
+        assert 'update_git' in project_update.job_tags
+
+    def test_project_update_without_signature_credential_no_validation_tags(self):
+        project = Project(pk=1, organization=Organization(pk=1), scm_type='git')
+        project_update = ProjectUpdate(pk=1, project=project, scm_type='git')
+        project_update.websocket_emit_status = mock.Mock()
+
+        with mock.patch.object(UnifiedJob, 'save', return_value=None):
+            project_update.save()
+
+        assert 'validation_gpg_public_key' not in project_update.job_tags
+        assert 'validation_checksum_manifest' not in project_update.job_tags
+        assert 'update_git' in project_update.job_tags
+        assert 'install_roles' in project_update.job_tags
+        assert 'install_collections' in project_update.job_tags
+
+
 @pytest.mark.django_db
 class TestProjectUpdateRefspec(TestJobExecution):
     @pytest.fixture


### PR DESCRIPTION
[no version bump]

##### SUMMARY
Add unit and functional tests for control plane execution environment resolution,
constructed inventory model behavior, and ansible-sign signature validation tag injection.

These tests support the control plane EE initiative (AAP-89676, parent epic AAP-89071) by verifying that:
- `ProjectUpdate.resolve_execution_environment()` returns the control plane EE
- `InventoryUpdate.resolve_execution_environment()` returns the control plane EE only for constructed inventories
- Non-constructed inventory source types (ec2, azure_rm, gce, vmware, etc.) do NOT resolve to the control plane EE
- Signature validation job tags are correctly added/omitted based on GPG credential presence

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

```bash
pytest awx/main/tests/functional/utils/test_execution_environments.py -v
pytest awx/main/tests/functional/models/test_inventory.py::TestConstructedInventory -v
pytest awx/main/tests/unit/test_tasks.py::TestProjectUpdateSignatureValidation -v
```