### PR TITLE
fix(api): allow label disassociation over limit

### DIFF
--- a/awx/api/views/labels.py
+++ b/awx/api/views/labels.py
@@ -53,10 +53,13 @@ class LabelSubListCreateAttachDetachView(SubListCreateAttachDetachAPIView):
                 del request.data['name']
                 del request.data['organization']
 
-        # Give a 400 error if we have attached too many labels to this object
-        label_filter = self.parent_model._meta.get_field(self.relationship).remote_field.name
-        if Label.objects.filter(**{label_filter: self.kwargs['pk']}).count() > 100:
-            return Response(dict(msg=_(f'Maximum number of labels for {self.parent_model._meta.verbose_name_raw} reached.')), status=HTTP_400_BAD_REQUEST)
+        # Give a 400 error if we have attached too many labels to this object.
+        # Disassociation is handled by the parent post() and must remain available
+        # so an object over the limit can be recovered.
+        if 'disassociate' not in request.data:
+            label_filter = self.parent_model._meta.get_field(self.relationship).remote_field.name
+            if Label.objects.filter(**{label_filter: self.kwargs['pk']}).count() > 100:
+                return Response(dict(msg=_(f'Maximum number of labels for {self.parent_model._meta.verbose_name_raw} reached.')), status=HTTP_400_BAD_REQUEST)
 
         return super().post(request, *args, **kwargs)
 

--- a/awx/main/tests/unit/api/test_views.py
+++ b/awx/main/tests/unit/api/test_views.py
@@ -69,6 +69,7 @@ class TestJobTemplateLabelList:
             mixin_unattach.assert_called_with(mock_request, None, None)
 
     def test_disassociate_skips_label_limit(self):
+        """Disassociating a label skips the label limit validation."""
         view = JobTemplateLabelList()
         request = mock.MagicMock(data={'id': 1, 'disassociate': True})
 

--- a/awx/main/tests/unit/api/test_views.py
+++ b/awx/main/tests/unit/api/test_views.py
@@ -68,6 +68,16 @@ class TestJobTemplateLabelList:
             super(JobTemplateLabelList, view).unattach(mock_request, None, None)
             mixin_unattach.assert_called_with(mock_request, None, None)
 
+    def test_disassociate_skips_label_limit(self):
+        view = JobTemplateLabelList()
+        request = mock.MagicMock(data={'id': 1, 'disassociate': True})
+
+        with mock.patch.object(view, 'unattach') as unattach, mock.patch('awx.api.views.labels.Label.objects.filter') as label_filter:
+            view.post(request)
+
+        label_filter.assert_not_called()
+        unattach.assert_called_once_with(request)
+
 
 class TestInventoryInventorySourcesUpdate:
     @pytest.mark.parametrize(


### PR DESCRIPTION
### SUMMARY

Allow label disassociation through the API when a resource already has more than the maximum of 100 labels.

The label attach/detach endpoint uses the same `POST` handler for both operations. The label-count guard previously ran for disassociation requests as well, preventing an over-limit resource from removing labels and recovering to a valid state. The guard now applies only to attach/create requests, while disassociation remains available. A unit test verifies that disassociation skips the label-count query.

### ISSUE TYPE

 - Bug, Docs Fix or other nominal change

### COMPONENT NAME

 - API

### STEPS TO REPRODUCE AND EXTRA INFO

1. Associate more than 100 labels with a supported resource, such as a job template.

2. Send a request to the resource's labels endpoint to disassociate one of its labels:

   ```
   POST /api/v2/job_templates/<job_template_id>/labels/
   {"id": <label_id>, "disassociate": true}
   ```

3. Before this change, the request was rejected with HTTP 400 because the label-count limit was checked before disassociation. After this change, the label is disassociated successfully.

The 100-label limit remains enforced for new label attachments.

```bash
# Attach 101 labels
for i in $(seq -w 1 101); do
  curl -sk -u admin:<password> -X POST \
    "https://<controller-host>/api/v2/job_templates/8/labels/" \
    -H "Content-Type: application/json" \
    -d "{\"name\": \"label-${i}\", \"organization\": 1}"
done

# Before: disassociate fails
curl -sk -u admin:<password> -X POST \
  "https://<controller-host>/api/v2/job_templates/8/labels/" \
  -H "Content-Type: application/json" \
  -d '{"id": 105, "disassociate": true}'
# HTTP 400 {"msg":"Maximum number of labels for job template reached."}

# After: disassociate succeeds
curl -sk -u admin:<password> -X POST \
  "https://<controller-host>/api/v2/job_templates/8/labels/" \
  -H "Content-Type: application/json" \
  -d '{"id": 105, "disassociate": true}'
# HTTP 204
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Disassociating labels from objects that exceed the 100-label limit now works correctly.
  - Disassociation requests bypass label-limit validation, allowing recovery actions to proceed without an unnecessary error.
  - Label removal remains available even when an object is already over the maximum label count.

- **Tests**
  - Added coverage confirming that disassociation requests bypass the label-limit check and complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->