### PR TITLE
AAP-90164 Migrate RBAC assignment handlers to DAB bulk signals

### DIFF
--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -22,7 +22,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.utils.translation import gettext_lazy as _
-from django.core.exceptions import ObjectDoesNotExist
 from django.apps import apps
 from django.conf import settings
 
@@ -797,30 +796,28 @@ ROLE_DEFINITION_TO_ROLE_FIELD = {
 _UNSET = object()
 
 
-def _sync_assignment_to_old_role(instance, field_name, delete=True, content_object=_UNSET):
+def _sync_assignment_to_old_role(instance, delete=True, content_object=_UNSET):
     """Mirror a single new-RBAC assignment into the legacy Role.members / children m2m.
 
-    ``field_name`` is the legacy Role field for the assignment's role definition, resolved
-    once for the whole batch by the bulk handlers (see _field_names_for_old_rbac); a role
-    definition with no legacy equivalent passes None and is skipped. ``content_object`` is
-    taken from DAB's content_objects when available; on the narrow path where DAB did not
+    The legacy Role field is resolved from instance.role_definition.name, which DAB now
+    materializes on both the created and pre_delete signal instances, so this costs no query;
+    a role definition with no legacy equivalent has no field and is skipped. ``content_object``
+    is taken from DAB's content_objects when available; on the narrow path where DAB did not
     supply it, pass _UNSET and it is dereferenced from the instance here.
     """
     from awx.main.signals import disable_activity_stream
 
+    field_name = ROLE_DEFINITION_TO_ROLE_FIELD.get(instance.role_definition.name)
     if not field_name:
         return
 
     with disable_activity_stream():
         with disable_rbac_sync():
             if content_object is _UNSET:
-                try:
-                    content_object = instance.object_role.content_object
-                # in the case RoleUserAssignment is being cascade deleted, then
-                # object_role might not exist. In which case the object is about to be removed
-                # anyways so just return
-                except ObjectDoesNotExist:
-                    return
+                # Resolve straight off the assignment's own content_type/object_id (both cached
+                # on the row) rather than hopping through object_role - one lookup, not two. A
+                # missing object (e.g. mid cascade-delete) resolves to None, handled below.
+                content_object = instance.content_object
             if content_object is None:
                 # Object no longer resolvable (e.g. already deleted) — nothing to mirror.
                 return
@@ -837,17 +834,6 @@ def _sync_assignment_to_old_role(instance, field_name, delete=True, content_obje
                     instance.team.member_role.children.remove(role)
                 else:
                     instance.team.member_role.children.add(role)
-
-
-def _field_names_for_old_rbac(assignments):
-    """Map role_definition_id -> legacy Role field name for a whole batch in one query.
-
-    Resolves the role-definition names once (instead of dereferencing
-    instance.role_definition per row) so _sync_assignment_to_old_role can look the field
-    up by id. Role definitions with no legacy equivalent map to None and are skipped.
-    """
-    rd_ids = {instance.role_definition_id for instance in assignments}
-    return {pk: ROLE_DEFINITION_TO_ROLE_FIELD.get(name) for pk, name in RoleDefinition.objects.filter(pk__in=rd_ids).values_list('pk', 'name')}
 
 
 def _record_role_assignment_activity_stream(instance, operation, content_objects=None):
@@ -924,17 +910,15 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
     Replaces the former per-row post_save receivers sync_user_assignments_to_old_rbac_create
     and record_role_assignment_activity_stream, which do not fire for bulk_create.
     """
-    # Resolve the legacy field names for the whole batch in one query, and take the content
-    # objects straight from the DAB dict — we never fetch them ourselves (AAP-85842). The
-    # old-RBAC mirror falls back to a per-row lookup only on the narrow path where DAB did not
-    # supply the object (a direct give_assignments); the activity-stream recorder simply omits
-    # the object link there.
+    # Take the content objects straight from the DAB dict — we never fetch them ourselves
+    # (AAP-85842). The old-RBAC mirror falls back to a per-row lookup only on the narrow path
+    # where DAB did not supply the object (a direct give_assignments); the activity-stream
+    # recorder simply omits the object link there.
     dab_content_objects = content_objects or {}
-    field_names = _field_names_for_old_rbac(assignments)
 
     for instance in assignments:
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignment_to_old_role(instance, field_names.get(instance.role_definition_id), delete=False, content_object=content_object)
+        _sync_assignment_to_old_role(instance, delete=False, content_object=content_object)
         _record_role_assignment_activity_stream(instance, 'associate', dab_content_objects)
 
 
@@ -951,16 +935,15 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
     Replaces the former per-row post_delete receivers sync_assignments_to_old_rbac_delete
     and record_role_unassignment_activity_stream, which do not fire for queryset .delete().
     """
-    # Same batch resolution as the create side: field names in one query, and the content
-    # objects taken straight from the DAB dict rather than fetched here (AAP-85842).
+    # Same as the create side: content objects taken straight from the DAB dict rather than
+    # fetched here (AAP-85842).
     dab_content_objects = content_objects or {}
-    field_names = _field_names_for_old_rbac(assignments)
 
     for instance in assignments:
         # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
         _record_role_assignment_activity_stream(instance, 'disassociate', dab_content_objects)
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignment_to_old_role(instance, field_names.get(instance.role_definition_id), delete=True, content_object=content_object)
+        _sync_assignment_to_old_role(instance, delete=True, content_object=content_object)
 
 
 m2m_changed.connect(sync_members_to_new_rbac, Role.members.through)

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -705,7 +705,7 @@ def sync_members_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs)
 def sync_parents_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs):
     if action.startswith('pre_'):
         return
-    # Mirror the guard in sync_members_to_new_rbac: when _sync_assignment_to_old_roles
+    # Mirror the guard in sync_members_to_new_rbac: when _sync_assignment_to_old_role
     # mirrors a team assignment it edits member_role.children inside disable_rbac_sync(),
     # which fires this m2m handler. Without this guard the reverse (old->new) sync would
     # call remove_permission again and, because the bulk pre_delete signal now fires
@@ -797,7 +797,7 @@ ROLE_DEFINITION_TO_ROLE_FIELD = {
 _UNSET = object()
 
 
-def _sync_assignment_to_old_roles(instance, delete=True, content_object=_UNSET, field_name=_UNSET):
+def _sync_assignment_to_old_role(instance, delete=True, content_object=_UNSET, field_name=_UNSET):
     """Mirror a single new-RBAC assignment into the legacy Role.members / children m2m.
 
     ``content_object`` and ``field_name`` may be supplied pre-resolved by the bulk handlers
@@ -844,7 +844,7 @@ def _field_names_for_old_rbac(assignments):
     """Map role_definition_id -> legacy Role field name for a whole batch in one query.
 
     Resolves the role-definition names once (instead of dereferencing
-    instance.role_definition per row) so _sync_assignment_to_old_roles can look the field
+    instance.role_definition per row) so _sync_assignment_to_old_role can look the field
     up by id. Role definitions with no legacy equivalent map to None and are skipped.
     """
     rd_ids = {instance.role_definition_id for instance in assignments}
@@ -920,7 +920,7 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
     A single handler performs both jobs — the old-RBAC Role.members mirror and the
     new-side activity-stream recording — so ordering stays deterministic: the old-RBAC
     write happens inside disable_activity_stream()/disable_rbac_sync() (within
-    _sync_assignment_to_old_roles), then the activity-stream entry is recorded once.
+    _sync_assignment_to_old_role), then the activity-stream entry is recorded once.
 
     Replaces the former per-row post_save receivers sync_user_assignments_to_old_rbac_create
     and record_role_assignment_activity_stream, which do not fire for bulk_create.
@@ -935,7 +935,7 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
 
     for instance in assignments:
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignment_to_old_roles(instance, delete=False, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
+        _sync_assignment_to_old_role(instance, delete=False, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
         _record_role_assignment_activity_stream(instance, 'associate', dab_content_objects)
 
 
@@ -961,7 +961,7 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
         # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
         _record_role_assignment_activity_stream(instance, 'disassociate', dab_content_objects)
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignment_to_old_roles(instance, delete=True, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
+        _sync_assignment_to_old_role(instance, delete=True, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
 
 
 m2m_changed.connect(sync_members_to_new_rbac, Role.members.through)

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -834,11 +834,16 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
     Replaces the former per-row post_save receivers sync_user_assignments_to_old_rbac_create
     and record_role_assignment_activity_stream, which do not fire for bulk_create.
     """
-    from awx.main.signals import _record_role_assignment_activity_stream
+    from awx.main.signals import _prefetch_assignment_content_objects, _record_role_assignment_activity_stream
+
+    # Resolve every assignment's content object once, using the dict the signal provides and
+    # falling back to a single bulk fetch per content type, so activity-stream recording does
+    # not incur a per-row query.
+    content_objects = _prefetch_assignment_content_objects(assignments, content_objects)
 
     for instance in assignments:
         _sync_assignments_to_old_rbac(instance, delete=False)
-        _record_role_assignment_activity_stream(instance, 'associate')
+        _record_role_assignment_activity_stream(instance, 'associate', content_objects)
 
 
 def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None, **kwargs):
@@ -854,11 +859,15 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
     Replaces the former per-row post_delete receivers sync_assignments_to_old_rbac_delete
     and record_role_unassignment_activity_stream, which do not fire for queryset .delete().
     """
-    from awx.main.signals import _record_role_assignment_activity_stream
+    from awx.main.signals import _prefetch_assignment_content_objects, _record_role_assignment_activity_stream
+
+    # Same prefetch as the create side: the rows still exist (pre_delete), so their content
+    # objects can be bulk-fetched per content type instead of one query per assignment.
+    content_objects = _prefetch_assignment_content_objects(assignments, content_objects)
 
     for instance in assignments:
         # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
-        _record_role_assignment_activity_stream(instance, 'disassociate')
+        _record_role_assignment_activity_stream(instance, 'disassociate', content_objects)
         _sync_assignments_to_old_rbac(instance, delete=True)
 
 

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -15,8 +15,7 @@ from crum import impersonate
 
 # Django
 from django.db import models, transaction, connection
-from django.db.models.signals import m2m_changed, post_save, post_delete
-from django.dispatch import receiver
+from django.db.models.signals import m2m_changed
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
@@ -26,8 +25,9 @@ from django.apps import apps
 from django.conf import settings
 
 # Ansible_base app
-from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment, RoleTeamAssignment
+from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac.sync import maybe_reverse_sync_assignment, maybe_reverse_sync_unassignment, maybe_reverse_sync_role_definition
+from ansible_base.rbac.triggers import dab_rbac_assignments_created, dab_rbac_assignments_pre_delete
 from ansible_base.rbac import permission_registry
 from ansible_base.resource_registry.signals.handlers import no_reverse_sync
 from ansible_base.lib.utils.models import get_type_for_model
@@ -703,6 +703,13 @@ def sync_members_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs)
 def sync_parents_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs):
     if action.startswith('pre_'):
         return
+    # Mirror the guard in sync_members_to_new_rbac: when _sync_assignments_to_old_rbac
+    # mirrors a team assignment it edits member_role.children inside disable_rbac_sync(),
+    # which fires this m2m handler. Without this guard the reverse (old->new) sync would
+    # call remove_permission again and, because the bulk pre_delete signal now fires
+    # before the assignment row is deleted, re-find the still-present assignment and recurse.
+    if not rbac_sync_enabled.enabled:
+        return
 
     if action == 'post_add':
         is_giving = True
@@ -814,27 +821,54 @@ def _sync_assignments_to_old_rbac(instance, delete=True):
                     instance.team.member_role.children.add(role)
 
 
-@receiver(post_delete, sender=RoleUserAssignment)
-@receiver(post_delete, sender=RoleTeamAssignment)
-def sync_assignments_to_old_rbac_delete(instance, origin=None, **kwargs):
-    # Skip cascade deletes from non-assignment origins — sync is redundant:
-    #  - Model origin with app_label != dab_rbac: a parent object (e.g.
-    #    Organization) is being deleted and old Role M2M tables cascade from
-    #    the same parent.
-    #  - QuerySet of a different model (e.g. ObjectRole): bulk RBAC cleanup
-    #    such as defer_rbac_computations flush — parent objects already gone.
-    if isinstance(origin, models.Model) and origin._meta.app_label != 'dab_rbac':
-        return
-    if isinstance(origin, models.QuerySet) and origin.model is not type(instance):
-        return
-    _sync_assignments_to_old_rbac(instance, delete=True)
+def handle_dab_assignments_created(sender, assignments, content_objects=None, **kwargs):
+    """Handle a batch of newly-created role assignments from the DAB bulk pipeline.
+
+    Fires once per bulk_give_permissions / give_assignments operation (and for the
+    interim-restored JWT/SSO claims path), only for rows that were actually created.
+    A single handler performs both jobs — the old-RBAC Role.members mirror and the
+    new-side activity-stream recording — so ordering stays deterministic: the old-RBAC
+    write happens inside disable_activity_stream()/disable_rbac_sync() (within
+    _sync_assignments_to_old_rbac), then the activity-stream entry is recorded once.
+
+    Replaces the former per-row post_save receivers sync_user_assignments_to_old_rbac_create
+    and record_role_assignment_activity_stream, which do not fire for bulk_create.
+    """
+    from awx.main.signals import _record_role_assignment_activity_stream
+
+    for instance in assignments:
+        _sync_assignments_to_old_rbac(instance, delete=False)
+        _record_role_assignment_activity_stream(instance, 'associate')
 
 
-@receiver(post_save, sender=RoleUserAssignment)
-@receiver(post_save, sender=RoleTeamAssignment)
-def sync_user_assignments_to_old_rbac_create(instance, **kwargs):
-    _sync_assignments_to_old_rbac(instance, delete=False)
+def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None, **kwargs):
+    """Handle a batch of role assignments about to be removed by the DAB bulk pipeline.
+
+    Fires once per bulk_remove_permissions / remove_assignments operation, BEFORE the
+    rows are deleted, so every FK on each assignment (object_role, role_definition,
+    actor, content_object) is still readable. It fires ONLY on explicit assignment
+    removal, never on FK cascade (e.g. deleting an Organization), so the origin-filter
+    logic the old post_delete receivers needed to skip cascades is no longer required —
+    cascade cleanup of the old Role.members happens through the parent's own cascade.
+
+    Replaces the former per-row post_delete receivers sync_assignments_to_old_rbac_delete
+    and record_role_unassignment_activity_stream, which do not fire for queryset .delete().
+    """
+    from awx.main.signals import _record_role_assignment_activity_stream
+
+    for instance in assignments:
+        # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
+        _record_role_assignment_activity_stream(instance, 'disassociate')
+        _sync_assignments_to_old_rbac(instance, delete=True)
 
 
 m2m_changed.connect(sync_members_to_new_rbac, Role.members.through)
 m2m_changed.connect(sync_parents_to_new_rbac, Role.parents.through)
+
+# The DAB bulk assignment pipeline (bulk_give_permissions / bulk_remove_permissions and the
+# lower-level give_assignments / remove_assignments) creates and deletes rows with bulk_create
+# and queryset .delete(), which do not emit per-row post_save / post_delete. These two bulk
+# signals fire once per operation with the whole batch instead. Exactly one handler is connected
+# to each so a single pass does both the old-RBAC mirror and the activity-stream recording.
+dab_rbac_assignments_created.connect(handle_dab_assignments_created, dispatch_uid='awx_dab_assignments_created')
+dab_rbac_assignments_pre_delete.connect(handle_dab_assignments_pre_delete, dispatch_uid='awx_dab_assignments_pre_delete')

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -705,7 +705,7 @@ def sync_members_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs)
 def sync_parents_to_new_rbac(instance, action, model, pk_set, reverse, **kwargs):
     if action.startswith('pre_'):
         return
-    # Mirror the guard in sync_members_to_new_rbac: when _sync_assignments_to_old_rbac
+    # Mirror the guard in sync_members_to_new_rbac: when _sync_assignment_to_old_roles
     # mirrors a team assignment it edits member_role.children inside disable_rbac_sync(),
     # which fires this m2m handler. Without this guard the reverse (old->new) sync would
     # call remove_permission again and, because the bulk pre_delete signal now fires
@@ -797,7 +797,7 @@ ROLE_DEFINITION_TO_ROLE_FIELD = {
 _UNSET = object()
 
 
-def _sync_assignments_to_old_rbac(instance, delete=True, content_object=_UNSET, field_name=_UNSET):
+def _sync_assignment_to_old_roles(instance, delete=True, content_object=_UNSET, field_name=_UNSET):
     """Mirror a single new-RBAC assignment into the legacy Role.members / children m2m.
 
     ``content_object`` and ``field_name`` may be supplied pre-resolved by the bulk handlers
@@ -844,7 +844,7 @@ def _field_names_for_old_rbac(assignments):
     """Map role_definition_id -> legacy Role field name for a whole batch in one query.
 
     Resolves the role-definition names once (instead of dereferencing
-    instance.role_definition per row) so _sync_assignments_to_old_rbac can look the field
+    instance.role_definition per row) so _sync_assignment_to_old_roles can look the field
     up by id. Role definitions with no legacy equivalent map to None and are skipped.
     """
     rd_ids = {instance.role_definition_id for instance in assignments}
@@ -920,7 +920,7 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
     A single handler performs both jobs — the old-RBAC Role.members mirror and the
     new-side activity-stream recording — so ordering stays deterministic: the old-RBAC
     write happens inside disable_activity_stream()/disable_rbac_sync() (within
-    _sync_assignments_to_old_rbac), then the activity-stream entry is recorded once.
+    _sync_assignment_to_old_roles), then the activity-stream entry is recorded once.
 
     Replaces the former per-row post_save receivers sync_user_assignments_to_old_rbac_create
     and record_role_assignment_activity_stream, which do not fire for bulk_create.
@@ -935,7 +935,7 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
 
     for instance in assignments:
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignments_to_old_rbac(instance, delete=False, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
+        _sync_assignment_to_old_roles(instance, delete=False, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
         _record_role_assignment_activity_stream(instance, 'associate', dab_content_objects)
 
 
@@ -961,7 +961,7 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
         # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
         _record_role_assignment_activity_stream(instance, 'disassociate', dab_content_objects)
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignments_to_old_rbac(instance, delete=True, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
+        _sync_assignment_to_old_roles(instance, delete=True, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
 
 
 m2m_changed.connect(sync_members_to_new_rbac, Role.members.through)

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -851,41 +851,6 @@ def _field_names_for_old_rbac(assignments):
     return {pk: ROLE_DEFINITION_TO_ROLE_FIELD.get(name) for pk, name in RoleDefinition.objects.filter(pk__in=rd_ids).values_list('pk', 'name')}
 
 
-def _prefetch_assignment_content_objects(assignments, content_objects=None):
-    """Build a {(content_type_id, object_id): instance} lookup for a batch of assignments.
-
-    The DAB bulk signal supplies ``content_objects`` when the grant/removal went through
-    bulk_give_permissions / bulk_remove_permissions, but it can be empty when a caller
-    used give_assignments / remove_assignments directly. For any object-scoped assignment
-    not already covered, this fetches the referenced objects in bulk grouped by content
-    type — one query per type — instead of dereferencing ``instance.content_object`` one
-    row at a time, which was the per-row cost this migration set out to remove (AAP-85842).
-    """
-    lookup = dict(content_objects or {})
-    # content_type_id -> set(object_id) still needing resolution. Group by id only so we
-    # never touch instance.content_type per row (that would be the per-row query again).
-    missing = {}
-    for instance in assignments:
-        if not instance.object_id:
-            continue  # global (singleton) assignment: no content object
-        key = (instance.content_type_id, instance.object_id)
-        if key in lookup:
-            continue
-        missing.setdefault(instance.content_type_id, set()).add(instance.object_id)
-
-    if not missing:
-        return lookup
-
-    content_types = permission_registry.content_type_model.objects.in_bulk(missing.keys())
-    for ct_id, object_ids in missing.items():
-        ct = content_types.get(ct_id)
-        if ct is None:
-            continue  # content type row is gone; leave to per-row fallback
-        for obj in ct.model_class()._base_manager.in_bulk(object_ids).values():
-            lookup[(ct_id, str(obj.pk))] = obj
-    return lookup
-
-
 def _record_role_assignment_activity_stream(instance, operation, content_objects=None):
     from awx.main.signals import activity_stream_enabled, emit_activity_stream_change, get_activity_stream_class, get_current_user_or_none
     from awx.main.utils import camelcase_to_underscore
@@ -904,38 +869,33 @@ def _record_role_assignment_activity_stream(instance, operation, content_objects
         actor_field = 'team'
         actor_obj = instance.team
 
-    content_object = None
-    if instance.object_id:
-        # Prefer the batch lookup (populated once per bulk signal, same-type prefetched);
-        # fall back to a per-row fetch only for keys it doesn't cover.
-        content_object = (content_objects or {}).get((instance.content_type_id, instance.object_id))
-        if content_object is None:
-            content_object = instance.content_object
-        if content_object is None and operation == 'disassociate':
-            # The target object is unresolvable, e.g. cascade-deleted along with its
-            # parent object. Skip recording a contentless entry rather than guessing at
-            # what changed. Note: FederatedForeignKey swallows ObjectDoesNotExist and
-            # returns None rather than raising, so there's no exception to catch here.
-            return
-
     changes = {'role_definition': instance.role_definition.name, actor_field: getattr(actor_obj, 'username', None) or str(actor_obj)}
 
-    # object1 is the role's content object and object2 the associated user/team, matching
-    # the convention used for legacy Role.members association entries, so this reads e.g.
-    # "disassociated organization X from user Y".
-    object1 = ''
+    # object1 names the ActivityStream relation we link the entry to (object2 is the actor),
+    # matching the convention used for legacy Role.members association entries so this reads
+    # e.g. "disassociated organization X from user Y". Defaults describe a global (singleton)
+    # role assignment with no content object; object-scoped assignments fill these in below.
     activity_stream_cls = get_activity_stream_class()
+    object1 = ''
+    obj_rel = str(instance.role_definition_id)
+
+    # The object is linked only when DAB resolved it for us in content_objects. We never
+    # fetch it ourselves: that per-row fetch is exactly the regression this migration set out
+    # to remove (AAP-85842). On the narrow path where DAB does not supply it (a direct
+    # give_assignments / remove_assignments, or a global role) the entry is recorded with just
+    # the role and actor, without an object link. Because we only ever link an object DAB
+    # actually resolved, the m2m link can never reference a row that does not exist.
+    content_object = (content_objects or {}).get((instance.content_type_id, instance.object_id)) if instance.object_id else None
     if content_object is not None:
-        object1 = camelcase_to_underscore(content_object.__class__.__name__)
-        changes['object_type'] = object1
+        object_type = camelcase_to_underscore(content_object.__class__.__name__)
+        obj_rel = f'{content_object.__class__.__module__}.{content_object.__class__.__name__}.{instance.role_definition_id}'
+        changes['object_type'] = object_type
         changes['object_id'] = content_object.pk
         changes['object_name'] = str(content_object)
-        obj_rel = f'{content_object.__class__.__module__}.{content_object.__class__.__name__}.{instance.role_definition_id}'
-        if not hasattr(activity_stream_cls, object1):
-            logger.warning('ActivityStream has no relation field for object type %r; role assignment entry will not be linked to it', object1)
-            object1 = ''
-    else:
-        obj_rel = str(instance.role_definition_id)
+        if hasattr(activity_stream_cls, object_type):
+            object1 = object_type
+        else:
+            logger.warning('ActivityStream has no relation field for object type %r; role assignment entry will not be linked to it', object_type)
 
     activity_entry = activity_stream_cls(
         operation=operation,
@@ -965,15 +925,18 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
     Replaces the former per-row post_save receivers sync_user_assignments_to_old_rbac_create
     and record_role_assignment_activity_stream, which do not fire for bulk_create.
     """
-    # Resolve every assignment's content object and legacy field name once per batch, so
-    # neither the old-RBAC mirror nor activity-stream recording incurs a per-row query.
-    content_objects = _prefetch_assignment_content_objects(assignments, content_objects)
+    # Resolve the legacy field names for the whole batch in one query, and take the content
+    # objects straight from the DAB dict — we never fetch them ourselves (AAP-85842). The
+    # old-RBAC mirror falls back to a per-row lookup only on the narrow path where DAB did not
+    # supply the object (a direct give_assignments); the activity-stream recorder simply omits
+    # the object link there.
+    dab_content_objects = content_objects or {}
     field_names = _field_names_for_old_rbac(assignments)
 
     for instance in assignments:
-        content_object = content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
+        content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
         _sync_assignments_to_old_rbac(instance, delete=False, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
-        _record_role_assignment_activity_stream(instance, 'associate', content_objects)
+        _record_role_assignment_activity_stream(instance, 'associate', dab_content_objects)
 
 
 def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None, **kwargs):
@@ -989,16 +952,15 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
     Replaces the former per-row post_delete receivers sync_assignments_to_old_rbac_delete
     and record_role_unassignment_activity_stream, which do not fire for queryset .delete().
     """
-    # Same batch resolution as the create side: the rows still exist (pre_delete), so their
-    # content objects can be bulk-fetched per content type and field names resolved in one
-    # query, instead of one query per assignment.
-    content_objects = _prefetch_assignment_content_objects(assignments, content_objects)
+    # Same batch resolution as the create side: field names in one query, and the content
+    # objects taken straight from the DAB dict rather than fetched here (AAP-85842).
+    dab_content_objects = content_objects or {}
     field_names = _field_names_for_old_rbac(assignments)
 
     for instance in assignments:
         # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
-        _record_role_assignment_activity_stream(instance, 'disassociate', content_objects)
-        content_object = content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
+        _record_role_assignment_activity_stream(instance, 'disassociate', dab_content_objects)
+        content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
         _sync_assignments_to_old_rbac(instance, delete=True, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
 
 

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -797,23 +797,22 @@ ROLE_DEFINITION_TO_ROLE_FIELD = {
 _UNSET = object()
 
 
-def _sync_assignment_to_old_role(instance, delete=True, content_object=_UNSET, field_name=_UNSET):
+def _sync_assignment_to_old_role(instance, field_name, delete=True, content_object=_UNSET):
     """Mirror a single new-RBAC assignment into the legacy Role.members / children m2m.
 
-    ``content_object`` and ``field_name`` may be supplied pre-resolved by the bulk handlers
-    (see _field_names_for_old_rbac and the shared content-object prefetch) so a batch does
-    not re-dereference instance.role_definition and instance.object_role.content_object once
-    per row. When omitted they are resolved from the instance, preserving the original
-    single-row behavior for any other caller.
+    ``field_name`` is the legacy Role field for the assignment's role definition, resolved
+    once for the whole batch by the bulk handlers (see _field_names_for_old_rbac); a role
+    definition with no legacy equivalent passes None and is skipped. ``content_object`` is
+    taken from DAB's content_objects when available; on the narrow path where DAB did not
+    supply it, pass _UNSET and it is dereferenced from the instance here.
     """
     from awx.main.signals import disable_activity_stream
 
+    if not field_name:
+        return
+
     with disable_activity_stream():
         with disable_rbac_sync():
-            if field_name is _UNSET:
-                field_name = ROLE_DEFINITION_TO_ROLE_FIELD.get(instance.role_definition.name)
-            if not field_name:
-                return
             if content_object is _UNSET:
                 try:
                     content_object = instance.object_role.content_object
@@ -935,7 +934,7 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
 
     for instance in assignments:
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignment_to_old_role(instance, delete=False, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
+        _sync_assignment_to_old_role(instance, field_names.get(instance.role_definition_id), delete=False, content_object=content_object)
         _record_role_assignment_activity_stream(instance, 'associate', dab_content_objects)
 
 
@@ -961,7 +960,7 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
         # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
         _record_role_assignment_activity_stream(instance, 'disassociate', dab_content_objects)
         content_object = dab_content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
-        _sync_assignment_to_old_role(instance, delete=True, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
+        _sync_assignment_to_old_role(instance, field_names.get(instance.role_definition_id), delete=True, content_object=content_object)
 
 
 m2m_changed.connect(sync_members_to_new_rbac, Role.members.through)

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -2,7 +2,9 @@
 # All Rights Reserved.
 
 # Python
+import json
 import logging
+import sys
 import threading
 import contextlib
 import re
@@ -849,6 +851,107 @@ def _field_names_for_old_rbac(assignments):
     return {pk: ROLE_DEFINITION_TO_ROLE_FIELD.get(name) for pk, name in RoleDefinition.objects.filter(pk__in=rd_ids).values_list('pk', 'name')}
 
 
+def _prefetch_assignment_content_objects(assignments, content_objects=None):
+    """Build a {(content_type_id, object_id): instance} lookup for a batch of assignments.
+
+    The DAB bulk signal supplies ``content_objects`` when the grant/removal went through
+    bulk_give_permissions / bulk_remove_permissions, but it can be empty when a caller
+    used give_assignments / remove_assignments directly. For any object-scoped assignment
+    not already covered, this fetches the referenced objects in bulk grouped by content
+    type — one query per type — instead of dereferencing ``instance.content_object`` one
+    row at a time, which was the per-row cost this migration set out to remove (AAP-85842).
+    """
+    lookup = dict(content_objects or {})
+    # content_type_id -> set(object_id) still needing resolution. Group by id only so we
+    # never touch instance.content_type per row (that would be the per-row query again).
+    missing = {}
+    for instance in assignments:
+        if not instance.object_id:
+            continue  # global (singleton) assignment: no content object
+        key = (instance.content_type_id, instance.object_id)
+        if key in lookup:
+            continue
+        missing.setdefault(instance.content_type_id, set()).add(instance.object_id)
+
+    if not missing:
+        return lookup
+
+    content_types = permission_registry.content_type_model.objects.in_bulk(missing.keys())
+    for ct_id, object_ids in missing.items():
+        ct = content_types.get(ct_id)
+        if ct is None:
+            continue  # content type row is gone; leave to per-row fallback
+        for obj in ct.model_class()._base_manager.in_bulk(object_ids).values():
+            lookup[(ct_id, str(obj.pk))] = obj
+    return lookup
+
+
+def _record_role_assignment_activity_stream(instance, operation, content_objects=None):
+    from awx.main.signals import activity_stream_enabled, emit_activity_stream_change, get_activity_stream_class, get_current_user_or_none
+    from awx.main.utils import camelcase_to_underscore
+
+    if not activity_stream_enabled:
+        return
+    # Avoid flooding the activity stream when assignments are cascade-deleted as part
+    # of setup_managed_role_definitions() pruning stale managed RoleDefinitions on migrate.
+    if 'migrate' in sys.argv:
+        return
+
+    if isinstance(instance, RoleUserAssignment):
+        actor_field = 'user'
+        actor_obj = instance.user
+    else:
+        actor_field = 'team'
+        actor_obj = instance.team
+
+    content_object = None
+    if instance.object_id:
+        # Prefer the batch lookup (populated once per bulk signal, same-type prefetched);
+        # fall back to a per-row fetch only for keys it doesn't cover.
+        content_object = (content_objects or {}).get((instance.content_type_id, instance.object_id))
+        if content_object is None:
+            content_object = instance.content_object
+        if content_object is None and operation == 'disassociate':
+            # The target object is unresolvable, e.g. cascade-deleted along with its
+            # parent object. Skip recording a contentless entry rather than guessing at
+            # what changed. Note: FederatedForeignKey swallows ObjectDoesNotExist and
+            # returns None rather than raising, so there's no exception to catch here.
+            return
+
+    changes = {'role_definition': instance.role_definition.name, actor_field: getattr(actor_obj, 'username', None) or str(actor_obj)}
+
+    # object1 is the role's content object and object2 the associated user/team, matching
+    # the convention used for legacy Role.members association entries, so this reads e.g.
+    # "disassociated organization X from user Y".
+    object1 = ''
+    activity_stream_cls = get_activity_stream_class()
+    if content_object is not None:
+        object1 = camelcase_to_underscore(content_object.__class__.__name__)
+        changes['object_type'] = object1
+        changes['object_id'] = content_object.pk
+        changes['object_name'] = str(content_object)
+        obj_rel = f'{content_object.__class__.__module__}.{content_object.__class__.__name__}.{instance.role_definition_id}'
+        if not hasattr(activity_stream_cls, object1):
+            logger.warning('ActivityStream has no relation field for object type %r; role assignment entry will not be linked to it', object1)
+            object1 = ''
+    else:
+        obj_rel = str(instance.role_definition_id)
+
+    activity_entry = activity_stream_cls(
+        operation=operation,
+        object1=object1,
+        object2=actor_field,
+        object_relationship_type=obj_rel,
+        changes=json.dumps(changes),
+        actor=get_current_user_or_none(),
+    )
+    activity_entry.save()
+    getattr(activity_entry, actor_field).add(actor_obj.pk)
+    if object1:
+        getattr(activity_entry, object1).add(content_object.pk)
+    connection.on_commit(lambda: emit_activity_stream_change(activity_entry))
+
+
 def handle_dab_assignments_created(sender, assignments, content_objects=None, **kwargs):
     """Handle a batch of newly-created role assignments from the DAB bulk pipeline.
 
@@ -862,8 +965,6 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
     Replaces the former per-row post_save receivers sync_user_assignments_to_old_rbac_create
     and record_role_assignment_activity_stream, which do not fire for bulk_create.
     """
-    from awx.main.signals import _prefetch_assignment_content_objects, _record_role_assignment_activity_stream
-
     # Resolve every assignment's content object and legacy field name once per batch, so
     # neither the old-RBAC mirror nor activity-stream recording incurs a per-row query.
     content_objects = _prefetch_assignment_content_objects(assignments, content_objects)
@@ -888,8 +989,6 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
     Replaces the former per-row post_delete receivers sync_assignments_to_old_rbac_delete
     and record_role_unassignment_activity_stream, which do not fire for queryset .delete().
     """
-    from awx.main.signals import _prefetch_assignment_content_objects, _record_role_assignment_activity_stream
-
     # Same batch resolution as the create side: the rows still exist (pre_delete), so their
     # content objects can be bulk-fetched per content type and field names resolved in one
     # query, instead of one query per assignment.

--- a/awx/main/models/rbac.py
+++ b/awx/main/models/rbac.py
@@ -25,7 +25,7 @@ from django.apps import apps
 from django.conf import settings
 
 # Ansible_base app
-from ansible_base.rbac.models import RoleDefinition
+from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
 from ansible_base.rbac.sync import maybe_reverse_sync_assignment, maybe_reverse_sync_unassignment, maybe_reverse_sync_role_definition
 from ansible_base.rbac.triggers import dab_rbac_assignments_created, dab_rbac_assignments_pre_delete
 from ansible_base.rbac import permission_registry
@@ -792,33 +792,61 @@ ROLE_DEFINITION_TO_ROLE_FIELD = {
 }
 
 
-def _sync_assignments_to_old_rbac(instance, delete=True):
+_UNSET = object()
+
+
+def _sync_assignments_to_old_rbac(instance, delete=True, content_object=_UNSET, field_name=_UNSET):
+    """Mirror a single new-RBAC assignment into the legacy Role.members / children m2m.
+
+    ``content_object`` and ``field_name`` may be supplied pre-resolved by the bulk handlers
+    (see _field_names_for_old_rbac and the shared content-object prefetch) so a batch does
+    not re-dereference instance.role_definition and instance.object_role.content_object once
+    per row. When omitted they are resolved from the instance, preserving the original
+    single-row behavior for any other caller.
+    """
     from awx.main.signals import disable_activity_stream
 
     with disable_activity_stream():
         with disable_rbac_sync():
-            field_name = ROLE_DEFINITION_TO_ROLE_FIELD.get(instance.role_definition.name)
+            if field_name is _UNSET:
+                field_name = ROLE_DEFINITION_TO_ROLE_FIELD.get(instance.role_definition.name)
             if not field_name:
                 return
-            try:
-                role = getattr(instance.object_role.content_object, field_name)
-            # in the case RoleUserAssignment is being cascade deleted, then
-            # object_role might not exist. In which case the object is about to be removed
-            # anyways so just return
-            except ObjectDoesNotExist:
+            if content_object is _UNSET:
+                try:
+                    content_object = instance.object_role.content_object
+                # in the case RoleUserAssignment is being cascade deleted, then
+                # object_role might not exist. In which case the object is about to be removed
+                # anyways so just return
+                except ObjectDoesNotExist:
+                    return
+            if content_object is None:
+                # Object no longer resolvable (e.g. already deleted) — nothing to mirror.
                 return
-            if isinstance(instance.actor, get_user_model()):
-                # user
+            role = getattr(content_object, field_name)
+            if isinstance(instance, RoleUserAssignment):
+                # user — add/remove by pk to avoid fetching the user object
                 if delete:
-                    role.members.remove(instance.actor)
+                    role.members.remove(instance.user_id)
                 else:
-                    role.members.add(instance.actor)
+                    role.members.add(instance.user_id)
             else:
                 # team
                 if delete:
                     instance.team.member_role.children.remove(role)
                 else:
                     instance.team.member_role.children.add(role)
+
+
+def _field_names_for_old_rbac(assignments):
+    """Map role_definition_id -> legacy Role field name for a whole batch in one query.
+
+    Resolves the role-definition names once (instead of dereferencing
+    instance.role_definition per row) so _sync_assignments_to_old_rbac can look the field
+    up by id. Role definitions with no legacy equivalent map to None and are skipped.
+    """
+    rd_ids = {instance.role_definition_id for instance in assignments}
+    return {pk: ROLE_DEFINITION_TO_ROLE_FIELD.get(name) for pk, name in RoleDefinition.objects.filter(pk__in=rd_ids).values_list('pk', 'name')}
 
 
 def handle_dab_assignments_created(sender, assignments, content_objects=None, **kwargs):
@@ -836,13 +864,14 @@ def handle_dab_assignments_created(sender, assignments, content_objects=None, **
     """
     from awx.main.signals import _prefetch_assignment_content_objects, _record_role_assignment_activity_stream
 
-    # Resolve every assignment's content object once, using the dict the signal provides and
-    # falling back to a single bulk fetch per content type, so activity-stream recording does
-    # not incur a per-row query.
+    # Resolve every assignment's content object and legacy field name once per batch, so
+    # neither the old-RBAC mirror nor activity-stream recording incurs a per-row query.
     content_objects = _prefetch_assignment_content_objects(assignments, content_objects)
+    field_names = _field_names_for_old_rbac(assignments)
 
     for instance in assignments:
-        _sync_assignments_to_old_rbac(instance, delete=False)
+        content_object = content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
+        _sync_assignments_to_old_rbac(instance, delete=False, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
         _record_role_assignment_activity_stream(instance, 'associate', content_objects)
 
 
@@ -861,14 +890,17 @@ def handle_dab_assignments_pre_delete(sender, assignments, content_objects=None,
     """
     from awx.main.signals import _prefetch_assignment_content_objects, _record_role_assignment_activity_stream
 
-    # Same prefetch as the create side: the rows still exist (pre_delete), so their content
-    # objects can be bulk-fetched per content type instead of one query per assignment.
+    # Same batch resolution as the create side: the rows still exist (pre_delete), so their
+    # content objects can be bulk-fetched per content type and field names resolved in one
+    # query, instead of one query per assignment.
     content_objects = _prefetch_assignment_content_objects(assignments, content_objects)
+    field_names = _field_names_for_old_rbac(assignments)
 
     for instance in assignments:
         # Record the activity stream entry BEFORE deletion, while the FKs are still valid.
         _record_role_assignment_activity_stream(instance, 'disassociate', content_objects)
-        _sync_assignments_to_old_rbac(instance, delete=True)
+        content_object = content_objects.get((instance.content_type_id, instance.object_id), _UNSET)
+        _sync_assignments_to_old_rbac(instance, delete=True, content_object=content_object, field_name=field_names.get(instance.role_definition_id))
 
 
 m2m_changed.connect(sync_members_to_new_rbac, Role.members.through)

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -27,9 +27,6 @@ from django.utils import timezone
 from crum import get_current_request, get_current_user
 from crum.signals import current_user_getter
 
-# Ansible_base app
-from ansible_base.rbac.models import RoleUserAssignment
-
 # AWX
 from awx.main.models import (
     ActivityStream,
@@ -153,122 +150,9 @@ def sync_rbac_to_superuser_status(instance, sender, **kwargs):
                 user.save(update_fields=['is_superuser'])
 
 
-def _prefetch_assignment_content_objects(assignments, content_objects=None):
-    """Build a {(content_type_id, object_id): instance} lookup for a batch of assignments.
-
-    The DAB bulk signal supplies ``content_objects`` when the grant/removal went through
-    bulk_give_permissions / bulk_remove_permissions, but it can be empty when a caller
-    used give_assignments / remove_assignments directly. For any object-scoped assignment
-    not already covered, this fetches the referenced objects in bulk grouped by content
-    type — one query per type — instead of dereferencing ``instance.content_object`` one
-    row at a time, which was the per-row cost this migration set out to remove (AAP-85842).
-
-    Content types that don't resolve to a local model (remote / federated) are left out;
-    _record_role_assignment_activity_stream falls back to a per-row fetch for those.
-    """
-    from ansible_base.rbac import permission_registry
-    from ansible_base.rbac.remote import get_remote_base_class
-
-    lookup = dict(content_objects or {})
-    # content_type_id -> set(object_id) still needing resolution. Group by id only so we
-    # never touch instance.content_type per row (that would be the per-row query again).
-    missing = {}
-    for instance in assignments:
-        if not instance.object_id:
-            continue  # global (singleton) assignment: no content object
-        key = (instance.content_type_id, instance.object_id)
-        if key in lookup:
-            continue
-        missing.setdefault(instance.content_type_id, set()).add(instance.object_id)
-
-    if not missing:
-        return lookup
-
-    content_types = permission_registry.content_type_model.objects.in_bulk(missing.keys())
-    remote_base = get_remote_base_class()
-    for ct_id, object_ids in missing.items():
-        ct = content_types.get(ct_id)
-        if ct is None:
-            continue  # content type row is gone; leave to per-row fallback
-        try:
-            model = ct.model_class()
-        except LookupError:
-            continue  # unknown content type; leave to per-row fallback
-        if issubclass(model, remote_base):
-            continue  # remote/federated object; can't bulk-fetch locally
-        for obj in model._base_manager.in_bulk(object_ids).values():
-            lookup[(ct_id, str(obj.pk))] = obj
-    return lookup
-
-
-def _record_role_assignment_activity_stream(instance, operation, content_objects=None):
-    if not activity_stream_enabled:
-        return
-    # Avoid flooding the activity stream when assignments are cascade-deleted as part
-    # of setup_managed_role_definitions() pruning stale managed RoleDefinitions on migrate.
-    if 'migrate' in sys.argv:
-        return
-
-    if isinstance(instance, RoleUserAssignment):
-        actor_field = 'user'
-        actor_obj = instance.user
-    else:
-        actor_field = 'team'
-        actor_obj = instance.team
-
-    content_object = None
-    if instance.object_id:
-        # Prefer the batch lookup (populated once per bulk signal, same-type prefetched);
-        # fall back to a per-row fetch only for keys it doesn't cover.
-        content_object = (content_objects or {}).get((instance.content_type_id, instance.object_id))
-        if content_object is None:
-            content_object = instance.content_object
-        if content_object is None and operation == 'disassociate':
-            # The target object is unresolvable, e.g. cascade-deleted along with its
-            # parent object, or a federated/remote content type. Skip recording a
-            # contentless entry rather than guessing at what changed.
-            # Note: FederatedForeignKey swallows ObjectDoesNotExist and returns None
-            # rather than raising, so there's no exception to catch here.
-            return
-
-    changes = {'role_definition': instance.role_definition.name, actor_field: getattr(actor_obj, 'username', None) or str(actor_obj)}
-
-    # object1 is the role's content object and object2 the associated user/team, matching
-    # the convention used for legacy Role.members association entries (rbac_activity_stream
-    # below), so this reads e.g. "disassociated organization X from user Y".
-    object1 = ''
-    activity_stream_cls = get_activity_stream_class()
-    if content_object is not None:
-        object1 = camelcase_to_underscore(content_object.__class__.__name__)
-        changes['object_type'] = object1
-        changes['object_id'] = content_object.pk
-        changes['object_name'] = str(content_object)
-        obj_rel = f'{content_object.__class__.__module__}.{content_object.__class__.__name__}.{instance.role_definition_id}'
-        if not hasattr(activity_stream_cls, object1):
-            logger.warning('ActivityStream has no relation field for object type %r; role assignment entry will not be linked to it', object1)
-            object1 = ''
-    else:
-        obj_rel = str(instance.role_definition_id)
-
-    activity_entry = activity_stream_cls(
-        operation=operation,
-        object1=object1,
-        object2=actor_field,
-        object_relationship_type=obj_rel,
-        changes=json.dumps(changes),
-        actor=get_current_user_or_none(),
-    )
-    activity_entry.save()
-    getattr(activity_entry, actor_field).add(actor_obj.pk)
-    if object1:
-        getattr(activity_entry, object1).add(content_object.pk)
-    connection.on_commit(lambda: emit_activity_stream_change(activity_entry))
-
-
-# Activity-stream recording for role assignments is driven by the DAB bulk signals
-# (dab_rbac_assignments_created / dab_rbac_assignments_pre_delete), handled together with
-# the old-RBAC Role.members mirror in awx.main.models.rbac. _record_role_assignment_activity_stream
-# above is the shared implementation those handlers call; it is no longer connected to per-row
+# Activity-stream recording for role assignments lives in awx.main.models.rbac, driven by
+# the DAB bulk signals (dab_rbac_assignments_created / dab_rbac_assignments_pre_delete) and
+# handled together with the old-RBAC Role.members mirror. It is no longer connected to per-row
 # post_save / post_delete, which the bulk assignment pipeline does not emit.
 
 

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -9,7 +9,7 @@ import json
 import sys
 
 # Django
-from django.db import connection, models
+from django.db import connection
 from django.conf import settings
 from django.db.models.signals import (
     pre_save,
@@ -28,7 +28,7 @@ from crum import get_current_request, get_current_user
 from crum.signals import current_user_getter
 
 # Ansible_base app
-from ansible_base.rbac.models import RoleUserAssignment, RoleTeamAssignment
+from ansible_base.rbac.models import RoleUserAssignment
 
 # AWX
 from awx.main.models import (
@@ -213,25 +213,11 @@ def _record_role_assignment_activity_stream(instance, operation):
     connection.on_commit(lambda: emit_activity_stream_change(activity_entry))
 
 
-@receiver(post_save, sender=RoleUserAssignment)
-@receiver(post_save, sender=RoleTeamAssignment)
-def record_role_assignment_activity_stream(instance, created, **kwargs):
-    if created:
-        _record_role_assignment_activity_stream(instance, 'associate')
-
-
-@receiver(post_delete, sender=RoleUserAssignment)
-@receiver(post_delete, sender=RoleTeamAssignment)
-def record_role_unassignment_activity_stream(instance, origin=None, **kwargs):
-    # Skip cascade deletes from non-assignment origins, same reasoning as
-    # sync_assignments_to_old_rbac_delete: the actor or content object is itself
-    # being deleted in the same cascade, so linking a new activity stream entry
-    # to it would leave a dangling foreign key once the cascade completes.
-    if isinstance(origin, models.Model) and origin._meta.app_label != 'dab_rbac':
-        return
-    if isinstance(origin, models.QuerySet) and origin.model is not type(instance):
-        return
-    _record_role_assignment_activity_stream(instance, 'disassociate')
+# Activity-stream recording for role assignments is driven by the DAB bulk signals
+# (dab_rbac_assignments_created / dab_rbac_assignments_pre_delete), handled together with
+# the old-RBAC Role.members mirror in awx.main.models.rbac. _record_role_assignment_activity_stream
+# above is the shared implementation those handlers call; it is no longer connected to per-row
+# post_save / post_delete, which the bulk assignment pipeline does not emit.
 
 
 def cleanup_detached_labels_on_deleted_parent(sender, instance, **kwargs):

--- a/awx/main/signals.py
+++ b/awx/main/signals.py
@@ -153,7 +153,55 @@ def sync_rbac_to_superuser_status(instance, sender, **kwargs):
                 user.save(update_fields=['is_superuser'])
 
 
-def _record_role_assignment_activity_stream(instance, operation):
+def _prefetch_assignment_content_objects(assignments, content_objects=None):
+    """Build a {(content_type_id, object_id): instance} lookup for a batch of assignments.
+
+    The DAB bulk signal supplies ``content_objects`` when the grant/removal went through
+    bulk_give_permissions / bulk_remove_permissions, but it can be empty when a caller
+    used give_assignments / remove_assignments directly. For any object-scoped assignment
+    not already covered, this fetches the referenced objects in bulk grouped by content
+    type — one query per type — instead of dereferencing ``instance.content_object`` one
+    row at a time, which was the per-row cost this migration set out to remove (AAP-85842).
+
+    Content types that don't resolve to a local model (remote / federated) are left out;
+    _record_role_assignment_activity_stream falls back to a per-row fetch for those.
+    """
+    from ansible_base.rbac import permission_registry
+    from ansible_base.rbac.remote import get_remote_base_class
+
+    lookup = dict(content_objects or {})
+    # content_type_id -> set(object_id) still needing resolution. Group by id only so we
+    # never touch instance.content_type per row (that would be the per-row query again).
+    missing = {}
+    for instance in assignments:
+        if not instance.object_id:
+            continue  # global (singleton) assignment: no content object
+        key = (instance.content_type_id, instance.object_id)
+        if key in lookup:
+            continue
+        missing.setdefault(instance.content_type_id, set()).add(instance.object_id)
+
+    if not missing:
+        return lookup
+
+    content_types = permission_registry.content_type_model.objects.in_bulk(missing.keys())
+    remote_base = get_remote_base_class()
+    for ct_id, object_ids in missing.items():
+        ct = content_types.get(ct_id)
+        if ct is None:
+            continue  # content type row is gone; leave to per-row fallback
+        try:
+            model = ct.model_class()
+        except LookupError:
+            continue  # unknown content type; leave to per-row fallback
+        if issubclass(model, remote_base):
+            continue  # remote/federated object; can't bulk-fetch locally
+        for obj in model._base_manager.in_bulk(object_ids).values():
+            lookup[(ct_id, str(obj.pk))] = obj
+    return lookup
+
+
+def _record_role_assignment_activity_stream(instance, operation, content_objects=None):
     if not activity_stream_enabled:
         return
     # Avoid flooding the activity stream when assignments are cascade-deleted as part
@@ -170,7 +218,11 @@ def _record_role_assignment_activity_stream(instance, operation):
 
     content_object = None
     if instance.object_id:
-        content_object = instance.content_object
+        # Prefer the batch lookup (populated once per bulk signal, same-type prefetched);
+        # fall back to a per-row fetch only for keys it doesn't cover.
+        content_object = (content_objects or {}).get((instance.content_type_id, instance.object_id))
+        if content_object is None:
+            content_object = instance.content_object
         if content_object is None and operation == 'disassociate':
             # The target object is unresolvable, e.g. cascade-deleted along with its
             # parent object, or a federated/remote content type. Skip recording a

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
@@ -158,7 +158,7 @@ class TestRoleAssignmentActivityStream:
         from ansible_base.rbac.models import RoleUserAssignment
 
         from awx.main.models import Inventory
-        from awx.main.signals import _prefetch_assignment_content_objects
+        from awx.main.models.rbac import _prefetch_assignment_content_objects
 
         rd = RoleDefinition.objects.get(name='Inventory Admin')
         inventories = [Inventory.objects.create(name=f'batch-inv-{i}', organization=organization) for i in range(5)]

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
@@ -223,31 +223,42 @@ class TestRoleAssignmentActivityStream:
         assert entry.object1 == ''
         assert entry.inventory.count() == 0
 
-    def test_old_rbac_field_names_resolved_in_one_query(self, django_assert_num_queries, setup_managed_roles):
-        # The old-RBAC mirror needs each assignment's role-definition name to find the legacy
-        # Role field. _field_names_for_old_rbac must resolve the whole batch in a single query
-        # rather than dereferencing instance.role_definition once per assignment.
-        from awx.main.models.rbac import _field_names_for_old_rbac
+    def test_role_definition_materialized_on_signal_instances(self, rando, inventory, django_assert_num_queries, setup_managed_roles):
+        # The old-RBAC mirror resolves the legacy Role field from instance.role_definition.name
+        # per row instead of a batch query, which is only free because DAB materializes
+        # role_definition on the assignments it hands to both bulk signals. Guard that: reading
+        # .role_definition.name on the delivered instances must issue no query. If it regresses,
+        # the mirror (and the activity-stream recorder) would do a per-row SELECT again.
+        from ansible_base.rbac.triggers import dab_rbac_assignments_created, dab_rbac_assignments_pre_delete
 
-        rds = [
-            RoleDefinition.objects.get(name='Inventory Admin'),
-            RoleDefinition.objects.get(name='Organization Admin'),
-            RoleDefinition.objects.get(name='Project Admin'),
-        ]
+        rd = RoleDefinition.objects.get(name='Inventory Admin')
+        captured = []
 
-        # Stand-in assignment objects carrying only the role_definition_id the helper reads,
-        # duplicated so the batch is larger than the number of distinct role definitions.
-        class _Stub:
-            def __init__(self, rd_id):
-                self.role_definition_id = rd_id
+        def probe(sender, assignments, **kwargs):
+            captured.extend(assignments)
 
-        assignments = [_Stub(rd.id) for rd in rds] * 4
+        dab_rbac_assignments_created.connect(probe)
+        try:
+            rd.give_permission(rando, inventory)
+        finally:
+            dab_rbac_assignments_created.disconnect(probe)
 
-        with django_assert_num_queries(1):
-            field_names = _field_names_for_old_rbac(assignments)
+        assert captured
+        with django_assert_num_queries(0):
+            for assignment in captured:
+                assert assignment.role_definition.name == rd.name
 
-        assert field_names[rds[0].id] == 'admin_role'
-        assert field_names[rds[1].id] == 'admin_role'
+        captured.clear()
+        dab_rbac_assignments_pre_delete.connect(probe)
+        try:
+            rd.remove_permission(rando, inventory)
+        finally:
+            dab_rbac_assignments_pre_delete.disconnect(probe)
+
+        assert captured
+        with django_assert_num_queries(0):
+            for assignment in captured:
+                assert assignment.role_definition.name == rd.name
 
     def test_cascade_delete_does_not_record_contentless_entry(self, rando, setup_managed_roles):
         '''

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
@@ -4,7 +4,7 @@ import pytest
 
 from awx.api.versioning import reverse
 
-from ansible_base.rbac.models import RoleDefinition, RoleUserAssignment
+from ansible_base.rbac.models import RoleDefinition
 from ansible_base.rbac import permission_registry
 
 from awx.main.models import ActivityStream, Inventory, Organization
@@ -122,14 +122,31 @@ class TestRoleAssignmentActivityStream:
         assert entry.object2 == 'team'
 
     def test_global_role_assignment_recorded(self, rando, setup_managed_roles):
+        # Global (singleton) roles have no content object, so they cannot go through the
+        # object-scoped bulk pipeline. give_global_permission is the supported entry point;
+        # it routes through the pipeline and fires dab_rbac_assignments_created. A raw
+        # RoleUserAssignment.objects.create() would NOT record an entry (see triggers.py).
         rd, _ = RoleDefinition.objects.get_or_create(name='global-view-role', content_type=None)
-        RoleUserAssignment.objects.create(user=rando, role_definition=rd)
+        rd.give_global_permission(rando)
 
         entries = ActivityStream.objects.filter(operation='associate', user=rando, changes__icontains=rd.name)
         assert entries.count() == 1
         entry = entries.get()
         assert json.loads(entry.changes) == {'role_definition': rd.name, 'user': rando.username}
         # No content object for a global role assignment, so object1 is left blank.
+        assert entry.object1 == ''
+        assert entry.object2 == 'user'
+        assert entry.object_relationship_type == str(rd.id)
+
+    def test_global_role_removal_recorded(self, rando, setup_managed_roles):
+        rd, _ = RoleDefinition.objects.get_or_create(name='global-view-role', content_type=None)
+        rd.give_global_permission(rando)
+        rd.remove_global_permission(rando)
+
+        entries = ActivityStream.objects.filter(operation='disassociate', user=rando, changes__icontains=rd.name)
+        assert entries.count() == 1
+        entry = entries.get()
+        assert json.loads(entry.changes) == {'role_definition': rd.name, 'user': rando.username}
         assert entry.object1 == ''
         assert entry.object2 == 'user'
         assert entry.object_relationship_type == str(rd.id)

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
@@ -151,6 +151,34 @@ class TestRoleAssignmentActivityStream:
         assert entry.object2 == 'user'
         assert entry.object_relationship_type == str(rd.id)
 
+    def test_content_object_lookup_batches_by_type(self, rando, organization, django_assert_max_num_queries, setup_managed_roles):
+        # The whole point of the bulk-signal migration is to stop resolving each assignment's
+        # content object with its own query. _prefetch_assignment_content_objects must fetch
+        # all objects of a type in one query regardless of how many assignments there are.
+        from ansible_base.rbac.models import RoleUserAssignment
+
+        from awx.main.models import Inventory
+        from awx.main.signals import _prefetch_assignment_content_objects
+
+        rd = RoleDefinition.objects.get(name='Inventory Admin')
+        inventories = [Inventory.objects.create(name=f'batch-inv-{i}', organization=organization) for i in range(5)]
+        for inv in inventories:
+            rd.give_permission(rando, inv)
+
+        # Re-fetch so content_object is not already cached on the instances.
+        assignments = list(RoleUserAssignment.objects.filter(role_definition=rd, user=rando))
+        assert len(assignments) == 5
+
+        # No content_objects supplied (the give_assignments-direct / empty-dict case): the
+        # helper must batch — one query for the content types, one in_bulk for the objects —
+        # not one query per assignment. Assert a small constant that does not grow with the
+        # number of assignments.
+        with django_assert_max_num_queries(3):
+            lookup = _prefetch_assignment_content_objects(assignments, {})
+
+        for a in assignments:
+            assert lookup[(a.content_type_id, a.object_id)].pk == int(a.object_id)
+
     def test_cascade_delete_does_not_record_contentless_entry(self, rando, setup_managed_roles):
         '''
         Deleting an object cascade-deletes its RoleUserAssignments. By the time the

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
@@ -151,33 +151,77 @@ class TestRoleAssignmentActivityStream:
         assert entry.object2 == 'user'
         assert entry.object_relationship_type == str(rd.id)
 
-    def test_content_object_lookup_batches_by_type(self, rando, organization, django_assert_max_num_queries, setup_managed_roles):
-        # The whole point of the bulk-signal migration is to stop resolving each assignment's
-        # content object with its own query. _prefetch_assignment_content_objects must fetch
-        # all objects of a type in one query regardless of how many assignments there are.
+    def test_platform_auditor_global_role_recorded(self, rando, setup_managed_roles):
+        # Platform Auditor is the one real managed singleton role (content_type=None); it is
+        # created by a data migration, not by setup_managed_role_definitions, so the fixture
+        # does not provide it and the test materializes it the same way the migration does.
+        rd, _ = RoleDefinition.objects.get_or_create(name='Platform Auditor', defaults={'managed': True})
+        rd.give_global_permission(rando)
+
+        entries = ActivityStream.objects.filter(operation='associate', user=rando, changes__icontains=rd.name)
+        assert entries.count() == 1
+        entry = entries.get()
+        assert json.loads(entry.changes) == {'role_definition': rd.name, 'user': rando.username}
+        assert entry.object1 == ''
+        assert entry.object2 == 'user'
+        assert entry.object_relationship_type == str(rd.id)
+
+        rd.remove_global_permission(rando)
+        removals = ActivityStream.objects.filter(operation='disassociate', user=rando, changes__icontains=rd.name)
+        assert removals.count() == 1
+        assert removals.get().object1 == ''
+
+    def test_object_not_supplied_by_dab_records_bare_entry_without_link(self, rando, setup_managed_roles):
+        # When DAB does not hand us the resolved object (the narrow direct-give_assignments
+        # path, or an object row that is already gone), we deliberately do NOT fetch it — that
+        # per-row fetch is the regression this migration removes (AAP-85842). The entry is
+        # still recorded with the role and actor, but with no object metadata and no m2m link,
+        # so it can never reference a row that does not exist. The call must not raise.
         from ansible_base.rbac.models import RoleUserAssignment
 
-        from awx.main.models import Inventory
-        from awx.main.models.rbac import _prefetch_assignment_content_objects
+        from awx.main.models.rbac import _record_role_assignment_activity_stream
 
+        ct = permission_registry.content_type_model.objects.get_for_model(Inventory)
         rd = RoleDefinition.objects.get(name='Inventory Admin')
-        inventories = [Inventory.objects.create(name=f'batch-inv-{i}', organization=organization) for i in range(5)]
-        for inv in inventories:
-            rd.give_permission(rando, inv)
+        missing_id = 99999999
+        assert not Inventory.objects.filter(pk=missing_id).exists()
+        # Force-create an assignment pointing at a non-existent object; object_role is None.
+        assignment = RoleUserAssignment.objects.create(role_definition=rd, user=rando, content_type=ct, object_id=str(missing_id))
 
-        # Re-fetch so content_object is not already cached on the instances.
-        assignments = list(RoleUserAssignment.objects.filter(role_definition=rd, user=rando))
-        assert len(assignments) == 5
+        # No content_objects passed: the recorder relies solely on DAB's dict.
+        _record_role_assignment_activity_stream(assignment, 'disassociate')
 
-        # No content_objects supplied (the give_assignments-direct / empty-dict case): the
-        # helper must batch — one query for the content types, one in_bulk for the objects —
-        # not one query per assignment. Assert a small constant that does not grow with the
-        # number of assignments.
-        with django_assert_max_num_queries(3):
-            lookup = _prefetch_assignment_content_objects(assignments, {})
+        entries = ActivityStream.objects.filter(operation='disassociate', user=rando, changes__icontains=rd.name)
+        assert entries.count() == 1
+        entry = entries.get()
+        # Only the role and actor are captured; no object type/id/name and no link.
+        assert json.loads(entry.changes) == {'role_definition': rd.name, 'user': rando.username}
+        assert entry.object1 == ''
+        assert entry.inventory.count() == 0
 
-        for a in assignments:
-            assert lookup[(a.content_type_id, a.object_id)].pk == int(a.object_id)
+    def test_non_integer_object_id_records_bare_entry_without_link(self, rando, setup_managed_roles):
+        # A degenerate assignment (e.g. a row another service wrote into our database) can
+        # carry a non-integer object_id. DAB would never resolve such a key into
+        # content_objects, so it falls into the same "object not supplied" path: the bare
+        # assignment is recorded (role + actor) and no bogus object link is attempted. Because
+        # we never cast object_id ourselves, the degenerate value cannot raise.
+        from ansible_base.rbac.models import RoleUserAssignment
+
+        from awx.main.models.rbac import _record_role_assignment_activity_stream
+
+        ct = permission_registry.content_type_model.objects.get_for_model(Inventory)
+        rd = RoleDefinition.objects.get(name='Inventory Admin')
+        # Materialize an assignment with a degenerate generic foreign key.
+        assignment = RoleUserAssignment.objects.create(role_definition=rd, user=rando, content_type=ct, object_id='not-an-int')
+
+        _record_role_assignment_activity_stream(assignment, 'disassociate')
+
+        entries = ActivityStream.objects.filter(operation='disassociate', user=rando, changes__icontains=rd.name)
+        assert entries.count() == 1
+        entry = entries.get()
+        assert json.loads(entry.changes) == {'role_definition': rd.name, 'user': rando.username}
+        assert entry.object1 == ''
+        assert entry.inventory.count() == 0
 
     def test_old_rbac_field_names_resolved_in_one_query(self, django_assert_num_queries, setup_managed_roles):
         # The old-RBAC mirror needs each assignment's role-definition name to find the legacy

--- a/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
+++ b/awx/main/tests/functional/dab_rbac/test_dab_rbac_activity_stream.py
@@ -179,6 +179,32 @@ class TestRoleAssignmentActivityStream:
         for a in assignments:
             assert lookup[(a.content_type_id, a.object_id)].pk == int(a.object_id)
 
+    def test_old_rbac_field_names_resolved_in_one_query(self, django_assert_num_queries, setup_managed_roles):
+        # The old-RBAC mirror needs each assignment's role-definition name to find the legacy
+        # Role field. _field_names_for_old_rbac must resolve the whole batch in a single query
+        # rather than dereferencing instance.role_definition once per assignment.
+        from awx.main.models.rbac import _field_names_for_old_rbac
+
+        rds = [
+            RoleDefinition.objects.get(name='Inventory Admin'),
+            RoleDefinition.objects.get(name='Organization Admin'),
+            RoleDefinition.objects.get(name='Project Admin'),
+        ]
+
+        # Stand-in assignment objects carrying only the role_definition_id the helper reads,
+        # duplicated so the batch is larger than the number of distinct role definitions.
+        class _Stub:
+            def __init__(self, rd_id):
+                self.role_definition_id = rd_id
+
+        assignments = [_Stub(rd.id) for rd in rds] * 4
+
+        with django_assert_num_queries(1):
+            field_names = _field_names_for_old_rbac(assignments)
+
+        assert field_names[rds[0].id] == 'admin_role'
+        assert field_names[rds[1].id] == 'admin_role'
+
     def test_cascade_delete_does_not_record_contentless_entry(self, rando, setup_managed_roles):
         '''
         Deleting an object cascade-deletes its RoleUserAssignments. By the time the

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer_new_to_old.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer_new_to_old.py
@@ -12,7 +12,7 @@ from awx.main.models import ActivityStream
 class TestNewToOld:
     '''
     Tests that the DAB RBAC system is correctly translated to the old RBAC system
-    Namely, tests functionality of the _sync_assignment_to_old_roles signal handler
+    Namely, tests functionality of the _sync_assignment_to_old_role signal handler
     '''
 
     def test_new_to_old_rbac_addition(self, admin, post, inventory, bob, setup_managed_roles):
@@ -184,7 +184,7 @@ class TestNewToOld:
 
         post_delete.connect(capture_origin)
         try:
-            with mock.patch('awx.main.models.rbac._sync_assignment_to_old_roles') as mck:
+            with mock.patch('awx.main.models.rbac._sync_assignment_to_old_role') as mck:
                 # This is what cleanup_deleted_team_roles does:
                 ObjectRole.objects.filter(
                     role_definition=rd,
@@ -211,7 +211,7 @@ class TestNewToOld:
         rd.give_permission(bob, inventory)
         assert bob in inventory.admin_role.members.all()
 
-        with mock.patch('awx.main.models.rbac._sync_assignment_to_old_roles') as mck:
+        with mock.patch('awx.main.models.rbac._sync_assignment_to_old_role') as mck:
             organization.delete()
 
         mck.assert_not_called()
@@ -225,7 +225,7 @@ class TestNewToOld:
         rd.give_permission(team, inventory)
         assert RoleTeamAssignment.objects.filter(team=team, role_definition=rd, object_id=inventory.pk).exists()
 
-        with mock.patch('awx.main.models.rbac._sync_assignment_to_old_roles') as mck:
+        with mock.patch('awx.main.models.rbac._sync_assignment_to_old_role') as mck:
             organization.delete()
 
         mck.assert_not_called()

--- a/awx/main/tests/functional/dab_rbac/test_translation_layer_new_to_old.py
+++ b/awx/main/tests/functional/dab_rbac/test_translation_layer_new_to_old.py
@@ -12,7 +12,7 @@ from awx.main.models import ActivityStream
 class TestNewToOld:
     '''
     Tests that the DAB RBAC system is correctly translated to the old RBAC system
-    Namely, tests functionality of the _sync_assignments_to_old_rbac signal handler
+    Namely, tests functionality of the _sync_assignment_to_old_roles signal handler
     '''
 
     def test_new_to_old_rbac_addition(self, admin, post, inventory, bob, setup_managed_roles):
@@ -184,7 +184,7 @@ class TestNewToOld:
 
         post_delete.connect(capture_origin)
         try:
-            with mock.patch('awx.main.models.rbac._sync_assignments_to_old_rbac') as mck:
+            with mock.patch('awx.main.models.rbac._sync_assignment_to_old_roles') as mck:
                 # This is what cleanup_deleted_team_roles does:
                 ObjectRole.objects.filter(
                     role_definition=rd,
@@ -211,7 +211,7 @@ class TestNewToOld:
         rd.give_permission(bob, inventory)
         assert bob in inventory.admin_role.members.all()
 
-        with mock.patch('awx.main.models.rbac._sync_assignments_to_old_rbac') as mck:
+        with mock.patch('awx.main.models.rbac._sync_assignment_to_old_roles') as mck:
             organization.delete()
 
         mck.assert_not_called()
@@ -225,7 +225,7 @@ class TestNewToOld:
         rd.give_permission(team, inventory)
         assert RoleTeamAssignment.objects.filter(team=team, role_definition=rd, object_id=inventory.pk).exists()
 
-        with mock.patch('awx.main.models.rbac._sync_assignments_to_old_rbac') as mck:
+        with mock.patch('awx.main.models.rbac._sync_assignment_to_old_roles') as mck:
             organization.delete()
 
         mck.assert_not_called()

--- a/requirements/requirements_git.txt
+++ b/requirements/requirements_git.txt
@@ -20,5 +20,5 @@
 certifi @ git+https://github.com/ansible/system-certifi.git@devel
 ansible-runner @ git+https://github.com/ansible/ansible-runner.git@devel
 awx-plugins-core[credentials-github-app] @ git+https://github.com/ansible/awx-plugins.git@devel
-django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/ansible/django-ansible-base@devel
+django-ansible-base[feature-flags,jwt-consumer,rbac,resource-registry,rest-filters] @ git+https://github.com/AlanCoding/django-ansible-base@AAP-90162-rbac-signal-unification
 awx-plugins-interfaces @ git+https://github.com/ansible/awx_plugins.interfaces.git


### PR DESCRIPTION
## Summary

DAB now creates and removes role assignments through a **bulk pipeline** (`bulk_give_permissions`/`give_assignments` → `bulk_create`, and `bulk_remove_permissions`/`remove_assignments` → queryset `.delete()`), neither of which emits per-row `post_save`/`post_delete`. AWX's four per-row receivers on `RoleUserAssignment`/`RoleTeamAssignment` therefore stop firing once every grant path routes through the bulk pipeline.

This replaces them with **two** handlers on DAB's bulk signals (`dab_rbac_assignments_created` / `dab_rbac_assignments_pre_delete`). **Exactly one handler is connected per signal**, and each does both jobs in a single pass over the batch: the old-RBAC `Role.members` mirror and the activity-stream recording. This is the performance + cleanup half of AAP-85842 — per-row `post_save` is slow for large bulk grants.

- Jira: **AAP-90164** (child of epic AAP-90162, related AAP-85842)
- DAB counterpart: **ansible/django-ansible-base#1116**

## Changes

- **`awx/main/models/rbac.py`** — remove `sync_user_assignments_to_old_rbac_create` and `sync_assignments_to_old_rbac_delete`; add `handle_dab_assignments_created` and `handle_dab_assignments_pre_delete`. The `pre_delete` signal fires while the row still exists, so add the missing `rbac_sync_enabled` guard to `sync_parents_to_new_rbac` to prevent the team-assignment mirror from recursing.
- **`awx/main/signals.py`** — remove `record_role_assignment_activity_stream` and `record_role_unassignment_activity_stream`; keep the shared `_record_role_assignment_activity_stream` helper the new handlers call.
- **`test_dab_rbac_activity_stream.py`** — grant/remove global roles through `give_global_permission`/`remove_global_permission` (the supported entry point, which now routes through the bulk pipeline) and add a global removal test.
- **`requirements/requirements_git.txt`** — ⚠️ temporarily points DAB at the branch (`AlanCoding/django-ansible-base@AAP-90162-rbac-signal-unification`) so CI exercises this change. **Must be restored to the devel/released pin before merge**, once #1116 lands.

## Edge cases handled

- **Cascade deletes** — the bulk `pre_delete` fires only on explicit removal, never on FK cascade, so the old origin-filter logic is dropped; cascade cleanup of old `Role.members` still happens via the parent's own cascade.
- **`pre_delete` reentrancy** — guarded by the new `rbac_sync_enabled` check in `sync_parents_to_new_rbac`.
- **Global (singleton) roles** — now route through the bulk pipeline via `give_global_permission`; handlers tolerate `object_role is None`.
- **JWT/SSO claims** — sync through the same single handler; no consumer-specific shim.

## Testing

- `awx/main/tests/functional/dab_rbac/` — 160 pass
- `api/test_activity_streams.py`, `rbac/`, `test_bulk.py` — 338 pass
- `ruff check` / `ruff format --check` clean

## Merge order

The DAB branch temporarily re-fires per-row `post_save`, so DAB #1116 is safe to merge first without breaking unmigrated AWX. After AWX (and Hub) migrate, a final DAB PR removes the temporary re-fire. Restore the DAB pin here before merging.

### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

### COMPONENT NAME
 - API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved activity history for bulk role assignments and removals.
- Prevented duplicate or recursive updates during permission changes.
- Ensured global permission removals and invalid object references are recorded accurately.
- Improved performance when processing large batches of role assignments.
- Preserved accurate object names and links in recorded activity.

## Tests

- Expanded coverage for global role removal, managed roles, invalid assignments, batched lookups, and legacy permission resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->