### PR TITLE
[AAP-90130] Updating project update playbook for ansible-core 2.20

### DIFF
--- a/awx/playbooks/project_update.yml
+++ b/awx/playbooks/project_update.yml
@@ -156,8 +156,8 @@
           ansible.builtin.file:
             path: "{{ item.path }}"
             state: absent
-          loop: "{{ previous_archive.files }}"
-          when: previous_archive.files | default([])
+          loop: "{{ previous_archive.files | default([]) }}"
+          when: previous_archive.files | default([]) | length > 0
 
         - name: Set scm_version to archive sha1 checksum
           ansible.builtin.set_fact:
@@ -253,7 +253,6 @@
               skip: True
           changed_when: "'Nothing to do.' not in galaxy_collection_result.stdout"
           when:
-            - "ansible_version.full is version_compare('2.9', '>=')"
             - collections_enabled | bool
             - req_file | length > 0
           tags:
@@ -273,7 +272,6 @@
               skip: True
           changed_when: "'Nothing to do.' not in galaxy_combined_result.stdout"
           when:
-            - "ansible_version.full is version_compare('2.10', '>=')"
             - collections_enabled | bool
             - roles_enabled | bool
             - req_file | length > 0


### PR DESCRIPTION
##### SUMMARY
Update the project update playbook to be compatible with ansible-core 2.20. 
Fixing conditional logic on `ansible.builtin.file` call, removed dead ansible version checks.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Run a second project sync on an archive project with ansible-core 2.20 and see the error:
```
TASK [Remove previous archives] ************************************************
[ERROR]: Task failed: object of type 'dict' has no attribute 'files'
Task failed.
Origin: /runner/project/project_update.yml:155:11

153 register: previous_archive
154
155 - name: Remove previous archives
^ column 11

<<< caused by >>>

object of type 'dict' has no attribute 'files'
Origin: /runner/project/project_update.yml:159:17

157 path: "{{ item.path }}"
158 state: absent
159 loop: "{{ previous_archive.files }}"
^ column 17

fatal: [localhost]: FAILED! => {"changed": false, "msg": "Task failed: object of type 'dict' has no attribute 'files'"}
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive cleanup reliability when no previous archive files are available.
  * Simplified Galaxy role and collection installation across supported Ansible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->