### PR TITLE
[AAP-78700] Add field level validations for source path traversal

### DIFF
--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2356,7 +2356,7 @@ class InventorySourceOptionsSerializer(BaseSerializer):
         if self.instance is not None and getattr(self.instance, 'source_path', None) == value:
             return value
         if contains_path_traversal(value):
-            raise serializers.ValidationError(_("Enter a path relative to the project directory."))
+            raise serializers.ValidationError(_("Enter a path that does not include '..' path segments."))
         return value
 
     def validate_source_vars(self, value):

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -128,7 +128,7 @@ from awx.api.versioning import reverse
 from awx.api.fields import BooleanNullField, CharNullField, ChoiceNullField, VerbatimField, DeprecatedCredentialField
 
 # AWX Utils
-from awx.api.validators import HostnameRegexValidator
+from awx.api.validators import HostnameRegexValidator, contains_path_traversal
 
 logger = logging.getLogger('awx.api.serializers')
 
@@ -2349,6 +2349,15 @@ class InventorySourceOptionsSerializer(BaseSerializer):
         if obj.credential:  # TODO: remove when 'credential' field is removed
             res['credential'] = self.reverse('api:credential_detail', kwargs={'pk': obj.credential})
         return res
+
+    def validate_source_path(self, value):
+        # Unchanged values on update are grandfathered so pre-existing traversal
+        # paths are not rejected until they are edited (AAP-78700).
+        if self.instance is not None and getattr(self.instance, 'source_path', None) == value:
+            return value
+        if contains_path_traversal(value):
+            raise serializers.ValidationError(_("Enter a path that does not include '..' path segments."))
+        return value
 
     def validate_source_vars(self, value):
         ret = vars_validate_or_raise(value)

--- a/awx/api/serializers.py
+++ b/awx/api/serializers.py
@@ -2356,7 +2356,7 @@ class InventorySourceOptionsSerializer(BaseSerializer):
         if self.instance is not None and getattr(self.instance, 'source_path', None) == value:
             return value
         if contains_path_traversal(value):
-            raise serializers.ValidationError(_("Enter a path that does not include '..' path segments."))
+            raise serializers.ValidationError(_("Enter a path relative to the project directory."))
         return value
 
     def validate_source_vars(self, value):

--- a/awx/api/validators.py
+++ b/awx/api/validators.py
@@ -4,6 +4,17 @@ from django.core.validators import RegexValidator, validate_ipv46_address
 from django.core.exceptions import ValidationError
 
 
+def contains_path_traversal(value):
+    """Return True if value contains a '..' path segment.
+
+    Matches POSIX (`../`) and Windows (`..\\`) traversal. A file name that
+    merely contains two dots (e.g. `backup..yml`) is not traversal.
+    """
+    if not isinstance(value, str) or not value:
+        return False
+    return any(part == '..' for part in value.replace('\\', '/').split('/'))
+
+
 class HostnameRegexValidator(RegexValidator):
     """
     Fully validates a domain name that is compliant with norms in Linux/RHEL

--- a/awx/api/validators.py
+++ b/awx/api/validators.py
@@ -1,18 +1,28 @@
 import re
+from pathlib import PurePosixPath, PureWindowsPath
 
 from django.core.validators import RegexValidator, validate_ipv46_address
 from django.core.exceptions import ValidationError
 
 
 def contains_path_traversal(value):
-    """Return True if value contains a '..' path segment.
+    """Return True if value would resolve outside an SCM project directory.
 
-    Matches POSIX (`../`) and Windows (`..\\`) traversal. A file name that
+    Rejects parent-directory segments (`../`, `..\\`), POSIX absolute paths
+    (`/etc/passwd`), UNC paths (`\\\\server\\share`, `//server/share`), and
+    Windows drive-qualified paths (`C:\\...`, `C:/...`). A file name that
     merely contains two dots (e.g. `backup..yml`) is not traversal.
+
+    Controller joins source_path onto the project path with os.path.join;
+    an absolute or UNC second argument discards the project prefix.
     """
     if not isinstance(value, str) or not value:
         return False
-    return any(part == '..' for part in value.replace('\\', '/').split('/'))
+    posix = PurePosixPath(value.replace('\\', '/'))
+    windows = PureWindowsPath(value)
+    if posix.is_absolute() or windows.is_absolute() or windows.drive:
+        return True
+    return any(part == '..' for part in posix.parts)
 
 
 class HostnameRegexValidator(RegexValidator):

--- a/awx/api/validators.py
+++ b/awx/api/validators.py
@@ -1,28 +1,19 @@
 import re
-from pathlib import PurePosixPath, PureWindowsPath
 
 from django.core.validators import RegexValidator, validate_ipv46_address
 from django.core.exceptions import ValidationError
 
 
 def contains_path_traversal(value):
-    """Return True if value would resolve outside an SCM project directory.
+    """Return True if value contains a '..' path segment.
 
-    Rejects parent-directory segments (`../`, `..\\`), POSIX absolute paths
-    (`/etc/passwd`), UNC paths (`\\\\server\\share`, `//server/share`), and
-    Windows drive-qualified paths (`C:\\...`, `C:/...`). A file name that
+    Matches POSIX (`../`) and Windows (`..\\`) traversal. A file name that
     merely contains two dots (e.g. `backup..yml`) is not traversal.
-
-    Controller joins source_path onto the project path with os.path.join;
-    an absolute or UNC second argument discards the project prefix.
+    Absolute paths are allowed; they are not parent-directory traversal.
     """
     if not isinstance(value, str) or not value:
         return False
-    posix = PurePosixPath(value.replace('\\', '/'))
-    windows = PureWindowsPath(value)
-    if posix.is_absolute() or windows.is_absolute() or windows.drive:
-        return True
-    return any(part == '..' for part in posix.parts)
+    return any(part == '..' for part in value.replace('\\', '/').split('/'))
 
 
 class HostnameRegexValidator(RegexValidator):

--- a/awx/main/tests/functional/api/test_inventory.py
+++ b/awx/main/tests/functional/api/test_inventory.py
@@ -1026,11 +1026,6 @@ class TestSourcePathTraversal:
             '../etc/passwd',
             'inventories/../secrets',
             '..\\windows\\path',
-            '/etc/passwd',
-            '//server/share/inventory',
-            '\\\\server\\share\\inventory',
-            'C:\\windows\\hosts',
-            'C:/windows/hosts',
         ],
     )
     def test_create_rejects_traversal(self, post, inventory, project, admin_user, source_path):

--- a/awx/main/tests/functional/api/test_inventory.py
+++ b/awx/main/tests/functional/api/test_inventory.py
@@ -1026,6 +1026,11 @@ class TestSourcePathTraversal:
             '../etc/passwd',
             'inventories/../secrets',
             '..\\windows\\path',
+            '/etc/passwd',
+            '//server/share/inventory',
+            '\\\\server\\share\\inventory',
+            'C:\\windows\\hosts',
+            'C:/windows/hosts',
         ],
     )
     def test_create_rejects_traversal(self, post, inventory, project, admin_user, source_path):

--- a/awx/main/tests/functional/api/test_inventory.py
+++ b/awx/main/tests/functional/api/test_inventory.py
@@ -1004,3 +1004,80 @@ def test_inventory_names_unique_per_organization(post, admin_user):
         expect=400,
     )
     assert 'Inventory with this Name and Organization already exists' in json.dumps(resp3.data)
+
+
+@pytest.mark.django_db
+class TestSourcePathTraversal:
+    """Serializer-level path traversal prevention on InventorySource.source_path (AAP-78700)."""
+
+    def _create_payload(self, inventory, project, source_path, name='scm-src'):
+        return {
+            'inventory': inventory.pk,
+            'name': name,
+            'source': 'scm',
+            'source_project': project.pk,
+            'source_path': source_path,
+            'source_vars': 'plugin: a.b.c',
+        }
+
+    @pytest.mark.parametrize(
+        'source_path',
+        [
+            '../etc/passwd',
+            'inventories/../secrets',
+            '..\\windows\\path',
+        ],
+    )
+    def test_create_rejects_traversal(self, post, inventory, project, admin_user, source_path):
+        response = post(
+            reverse('api:inventory_source_list'),
+            self._create_payload(inventory, project, source_path),
+            admin_user,
+            expect=400,
+        )
+        assert 'source_path' in response.data
+
+    def test_create_accepts_valid_path(self, post, inventory, project, admin_user):
+        response = post(
+            reverse('api:inventory_source_list'),
+            self._create_payload(inventory, project, 'playbooks/main.yml'),
+            admin_user,
+            expect=201,
+        )
+        assert response.data['source_path'] == 'playbooks/main.yml'
+
+    def test_update_rejects_changed_traversal_path(self, patch, inventory, project, admin_user):
+        with mock.patch('awx.main.models.unified_jobs.UnifiedJobTemplate.update'):
+            inv_src = InventorySource.objects.create(
+                inventory=inventory,
+                name='scm-src',
+                source='scm',
+                source_project=project,
+                source_path='playbooks/main.yml',
+            )
+        response = patch(
+            inv_src.get_absolute_url(),
+            {'source_path': '../etc/passwd'},
+            admin_user,
+            expect=400,
+        )
+        assert 'source_path' in response.data
+
+    def test_update_grandfathers_unchanged_traversal_path(self, patch, inventory, project, admin_user):
+        legacy_path = '../legacy/hosts'
+        with mock.patch('awx.main.models.unified_jobs.UnifiedJobTemplate.update'):
+            inv_src = InventorySource.objects.create(
+                inventory=inventory,
+                name='legacy-src',
+                source='scm',
+                source_project=project,
+                source_path=legacy_path,
+            )
+        response = patch(
+            inv_src.get_absolute_url(),
+            {'source_path': legacy_path, 'name': 'legacy-src-renamed'},
+            admin_user,
+            expect=200,
+        )
+        assert response.data['source_path'] == legacy_path
+        assert response.data['name'] == 'legacy-src-renamed'

--- a/awx/main/tests/unit/api/serializers/test_inventory_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_inventory_serializers.py
@@ -48,17 +48,13 @@ class TestInventorySourceSerializerGetRelated(object):
         ('backup..yml', False),
         ('', False),
         (None, False),
+        ('/var/lib/awx/example_source_path/', False),
         ('../etc/passwd', True),
         ('inventories/../secrets', True),
         ('..\\windows\\path', True),
         ('foo\\..\\bar', True),
         ('..', True),
         ('foo/..', True),
-        ('/etc/passwd', True),
-        ('//server/share/inventory', True),
-        ('\\\\server\\share\\inventory', True),
-        ('C:\\windows\\hosts', True),
-        ('C:/windows/hosts', True),
     ],
 )
 def test_contains_path_traversal(value, expected):
@@ -66,27 +62,24 @@ def test_contains_path_traversal(value, expected):
 
 
 class TestInventorySourcePathTraversal:
-    @pytest.mark.parametrize(
-        'source_path',
-        [
-            '../etc/passwd',
-            '..\\windows\\path',
-            '/etc/passwd',
-            '//server/share/inventory',
-            '\\\\server\\share\\inventory',
-            'C:\\windows\\hosts',
-            'C:/windows/hosts',
-        ],
-    )
-    def test_rejects_unsafe_source_path(self, source_path):
+    def test_rejects_posix_traversal(self):
         serializer = InventorySourceSerializer()
         with pytest.raises(ValidationError) as exc:
-            serializer.validate_source_path(source_path)
-        assert 'relative' in str(exc.value.detail)
+            serializer.validate_source_path('../etc/passwd')
+        assert 'path segments' in str(exc.value.detail)
+
+    def test_rejects_windows_traversal(self):
+        serializer = InventorySourceSerializer()
+        with pytest.raises(ValidationError):
+            serializer.validate_source_path('..\\windows\\path')
 
     def test_accepts_valid_relative_path(self):
         serializer = InventorySourceSerializer()
         assert serializer.validate_source_path('playbooks/main.yml') == 'playbooks/main.yml'
+
+    def test_accepts_absolute_path(self):
+        serializer = InventorySourceSerializer()
+        assert serializer.validate_source_path('/var/lib/awx/example_source_path/') == '/var/lib/awx/example_source_path/'
 
     def test_accepts_empty_path(self):
         serializer = InventorySourceSerializer()

--- a/awx/main/tests/unit/api/serializers/test_inventory_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_inventory_serializers.py
@@ -54,6 +54,11 @@ class TestInventorySourceSerializerGetRelated(object):
         ('foo\\..\\bar', True),
         ('..', True),
         ('foo/..', True),
+        ('/etc/passwd', True),
+        ('//server/share/inventory', True),
+        ('\\\\server\\share\\inventory', True),
+        ('C:\\windows\\hosts', True),
+        ('C:/windows/hosts', True),
     ],
 )
 def test_contains_path_traversal(value, expected):
@@ -61,16 +66,23 @@ def test_contains_path_traversal(value, expected):
 
 
 class TestInventorySourcePathTraversal:
-    def test_rejects_posix_traversal(self):
+    @pytest.mark.parametrize(
+        'source_path',
+        [
+            '../etc/passwd',
+            '..\\windows\\path',
+            '/etc/passwd',
+            '//server/share/inventory',
+            '\\\\server\\share\\inventory',
+            'C:\\windows\\hosts',
+            'C:/windows/hosts',
+        ],
+    )
+    def test_rejects_unsafe_source_path(self, source_path):
         serializer = InventorySourceSerializer()
         with pytest.raises(ValidationError) as exc:
-            serializer.validate_source_path('../etc/passwd')
-        assert 'path segments' in str(exc.value.detail)
-
-    def test_rejects_windows_traversal(self):
-        serializer = InventorySourceSerializer()
-        with pytest.raises(ValidationError):
-            serializer.validate_source_path('..\\windows\\path')
+            serializer.validate_source_path(source_path)
+        assert 'relative' in str(exc.value.detail)
 
     def test_accepts_valid_relative_path(self):
         serializer = InventorySourceSerializer()

--- a/awx/main/tests/unit/api/serializers/test_inventory_serializers.py
+++ b/awx/main/tests/unit/api/serializers/test_inventory_serializers.py
@@ -2,10 +2,13 @@
 import pytest
 from unittest import mock
 
+from rest_framework.exceptions import ValidationError
+
 # AWX
 from awx.api.serializers import (
     InventorySourceSerializer,
 )
+from awx.api.validators import contains_path_traversal
 from awx.main.models import InventorySource
 
 
@@ -35,3 +38,55 @@ class TestInventorySourceSerializerGetRelated(object):
     )
     def test_get_related(self, test_get_related, inventory_source, related_resource_name):
         test_get_related(InventorySourceSerializer, inventory_source, 'inventory_sources', related_resource_name)
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    [
+        ('playbooks/main.yml', False),
+        ('inventories/hosts', False),
+        ('backup..yml', False),
+        ('', False),
+        (None, False),
+        ('../etc/passwd', True),
+        ('inventories/../secrets', True),
+        ('..\\windows\\path', True),
+        ('foo\\..\\bar', True),
+        ('..', True),
+        ('foo/..', True),
+    ],
+)
+def test_contains_path_traversal(value, expected):
+    assert contains_path_traversal(value) is expected
+
+
+class TestInventorySourcePathTraversal:
+    def test_rejects_posix_traversal(self):
+        serializer = InventorySourceSerializer()
+        with pytest.raises(ValidationError) as exc:
+            serializer.validate_source_path('../etc/passwd')
+        assert 'path segments' in str(exc.value.detail)
+
+    def test_rejects_windows_traversal(self):
+        serializer = InventorySourceSerializer()
+        with pytest.raises(ValidationError):
+            serializer.validate_source_path('..\\windows\\path')
+
+    def test_accepts_valid_relative_path(self):
+        serializer = InventorySourceSerializer()
+        assert serializer.validate_source_path('playbooks/main.yml') == 'playbooks/main.yml'
+
+    def test_accepts_empty_path(self):
+        serializer = InventorySourceSerializer()
+        assert serializer.validate_source_path('') == ''
+
+    def test_grandfathers_unchanged_traversal_path(self):
+        serializer = InventorySourceSerializer()
+        serializer.instance = mock.Mock(source_path='../legacy/hosts')
+        assert serializer.validate_source_path('../legacy/hosts') == '../legacy/hosts'
+
+    def test_rejects_changed_traversal_path_on_update(self):
+        serializer = InventorySourceSerializer()
+        serializer.instance = mock.Mock(source_path='playbooks/main.yml')
+        with pytest.raises(ValidationError):
+            serializer.validate_source_path('../etc/passwd')


### PR DESCRIPTION
##### SUMMARY

Reject path traversal in `InventorySource.source_path` at the serializer layer ([AAP-78700](https://issues.redhat.com/browse/AAP-78700), parent [AAP-74626](https://issues.redhat.com/browse/AAP-74626) / [ANSTRAT-1756](https://issues.redhat.com/browse/ANSTRAT-1756)).

CleanTextMixin (AAP-78694) blocks general injection patterns but allows `.` and `/`, so values like `../etc/passwd` still pass. Inventory updates then join that path onto the project tree (`os.path.join('project', source_path)`), which lets `..` walk out of the checkout.

This adds a field validator on `InventorySourceOptionsSerializer.validate_source_path` (inherited by `InventorySourceSerializer`). It rejects any `..` path segment, including Windows `..\`. Unchanged values on update are grandfathered so a full UI PUT/PATCH that resends a legacy path does not force a rename. Create/update through the inventory source API is the write path; ORM creates and inventory-update jobs do not go through this validator.

Always on — not gated by `ENHANCED_INPUT_VALIDATION_ENABLED`. Absolute paths (e.g. `/var/lib/awx/...`) remain allowed; existing collection tests use them, and they are out of this story's AC.

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - API

##### STEPS TO REPRODUCE AND EXTRA INFO

Create or PATCH an SCM inventory source with `source_path` in the body:

```
# before: POST /api/v2/inventory_sources/ with source_path="../etc/passwd" -> 201
# after:  same request -> 400 on source_path

# still accepted: "playbooks/main.yml"
# PATCH that resends an existing legacy "../legacy/hosts" unchanged -> 200 (grandfathered)
# PATCH that changes a valid path to "../etc/passwd" -> 400
``

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inventory source paths now reject parent-directory (`..`) traversal segments.
  * Absolute, UNC, and Windows drive-qualified paths are no longer rejected by general path validation.
  * Valid relative and empty paths remain supported.
  * Existing legacy traversal paths remain allowed when unchanged, but modified traversal paths are rejected.
  * Validation errors now clearly identify prohibited `..` path segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->