### PR TITLE
Reclaim runner disk before the awx-operator molecule test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,22 @@ jobs:
         run: |
           make print-PYTHON
       
+      - name: Free up runner disk space before the image build
+        # This job builds the AWX and operator images, loads a SECOND copy of
+        # each into the kind node, then pulls awx-ee, postgres, redis and
+        # ingress-nginx on top - about 10G at peak, most of it under
+        # /var/lib/docker. The runner image itself already occupies ~60G
+        # before any of that, and none of these toolchains are used here.
+        #
+        # /opt/hostedtoolcache is deliberately NOT removed - setup-python
+        # installs into it.
+        run: |
+          echo "before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android \
+                      /usr/local/.ghcup /usr/local/share/boost \
+                      /usr/share/swift /opt/hostedtoolcache/CodeQL
+          echo "after:"; df -h /
+
       - name: Build AWX image
         working-directory: awx
         run: |
@@ -286,11 +302,24 @@ jobs:
           AWX_EE_TEST_IMAGE: quay.io/ansible/awx-ee:latest
           STORE_DEBUG_OUTPUT: true
 
-      - name: Collect awx-operator logs on timeout
-        # Only run on timeout; normal failures should use molecule's built-in log collection.
-        if: steps.awx_operator_test.outputs.timed_out == 'true'
+      - name: Collect awx-operator logs on failure
+        # Any failure, not just a timeout. A run that dies because the disk
+        # filled up is not a timeout, so it would otherwise leave no molecule
+        # log and no artifact at all, which reads like a hang.
+        if: steps.awx_operator_test.outcome != 'success'
         run: |
+          # Reclaim space FIRST, before creating or writing anything. When
+          # this step matters most the filesystem is genuinely at 0 bytes,
+          # and mkdir/the redirects below can fail before a later cleanup
+          # ever runs — CodeRabbit caught this on the first review.
+          if [ "$(df -P / | awk 'NR==2 {print $4}')" -lt 1048576 ]; then
+            echo "under 1G free - reclaiming space so the bundle can be written"
+            docker image prune -af >/dev/null 2>&1 || true
+            sudo rm -rf /usr/share/dotnet /usr/local/lib/android >/dev/null 2>&1 || true
+          fi
           mkdir -p "$DEBUG_OUTPUT_DIR"
+          df -h / > "$DEBUG_OUTPUT_DIR/df.txt" 2>&1 || true
+          docker system df -v > "$DEBUG_OUTPUT_DIR/docker-df.txt" 2>&1 || true
           if command -v kind >/dev/null 2>&1; then
             for cluster in $(kind get clusters 2>/dev/null); do
               kind export logs "$DEBUG_OUTPUT_DIR/$cluster" --name "$cluster" || true


### PR DESCRIPTION
##### SUMMARY

Two changes to the `awx-operator` job, both about disk headroom and about being able to diagnose it when it runs out.

**1. Reclaim runner disk before the image build.**

The job builds the AWX and operator images, loads a *second* copy of each into the kind node (containerd keeps its own), then pulls `awx-ee`, postgres, redis and ingress-nginx on top. Instrumenting the job puts the peak at roughly **10G**, almost all of it under `/var/lib/docker`, and about 7G of that in a single docker volume — the kind node's `/var`.

The runner image itself already occupies **~60G before any of that**, so the existing `Free disk space after Docker build` step has almost nothing to prune. It logs `Total reclaimed space: 0B` in every run I checked, including recent green ones on this repo.

This removes the preinstalled toolchains the job never uses, before the build. Measured sizes on the `ubuntu-latest` image: Android SDK 11.6G, dotnet 5.7G, ghcup 3.7G, swift 3.4G, CodeQL 1.7G — around 20G reclaimed. `/opt/hostedtoolcache` is deliberately left alone because `setup-python` installs into it.

**2. Collect the debug bundle on any failure, not only on a timeout.**

A run that dies because the filesystem filled up is *not* a timeout, so `steps.awx_operator_test.outputs.timed_out` is never set and nothing is uploaded — the job just stops mid-molecule with no artifact, which reads like a hang. This switches the condition to any non-success outcome and records `df -h` and `docker system df -v` into the bundle. It also frees space *before* writing, because at 0 bytes free `kind export logs` and `kubectl describe` fail silently, which is exactly the case the step exists for.

##### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME

 - Other

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKgCs96cP5LsdUFrBp4wX3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores

- Improved build environment management to support more reliable image builds.
- Enhanced diagnostics for failed operator tests, including filesystem and Docker usage details.
- Added disk-space reclamation before diagnostic collection to help preserve failure evidence.
- Failure logs and cluster diagnostics are now collected for operator test failures, regardless of timeout status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->