### PR TITLE
Fix: free disk space before awx-operator molecule test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,12 @@ jobs:
           DEV_DOCKER_TAG_BASE: local
           HEADLESS: yes
 
+      - name: Free disk space after Docker build
+        run: |
+          docker builder prune -af
+          docker image prune -f
+          df -h /
+
       - name: Run test deployment with awx-operator
         working-directory: awx-operator
         id: awx_operator_test


### PR DESCRIPTION
## Summary
- The GitHub Actions runner image update reduced available disk space on the runner
- This causes the `awx-operator` molecule test to hang and timeout waiting for pods that can't start due to disk pressure
- Adds a Docker cleanup step after the AWX image build to prune BuildKit cache and dangling images before the molecule test runs, reclaiming several GB of disk space
- Same fix as ansible/tower PRs #7905 (stable-2.6), #7926 (stable-2.7), and #7927 (release_4.6)

**Failing CI runs (awx-operator job failing on every run since Aug 20):**
- https://github.com/ansible/awx/actions/runs/32755014493
- https://github.com/ansible/awx/actions/runs/32720217970
- https://github.com/ansible/awx/actions/runs/32506480033

## Test plan
- [ ] CI passes on this PR (awx-operator job completes without disk space errors)
- [ ] `df -h /` output in logs confirms disk space was reclaimed
- [ ] `local/awx:ci` image is preserved for the molecule test

Bug, Docs Fix or other nominal change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build workflow cleanup by removing unused Docker data after AWX image builds.
  * Added disk usage reporting to help monitor available build space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->