### PR TITLE
AAP-52517: Fix project.py: allow clearing credential with empty value

### DIFF
--- a/awx_collection/plugins/modules/project.py
+++ b/awx_collection/plugins/modules/project.py
@@ -247,6 +247,18 @@ def wait_for_project_update(module, last_request):
 
 
 def main():
+    """Entry point for the project module.
+
+    Builds the argument spec, resolves related resources (organization,
+    execution environment, credential, signature_validation_credential,
+    notification templates), and creates, updates, or deletes the
+    Automation Platform Controller project accordingly.
+
+    For credential and signature_validation_credential specifically: an
+    empty string ("") is treated as an explicit request to clear the
+    field, mapping it to None instead of attempting (and failing) to
+    resolve a credential literally named "".
+    """
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         name=dict(required=True),
@@ -383,7 +395,7 @@ def main():
         (signature_validation_credential, 'signature_validation_credential', 'credentials'),
     ):
         if variable is not None:
-            project_fields[field] = module.resolve_name_to_id(endpoint, variable)
+            project_fields[field] = module.resolve_name_to_id(endpoint, variable) if variable else None
 
     if org_id is not None:
         # this is resolved earlier, so save an API call and don't do it again in the loop above

--- a/awx_collection/test/awx/test_project.py
+++ b/awx_collection/test/awx/test_project.py
@@ -66,3 +66,40 @@ def test_create_project_copy_from(run_module, admin_user, organization, silence_
         admin_user,
     )
     silence_warning.assert_called_with("A project with the name {0} already exists.".format(proj_name))
+
+
+@pytest.mark.django_db
+def test_clear_project_credential(run_module, admin_user, organization, scm_credential):
+    result = run_module(
+        'project',
+        dict(
+            name='foo',
+            organization=organization.name,
+            scm_type='git',
+            scm_url='https://foo.invalid',
+            credential=scm_credential.name,
+            wait=False,
+        ),
+        admin_user,
+    )
+    assert result.pop('changed', None), result
+
+    proj = Project.objects.get(name='foo')
+    assert proj.credential_id == scm_credential.id
+
+    result = run_module(
+        'project',
+        dict(
+            name='foo',
+            organization=organization.name,
+            scm_type='git',
+            scm_url='https://foo.invalid',
+            credential='',
+            wait=False,
+        ),
+        admin_user,
+    )
+    assert result.pop('changed', None), result
+
+    proj.refresh_from_db()
+    assert proj.credential_id is None


### PR DESCRIPTION
##### SUMMARY

This addresses the same root cause reported in #14843 (empty value not
clearing a credential field), but for the `project` module's `credential`
and `signature_validation_credential` fields rather than `job_template`'s
`webhook_credential`.

Both fields were always passed through `resolve_name_to_id()` when not
`None`, even when the value was an empty string (`""`). This caused the
module to try to look up a credential literally named `""` and fail with
"Request to /api/controller/v2/credentials/ returned N items, expected 1",
instead of treating an empty string as "clear this field" (which the UI
already supports).

This change treats a falsy-but-not-`None` value (i.e. `""`) as an explicit
request to clear the field, setting it to `null` instead of attempting name
resolution.

Note: this also changes behavior for `default_environment` (the third
field in the same loop) — passing `default_environment: ""` will now
also clear that field rather than attempting to resolve "" as an
execution environment name. This is consistent with the credential
fields above and matches expected UI behavior, but is called out
explicitly here since it wasn't the field originally reported in #14843.

A separate, module-specific fix will still be needed for #14843 itself
(job_template's webhook_credential) and for the related reports on the same
resolver behavior: #15844, #15846, #16167.

##### ISSUE TYPE

- Bug, Docs Fix or other nominal change

##### COMPONENT NAME

- Collection

##### STEPS TO REPRODUCE AND EXTRA INFO

Before the fix, running the `project` module with `credential: ""` on a
project that already had a credential set would fail trying to resolve
`""` as a credential name, instead of clearing the field.

Added `test_clear_project_credential` to `test_project.py`, which:

1. Creates a project with a real SCM credential attached
2. Re-runs the module with `credential: ''`
3. Asserts the call succeeds and the credential is actually cleared in the
   database

Full collection test suite passes (202/202 in `test/awx/`), and
`ansible-test sanity --python 3.11` passes cleanly on the changed module
(`plugins/modules/project.py`).