### PR TITLE
AAP-91781: Make organization new_name lookup idempotent on collection reruns

### DIFF
--- a/awx_collection/plugins/modules/organization.py
+++ b/awx_collection/plugins/modules/organization.py
@@ -147,6 +147,9 @@ def main():
 
     # Attempt to look up organization based on the provided name
     organization = module.get_one('organizations', name_or_id=name, check_exists=(state == 'exists'))
+    # If already renamed, look up by new_name so reruns stay idempotent
+    if new_name and not organization:
+        organization = module.get_one('organizations', name_or_id=new_name, check_exists=(state == 'exists'))
 
     if state == 'absent':
         # If the state was absent we can let the module delete it if needed, the module will handle exiting from this

--- a/awx_collection/test/awx/test_organization.py
+++ b/awx_collection/test/awx/test_organization.py
@@ -34,6 +34,32 @@ def test_create_organization(run_module, admin_user):
 
 
 @pytest.mark.django_db
+def test_rename_organization_idempotent(run_module, admin_user):
+    Organization.objects.create(name='foo')
+    module_args = {
+        'name': 'foo',
+        'new_name': 'bar',
+        'state': 'present',
+        'controller_host': None,
+        'controller_username': None,
+        'controller_password': None,
+        'validate_certs': None,
+        'aap_token': None,
+        'controller_config_file': None,
+    }
+
+    result = run_module('organization', module_args, admin_user)
+    assert result.get('changed'), result
+    assert Organization.objects.filter(name='bar').count() == 1
+    assert not Organization.objects.filter(name='foo').exists()
+
+    result = run_module('organization', module_args, admin_user)
+    assert result.get('changed') is False, result
+    assert Organization.objects.filter(name='bar').count() == 1
+    assert not Organization.objects.filter(name='foo').exists()
+
+
+@pytest.mark.django_db
 def test_galaxy_credential_order(run_module, admin_user):
     org = Organization.objects.create(name='foo')
     cred_type = CredentialType.defaults['galaxy_api_token']()


### PR DESCRIPTION
## Summary
The organization module looks up an organization only by `name`. After a successful rename via `new_name`, a second run with the same task does not find the original name, tries to create the organization again, and fails. This change looks up by `new_name` when `name` is missing so reruns are idempotent.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

## Problem
When `awx.awx.organization` is called with both `name` and `new_name`, the first run renames the organization correctly. On the second run the module still searches only for `name`. That lookup misses, `create_or_update_if_needed` treats it as a create, and the API returns that the organization name already exists.

## Expected behavior
A second run of the same task with `name` and `new_name` should find the already-renamed organization and return `ok` with `changed: false`.

## Actual behavior
The second run fails with:
`Unable to create organization <new_name>: {'name': ['Organization with this Name already exists.']}`

## Solution
After the existing lookup by `name`, if no organization is found and `new_name` is set, look up by `new_name`. Create, update, and delete paths are unchanged. If `new_name` is not set, behavior is the same as today.

## Changes made
- `awx_collection/plugins/modules/organization.py`: fallback `get_one()` by `new_name` when the original name is not found
- `awx_collection/test/awx/test_organization.py`: added `test_rename_organization_idempotent` (rename once, rerun with no change)

## Testing Results
- Existing organization collection tests were not modified
- New unit test covers first-run rename and second-run idempotency

## Related Issue
Fixes #15572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Organization renaming is now idempotent: repeating the same rename operation no longer reports an unnecessary change.
  - Renamed organizations can be found reliably during subsequent runs, including when only the new name is available.
  - Repeated rename operations now complete consistently without creating duplicate changes or unexpected failures.

- **Tests**
  - Added coverage to verify that repeated organization renames complete without additional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->