### PR TITLE
Remove unused setting

### DIFF
--- a/awx/settings/defaults.py
+++ b/awx/settings/defaults.py
@@ -262,10 +262,6 @@ TASK_MANAGER_TIMEOUT = 300
 TASK_MANAGER_TIMEOUT_GRACE_PERIOD = 60
 TASK_MANAGER_LOCK_TIMEOUT = TASK_MANAGER_TIMEOUT + TASK_MANAGER_TIMEOUT_GRACE_PERIOD
 
-# Number of seconds _in addition to_ the task manager timeout a job can stay
-# in waiting without being reaped
-JOB_WAITING_GRACE_PERIOD = 60
-
 # Number of seconds after a container group job finished time to wait
 # before the awx_k8s_reaper task will tear down the pods
 K8S_POD_REAPER_GRACE_PERIOD = 60


### PR DESCRIPTION
##### SUMMARY
the waiting job reaper was removed but this was still lying around

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - API



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the obsolete job waiting grace-period setting from the application’s default configuration.
  * Removed the associated configuration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->