### PR TITLE
fix: awxkit user creation race condition with gateway sync

### DIFF
--- a/awxkit/awxkit/api/pages/users.py
+++ b/awxkit/awxkit/api/pages/users.py
@@ -1,5 +1,5 @@
 from awxkit.api.mixins import HasCreate, DSAdapter
-from awxkit.utils import random_title, PseudoNamespace
+from awxkit.utils import random_title, PseudoNamespace, poll_until
 from awxkit.api.resources import resources
 from awxkit.config import config
 
@@ -40,8 +40,13 @@ class User(HasCreate, base.Base):
             # Cleanup controller attributes
             payload["is_platform_auditor"] = payload.get("is_system_auditor")
             payload.pop("is_system_auditor")
-            # Create gw user
+            # Create gw user, then wait for controller sync
             gw_user = gw_users_api.post(payload)
+            poll_until(
+                lambda: len(ctrl_users_api.get(username=gw_user.username).results) > 0,
+                interval=1,
+                timeout=30,
+            )
             user = ctrl_users_api.get(username=gw_user.username).results.pop()
             user.json["password"] = payload.password
             self.update_identity(user)


### PR DESCRIPTION
##### SUMMARY

After creating a user on the gateway API (`/api/gateway/v1/users/`), awxkit
immediately queries the controller API to find the synced user. On gateway installs, the gateway-to-controller sync may not have completed yet, causing `IndexError: pop from empty list` when `.results.pop()` is called on empty results.

The fix adds a `poll_until` wait (1s interval, 30s timeout) between the gateway POST and the controller GET, ensuring the user has been synced before proceeding.

This affected ~32 tests across the tower legacy suite on every containerized pipeline run, all failing in fixture setup with:
```
awxkit/api/pages/users.py:45
    user = ctrl_users_api.get(username=gw_user.username).results.pop()
IndexError: pop from empty list
```

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### COMPONENT NAME
 - CLI

##### STEPS TO REPRODUCE AND EXTRA INFO

1. Run any tower test that creates a user via factories against a gateway environment with `--bypass-gateway=no`
2. The user is created on the gateway but the immediate controller lookup returns empty results due to sync latency

Before fix:
```
IndexError: pop from empty list
```

After fix:
```
3 passed, 11 warnings in 238.68s
```

Verified against a live containerized AIO environment. Tests that were failing for 2-16 consecutive builds now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway user creation reliability by waiting for the new user to appear in the controller before completing identity updates.
  * Added a timeout to prevent the operation from waiting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->