### PR TITLE
Log Receptor, runner, and EE stage durations in job_lifecycle.

### DIFF
--- a/awx/main/models/unified_jobs.py
+++ b/awx/main/models/unified_jobs.py
@@ -1617,13 +1617,16 @@ class UnifiedJob(
     def is_container_group_task(self):
         return False
 
-    def log_lifecycle(self, state, blocked_by=None):
-        extra = {
-            'type': self._meta.model_name,
-            'task_id': self.id,
-            'state': state,
-            'work_unit_id': self.work_unit_id,
-        }
+    def log_lifecycle(self, state, blocked_by=None, **extra_fields):
+        extra = dict(extra_fields)
+        extra.update(
+            {
+                'type': self._meta.model_name,
+                'task_id': self.id,
+                'state': state,
+                'work_unit_id': self.work_unit_id,
+            }
+        )
         if self.name:
             extra["task_name"] = self.name
         if state == "blocked" and blocked_by:

--- a/awx/main/tasks/callback.py
+++ b/awx/main/tasks/callback.py
@@ -91,6 +91,10 @@ class RunnerCallback:
         self.wrapup_event_dispatched = False
         self.artifacts_processed = False
         self.extra_update_fields = {}
+        # Monotonic clocks for Receptor / runner / EE timing (see AWXReceptorJob).
+        self.runner_starting_at = None
+        self.first_event_at = None
+        self.wrapup_event_at = None
 
     def update_model(self, pk, _attempt=0, **updates):
         return update_model(self.model, pk, _attempt=0, _max_attempts=self.update_attempts, **updates)
@@ -146,6 +150,10 @@ class RunnerCallback:
         # logger
         if event_data.get('event') == 'keepalive':
             return
+
+        now = time.monotonic()
+        if self.first_event_at is None:
+            self.first_event_at = now
 
         if event_data.get(self.event_data_key, None):
             if self.event_data_key != 'job_id':
@@ -219,6 +227,7 @@ class RunnerCallback:
             self.recent_event_timings.append(time.time())
 
         if event_data.get('event', '') == self.wrapup_event_type:
+            self.wrapup_event_at = now
             self.wrapup_event_dispatched = True
 
         event_data.setdefault(self.event_data_key, self.instance.id)
@@ -245,6 +254,7 @@ class RunnerCallback:
         event_data.setdefault(self.event_data_key, self.instance.id)
         self.dispatcher.dispatch(event_data)
         if self.wrapup_event_type == 'EOF':
+            self.wrapup_event_at = time.monotonic()
             self.wrapup_event_dispatched = True
 
     def status_handler(self, status_data, runner_config):
@@ -252,6 +262,9 @@ class RunnerCallback:
         Ansible runner callback triggered on status transition
         """
         if status_data['status'] == 'starting':
+            self.runner_starting_at = time.monotonic()
+            if self.instance:
+                self.instance.log_lifecycle("runner_starting")
             job_env = dict(runner_config.env)
             '''
             Take the safe environment variables and overwrite

--- a/awx/main/tasks/receptor.py
+++ b/awx/main/tasks/receptor.py
@@ -47,6 +47,27 @@ __RECEPTOR_CONF_LOCKFILE = f'{__RECEPTOR_CONF}.lock'
 RECEPTOR_ACTIVE_STATES = ('Pending', 'Running')
 
 
+def compute_execution_timing(work_type, marks, runner_starting_at=None, first_event_at=None, wrapup_event_at=None):
+    """Build Receptor / runner / EE duration fields from monotonic timestamps.
+
+    marks keys: transmit_start, transmit_end, processor_end
+    """
+
+    def delta(start, end):
+        if start is None or end is None:
+            return None
+        return round(end - start, 3)
+
+    return {
+        'work_type': work_type,
+        'receptor_transmit_s': delta(marks.get('transmit_start'), marks.get('transmit_end')),
+        'runner_setup_s': delta(marks.get('transmit_end'), runner_starting_at),
+        'ee_start_s': delta(runner_starting_at, first_event_at),
+        'playbook_s': delta(first_event_at, wrapup_event_at),
+        'result_stream_s': delta(wrapup_event_at, marks.get('processor_end')),
+    }
+
+
 class ReceptorConnectionType(Enum):
     DATAGRAM = 0
     STREAM = 1
@@ -391,6 +412,7 @@ class AWXReceptorJob:
         self.task = task
         self.runner_params = runner_params
         self.unit_id = None
+        self.timing = {}
 
         if self.task and not self.task.instance.is_container_group_task:
             execution_environment_params = self.task.build_execution_environment_params(self.task.instance, runner_params['private_data_dir'])
@@ -444,6 +466,25 @@ class AWXReceptorJob:
         except Exception:
             logger.exception(f"Error releasing work unit {self.unit_id}.")
 
+    def _mark(self, key):
+        self.timing[key] = time.monotonic()
+
+    def _log_execution_timing(self):
+        try:
+            callback = getattr(self.task, 'runner_callback', None)
+            timing = compute_execution_timing(
+                self.work_type,
+                self.timing,
+                runner_starting_at=getattr(callback, 'runner_starting_at', None),
+                first_event_at=getattr(callback, 'first_event_at', None),
+                wrapup_event_at=getattr(callback, 'wrapup_event_at', None),
+            )
+            if self.task and self.task.instance:
+                self.task.instance.log_lifecycle("execution_timing", timing=timing)
+            logger.info('%s execution timing: %s', getattr(self.task.instance, 'log_format', 'job'), timing)
+        except Exception:
+            logger.exception('Failed to record execution timing')
+
     def _run_internal(self, receptor_ctl):
         # Create a socketpair. Where the left side will be used for writing our payload
         # (private data dir, kwargs). The right side will be passed to Receptor for
@@ -457,11 +498,15 @@ class AWXReceptorJob:
             use_stream_tls = get_conn_type(work_submit_kw['node'], receptor_ctl).name == "STREAMTLS"
             work_submit_kw['tlsclient'] = get_tls_client(self.config_data, use_stream_tls)
 
+        self._mark('transmit_start')
+        self.task.instance.log_lifecycle("receptor_transmit_start", work_type=self.work_type)
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
             transmitter_future = executor.submit(self.transmit, sockin)
 
             # submit our work, passing in the right side of our socketpair for reading.
             result = receptor_ctl.submit_work(payload=sockout.makefile('rb'), **work_submit_kw)
+            self._mark('submit_work')
 
             sockin.close()
             sockout.close()
@@ -486,6 +531,8 @@ class AWXReceptorJob:
         # Throws an exception if the transmit failed.
         # Will be caught by the try/except in BaseTask#run.
         transmitter_future.result()
+        self._mark('transmit_end')
+        self.task.instance.log_lifecycle("receptor_transmit_end")
 
         # Artifacts are an output, but sometimes they are an input as well
         # this is the case with fact cache, where clearing facts deletes a file, and this must be captured
@@ -518,6 +565,8 @@ class AWXReceptorJob:
                 res = result('canceled', 1)
             finally:
                 signal_state.raise_exception = False
+                self._mark('processor_end')
+                self._log_execution_timing()
 
             if res.status == 'error':
                 # If ansible-runner ran, but an error occured at runtime, the traceback information

--- a/awx/main/tests/unit/models/test_unified_job_unit.py
+++ b/awx/main/tests/unit/models/test_unified_job_unit.py
@@ -41,6 +41,16 @@ def test_log_representation():
     assert uj.log_format == 'unified_job 4 (running)'
 
 
+def test_log_lifecycle_accepts_timing_extra_fields():
+    job = Job(status='running', id=4, name='example')
+    with mock.patch('awx.main.models.unified_jobs.logger_job_lifecycle') as log:
+        job.log_lifecycle('execution_timing', timing={'playbook_s': 1.25, 'ee_start_s': None})
+    extra = log.info.call_args.kwargs['extra']['lifecycle_data']
+    assert extra['state'] == 'execution_timing'
+    assert extra['task_id'] == 4
+    assert extra['timing'] == {'playbook_s': 1.25, 'ee_start_s': None}
+
+
 class TestMetaVars:
     """
     Corresponding functional test exists for cases with indirect relationships

--- a/awx/main/tests/unit/tasks/test_runner_callback.py
+++ b/awx/main/tests/unit/tasks/test_runner_callback.py
@@ -154,3 +154,40 @@ class TestArtifactsHandler:
         assert 'installed_collections' not in rc.extra_update_fields
         assert 'ansible_version' not in rc.extra_update_fields
         assert rc.artifacts_processed is True
+
+
+def test_event_clocks_skip_keepalive_and_keep_first_event(mock_me):
+    rc = RunnerCallback()
+    rc.instance = mock.Mock(id=1)
+    rc.dispatcher = mock.MagicMock()
+    rc.event_data_key = 'job_id'
+    rc.wrapup_event_type = 'playbook_on_stats'
+
+    rc.event_handler({'event': 'keepalive'})
+    assert rc.first_event_at is None
+
+    rc.event_handler({'event': 'playbook_on_start', 'event_data': {}})
+    first = rc.first_event_at
+    assert first is not None
+
+    rc.event_handler({'event': 'runner_on_ok', 'event_data': {}})
+    assert rc.first_event_at == first
+    assert rc.wrapup_event_at is None
+
+    rc.event_handler({'event': 'playbook_on_stats', 'event_data': {}})
+    assert rc.wrapup_event_at is not None
+    assert rc.wrapup_event_at >= first
+
+
+def test_status_handler_records_runner_starting(mock_me):
+    rc = RunnerCallback()
+    rc.instance = mock.Mock(pk=1)
+    rc.safe_env = {}
+    rc.update_model = mock.Mock(return_value=rc.instance)
+    runner_config = mock.Mock(command=['podman', 'run'], cwd='/runner', env={})
+
+    rc.status_handler({'status': 'starting'}, runner_config)
+
+    assert rc.runner_starting_at is not None
+    rc.instance.log_lifecycle.assert_called_with('runner_starting')
+

--- a/awx/main/tests/unit/utils/test_receptor.py
+++ b/awx/main/tests/unit/utils/test_receptor.py
@@ -1,4 +1,4 @@
-from awx.main.tasks.receptor import _convert_args_to_cli
+from awx.main.tasks.receptor import _convert_args_to_cli, compute_execution_timing
 
 
 def test_file_cleanup_scenario():
@@ -20,3 +20,30 @@ def test_image_cleanup_scenario():
         ' '.join(args)
         == 'cleanup --remove-images "quay.invalid/foo/bar:latest" "quay.invalid/foo/bar:devel" --image-prune --process-isolation-executable=podman'
     )
+
+
+def test_compute_execution_timing_deltas():
+    marks = {'transmit_start': 10.0, 'transmit_end': 12.5, 'processor_end': 40.0}
+    timing = compute_execution_timing(
+        'ansible-runner',
+        marks,
+        runner_starting_at=13.0,
+        first_event_at=18.0,
+        wrapup_event_at=38.0,
+    )
+    assert timing == {
+        'work_type': 'ansible-runner',
+        'receptor_transmit_s': 2.5,
+        'runner_setup_s': 0.5,
+        'ee_start_s': 5.0,
+        'playbook_s': 20.0,
+        'result_stream_s': 2.0,
+    }
+
+
+def test_compute_execution_timing_missing_clocks():
+    timing = compute_execution_timing('local', {'transmit_start': 1.0})
+    assert timing['work_type'] == 'local'
+    assert timing['receptor_transmit_s'] is None
+    assert timing['ee_start_s'] is None
+    assert timing['playbook_s'] is None

--- a/examples/execution_timing.patch
+++ b/examples/execution_timing.patch
@@ -1,0 +1,192 @@
+# Job execution timing — production files only (no tests).
+#
+# Apply on every control-plane TASK instance. Do not apply on execution, hop,
+# ee, web, postgres, or redis. After patching, restart awx-dispatcher.
+#
+#   python3 -c 'import awx,os; print(os.path.dirname(awx.__file__))'
+#   # cd to the parent of that awx/ directory, then:
+#   patch -p1 < execution_timing.patch
+#   supervisorctl restart awx-dispatcher
+#
+# Repeat on every control-plane replica. Grep job_lifecycle for "execution_timing".
+
+diff --git a/awx/main/models/unified_jobs.py b/awx/main/models/unified_jobs.py
+index bca6b2c4d6..3d34badb0c 100644
+--- a/awx/main/models/unified_jobs.py
++++ b/awx/main/models/unified_jobs.py
+@@ -1617,13 +1617,16 @@ class UnifiedJob(
+     def is_container_group_task(self):
+         return False
+ 
+-    def log_lifecycle(self, state, blocked_by=None):
+-        extra = {
+-            'type': self._meta.model_name,
+-            'task_id': self.id,
+-            'state': state,
+-            'work_unit_id': self.work_unit_id,
+-        }
++    def log_lifecycle(self, state, blocked_by=None, **extra_fields):
++        extra = dict(extra_fields)
++        extra.update(
++            {
++                'type': self._meta.model_name,
++                'task_id': self.id,
++                'state': state,
++                'work_unit_id': self.work_unit_id,
++            }
++        )
+         if self.name:
+             extra["task_name"] = self.name
+         if state == "blocked" and blocked_by:
+diff --git a/awx/main/tasks/callback.py b/awx/main/tasks/callback.py
+index 266fd22015..bf65912b1e 100644
+--- a/awx/main/tasks/callback.py
++++ b/awx/main/tasks/callback.py
+@@ -91,6 +91,10 @@ class RunnerCallback:
+         self.wrapup_event_dispatched = False
+         self.artifacts_processed = False
+         self.extra_update_fields = {}
++        # Monotonic clocks for Receptor / runner / EE timing (see AWXReceptorJob).
++        self.runner_starting_at = None
++        self.first_event_at = None
++        self.wrapup_event_at = None
+ 
+     def update_model(self, pk, _attempt=0, **updates):
+         return update_model(self.model, pk, _attempt=0, _max_attempts=self.update_attempts, **updates)
+@@ -147,6 +151,10 @@ class RunnerCallback:
+         if event_data.get('event') == 'keepalive':
+             return
+ 
++        now = time.monotonic()
++        if self.first_event_at is None:
++            self.first_event_at = now
++
+         if event_data.get(self.event_data_key, None):
+             if self.event_data_key != 'job_id':
+                 event_data.pop('parent_uuid', None)
+@@ -219,6 +227,7 @@ class RunnerCallback:
+             self.recent_event_timings.append(time.time())
+ 
+         if event_data.get('event', '') == self.wrapup_event_type:
++            self.wrapup_event_at = now
+             self.wrapup_event_dispatched = True
+ 
+         event_data.setdefault(self.event_data_key, self.instance.id)
+@@ -245,6 +254,7 @@ class RunnerCallback:
+         event_data.setdefault(self.event_data_key, self.instance.id)
+         self.dispatcher.dispatch(event_data)
+         if self.wrapup_event_type == 'EOF':
++            self.wrapup_event_at = time.monotonic()
+             self.wrapup_event_dispatched = True
+ 
+     def status_handler(self, status_data, runner_config):
+@@ -252,6 +262,9 @@ class RunnerCallback:
+         Ansible runner callback triggered on status transition
+         """
+         if status_data['status'] == 'starting':
++            self.runner_starting_at = time.monotonic()
++            if self.instance:
++                self.instance.log_lifecycle("runner_starting")
+             job_env = dict(runner_config.env)
+             '''
+             Take the safe environment variables and overwrite
+diff --git a/awx/main/tasks/receptor.py b/awx/main/tasks/receptor.py
+index e1ccf4d7c4..9aaab399a8 100644
+--- a/awx/main/tasks/receptor.py
++++ b/awx/main/tasks/receptor.py
+@@ -47,6 +47,27 @@ __RECEPTOR_CONF_LOCKFILE = f'{__RECEPTOR_CONF}.lock'
+ RECEPTOR_ACTIVE_STATES = ('Pending', 'Running')
+ 
+ 
++def compute_execution_timing(work_type, marks, runner_starting_at=None, first_event_at=None, wrapup_event_at=None):
++    """Build Receptor / runner / EE duration fields from monotonic timestamps.
++
++    marks keys: transmit_start, transmit_end, processor_end
++    """
++
++    def delta(start, end):
++        if start is None or end is None:
++            return None
++        return round(end - start, 3)
++
++    return {
++        'work_type': work_type,
++        'receptor_transmit_s': delta(marks.get('transmit_start'), marks.get('transmit_end')),
++        'runner_setup_s': delta(marks.get('transmit_end'), runner_starting_at),
++        'ee_start_s': delta(runner_starting_at, first_event_at),
++        'playbook_s': delta(first_event_at, wrapup_event_at),
++        'result_stream_s': delta(wrapup_event_at, marks.get('processor_end')),
++    }
++
++
+ class ReceptorConnectionType(Enum):
+     DATAGRAM = 0
+     STREAM = 1
+@@ -391,6 +412,7 @@ class AWXReceptorJob:
+         self.task = task
+         self.runner_params = runner_params
+         self.unit_id = None
++        self.timing = {}
+ 
+         if self.task and not self.task.instance.is_container_group_task:
+             execution_environment_params = self.task.build_execution_environment_params(self.task.instance, runner_params['private_data_dir'])
+@@ -444,6 +466,25 @@ class AWXReceptorJob:
+         except Exception:
+             logger.exception(f"Error releasing work unit {self.unit_id}.")
+ 
++    def _mark(self, key):
++        self.timing[key] = time.monotonic()
++
++    def _log_execution_timing(self):
++        try:
++            callback = getattr(self.task, 'runner_callback', None)
++            timing = compute_execution_timing(
++                self.work_type,
++                self.timing,
++                runner_starting_at=getattr(callback, 'runner_starting_at', None),
++                first_event_at=getattr(callback, 'first_event_at', None),
++                wrapup_event_at=getattr(callback, 'wrapup_event_at', None),
++            )
++            if self.task and self.task.instance:
++                self.task.instance.log_lifecycle("execution_timing", timing=timing)
++            logger.info('%s execution timing: %s', getattr(self.task.instance, 'log_format', 'job'), timing)
++        except Exception:
++            logger.exception('Failed to record execution timing')
++
+     def _run_internal(self, receptor_ctl):
+         # Create a socketpair. Where the left side will be used for writing our payload
+         # (private data dir, kwargs). The right side will be passed to Receptor for
+@@ -457,11 +498,15 @@ class AWXReceptorJob:
+             use_stream_tls = get_conn_type(work_submit_kw['node'], receptor_ctl).name == "STREAMTLS"
+             work_submit_kw['tlsclient'] = get_tls_client(self.config_data, use_stream_tls)
+ 
++        self._mark('transmit_start')
++        self.task.instance.log_lifecycle("receptor_transmit_start", work_type=self.work_type)
++
+         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+             transmitter_future = executor.submit(self.transmit, sockin)
+ 
+             # submit our work, passing in the right side of our socketpair for reading.
+             result = receptor_ctl.submit_work(payload=sockout.makefile('rb'), **work_submit_kw)
++            self._mark('submit_work')
+ 
+             sockin.close()
+             sockout.close()
+@@ -486,6 +531,8 @@ class AWXReceptorJob:
+         # Throws an exception if the transmit failed.
+         # Will be caught by the try/except in BaseTask#run.
+         transmitter_future.result()
++        self._mark('transmit_end')
++        self.task.instance.log_lifecycle("receptor_transmit_end")
+ 
+         # Artifacts are an output, but sometimes they are an input as well
+         # this is the case with fact cache, where clearing facts deletes a file, and this must be captured
+@@ -518,6 +565,8 @@ class AWXReceptorJob:
+                 res = result('canceled', 1)
+             finally:
+                 signal_state.raise_exception = False
++                self._mark('processor_end')
++                self._log_execution_timing()
+ 
+             if res.status == 'error':
+                 # If ansible-runner ran, but an error occured at runtime, the traceback information


### PR DESCRIPTION
Record monotonic clocks around transmit, runner start, first event, and wrapup so operators can split mesh, image pull, and playbook time without a schema change.

##### SUMMARY
AAPRFE-3143. Operators cannot tell whether a slow job is Receptor mesh, EE image pull, or playbook time. `UnifiedJob.elapsed` is a single wall-clock number, so those stages are mixed together.

This records monotonic clocks around Receptor transmit, ansible-runner start, first event, and wrapup, then emits them on the existing `job_lifecycle` logger as state `execution_timing`. No new DB column or API field.

Design:
- Reuse `log_lifecycle` with optional extra fields (`timing`, `work_type`) instead of a new table or JSON on the job.
- Use `time.monotonic()` so NTP/clock skew does not distort deltas.
- Keep event-path cost to a few attribute writes; duration math runs once in `AWXReceptorJob` after the processor finishes.
- Missing clocks become `null` so canceled/error jobs still log a partial record.
- `examples/execution_timing.patch` is the production-only subset (no tests) for control-plane TASK nodes.

New `job_lifecycle` states: `receptor_transmit_start`, `receptor_transmit_end`, `runner_starting`, `execution_timing`.

Duration fields on `execution_timing`:
- `receptor_transmit_s` — pack + send `private_data_dir` (`transmit_start` → `transmit_end`)
- `runner_setup_s` — mesh + worker unpack + runner prep (`transmit_end` → runner `starting`)
- `ee_start_s` — podman/k8s start, including image pull (`starting` → first event)
- `playbook_s` — ansible-playbook (first event → wrapup/stats)
- `result_stream_s` — result stream / processor (wrapup → `processor_end`)

##### ISSUE TYPE
 - New or Enhanced Feature

##### COMPONENT NAME
 - Other

##### STEPS TO REPRODUCE AND EXTRA INFO
Launch a Job Template (or ad hoc command) that runs on Receptor (`work_type=ansible-runner` or `local`). After the job finishes, grep control-plane TASK logs:

  grep execution_timing /var/log/tower/job_lifecycle.log
  # containerized:
  podman logs automation-controller-task | grep execution_timing

Expected extra lifecycle states: `receptor_transmit_start`, `receptor_transmit_end`, `runner_starting`, then `execution_timing` with the duration object.

Unit coverage:
- `awx/main/tests/unit/models/test_unified_job_unit.py` — extra fields on `log_lifecycle`
- `awx/main/tests/unit/tasks/test_runner_callback.py` — first/wrapup clocks skip keepalive
- `awx/main/tests/unit/utils/test_receptor.py` — `compute_execution_timing` deltas and missing clocks

```
2026-09-04 17:01:09,938 INFO [-] awx.analytics.job_lifecycle job-57 execution timing {"timing": {"work_type": "ansible-runner", "receptor_transmit_s": 8.347, "runner_setup_s": 2.265, "ee_start_s": 2.252, "playbook_s": 2.003, "result_stream_s": 1.037}, "type": "job", "task_id": 57, "state": "execution_timing", "work_unit_id": "100782182uTcwrz2", "task_name": "Rbertol - repro - always pp"} 2026-09-04 17:01:09,940 INFO [-] awx.main.tasks.receptor job 57 (running) execution timing: {'work_type': 'ansible-runner', 'receptor_transmit_s': 8.347, 'runner_setup_s': 2.265, 'ee_start_s': 2.252, 'playbook_s': 2.003, 'result_stream_s': 1.037}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added execution timing details to job lifecycle records and application logs.
  * Job execution now tracks key phases, including runner startup, environment startup, playbook execution, result streaming, and processing.
  * Lifecycle entries can include additional contextual information alongside standard job details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->