### PR TITLE
AAP-91782: Make workflow_node_wait wait until approval nodes leave pending

### DIFF
--- a/awx_collection/plugins/module_utils/controller_api.py
+++ b/awx_collection/plugins/module_utils/controller_api.py
@@ -1183,7 +1183,7 @@ class ControllerAPIModule(ControllerModule):
         wait_on_field = 'event_processing_finished'
         if wait_on_field not in result['json']:
             wait_on_field = 'finished'
-        while not result['json'][wait_on_field]:
+        while (not result['json'][wait_on_field]) or (not self.is_job_done(result['json'].get('status'))):
             # If we are past our time out fail with a message
             if timeout and timeout < time.time() - start:
                 # Account for Legacy messages


### PR DESCRIPTION
## Summary
`workflow_node_wait` looks only at `event_processing_finished`. After a successful launch of an approval node, that field is already true while `status` is still `pending`. A wait task then returns `ok` immediately instead of waiting for approve, deny, or timeout. This change also waits while the job is still `new`, `pending`, `waiting`, or `running`.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - Collection

## Problem
When `awx.awx.workflow_node_wait` is used on an approval node (collection 24.3.1+), the first poll sees `event_processing_finished: true`. The wait loop never runs. The playbook continues while the workflow is still waiting for a human.

## Expected behavior
The wait task should stay running until the approval node is approved, denied, or the timeout is reached.

## Actual behavior
The wait task returns `ok` in about 2 seconds with `status: pending`. Nobody has approved yet.

## Solution
In `wait_on_url`, keep looping while `event_processing_finished` is false **or** `is_job_done(status)` is false. Approve then returns `ok`. Deny fails the wait. No action hits the timeout. Other job waits are unchanged.

## Changes made
- `awx_collection/plugins/module_utils/controller_api.py`: wait while the job status is still in progress

## Testing Results
- Unpatched 24.6.1 on lab: wait returned `ok` in ~2s, `status=pending` (workflow job 145)
- Patched: nobody approved → timeout; Approve while waiting → `successful`; Deny while waiting → wait failed

## Related Issue
Fixes #15503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous operation tracking so status updates continue until the event or job is fully complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->