### PR TITLE
fix(rbac): add can_copy to CredentialAccess for org credentials

### DIFF
--- a/awx/main/access.py
+++ b/awx/main/access.py
@@ -1165,6 +1165,11 @@ class CredentialAccess(BaseAccess):
         #    return True
         return self.can_change(obj, None)
 
+    def can_copy(self, obj):
+        if obj.organization_id:
+            return self.can_add({'organization': obj.organization_id})
+        return self.can_add({'reference_obj': obj})
+
     def get_user_capabilities(self, obj, **kwargs):
         user_capabilities = super(CredentialAccess, self).get_user_capabilities(obj, **kwargs)
         user_capabilities['use'] = self.can_use(obj)

--- a/awx/main/tests/functional/rbac/test_rbac_credential.py
+++ b/awx/main/tests/functional/rbac/test_rbac_credential.py
@@ -69,6 +69,45 @@ def test_org_credential_access_admin(role_name, alice, org_credential):
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("role_name", ["admin_role", "credential_admin_role"])
+def test_org_credential_copy_capability(role_name, alice, org_credential):
+    """Org credential admins must be able to copy credentials (AAP-64683)."""
+    role = getattr(org_credential.organization, role_name)
+    role.members.add(alice)
+    access = CredentialAccess(alice)
+    assert access.can_copy(org_credential)
+
+
+@pytest.mark.django_db
+def test_org_credential_copy_denied_for_plain_member(alice, org_credential):
+    """Plain org members (non-admin) must NOT be able to copy credentials."""
+    org_credential.organization.member_role.members.add(alice)
+    access = CredentialAccess(alice)
+    assert not access.can_copy(org_credential)
+
+
+@pytest.mark.django_db
+def test_credential_without_org_not_copyable_by_non_superuser(alice, credential):
+    """Credentials with no organization must not be copyable by non-superusers.
+    Verifies that the can_copy fallback path does not regress.
+    The `credential` fixture has no organization set (organization_id is None)."""
+    access = CredentialAccess(alice)
+    assert not access.can_copy(credential)
+
+
+@pytest.mark.django_db
+def test_org_credential_copy_denied_for_direct_admin(alice, org_credential):
+    """A direct credential admin (admin_role on the credential itself, no org role)
+    cannot copy an org credential even though can_change passes for them.
+    Copying routes through can_add which requires org-level creation rights;
+    being in obj.admin_role alone is not sufficient."""
+    org_credential.admin_role.members.add(alice)
+    access = CredentialAccess(alice)
+    assert access.can_change(org_credential, {'description': 'updated'})
+    assert not access.can_copy(org_credential)
+
+
+@pytest.mark.django_db
 def test_org_and_user_credential_access(alice, organization):
     """Address specific bug where any user could make an org credential
     in another org without any permissions to that org

--- a/awx/main/tests/functional/test_copy.py
+++ b/awx/main/tests/functional/test_copy.py
@@ -256,6 +256,29 @@ def test_credential_copy(post, get, machine_credential, credentialtype_ssh, admi
 
 
 @pytest.mark.django_db
+def test_org_credential_copy_rbac(post, get, org_credential, alice):
+    """Org member alone is denied copy; org credential_admin_role grants it.
+    Both the copy endpoint (can_copy) and the detail API (user_capabilities.copy)
+    must reflect the same RBAC decision (AAP-64683)."""
+    # auditor_role is in Credential.read_role (via organization.auditor_role), so GETs return 200;
+    # it does not flow into admin_role or credential_admin_role, so copy is correctly denied.
+    org_credential.organization.auditor_role.members.add(alice)
+    assert get(reverse('api:credential_copy', kwargs={'pk': org_credential.pk}), alice, expect=200).data['can_copy'] is False
+    detail = get(reverse('api:credential_detail', kwargs={'pk': org_credential.pk}), alice, expect=200).data
+    assert detail['summary_fields']['user_capabilities']['copy'] is False
+
+    org_credential.organization.credential_admin_role.members.add(alice)
+    assert get(reverse('api:credential_copy', kwargs={'pk': org_credential.pk}), alice, expect=200).data['can_copy'] is True
+    detail = get(reverse('api:credential_detail', kwargs={'pk': org_credential.pk}), alice, expect=200).data
+    # Regression: unfixed code returns can_copy=True but user_capabilities.copy=False here.
+    assert detail['summary_fields']['user_capabilities']['copy'] is True
+    copy_id = post(reverse('api:credential_copy', kwargs={'pk': org_credential.pk}), {'name': 'copied-by-alice'}, alice, expect=201).data['id']
+    credential_copy = type(org_credential).objects.get(pk=copy_id)
+    assert credential_copy.organization == org_credential.organization
+    assert credential_copy.credential_type == org_credential.credential_type
+
+
+@pytest.mark.django_db
 def test_notification_template_copy(post, get, notification_template_with_encrypt, organization, alice):
     notification_template_with_encrypt.organization.auditor_role.members.add(alice)
     assert get(reverse('api:notification_template_copy', kwargs={'pk': notification_template_with_encrypt.pk}), alice, expect=200).data['can_copy'] is False


### PR DESCRIPTION
### SUMMARY

**The problem**

Users who are allowed to manage credentials in an organization—org admins and users with the org **Credential Admin** role—could not use the **Duplicate** button on organization-owned credentials. The button stayed greyed out even though those users were permitted to create credentials in that org.

Behind the scenes, the platform was giving two different answers to the same question (“can this user copy this credential?”):

- The **web UI** looked at a flag on the credential detail API (`user_capabilities.copy`) and said **no**.
- The **copy API** (`/credentials/<id>/copy/`) said **yes** and would actually perform the copy if called directly.

So this was a permissions **signaling** bug: the user had the right access, but the UI was not told about it. Superusers were unaffected because they bypass these checks.

**Why it happened**

When the UI asks whether someone can duplicate a credential, the code checks “can this user **create** a new credential like this one?” For org credentials, that means “can they create a credential **in this organization**?”

The check for the UI was not passing the organization along—it only handed over a reference to the existing credential. The permission logic did not look inside that object for the org, so it treated the request as if no owner was specified and denied access. The copy API, by contrast, already included the organization in its request, so it correctly allowed the action.

**What this commit does**

Adds a dedicated `can_copy` rule for credentials that, for organization-owned credentials, asks the same question the copy API already asks: “can this user create a credential in this organization?” That aligns `user_capabilities.copy` with the copy endpoint so the Duplicate button matches what users are actually allowed to do.

**What this does not change**

- **Personal credentials** (no organization): behavior is unchanged; this fix targets org-owned credentials.
- **Direct admin on one credential only** (without org Credential Admin): users can still edit that credential but cannot duplicate it—they need org-level create permission to copy.
- **Plain org members and auditors**: still cannot duplicate credentials.
- Other resource types and other permission checks are untouched.

### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

### COMPONENT NAME
 - API

### STEPS TO REPRODUCE AND EXTRA INFO

**Prerequisites:** Controller API access; non-superuser with org **Credential Admin** on an org that has at least one org-scoped credential.

1. Create org, team, and non-superuser `testuser`.
2. Assign org **Credential Admin** to the team; add `testuser` to the team.
3. Create an org-scoped Machine credential in that org.
4. As `testuser`:

```bash
BASE='https://<controller>/api/controller/v2'
AUTH='testuser:<password>'
CRED_ID=<id>

# Before fix: copy false
curl -sk -u "$AUTH" "$BASE/credentials/$CRED_ID/" \
  | jq '.summary_fields.user_capabilities.copy'

# Before fix: can_copy true (mismatch)
curl -sk -u "$AUTH" "$BASE/credentials/$CRED_ID/copy/" \
  | jq '.can_copy'

# Copy API works even when UI Duplicate is disabled
curl -sk -u "$AUTH" -X POST "$BASE/credentials/$CRED_ID/copy/" \
  -H 'Content-Type: application/json' \
  -d '{"name": "copied-credential"}'
```

**Expected after fix:** `user_capabilities.copy` and `can_copy` are both `true` for org Credential Admin; Duplicate is enabled in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected credential copy permissions based on organization membership and assigned roles.
  * Organization credential administrators can copy credentials, while auditors and standard members cannot.
  * Copy permissions are now consistently reflected in the API and copy operation.
  * Copied credentials preserve their organization and credential type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->