### PR TITLE
AAP-87433 | feat: remove indirect node counting feature flag

### DIFF
--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -9,7 +9,6 @@ from awx.main.models.event_query import EventQuery
 
 # Django
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django_guid import get_guid
 from django.utils.functional import cached_property
 from django.db import connections
@@ -270,6 +269,7 @@ class RunnerCallback:
                     self.delay_update(**{field_name: field_value})
 
     def artifacts_handler(self, artifact_dir):
+        """Persist collection/ansible_version metadata and host-query records from a completed run's artifacts."""
         success, query_file_contents = try_load_query_file(artifact_dir)
         if success:
             if 'installed_collections' in query_file_contents:

--- a/awx/main/tasks/jobs.py
+++ b/awx/main/tasks/jobs.py
@@ -1086,6 +1086,22 @@ class RunJob(SourceControlMixin, BaseTask):
 
         return private_data
 
+    def build_private_data_files(self, job, private_data_dir):
+        private_data_files, ssh_key_data = super(RunJob, self).build_private_data_files(job, private_data_dir)
+
+        # Copy vendor collections to private_data_dir for indirect node counting
+        # This makes external query files available to the callback plugin in EEs
+        vendor_src = '/var/lib/awx/vendor_collections'
+        vendor_dest = os.path.join(private_data_dir, 'vendor_collections')
+        if os.path.exists(vendor_src):
+            try:
+                shutil.copytree(vendor_src, vendor_dest)
+                logger.debug(f"Copied vendor collections from {vendor_src} to {vendor_dest}")
+            except Exception as e:
+                logger.warning(f"Failed to copy vendor collections: {e}")
+
+        return private_data_files, ssh_key_data
+
     def build_passwords(self, job, runtime_passwords):
         """
         Build a dictionary of passwords for SSH private key, SSH user, sudo/su

--- a/awx/main/tests/unit/tasks/test_runner_callback.py
+++ b/awx/main/tests/unit/tasks/test_runner_callback.py
@@ -128,8 +128,10 @@ class TestArtifactsHandler:
         assert rc.extra_update_fields['installed_collections'] == SAMPLE_ANSIBLE_DATA['installed_collections']
         assert rc.extra_update_fields['ansible_version'] == '2.16.0'
         assert rc.extra_update_fields['event_queries_processed'] is False
-        mock_event_query.assert_called_once()
+        mock_event_query.objects.get_or_create.assert_called_once()
+        assert rc.artifacts_processed is True
 
+    @mock.patch('awx.main.tasks.callback.logger')
     @mock.patch('awx.main.tasks.callback.EventQuery')
     def test_no_event_queries_when_indirect_node_counting_disabled(self, mock_event_query, mock_me):
         rc = RunnerCallback()
@@ -141,7 +143,11 @@ class TestArtifactsHandler:
             with mock.patch('awx.main.tasks.callback.settings.INDIRECT_NODE_COUNTING_ENABLED', False):
                 rc.artifacts_handler(tmpdir)
 
-        mock_event_query.assert_not_called()
+        mock_event_query.objects.get_or_create.assert_called_once()
+        # nothing was created, so no "created" line is logged
+        mock_logger.info.assert_not_called()
+        assert rc.extra_update_fields['event_queries_processed'] is False
+        assert rc.artifacts_processed is True
 
     def test_handles_missing_artifact_file(self, mock_me):
         rc = RunnerCallback()

--- a/awx/main/tests/unit/test_indirect_query_discovery.py
+++ b/awx/main/tests/unit/test_indirect_query_discovery.py
@@ -422,13 +422,13 @@ class TestPrivateDataDirIntegration:
     @mock.patch('awx.main.tasks.jobs.settings.INDIRECT_NODE_COUNTING_ENABLED', True)
     @mock.patch('awx.main.tasks.jobs.shutil.copytree')
     @mock.patch('awx.main.tasks.jobs.os.path.exists')
-    def test_vendor_collections_copied(self, mock_exists, mock_copytree):
-        """AC7.10: build_private_data_files() copies vendor collections to private_data_dir."""
-        from awx.main.tasks.jobs import BaseTask
+    def test_vendor_collections_copied(self, mock_exists, mock_copytree, mock_flag):
+        """AC7.10: RunJob.build_private_data_files() copies vendor collections to private_data_dir."""
+        from awx.main.tasks.jobs import RunJob
 
         mock_exists.return_value = True
 
-        task = BaseTask()
+        task = RunJob()
         task.instance = mock.Mock()
         task.cleanup_paths = []
         task.build_private_data = mock.Mock(return_value=None)
@@ -444,11 +444,11 @@ class TestPrivateDataDirIntegration:
     @mock.patch('awx.main.tasks.jobs.os.path.exists')
     def test_missing_source_handled_gracefully(self, mock_exists, mock_copytree, mock_logger):
         """AC7.11: Collection copy handles missing source directory gracefully."""
-        from awx.main.tasks.jobs import BaseTask
+        from awx.main.tasks.jobs import RunJob
 
         mock_exists.return_value = False
 
-        task = BaseTask()
+        task = RunJob()
         task.instance = mock.Mock()
         task.cleanup_paths = []
         task.build_private_data = mock.Mock(return_value=None)
@@ -459,4 +459,29 @@ class TestPrivateDataDirIntegration:
         # copytree should not be called when source doesn't exist
         mock_copytree.assert_not_called()
         # Function should complete without raising an exception
+        assert result is not None
+
+    @mock.patch('awx.main.tasks.jobs.flag_enabled')
+    @mock.patch('awx.main.tasks.jobs.logger')
+    @mock.patch('awx.main.tasks.jobs.shutil.copytree')
+    @mock.patch('awx.main.tasks.jobs.os.path.exists')
+    def test_copy_failure_logged(self, mock_exists, mock_copytree, mock_logger, mock_flag):
+        """A failed vendor-collection copy is caught and logged as a warning, not raised."""
+        from awx.main.tasks.jobs import RunJob
+
+        mock_flag.return_value = True
+        mock_exists.return_value = True
+        mock_copytree.side_effect = OSError('disk full')
+
+        task = RunJob()
+        task.instance = mock.Mock()
+        task.cleanup_paths = []
+        task.build_private_data = mock.Mock(return_value=None)
+
+        private_data_dir = '/tmp/awx_123_abc'
+        result = task.build_private_data_files(task.instance, private_data_dir)
+
+        mock_copytree.assert_called_once()
+        mock_logger.warning.assert_called_once()
+        # failure is swallowed; the method still returns normally
         assert result is not None

--- a/awx/main/tests/unit/test_tasks.py
+++ b/awx/main/tests/unit/test_tasks.py
@@ -991,7 +991,7 @@ class TestCallbacksEnabled(TestJobExecution):
             with mock.patch('awx.main.tasks.jobs.settings.INDIRECT_NODE_COUNTING_ENABLED', False):
                 env = task.build_env(job, private_data_dir)
 
-        assert 'AWX_COLLECT_HOST_QUERIES' not in env
+        assert env['AWX_COLLECT_HOST_QUERIES'] == '1'
 
 
 @pytest.mark.usefixtures("patch_Organization")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

https://redhat.atlassian.net/browse/AAP-87433

Remove the FEATURE_INDIRECT_NODE_COUNTING_ENABLED feature flag so that indirect managed-node counting always runs when collections provide event query files.

This is related to ANSTRAT-1628, which is GA for indirect node counting in v2.7

The PR removes `FEATURE_INDIRECT_NODE_COUNTING_ENABLED` from `awx/settings/defaults.py` and `development_defaults.py`. It also removes all `flag_enabled("FEATURE_INDIRECT_NODE_COUNTING_ENABLED")` checks and `flag_enabled`, and other changes due to removal of indirect node feature flag gating

Obsolete + tests now outdated due to this removal were updated, and checked against a local `awx` instance

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does. Also please make sure that if this PR has an attached JIRA, put AAP-<number>
in as the first entry for your PR title.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Collection



##### STEPS TO REPRODUCE AND EXTRA INFO
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The goal of this PR is to completely remove the feature flag for indirect node gathering, for the 2.7 GA. This means, when AWX starts, it no longer looks at the feature flag to determine whether certain features (for indirect node counting) should be enabled. Those features are now enabled always. I will be doing further testing with the entire AAP platform running in the future, but my local tests went fine (testing a simple job template + playbook, and making sure everything starts fine, _as well as_ making sure tests passed)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
make docker-compose-build
make docker-compose
docker exec -ti tools_awx_1 bash
make test
```

Should see same failures as the devel branch

```
make docker-compose-build
make docker-compose
docker exec -ti tools_awx_1 awx-manage createsuperuser
# Create a playbook in the container with the following text:
# - name: Indirect node counting test
#    hosts: localhost
#    connection: local
#    gather_facts: false
#    tasks:
#     - name: Generate an indirect managed node record
#        demo.query.example:
#        host_name: my_fake_vm

docker cp <PLAYBOOK FILE>.yml tools_awx_1:/var/lib/awx/projects/<PROJECT DIR>/<PLAYBOOK FILE>yml

# Log into UI, create job template + project + inventory linked together, launch the template
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Indirect host counting, event-query processing, host-query collection, and vendor collection setup now run automatically for applicable jobs.
  - Fallback processing occurs whenever applicable without requiring a separate feature setting.

- **Bug Fixes**
  - Duplicate event-query records are handled more reliably during processing.
  - Vendor collection copy failures are logged without interrupting job preparation.

- **Configuration**
  - The indirect node-counting feature setting has been removed.

- **Tests**
  - Updated coverage to reflect always-on behavior and streamlined configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# MUST BE BACKPORTED FOR ASYNC 2.7 RELEASE